### PR TITLE
Adding a generic method invokeOperation for abstract delegating clien…

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
@@ -20,15 +20,21 @@ import static java.util.stream.Collectors.toList;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeVariableName;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
@@ -88,14 +94,9 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
 
     @Override
     protected void addAdditionalMethods(TypeSpec.Builder type) {
-        MethodSpec delegate = MethodSpec.methodBuilder("delegate")
-                                        .addModifiers(PUBLIC)
-                                        .addStatement("return this.delegate")
-                                        .returns(SdkClient.class)
-                                        .build();
-
         type.addMethod(nameMethod())
-            .addMethod(delegate);
+            .addMethod(delegateMethod())
+            .addMethod(invokeMethod());
     }
 
     private MethodSpec nameMethod() {
@@ -104,6 +105,34 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
                          .addModifiers(PUBLIC, FINAL)
                          .returns(String.class)
                          .addStatement("return delegate.serviceName()")
+                         .build();
+    }
+
+    private MethodSpec delegateMethod() {
+        return MethodSpec.methodBuilder("delegate")
+                         .addModifiers(PUBLIC)
+                         .addStatement("return this.delegate")
+                         .returns(SdkClient.class)
+                         .build();
+    }
+
+    private MethodSpec invokeMethod() {
+        TypeVariableName requestTypeVariableName =
+            TypeVariableName.get("T", poetExtensions.getModelClass(model.getSdkRequestBaseClassName()));
+
+        TypeVariableName responseTypeVariableName = STREAMING_TYPE_VARIABLE;
+
+        ParameterizedTypeName functionTypeName = ParameterizedTypeName
+            .get(ClassName.get(Function.class), requestTypeVariableName, responseTypeVariableName);
+
+        return MethodSpec.methodBuilder("invokeOperation")
+                         .addModifiers(PROTECTED)
+                         .addParameter(requestTypeVariableName, "request")
+                         .addParameter(functionTypeName, "operation")
+                         .addTypeVariable(requestTypeVariableName)
+                         .addTypeVariable(responseTypeVariableName)
+                         .returns(responseTypeVariableName)
+                         .addStatement("return operation.apply(request)")
                          .build();
     }
 
@@ -164,9 +193,19 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
         builder.addModifiers(PUBLIC)
                .addAnnotation(Override.class);
 
-        builder.addStatement("return delegate.$N($L)",
+        if (builder.parameters.size() < 1) {
+            throw new IllegalStateException("All client methods must have an argument");
+        }
+
+        List<ParameterSpec> parameters = new ArrayList<>(builder.parameters);
+        String requestParameter = parameters.remove(0).name;
+        String additionalParameters = String.format(", %s", parameters.stream().map(p -> p.name).collect(joining(", ")));
+
+        builder.addStatement("return invokeOperation($N, request -> delegate.$N(request$N))",
+                             requestParameter,
                              opModel.getMethodName(),
-                             builder.parameters.stream().map(p -> p.name).collect(joining(", ")));
+                             parameters.isEmpty() ? "" : additionalParameters);
+
         return builder;
     }
 
@@ -175,7 +214,9 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
         String methodName = PaginatorUtils.getPaginatedMethodName(opModel.getMethodName());
         return builder.addModifiers(PUBLIC)
                       .addAnnotation(Override.class)
-                      .addStatement("return delegate.$N($N)", methodName, opModel.getInput().getVariableName());
+                      .addStatement("return invokeOperation($N, request -> delegate.$N(request))",
+                                    opModel.getInput().getVariableName(),
+                                    methodName);
     }
 
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
@@ -33,7 +33,6 @@ import com.squareup.javapoet.TypeVariableName;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkPublicApi;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
@@ -1,6 +1,7 @@
 package software.amazon.awssdk.services.json;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersReque
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InputEventStream;
 import software.amazon.awssdk.services.json.model.InputEventStreamTwo;
+import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
@@ -86,7 +88,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<APostOperationResponse> aPostOperation(APostOperationRequest aPostOperationRequest) {
-        return delegate.aPostOperation(aPostOperationRequest);
+        return invokeOperation(aPostOperationRequest, request -> delegate.aPostOperation(request));
     }
 
     /**
@@ -115,7 +117,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<APostOperationWithOutputResponse> aPostOperationWithOutput(
         APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
-        return delegate.aPostOperationWithOutput(aPostOperationWithOutputRequest);
+        return invokeOperation(aPostOperationWithOutputRequest, request -> delegate.aPostOperationWithOutput(request));
     }
 
     /**
@@ -140,7 +142,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<BearerAuthOperationResponse> bearerAuthOperation(
         BearerAuthOperationRequest bearerAuthOperationRequest) {
-        return delegate.bearerAuthOperation(bearerAuthOperationRequest);
+        return invokeOperation(bearerAuthOperationRequest, request -> delegate.bearerAuthOperation(request));
     }
 
     /**
@@ -165,7 +167,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<Void> eventStreamOperation(EventStreamOperationRequest eventStreamOperationRequest,
                                                         Publisher<InputEventStream> requestStream, EventStreamOperationResponseHandler asyncResponseHandler) {
-        return delegate.eventStreamOperation(eventStreamOperationRequest, requestStream, asyncResponseHandler);
+        return invokeOperation(eventStreamOperationRequest,
+                               request -> delegate.eventStreamOperation(request, requestStream, asyncResponseHandler));
     }
 
     /**
@@ -192,7 +195,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     public CompletableFuture<EventStreamOperationWithOnlyInputResponse> eventStreamOperationWithOnlyInput(
         EventStreamOperationWithOnlyInputRequest eventStreamOperationWithOnlyInputRequest,
         Publisher<InputEventStreamTwo> requestStream) {
-        return delegate.eventStreamOperationWithOnlyInput(eventStreamOperationWithOnlyInputRequest, requestStream);
+        return invokeOperation(eventStreamOperationWithOnlyInputRequest,
+                               request -> delegate.eventStreamOperationWithOnlyInput(request, requestStream));
     }
 
     /**
@@ -219,7 +223,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     public CompletableFuture<Void> eventStreamOperationWithOnlyOutput(
         EventStreamOperationWithOnlyOutputRequest eventStreamOperationWithOnlyOutputRequest,
         EventStreamOperationWithOnlyOutputResponseHandler asyncResponseHandler) {
-        return delegate.eventStreamOperationWithOnlyOutput(eventStreamOperationWithOnlyOutputRequest, asyncResponseHandler);
+        return invokeOperation(eventStreamOperationWithOnlyOutputRequest,
+                               request -> delegate.eventStreamOperationWithOnlyOutput(request, asyncResponseHandler));
     }
 
     /**
@@ -244,7 +249,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<GetOperationWithChecksumResponse> getOperationWithChecksum(
         GetOperationWithChecksumRequest getOperationWithChecksumRequest) {
-        return delegate.getOperationWithChecksum(getOperationWithChecksumRequest);
+        return invokeOperation(getOperationWithChecksumRequest, request -> delegate.getOperationWithChecksum(request));
     }
 
     /**
@@ -273,7 +278,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<GetWithoutRequiredMembersResponse> getWithoutRequiredMembers(
         GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) {
-        return delegate.getWithoutRequiredMembers(getWithoutRequiredMembersRequest);
+        return invokeOperation(getWithoutRequiredMembersRequest, request -> delegate.getWithoutRequiredMembers(request));
     }
 
     /**
@@ -299,7 +304,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<OperationWithChecksumRequiredResponse> operationWithChecksumRequired(
         OperationWithChecksumRequiredRequest operationWithChecksumRequiredRequest) {
-        return delegate.operationWithChecksumRequired(operationWithChecksumRequiredRequest);
+        return invokeOperation(operationWithChecksumRequiredRequest, request -> delegate.operationWithChecksumRequired(request));
     }
 
     /**
@@ -325,7 +330,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<PaginatedOperationWithResultKeyResponse> paginatedOperationWithResultKey(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
-        return delegate.paginatedOperationWithResultKey(paginatedOperationWithResultKeyRequest);
+        return invokeOperation(paginatedOperationWithResultKeyRequest,
+                               request -> delegate.paginatedOperationWithResultKey(request));
     }
 
     /**
@@ -403,7 +409,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
-        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
+        return invokeOperation(paginatedOperationWithResultKeyRequest,
+                               request -> delegate.paginatedOperationWithResultKeyPaginator(request));
     }
 
     /**
@@ -429,7 +436,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<PaginatedOperationWithoutResultKeyResponse> paginatedOperationWithoutResultKey(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
-        return delegate.paginatedOperationWithoutResultKey(paginatedOperationWithoutResultKeyRequest);
+        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
+                               request -> delegate.paginatedOperationWithoutResultKey(request));
     }
 
     /**
@@ -507,7 +515,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
-        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
+        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
+                               request -> delegate.paginatedOperationWithoutResultKeyPaginator(request));
     }
 
     /**
@@ -551,7 +560,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     public <ReturnT> CompletableFuture<ReturnT> putOperationWithChecksum(
         PutOperationWithChecksumRequest putOperationWithChecksumRequest, AsyncRequestBody requestBody,
         AsyncResponseTransformer<PutOperationWithChecksumResponse, ReturnT> asyncResponseTransformer) {
-        return delegate.putOperationWithChecksum(putOperationWithChecksumRequest, requestBody, asyncResponseTransformer);
+        return invokeOperation(putOperationWithChecksumRequest,
+                               request -> delegate.putOperationWithChecksum(request, requestBody, asyncResponseTransformer));
     }
 
     /**
@@ -581,7 +591,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<StreamingInputOperationResponse> streamingInputOperation(
         StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestBody requestBody) {
-        return delegate.streamingInputOperation(streamingInputOperationRequest, requestBody);
+        return invokeOperation(streamingInputOperationRequest, request -> delegate.streamingInputOperation(request, requestBody));
     }
 
     /**
@@ -617,8 +627,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     public <ReturnT> CompletableFuture<ReturnT> streamingInputOutputOperation(
         StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, AsyncRequestBody requestBody,
         AsyncResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> asyncResponseTransformer) {
-        return delegate
-            .streamingInputOutputOperation(streamingInputOutputOperationRequest, requestBody, asyncResponseTransformer);
+        return invokeOperation(streamingInputOutputOperationRequest,
+                        request -> delegate.streamingInputOutputOperation(request, requestBody, asyncResponseTransformer));
     }
 
     /**
@@ -649,7 +659,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     public <ReturnT> CompletableFuture<ReturnT> streamingOutputOperation(
         StreamingOutputOperationRequest streamingOutputOperationRequest,
         AsyncResponseTransformer<StreamingOutputOperationResponse, ReturnT> asyncResponseTransformer) {
-        return delegate.streamingOutputOperation(streamingOutputOperationRequest, asyncResponseTransformer);
+        return invokeOperation(streamingOutputOperationRequest,
+                               request -> delegate.streamingOutputOperation(request, asyncResponseTransformer));
     }
 
     @Override
@@ -664,6 +675,10 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
 
     public SdkClient delegate() {
         return this.delegate;
+    }
+
+    protected <T extends JsonRequest, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
+        return operation.apply(request);
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
@@ -1,6 +1,7 @@
 package software.amazon.awssdk.services.json;
 
 import java.nio.file.Path;
+import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -22,6 +23,7 @@ import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersReque
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InvalidInputException;
 import software.amazon.awssdk.services.json.model.JsonException;
+import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
@@ -76,7 +78,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     @Deprecated
     public APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
                                                                                                      AwsServiceException, SdkClientException, JsonException {
-        return delegate.aPostOperation(aPostOperationRequest);
+        return invokeOperation(aPostOperationRequest, request -> delegate.aPostOperation(request));
     }
 
     /**
@@ -103,7 +105,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public APostOperationWithOutputResponse aPostOperationWithOutput(
         APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
                                                                                 SdkClientException, JsonException {
-        return delegate.aPostOperationWithOutput(aPostOperationWithOutputRequest);
+        return invokeOperation(aPostOperationWithOutputRequest, request -> delegate.aPostOperationWithOutput(request));
     }
 
     /**
@@ -125,7 +127,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     @Override
     public BearerAuthOperationResponse bearerAuthOperation(BearerAuthOperationRequest bearerAuthOperationRequest)
         throws AwsServiceException, SdkClientException, JsonException {
-        return delegate.bearerAuthOperation(bearerAuthOperationRequest);
+        return invokeOperation(bearerAuthOperationRequest, request -> delegate.bearerAuthOperation(request));
     }
 
     /**
@@ -148,7 +150,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public GetOperationWithChecksumResponse getOperationWithChecksum(
         GetOperationWithChecksumRequest getOperationWithChecksumRequest) throws AwsServiceException, SdkClientException,
                                                                                 JsonException {
-        return delegate.getOperationWithChecksum(getOperationWithChecksumRequest);
+        return invokeOperation(getOperationWithChecksumRequest, request -> delegate.getOperationWithChecksum(request));
     }
 
     /**
@@ -175,7 +177,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
         GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
                                                                                   SdkClientException, JsonException {
-        return delegate.getWithoutRequiredMembers(getWithoutRequiredMembersRequest);
+        return invokeOperation(getWithoutRequiredMembersRequest, request -> delegate.getWithoutRequiredMembers(request));
     }
 
     /**
@@ -198,7 +200,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public OperationWithChecksumRequiredResponse operationWithChecksumRequired(
         OperationWithChecksumRequiredRequest operationWithChecksumRequiredRequest) throws AwsServiceException,
                                                                                           SdkClientException, JsonException {
-        return delegate.operationWithChecksumRequired(operationWithChecksumRequiredRequest);
+        return invokeOperation(operationWithChecksumRequiredRequest, request -> delegate.operationWithChecksumRequired(request));
     }
 
     /**
@@ -243,7 +245,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
-        return delegate.paginatedOperationWithResultKey(paginatedOperationWithResultKeyRequest);
+        return invokeOperation(paginatedOperationWithResultKeyRequest,
+                               request -> delegate.paginatedOperationWithResultKey(request));
     }
 
     /**
@@ -398,7 +401,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
-        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
+        return invokeOperation(paginatedOperationWithResultKeyRequest,
+                               request -> delegate.paginatedOperationWithResultKeyPaginator(request));
     }
 
     /**
@@ -421,7 +425,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
-        return delegate.paginatedOperationWithoutResultKey(paginatedOperationWithoutResultKeyRequest);
+        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
+                               request -> delegate.paginatedOperationWithoutResultKey(request));
     }
 
     /**
@@ -499,7 +504,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
-        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
+        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
+                               request -> delegate.paginatedOperationWithoutResultKeyPaginator(request));
     }
 
     /**
@@ -548,7 +554,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public <ReturnT> ReturnT putOperationWithChecksum(PutOperationWithChecksumRequest putOperationWithChecksumRequest,
                                                       RequestBody requestBody, ResponseTransformer<PutOperationWithChecksumResponse, ReturnT> responseTransformer)
         throws AwsServiceException, SdkClientException, JsonException {
-        return delegate.putOperationWithChecksum(putOperationWithChecksumRequest, requestBody, responseTransformer);
+        return invokeOperation(putOperationWithChecksumRequest,
+                               request -> delegate.putOperationWithChecksum(request, requestBody, responseTransformer));
     }
 
     /**
@@ -624,7 +631,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     @Override
     public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
                                                                    RequestBody requestBody) throws AwsServiceException, SdkClientException, JsonException {
-        return delegate.streamingInputOperation(streamingInputOperationRequest, requestBody);
+        return invokeOperation(streamingInputOperationRequest, request -> delegate.streamingInputOperation(request, requestBody));
     }
 
     /**
@@ -694,7 +701,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
         StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, RequestBody requestBody,
         ResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                         SdkClientException, JsonException {
-        return delegate.streamingInputOutputOperation(streamingInputOutputOperationRequest, requestBody, responseTransformer);
+        return invokeOperation(streamingInputOutputOperationRequest,
+                               request -> delegate.streamingInputOutputOperation(request, requestBody, responseTransformer));
     }
 
     /**
@@ -759,7 +767,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
                                                       ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                                                                  SdkClientException, JsonException {
-        return delegate.streamingOutputOperation(streamingOutputOperationRequest, responseTransformer);
+        return invokeOperation(streamingOutputOperationRequest,
+                               request -> delegate.streamingOutputOperation(request, responseTransformer));
     }
 
     /**
@@ -861,6 +870,10 @@ public abstract class DelegatingJsonClient implements JsonClient {
 
     public SdkClient delegate() {
         return this.delegate;
+    }
+
+    protected <T extends JsonRequest, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
+        return operation.apply(request);
     }
 
     @Override


### PR DESCRIPTION
…t to allow overriding behavior changes for all operations

## Motivation and Context
Currently, a delegating service client that extends the ServiceDelegationClient abstract class must override all API operations it wishes to affect. With this change, a class can override `invokeOperation` and affect all client APIs. 

## Modifications
Added a generic invoke method `invokeOperation` and modified the operation body codegen to always call this method, sending the delegate invocation as a function parameter.

The async implementation has a generic return type `ReturnT` instead of CompletableFuture<ReturnT>, since some methods return a Publisher and not a future. 

## Testing
Tested by compiling the only service client that uses this feature, S3. 
