### PR TITLE
Add endpointProvider in ClientConfig and RequestOverrideConfig. Also add crossRegionBucketAccess in S3Configuration

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ServiceConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ServiceConfig.java
@@ -47,7 +47,7 @@ public class ServiceConfig {
 
     private boolean hasAccelerateModeEnabledProperty = false;
 
-    private boolean hasCrossRegionBucketAccessEnabledProperty = false;
+    private boolean hasCrossRegionAccessEnabledProperty = false;
 
     public String getClassName() {
         return className;
@@ -98,11 +98,11 @@ public class ServiceConfig {
     }
 
     public boolean hasCrossRegionAccessEnabledProperty() {
-        return hasCrossRegionBucketAccessEnabledProperty;
+        return hasCrossRegionAccessEnabledProperty;
     }
 
-    public void setHasCrossRegionBucketAccessEnabledProperty(boolean hasCrossRegionBucketAccessEnabledProperty) {
-        this.hasCrossRegionBucketAccessEnabledProperty = hasCrossRegionBucketAccessEnabledProperty;
+    public void setHasCrossRegionAccessEnabledProperty(boolean hasCrossRegionAccessEnabledProperty) {
+        this.hasCrossRegionAccessEnabledProperty = hasCrossRegionAccessEnabledProperty;
     }
 
     public boolean hasAccelerateModeEnabledProperty() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ServiceConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ServiceConfig.java
@@ -47,6 +47,8 @@ public class ServiceConfig {
 
     private boolean hasAccelerateModeEnabledProperty = false;
 
+    private boolean hasCrossRegionBucketAccessEnabledProperty = false;
+
     public String getClassName() {
         return className;
     }
@@ -93,6 +95,14 @@ public class ServiceConfig {
 
     public void setHasPathStyleAccessEnabledProperty(boolean hasPathStyleAccessEnabledProperty) {
         this.hasPathStyleAccessEnabledProperty = hasPathStyleAccessEnabledProperty;
+    }
+
+    public boolean hasCrossRegionAccessEnabledProperty() {
+        return hasCrossRegionBucketAccessEnabledProperty;
+    }
+
+    public void setHasCrossRegionBucketAccessEnabledProperty(boolean hasCrossRegionBucketAccessEnabledProperty) {
+        this.hasCrossRegionBucketAccessEnabledProperty = hasCrossRegionBucketAccessEnabledProperty;
     }
 
     public boolean hasAccelerateModeEnabledProperty() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
@@ -127,16 +127,14 @@ public class AsyncClientBuilderClass implements ClassSpec {
                          .addStatement("$T clientConfiguration = super.asyncClientConfiguration()", SdkClientConfiguration.class)
                          .addStatement("this.validateClientOptions(clientConfiguration)")
                          .addStatement("$T endpointOverride = null", URI.class)
-                         .addStatement("$T endpointProvider = null", EndpointProvider.class)
+                         .addStatement("$T endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER)",
+                                       EndpointProvider.class,
+                                       SdkClientOption.class)
                          .addCode("if (clientConfiguration.option($T.ENDPOINT_OVERRIDDEN) != null"
                                   + "&& $T.TRUE.equals(clientConfiguration.option($T.ENDPOINT_OVERRIDDEN))) {"
                                   + "endpointOverride = clientConfiguration.option($T.ENDPOINT);"
                                   + "}",
                                   SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
-                         .addCode("if (clientConfiguration.option($T.ENDPOINT_PROVIDER) != null) {"
-                                  + "endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER);"
-                                  + "}",
-                                  SdkClientOption.class, SdkClientOption.class)
                          .addStatement("$T serviceClientConfiguration = $T.builder()"
                                        + ".overrideConfiguration(overrideConfiguration())"
                                        + ".region(clientConfiguration.option($T.AWS_REGION))"

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
 import software.amazon.awssdk.codegen.utils.AuthUtils;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 
 public class AsyncClientBuilderClass implements ClassSpec {
     private final IntermediateModel model;
@@ -126,15 +127,21 @@ public class AsyncClientBuilderClass implements ClassSpec {
                          .addStatement("$T clientConfiguration = super.asyncClientConfiguration()", SdkClientConfiguration.class)
                          .addStatement("this.validateClientOptions(clientConfiguration)")
                          .addStatement("$T endpointOverride = null", URI.class)
+                         .addStatement("$T endpointProvider = null", EndpointProvider.class)
                          .addCode("if (clientConfiguration.option($T.ENDPOINT_OVERRIDDEN) != null"
                                   + "&& $T.TRUE.equals(clientConfiguration.option($T.ENDPOINT_OVERRIDDEN))) {"
                                   + "endpointOverride = clientConfiguration.option($T.ENDPOINT);"
                                   + "}",
                                   SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
+                         .addCode("if (clientConfiguration.option($T.ENDPOINT_PROVIDER) != null) {"
+                                  + "endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER);"
+                                  + "}",
+                                  SdkClientOption.class, SdkClientOption.class)
                          .addStatement("$T serviceClientConfiguration = $T.builder()"
                                        + ".overrideConfiguration(overrideConfiguration())"
                                        + ".region(clientConfiguration.option($T.AWS_REGION))"
                                        + ".endpointOverride(endpointOverride)"
+                                       + ".endpointProvider(endpointProvider)"
                                        + ".build()",
                                        serviceConfigClassName, serviceConfigClassName, AwsClientOption.class)
                          .addStatement("return new $T(serviceClientConfiguration, clientConfiguration)", clientClassName)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
@@ -127,17 +127,13 @@ public class SyncClientBuilderClass implements ClassSpec {
                          .addStatement("$T clientConfiguration = super.syncClientConfiguration()", SdkClientConfiguration.class)
                          .addStatement("this.validateClientOptions(clientConfiguration)")
                          .addStatement("$T endpointOverride = null", URI.class)
-                         .addStatement("$T endpointProvider = null", EndpointProvider.class)
+                         .addStatement("$T endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER)",
+                                       EndpointProvider.class, SdkClientOption.class)
                          .addCode("if (clientConfiguration.option($T.ENDPOINT_OVERRIDDEN) != null"
                                   + "&& $T.TRUE.equals(clientConfiguration.option($T.ENDPOINT_OVERRIDDEN))) {"
                                   + "endpointOverride = clientConfiguration.option($T.ENDPOINT);"
-
                                   + "}",
                                   SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
-                         .addCode("if (clientConfiguration.option($T.ENDPOINT_PROVIDER) != null) {"
-                                  + "endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER);"
-                                  + "}",
-                                  SdkClientOption.class, SdkClientOption.class)
                          .addStatement("$T serviceClientConfiguration = $T.builder()"
                                        + ".overrideConfiguration(overrideConfiguration())"
                                        + ".region(clientConfiguration.option($T.AWS_REGION))"

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
 import software.amazon.awssdk.codegen.utils.AuthUtils;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 
 public class SyncClientBuilderClass implements ClassSpec {
     private final IntermediateModel model;
@@ -126,15 +127,22 @@ public class SyncClientBuilderClass implements ClassSpec {
                          .addStatement("$T clientConfiguration = super.syncClientConfiguration()", SdkClientConfiguration.class)
                          .addStatement("this.validateClientOptions(clientConfiguration)")
                          .addStatement("$T endpointOverride = null", URI.class)
+                         .addStatement("$T endpointProvider = null", EndpointProvider.class)
                          .addCode("if (clientConfiguration.option($T.ENDPOINT_OVERRIDDEN) != null"
                                   + "&& $T.TRUE.equals(clientConfiguration.option($T.ENDPOINT_OVERRIDDEN))) {"
                                   + "endpointOverride = clientConfiguration.option($T.ENDPOINT);"
+
                                   + "}",
                                   SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
+                         .addCode("if (clientConfiguration.option($T.ENDPOINT_PROVIDER) != null) {"
+                                  + "endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER);"
+                                  + "}",
+                                  SdkClientOption.class, SdkClientOption.class)
                          .addStatement("$T serviceClientConfiguration = $T.builder()"
                                        + ".overrideConfiguration(overrideConfiguration())"
                                        + ".region(clientConfiguration.option($T.AWS_REGION))"
                                        + ".endpointOverride(endpointOverride)"
+                                       + ".endpointProvider(endpointProvider)"
                                        + ".build()",
                                        serviceConfigClassName, serviceConfigClassName, AwsClientOption.class)
                          .addStatement("return new $T(serviceClientConfiguration, clientConfiguration)", clientClassName)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceClientConfigurationClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceClientConfigurationClass.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.regions.Region;
 
 public class ServiceClientConfigurationClass implements ClassSpec {
@@ -110,6 +111,13 @@ public class ServiceClientConfigurationClass implements ClassSpec {
                                             .returns(className().nestedClass("Builder"))
                                             .addJavadoc("Configure the client override configuration")
                                             .build())
+                       .addMethod(MethodSpec.methodBuilder("endpointProvider")
+                                            .addAnnotation(Override.class)
+                                            .addModifiers(PUBLIC, ABSTRACT)
+                                            .addParameter(EndpointProvider.class, "endpointProvider")
+                                            .returns(className().nestedClass("Builder"))
+                                            .addJavadoc("Configure the endpointProvider")
+                                            .build())
                        .build();
     }
 
@@ -148,6 +156,14 @@ public class ServiceClientConfigurationClass implements ClassSpec {
                                             .addParameter(URI.class, "endpointOverride")
                                             .returns(className().nestedClass("Builder"))
                                             .addStatement("this.endpointOverride = endpointOverride")
+                                            .addStatement("return this")
+                                            .build())
+                       .addMethod(MethodSpec.methodBuilder("endpointProvider")
+                                            .addAnnotation(Override.class)
+                                            .addModifiers(PUBLIC)
+                                            .addParameter(EndpointProvider.class, "endpointProvider")
+                                            .returns(className().nestedClass("Builder"))
+                                            .addStatement("this.endpointProvider = endpointProvider")
                                             .addStatement("return this")
                                             .build())
                        .addMethod(MethodSpec.methodBuilder("build")

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
@@ -33,13 +34,17 @@ final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<J
         SdkClientConfiguration clientConfiguration = super.asyncClientConfiguration();
         this.validateClientOptions(clientConfiguration);
         URI endpointOverride = null;
+        EndpointProvider endpointProvider = null;
         if (clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN) != null
             && Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN))) {
             endpointOverride = clientConfiguration.option(SdkClientOption.ENDPOINT);
         }
+        if (clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER) != null) {
+            endpointProvider = clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER);
+        }
         JsonServiceClientConfiguration serviceClientConfiguration = JsonServiceClientConfiguration.builder()
                                                                                                   .overrideConfiguration(overrideConfiguration()).region(clientConfiguration.option(AwsClientOption.AWS_REGION))
-                                                                                                  .endpointOverride(endpointOverride).build();
+                                                                                                  .endpointOverride(endpointOverride).endpointProvider(endpointProvider).build();
         return new DefaultJsonAsyncClient(serviceClientConfiguration, clientConfiguration);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
@@ -34,13 +34,10 @@ final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<J
         SdkClientConfiguration clientConfiguration = super.asyncClientConfiguration();
         this.validateClientOptions(clientConfiguration);
         URI endpointOverride = null;
-        EndpointProvider endpointProvider = null;
+        EndpointProvider endpointProvider = clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER);
         if (clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN) != null
             && Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN))) {
             endpointOverride = clientConfiguration.option(SdkClientOption.ENDPOINT);
-        }
-        if (clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER) != null) {
-            endpointProvider = clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER);
         }
         JsonServiceClientConfiguration serviceClientConfiguration = JsonServiceClientConfiguration.builder()
                                                                                                   .overrideConfiguration(overrideConfiguration()).region(clientConfiguration.option(AwsClientOption.AWS_REGION))

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
@@ -33,13 +34,17 @@ final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonCl
         SdkClientConfiguration clientConfiguration = super.syncClientConfiguration();
         this.validateClientOptions(clientConfiguration);
         URI endpointOverride = null;
+        EndpointProvider endpointProvider = null;
         if (clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN) != null
             && Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN))) {
             endpointOverride = clientConfiguration.option(SdkClientOption.ENDPOINT);
         }
+        if (clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER) != null) {
+            endpointProvider = clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER);
+        }
         JsonServiceClientConfiguration serviceClientConfiguration = JsonServiceClientConfiguration.builder()
                                                                                                   .overrideConfiguration(overrideConfiguration()).region(clientConfiguration.option(AwsClientOption.AWS_REGION))
-                                                                                                  .endpointOverride(endpointOverride).build();
+                                                                                                  .endpointOverride(endpointOverride).endpointProvider(endpointProvider).build();
         return new DefaultJsonClient(serviceClientConfiguration, clientConfiguration);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
@@ -34,13 +34,10 @@ final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonCl
         SdkClientConfiguration clientConfiguration = super.syncClientConfiguration();
         this.validateClientOptions(clientConfiguration);
         URI endpointOverride = null;
-        EndpointProvider endpointProvider = null;
+        EndpointProvider endpointProvider = clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER);
         if (clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN) != null
             && Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN))) {
             endpointOverride = clientConfiguration.option(SdkClientOption.ENDPOINT);
-        }
-        if (clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER) != null) {
-            endpointProvider = clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER);
         }
         JsonServiceClientConfiguration serviceClientConfiguration = JsonServiceClientConfiguration.builder()
                                                                                                   .overrideConfiguration(overrideConfiguration()).region(clientConfiguration.option(AwsClientOption.AWS_REGION))

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/serviceclientconfiguration.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/serviceclientconfiguration.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.AwsServiceClientConfiguration;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.regions.Region;
 
 /**
@@ -45,6 +46,13 @@ public final class JsonProtocolTestsServiceClientConfiguration extends AwsServic
          */
         @Override
         Builder overrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration);
+
+        /**
+         * Configure the endpointProvider
+         */
+        @Override
+        Builder endpointProvider(EndpointProvider endpointProvider);
+
     }
 
     private static final class BuilderImpl extends AwsServiceClientConfiguration.BuilderImpl implements Builder {
@@ -70,6 +78,12 @@ public final class JsonProtocolTestsServiceClientConfiguration extends AwsServic
         @Override
         public Builder endpointOverride(URI endpointOverride) {
             this.endpointOverride = endpointOverride;
+            return this;
+        }
+
+        @Override
+        public Builder endpointProvider(EndpointProvider endpointProvider) {
+            this.endpointProvider = endpointProvider;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -88,6 +88,10 @@ public final class QueryEndpointParams {
         return operationContextParam;
     }
 
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
     public interface Builder {
         Builder region(Region region);
 
@@ -133,6 +137,22 @@ public final class QueryEndpointParams {
         private String stringContextParam;
 
         private String operationContextParam;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(QueryEndpointParams builder) {
+            this.region = builder.region;
+            this.useDualStackEndpoint = builder.useDualStackEndpoint;
+            this.useFIPSEndpoint = builder.useFIPSEndpoint;
+            this.endpointId = builder.endpointId;
+            this.defaultTrueParam = builder.defaultTrueParam;
+            this.defaultStringParam = builder.defaultStringParam;
+            this.deprecatedParam = builder.deprecatedParam;
+            this.booleanContextParam = builder.booleanContextParam;
+            this.stringContextParam = builder.stringContextParam;
+            this.operationContextParam = builder.operationContextParam;
+        }
 
         @Override
         public Builder region(Region region) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -3,13 +3,15 @@ package software.amazon.awssdk.services.query.endpoints;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * The parameters object used to resolve an endpoint for the Query service.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkPublicApi
-public final class QueryEndpointParams {
+public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpointParams.Builder, QueryEndpointParams> {
     private final Region region;
 
     private final Boolean useDualStackEndpoint;
@@ -92,7 +94,7 @@ public final class QueryEndpointParams {
         return new BuilderImpl(this);
     }
 
-    public interface Builder {
+    public interface Builder extends CopyableBuilder<Builder, QueryEndpointParams> {
         Builder region(Region region);
 
         Builder useDualStackEndpoint(Boolean useDualStackEndpoint);

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.SdkServiceClientConfiguration;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.regions.Region;
 
 /**
@@ -89,6 +90,7 @@ public abstract class AwsServiceClientConfiguration extends SdkServiceClientConf
         protected ClientOverrideConfiguration overrideConfiguration;
         protected Region region;
         protected URI endpointOverride;
+        protected EndpointProvider endpointProvider;
 
         protected BuilderImpl() {
         }
@@ -97,6 +99,7 @@ public abstract class AwsServiceClientConfiguration extends SdkServiceClientConf
             this.overrideConfiguration = awsServiceClientConfiguration.overrideConfiguration();
             this.region = awsServiceClientConfiguration.region();
             this.endpointOverride = awsServiceClientConfiguration.endpointOverride().orElse(null);
+            this.endpointProvider =  awsServiceClientConfiguration.endpointProvider().orElse(null);
         }
 
         @Override
@@ -112,6 +115,17 @@ public abstract class AwsServiceClientConfiguration extends SdkServiceClientConf
         @Override
         public final URI endpointOverride() {
             return endpointOverride;
+        }
+
+        @Override
+        public final EndpointProvider endpointProvider() {
+            return endpointProvider;
+        }
+
+        @Override
+        public Builder endpointProvider(EndpointProvider endpointProvider) {
+            this.endpointProvider = endpointProvider;
+            return this;
         }
     }
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
@@ -83,6 +83,9 @@ public abstract class AwsServiceClientConfiguration extends SdkServiceClientConf
         Builder endpointOverride(URI endpointOverride);
 
         @Override
+        Builder endpointProvider(EndpointProvider endpointProvider);
+
+        @Override
         AwsServiceClientConfiguration build();
     }
 
@@ -122,11 +125,6 @@ public abstract class AwsServiceClientConfiguration extends SdkServiceClientConf
             return endpointProvider;
         }
 
-        @Override
-        public Builder endpointProvider(EndpointProvider endpointProvider) {
-            this.endpointProvider = endpointProvider;
-            return this;
-        }
     }
 
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.InternalCoreExecutionAttribute;
 import software.amazon.awssdk.core.internal.util.HttpChecksumResolver;
 import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.metrics.MetricCollector;
 
 @SdkInternalApi
@@ -94,7 +95,8 @@ public final class AwsExecutionContextBuilder {
             .putAttribute(SdkExecutionAttribute.OPERATION_NAME, executionParams.getOperationName())
             .putAttribute(SdkExecutionAttribute.CLIENT_ENDPOINT, clientConfig.option(SdkClientOption.ENDPOINT))
             .putAttribute(SdkExecutionAttribute.ENDPOINT_OVERRIDDEN, clientConfig.option(SdkClientOption.ENDPOINT_OVERRIDDEN))
-            .putAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER, clientConfig.option(SdkClientOption.ENDPOINT_PROVIDER))
+            .putAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER,
+                          resolveEndpointProvider(originalRequest, clientConfig))
             .putAttribute(SdkInternalExecutionAttribute.CLIENT_CONTEXT_PARAMS,
                           clientConfig.option(SdkClientOption.CLIENT_CONTEXT_PARAMS))
             .putAttribute(SdkInternalExecutionAttribute.DISABLE_HOST_PREFIX_INJECTION,
@@ -203,5 +205,19 @@ public final class AwsExecutionContextBuilder {
     private static boolean isAuthenticatedRequest(ExecutionAttributes executionAttributes) {
         return executionAttributes.getOptionalAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST).orElse(true);
     }
+
+
+    /**
+     * Resolves the endpoint provider, with the request override configuration taking precedence over the
+     * provided default client clientConfig.
+     * @return The endpoint provider that will be used by the SDK to resolve endpoints.
+     */
+    private static EndpointProvider resolveEndpointProvider(SdkRequest request,
+                                                           SdkClientConfiguration clientConfig) {
+        return request.overrideConfiguration()
+                      .flatMap(RequestOverrideConfiguration::endpointProvider)
+                      .orElse(clientConfig.option(SdkClientOption.ENDPOINT_PROVIDER));
+    }
+
 
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
@@ -157,6 +157,14 @@ public abstract class RequestOverrideConfiguration {
         return executionAttributes;
     }
 
+    /**
+     * Returns the endpoint provider for resolving the endpoint for this request. This supersedes the
+     * endpoint provider set on the client.
+     */
+    public Optional<EndpointProvider> endpointProvider() {
+        return Optional.ofNullable(endpointProvider);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -417,15 +425,6 @@ public abstract class RequestOverrideConfiguration {
         <T> B putExecutionAttribute(ExecutionAttribute<T> attribute, T value);
 
         ExecutionAttributes executionAttributes();
-
-        /**
-         * Sets the signer to use for signing the request. This signer get priority over the signer set on the client while
-         * signing the requests. If this value is null, then the client level signer is used for signing the request.
-         *
-         * @param signer Signer for signing the request
-         * @return This object for method chaining
-         */
-
 
         /**
          * Sets the endpointProvider to use for resolving the endpoint of the request. This endpointProvider gets priority

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Validate;
@@ -51,6 +52,8 @@ public abstract class RequestOverrideConfiguration {
     private final List<MetricPublisher> metricPublishers;
     private final ExecutionAttributes executionAttributes;
 
+    private final EndpointProvider endpointProvider;
+
     protected RequestOverrideConfiguration(Builder<?> builder) {
         this.headers = CollectionUtils.deepUnmodifiableMap(builder.headers(), () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
         this.rawQueryParameters = CollectionUtils.deepUnmodifiableMap(builder.rawQueryParameters());
@@ -60,6 +63,7 @@ public abstract class RequestOverrideConfiguration {
         this.signer = builder.signer();
         this.metricPublishers = Collections.unmodifiableList(new ArrayList<>(builder.metricPublishers()));
         this.executionAttributes = ExecutionAttributes.unmodifiableExecutionAttributes(builder.executionAttributes());
+        this.endpointProvider = builder.endpointProvider();
     }
 
     /**
@@ -169,7 +173,8 @@ public abstract class RequestOverrideConfiguration {
                Objects.equals(apiCallAttemptTimeout, that.apiCallAttemptTimeout) &&
                Objects.equals(signer, that.signer) &&
                Objects.equals(metricPublishers, that.metricPublishers) &&
-               Objects.equals(executionAttributes, that.executionAttributes);
+               Objects.equals(executionAttributes, that.executionAttributes) &&
+               Objects.equals(endpointProvider, that.endpointProvider);
     }
 
     @Override
@@ -183,6 +188,7 @@ public abstract class RequestOverrideConfiguration {
         hashCode = 31 * hashCode + Objects.hashCode(signer);
         hashCode = 31 * hashCode + Objects.hashCode(metricPublishers);
         hashCode = 31 * hashCode + Objects.hashCode(executionAttributes);
+        hashCode = 31 * hashCode + Objects.hashCode(endpointProvider);
         return hashCode;
     }
 
@@ -413,6 +419,27 @@ public abstract class RequestOverrideConfiguration {
         ExecutionAttributes executionAttributes();
 
         /**
+         * Sets the signer to use for signing the request. This signer get priority over the signer set on the client while
+         * signing the requests. If this value is null, then the client level signer is used for signing the request.
+         *
+         * @param signer Signer for signing the request
+         * @return This object for method chaining
+         */
+
+
+        /**
+         * Sets the endpointProvider to use for resolving the endpoint of the request. This endpointProvider gets priority
+         * over the endpointProvider set on the client while resolving the endpoint for  the requests.
+         * If this value is null, then the client level endpointProvider is used for resolving the endpoint.
+         *
+         * @param endpointProvider Endpoint Provider that will override the resolving the endpoint for the request.
+         * @return This object for method chaining
+         */
+        B endpointProvider(EndpointProvider endpointProvider);
+
+        EndpointProvider endpointProvider();
+
+        /**
          * Create a new {@code SdkRequestOverrideConfiguration} with the properties set on this builder.
          *
          * @return The new {@code SdkRequestOverrideConfiguration}.
@@ -430,6 +457,9 @@ public abstract class RequestOverrideConfiguration {
         private List<MetricPublisher> metricPublishers = new ArrayList<>();
         private ExecutionAttributes.Builder executionAttributesBuilder = ExecutionAttributes.builder();
 
+        private EndpointProvider endpointProvider;
+
+
         protected BuilderImpl() {
         }
 
@@ -442,6 +472,7 @@ public abstract class RequestOverrideConfiguration {
             signer(sdkRequestOverrideConfig.signer().orElse(null));
             metricPublishers(sdkRequestOverrideConfig.metricPublishers());
             executionAttributes(sdkRequestOverrideConfig.executionAttributes());
+            endpointProvider(sdkRequestOverrideConfig.endpointProvider);
         }
 
         @Override
@@ -594,6 +625,22 @@ public abstract class RequestOverrideConfiguration {
 
         public void setExecutionAttributes(ExecutionAttributes executionAttributes) {
             executionAttributes(executionAttributes);
+        }
+
+
+        @Override
+        public B endpointProvider(EndpointProvider endpointProvider) {
+            this.endpointProvider = endpointProvider;
+            return (B) this;
+        }
+
+        public void setEndpointProvider(EndpointProvider endpointProvider) {
+            endpointProvider(endpointProvider);
+        }
+
+        @Override
+        public EndpointProvider endpointProvider() {
+            return endpointProvider;
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
@@ -57,6 +57,11 @@ public abstract class SdkServiceClientConfiguration {
         return Optional.ofNullable(this.endpointOverride);
     }
 
+    /**
+     *
+     * @return The configured endpoint provider of the SdkClient. If the endpoint provider was not configured, an empty
+     * Optional will be returned.
+     */
     public Optional<EndpointProvider> endpointProvider() {
         return Optional.ofNullable(this.endpointProvider);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 
 /**
  * Class to expose SDK service client settings to the user, e.g., ClientOverrideConfiguration
@@ -30,9 +31,12 @@ public abstract class SdkServiceClientConfiguration {
     private final ClientOverrideConfiguration overrideConfiguration;
     private final URI endpointOverride;
 
+    private final EndpointProvider endpointProvider;
+
     protected SdkServiceClientConfiguration(Builder builder) {
         this.overrideConfiguration = builder.overrideConfiguration();
         this.endpointOverride = builder.endpointOverride();
+        this.endpointProvider = builder.endpointProvider();
     }
 
     /**
@@ -53,6 +57,11 @@ public abstract class SdkServiceClientConfiguration {
         return Optional.ofNullable(this.endpointOverride);
     }
 
+    public Optional<EndpointProvider> endpointProvider() {
+        return Optional.ofNullable(this.endpointProvider);
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -64,13 +73,15 @@ public abstract class SdkServiceClientConfiguration {
 
         SdkServiceClientConfiguration serviceClientConfiguration = (SdkServiceClientConfiguration) o;
         return Objects.equals(overrideConfiguration, serviceClientConfiguration.overrideConfiguration())
-               && Objects.equals(endpointOverride, serviceClientConfiguration.endpointOverride().orElse(null));
+               && Objects.equals(endpointOverride, serviceClientConfiguration.endpointOverride().orElse(null))
+               && Objects.equals(endpointProvider, serviceClientConfiguration.endpointProvider().orElse(null));
     }
 
     @Override
     public int hashCode() {
         int result = overrideConfiguration != null ? overrideConfiguration.hashCode() : 0;
         result = 31 * result + (endpointOverride != null ? endpointOverride.hashCode() : 0);
+        result = 31 * result + (endpointProvider != null ? endpointProvider.hashCode() : 0);
         return result;
     }
 
@@ -88,6 +99,8 @@ public abstract class SdkServiceClientConfiguration {
          */
         URI endpointOverride();
 
+        EndpointProvider endpointProvider();
+
         /**
          * Configure the client override configuration
          */
@@ -97,6 +110,9 @@ public abstract class SdkServiceClientConfiguration {
          * Configure the endpoint override
          */
         Builder endpointOverride(URI endpointOverride);
+
+
+        Builder endpointProvider(EndpointProvider endpointProvider);
 
         /**
          * Build the service client configuration using the configuration on this builder

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
@@ -59,8 +59,8 @@ public abstract class SdkServiceClientConfiguration {
 
     /**
      *
-     * @return The configured endpoint provider of the SdkClient. If the endpoint provider was not configured, an empty
-     * Optional will be returned.
+     * @return The configured endpoint provider of the SdkClient. If the endpoint provider was not configured, the default
+     * endpoint provider will be returned.
      */
     public Optional<EndpointProvider> endpointProvider() {
         return Optional.ofNullable(this.endpointProvider);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -379,13 +379,15 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
 
         /**
          * <p> Configures whether cross-region bucket access is enabled for clients using the configuration.
-         * <p>The following behavior is <i>currently</i> used when this mode is enabled:
+         * <p>The following behavior is used when this mode is enabled:
          * <ol>
          *     <li>This method allows enabling or disabling cross-region bucket access for clients. When cross-region bucket
          *     access is enabled, requests that do not act on an existing bucket (e.g., createBucket API) will be routed to the
          *     region configured on the client</li>
          *     <li>The first time a request is made that references an existing bucket (e.g., putObject API), a request will be
-         *     made to the region configured on that client to determine the region in which the bucket was created.</li>
+         *     made to the client-configured region. If the bucket does not exist in this region, the service will include the
+         *     actual region in the error responses. Subsequently, the API will be called using the correct region obtained
+         *     from the error response. </li>
          *     <li>This location may be cached in the client for subsequent requests to the same bucket.</li>
          * </ol>
          * <p>Enabling this mode has several drawbacks, as it can increase latency if the bucket's location is physically far

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -72,7 +72,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
     private final FieldWithDefault<Boolean> dualstackEnabled;
     private final FieldWithDefault<Boolean> checksumValidationEnabled;
     private final FieldWithDefault<Boolean> chunkedEncodingEnabled;
-    private final FieldWithDefault<Boolean> crossRegionBucketAccessEnabled;
+    private final FieldWithDefault<Boolean> crossRegionAccessEnabled;
 
     private final Boolean useArnRegionEnabled;
     private final Boolean multiRegionEnabled;
@@ -95,7 +95,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         if (accelerateModeEnabled() && pathStyleAccessEnabled()) {
             throw new IllegalArgumentException("Accelerate mode cannot be used with path style addressing");
         }
-        this.crossRegionBucketAccessEnabled = FieldWithDefault.create(builder.crossRegionBucketAccessEnabled,
+        this.crossRegionAccessEnabled = FieldWithDefault.create(builder.crossRegionAccessEnabled,
                                                                 DEFAULT_CROSS_REGION_ACCESS_ENABLED);
 
     }
@@ -221,8 +221,8 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
      * <p>
      * @return True if cross Region Bucket Access Enabled
      */
-    public boolean crossRegionBucketAccessEnabled() {
-        return crossRegionBucketAccessEnabled.value();
+    public boolean crossRegionAccessEnabled() {
+        return crossRegionAccessEnabled.value();
     }
 
 
@@ -238,7 +238,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
                 .useArnRegionEnabled(useArnRegionEnabled)
                 .profileFile(profileFile.valueOrNullIfDefault())
                 .profileName(profileName.valueOrNullIfDefault())
-                .crossRegionBucketAccessEnabled(crossRegionBucketAccessEnabled.valueOrNullIfDefault());
+                .crossRegionAccessEnabled(crossRegionAccessEnabled.valueOrNullIfDefault());
     }
 
     @NotThreadSafe
@@ -292,21 +292,6 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         Builder pathStyleAccessEnabled(Boolean pathStyleAccessEnabled);
 
         Boolean checksumValidationEnabled();
-
-        Boolean crossRegionBucketAccessEnabled();
-
-        /**
-         * Option to enable using cross region bucket Access.
-         * With this option client can access bucket of any region.
-         *
-         * <p>
-         * Cross region bucket access Enabled is disabled by default.
-         * </p>
-         *
-         * @see S3Configuration#crossRegionBucketAccessEnabled().
-         */
-        Builder crossRegionBucketAccessEnabled(Boolean crossRegionBucketAccessEnabled);
-
 
         /**
          * Option to disable doing a validation of the checksum of an object stored in S3.
@@ -391,6 +376,32 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
          * </p>
          */
         Builder profileName(String profileName);
+
+        /**
+         * <p> Configures whether cross-region bucket access is enabled for clients using the configuration.
+         * <p>The following behavior is <i>currently</i> used when this mode is enabled:
+         * <ol>
+         *     <li>This method allows enabling or disabling cross-region bucket access for clients. When cross-region bucket
+         *     access is enabled, requests that do not act on an existing bucket (e.g., createBucket API) will be routed to the
+         *     region configured on the client</li>
+         *     <li>The first time a request is made that references an existing bucket (e.g., putObject API), a request will be
+         *     made to the region configured on that client to determine the region in which the bucket was created.</li>
+         *     <li>This location may be cached in the client for subsequent requests to the same bucket.</li>
+         * </ol>
+         * <p>Enabling this mode has several drawbacks, as it can increase latency if the bucket's location is physically far
+         * from the location of the request.Therefore, it is strongly advised, whenever possible, to know the location of your
+         * buckets and create a region-specific client to access them
+         *
+         * @param crossRegionAccessEnabled Whether cross region bucket access should be enabled.
+         * @return The builder object for method chaining.
+         */
+        Builder crossRegionAccessEnabled(Boolean crossRegionAccessEnabled);
+
+        /**
+         * Returns value of crossRegionAccessEnabled value set using {@link Builder#crossRegionAccessEnabled(Boolean)}
+         */
+        Boolean crossRegionAccessEnabled();
+
     }
 
     static final class DefaultS3ServiceConfigurationBuilder implements Builder {
@@ -404,7 +415,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         private Supplier<ProfileFile> profileFile;
         private String profileName;
 
-        private Boolean crossRegionBucketAccessEnabled;
+        private Boolean crossRegionAccessEnabled;
 
         @Override
         public Boolean dualstackEnabled() {
@@ -545,18 +556,22 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
 
 
         @Override
-        public Boolean crossRegionBucketAccessEnabled() {
-            return crossRegionBucketAccessEnabled;
+        public Boolean crossRegionAccessEnabled() {
+            return crossRegionAccessEnabled;
         }
 
         @Override
-        public Builder crossRegionBucketAccessEnabled(Boolean crossRegionBucketAccessEnabled) {
-            this.crossRegionBucketAccessEnabled = crossRegionBucketAccessEnabled;
+        public Builder crossRegionAccessEnabled(Boolean crossRegionAccessEnabled) {
+            this.crossRegionAccessEnabled = crossRegionAccessEnabled;
             return this;
         }
 
-        public void setCrossRegionAccessEnabled(Boolean crossRegionBucketAccessEnabled) {
-            crossRegionBucketAccessEnabled(crossRegionBucketAccessEnabled);
+        /**
+         * refer {@link  Builder#crossRegionAccessEnabled(Boolean)}
+         * @param crossRegionAccessEnabled
+         */
+        public void setCrossRegionAccessEnabled(Boolean crossRegionAccessEnabled) {
+            crossRegionAccessEnabled(crossRegionAccessEnabled);
         }
 
         @Override

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -64,11 +64,16 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
      */
     private static final boolean DEFAULT_CHUNKED_ENCODING_ENABLED = true;
 
+    private static final boolean DEFAULT_CROSS_REGION_ACCESS_ENABLED = false;
+
+
     private final FieldWithDefault<Boolean> pathStyleAccessEnabled;
     private final FieldWithDefault<Boolean> accelerateModeEnabled;
     private final FieldWithDefault<Boolean> dualstackEnabled;
     private final FieldWithDefault<Boolean> checksumValidationEnabled;
     private final FieldWithDefault<Boolean> chunkedEncodingEnabled;
+    private final FieldWithDefault<Boolean> crossRegionBucketAccessEnabled;
+
     private final Boolean useArnRegionEnabled;
     private final Boolean multiRegionEnabled;
     private final FieldWithDefault<Supplier<ProfileFile>> profileFile;
@@ -90,6 +95,9 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         if (accelerateModeEnabled() && pathStyleAccessEnabled()) {
             throw new IllegalArgumentException("Accelerate mode cannot be used with path style addressing");
         }
+        this.crossRegionBucketAccessEnabled = FieldWithDefault.create(builder.crossRegionBucketAccessEnabled,
+                                                                DEFAULT_CROSS_REGION_ACCESS_ENABLED);
+
     }
 
     private boolean resolveUseArnRegionEnabled() {
@@ -206,6 +214,18 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
                        .orElseGet(this::resolveMultiRegionEnabled);
     }
 
+
+
+    /**
+     * Returns whether the client is allowed to make cross-region calls based on bucket names.
+     * <p>
+     * @return True if cross Region Bucket Access Enabled
+     */
+    public boolean crossRegionBucketAccessEnabled() {
+        return crossRegionBucketAccessEnabled.value();
+    }
+
+
     @Override
     public Builder toBuilder() {
         return builder()
@@ -217,7 +237,8 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
                 .chunkedEncodingEnabled(chunkedEncodingEnabled.valueOrNullIfDefault())
                 .useArnRegionEnabled(useArnRegionEnabled)
                 .profileFile(profileFile.valueOrNullIfDefault())
-                .profileName(profileName.valueOrNullIfDefault());
+                .profileName(profileName.valueOrNullIfDefault())
+                .crossRegionBucketAccessEnabled(crossRegionBucketAccessEnabled.valueOrNullIfDefault());
     }
 
     @NotThreadSafe
@@ -271,6 +292,21 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         Builder pathStyleAccessEnabled(Boolean pathStyleAccessEnabled);
 
         Boolean checksumValidationEnabled();
+
+        Boolean crossRegionBucketAccessEnabled();
+
+        /**
+         * Option to enable using cross region bucket Access.
+         * With this option client can access bucket of any region.
+         *
+         * <p>
+         * Cross region bucket access Enabled is disabled by default.
+         * </p>
+         *
+         * @see S3Configuration#crossRegionBucketAccessEnabled().
+         */
+        Builder crossRegionBucketAccessEnabled(Boolean crossRegionBucketAccessEnabled);
+
 
         /**
          * Option to disable doing a validation of the checksum of an object stored in S3.
@@ -367,6 +403,8 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         private Boolean multiRegionEnabled;
         private Supplier<ProfileFile> profileFile;
         private String profileName;
+
+        private Boolean crossRegionBucketAccessEnabled;
 
         @Override
         public Boolean dualstackEnabled() {
@@ -503,6 +541,22 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
 
         public void setUseArnRegionEnabled(Boolean useArnRegionEnabled) {
             useArnRegionEnabled(useArnRegionEnabled);
+        }
+
+
+        @Override
+        public Boolean crossRegionBucketAccessEnabled() {
+            return crossRegionBucketAccessEnabled;
+        }
+
+        @Override
+        public Builder crossRegionBucketAccessEnabled(Boolean crossRegionBucketAccessEnabled) {
+            this.crossRegionBucketAccessEnabled = crossRegionBucketAccessEnabled;
+            return this;
+        }
+
+        public void setCrossRegionAccessEnabled(Boolean crossRegionBucketAccessEnabled) {
+            crossRegionBucketAccessEnabled(crossRegionBucketAccessEnabled);
         }
 
         @Override

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3ConfigurationTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3ConfigurationTest.java
@@ -46,7 +46,7 @@ public class S3ConfigurationTest {
         assertThat(config.multiRegionEnabled()).isEqualTo(true);
         assertThat(config.pathStyleAccessEnabled()).isEqualTo(false);
         assertThat(config.useArnRegionEnabled()).isEqualTo(false);
-        assertThat(config.crossRegionBucketAccessEnabled()).isEqualTo(false);
+        assertThat(config.crossRegionAccessEnabled()).isEqualTo(false);
     }
 
     @Test
@@ -118,11 +118,11 @@ public class S3ConfigurationTest {
 
     @Test
     public void crossRegionEnabled__enabledInConfigOnly_shouldResolveCorrectly() {
-        S3Configuration config = S3Configuration.builder().crossRegionBucketAccessEnabled(true).build();
-        assertThat(config.crossRegionBucketAccessEnabled()).isEqualTo(true);
+        S3Configuration config = S3Configuration.builder().crossRegionAccessEnabled(true).build();
+        assertThat(config.crossRegionAccessEnabled()).isEqualTo(true);
 
-        S3Configuration configDisabled = S3Configuration.builder().crossRegionBucketAccessEnabled(false).build();
-        assertThat(configDisabled.crossRegionBucketAccessEnabled()).isEqualTo(false);
+        S3Configuration configDisabled = S3Configuration.builder().crossRegionAccessEnabled(false).build();
+        assertThat(configDisabled.crossRegionAccessEnabled()).isEqualTo(false);
     }
 
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3ConfigurationTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3ConfigurationTest.java
@@ -46,6 +46,7 @@ public class S3ConfigurationTest {
         assertThat(config.multiRegionEnabled()).isEqualTo(true);
         assertThat(config.pathStyleAccessEnabled()).isEqualTo(false);
         assertThat(config.useArnRegionEnabled()).isEqualTo(false);
+        assertThat(config.crossRegionBucketAccessEnabled()).isEqualTo(false);
     }
 
     @Test
@@ -113,6 +114,15 @@ public class S3ConfigurationTest {
         String falseProfileConfig = getClass().getResource("internal/settingproviders/ProfileFile_false").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), falseProfileConfig);
         assertThat(config.useArnRegionEnabled()).isEqualTo(false);
+    }
+
+    @Test
+    public void crossRegionEnabled__enabledInConfigOnly_shouldResolveCorrectly() {
+        S3Configuration config = S3Configuration.builder().crossRegionBucketAccessEnabled(true).build();
+        assertThat(config.crossRegionBucketAccessEnabled()).isEqualTo(true);
+
+        S3Configuration configDisabled = S3Configuration.builder().crossRegionBucketAccessEnabled(false).build();
+        assertThat(configDisabled.crossRegionBucketAccessEnabled()).isEqualTo(false);
     }
 
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/serviceclientconfiguration/ServiceClientConfigurationTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/serviceclientconfiguration/ServiceClientConfigurationTest.java
@@ -21,9 +21,11 @@ import java.net.URI;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlAsyncClient;
 import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlClient;
+import software.amazon.awssdk.services.protocolrestxml.endpoints.ProtocolRestXmlEndpointProvider;
 
 public class ServiceClientConfigurationTest {
 
@@ -92,6 +94,26 @@ public class ServiceClientConfigurationTest {
     }
 
     @Test
+    public void syncClientWithEndpointProvide_serviceClientConfiguration_shouldReturnCorrectEndpointProvider() {
+        ProtocolRestXmlEndpointProvider clientEndpointProvider = ProtocolRestXmlEndpointProvider.defaultProvider();
+        ProtocolRestXmlClient client = ProtocolRestXmlClient.builder()
+                                                            .endpointProvider(clientEndpointProvider)
+                                                            .build();
+
+        EndpointProvider endpointProvider = client.serviceClientConfiguration().endpointProvider().orElse(null);
+        assertThat(endpointProvider).isEqualTo(clientEndpointProvider);
+    }
+
+    @Test
+    public void syncClientWithoutEndpointProvider_serviceClientConfiguration_shouldReturnDefaultEndpointProvider() {
+        ProtocolRestXmlClient client = ProtocolRestXmlClient.builder()
+                                                            .build();
+
+        EndpointProvider endpointOverride = client.serviceClientConfiguration().endpointProvider().orElse(null);
+        assertThat(endpointOverride instanceof ProtocolRestXmlEndpointProvider).isTrue();
+    }
+
+    @Test
     public void asyncClient_serviceClientConfiguration_shouldReturnCorrectRegion() {
         ProtocolRestXmlAsyncClient client = ProtocolRestXmlAsyncClient.builder()
                                                                       .region(Region.ME_SOUTH_1)
@@ -153,6 +175,27 @@ public class ServiceClientConfigurationTest {
         assertThat(client.serviceClientConfiguration().overrideConfiguration().retryPolicy()).isNotPresent();
         assertThat(client.serviceClientConfiguration().overrideConfiguration().defaultProfileFile()).isNotPresent();
         assertThat(client.serviceClientConfiguration().overrideConfiguration().metricPublishers()).isEmpty();
+    }
+
+
+    @Test
+    public void asyncClientWithEndpointProvider_serviceClientConfiguration_shouldReturnCorrectEndpointProvider() {
+        ProtocolRestXmlEndpointProvider clientEndpointProvider = ProtocolRestXmlEndpointProvider.defaultProvider();
+        ProtocolRestXmlAsyncClient client = ProtocolRestXmlAsyncClient.builder()
+                                                                      .endpointProvider(clientEndpointProvider)
+                                                                      .build();
+
+        EndpointProvider endpointProvider = client.serviceClientConfiguration().endpointProvider().orElse(null);
+        assertThat(endpointProvider).isEqualTo(clientEndpointProvider);
+    }
+
+    @Test
+    public void asyncClientWithoutEndpointProvider_serviceClientConfiguration_shouldReturnDefault() {
+        ProtocolRestXmlAsyncClient client = ProtocolRestXmlAsyncClient.builder()
+                                                                      .build();
+
+        EndpointProvider endpointProvider = client.serviceClientConfiguration().endpointProvider().orElse(null);
+        assertThat(endpointProvider instanceof ProtocolRestXmlEndpointProvider).isTrue();
     }
 
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/serviceclientconfiguration/ServiceClientConfigurationTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/serviceclientconfiguration/ServiceClientConfigurationTest.java
@@ -94,7 +94,7 @@ public class ServiceClientConfigurationTest {
     }
 
     @Test
-    public void syncClientWithEndpointProvide_serviceClientConfiguration_shouldReturnCorrectEndpointProvider() {
+    public void syncClientWithEndpointProvider_serviceClientConfiguration_shouldReturnCorrectEndpointProvider() {
         ProtocolRestXmlEndpointProvider clientEndpointProvider = ProtocolRestXmlEndpointProvider.defaultProvider();
         ProtocolRestXmlClient client = ProtocolRestXmlClient.builder()
                                                             .endpointProvider(clientEndpointProvider)
@@ -109,8 +109,8 @@ public class ServiceClientConfigurationTest {
         ProtocolRestXmlClient client = ProtocolRestXmlClient.builder()
                                                             .build();
 
-        EndpointProvider endpointOverride = client.serviceClientConfiguration().endpointProvider().orElse(null);
-        assertThat(endpointOverride instanceof ProtocolRestXmlEndpointProvider).isTrue();
+        EndpointProvider endpointProvider = client.serviceClientConfiguration().endpointProvider().orElse(null);
+        assertThat(endpointProvider instanceof ProtocolRestXmlEndpointProvider).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Add endpointProvider in ClientConfig and RequestOverrideConfig. Also add crossRegionBucketAccess in S3Configuration

Note : This PR just adds the interfaces in project branch to read/writ EndpointProviders/S3 config. The logic of overriding and resolving in COntectBuilders will be addded next PR

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- CrossRegionBucketAccess needs the endpointProviders of the client.
- Its needed to decorate endpointProviders so that region name is changed based on HeadBucket request


## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
