### PR TITLE
Add client configuration overriding of SCHEDULED_EXECUTOR_SERVICE option

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-c5f66b2.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-c5f66b2.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "scrocquesel",
+    "description": "Add client configuration overriding of SCHEDULED_EXECUTOR_SERVICE option"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -91,6 +91,7 @@ import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.Either;
+import software.amazon.awssdk.utils.ScheduledExecutorUtils;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 import software.amazon.awssdk.utils.Validate;
 
@@ -417,9 +418,10 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
                 .threadNamePrefix("sdk-ScheduledExecutor").build());
 
             return executor;
-        };            
+        };
 
         return Optional.ofNullable(config.option(SCHEDULED_EXECUTOR_SERVICE))
+            .map(ScheduledExecutorUtils::unmanagedScheduledExecutor)
             .orElseGet(defaultScheduledExecutor);
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -222,6 +222,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
 
         SdkClientConfiguration.Builder builder = configuration.toBuilder();
 
+        builder.option(SCHEDULED_EXECUTOR_SERVICE, clientOverrideConfiguration.scheduledExecutorService().orElse(null));
         builder.option(EXECUTION_INTERCEPTORS, clientOverrideConfiguration.executionInterceptors());
         builder.option(RETRY_POLICY, clientOverrideConfiguration.retryPolicy().orElse(null));
         builder.option(ADDITIONAL_HTTP_HEADERS, clientOverrideConfiguration.headers());
@@ -313,7 +314,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
     private SdkClientConfiguration finalizeConfiguration(SdkClientConfiguration config) {
         RetryPolicy retryPolicy = resolveRetryPolicy(config);
         return config.toBuilder()
-                     .option(SCHEDULED_EXECUTOR_SERVICE, resolveScheduledExecutorService())
+                     .option(SCHEDULED_EXECUTOR_SERVICE, resolveScheduledExecutorService(config))
                      .option(EXECUTION_INTERCEPTORS, resolveExecutionInterceptors(config))
                      .option(RETRY_POLICY, retryPolicy)
                      .option(CLIENT_USER_AGENT, resolveClientUserAgent(config, retryPolicy))
@@ -410,9 +411,16 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
      * Finalize the internal SDK scheduled executor service that is used for scheduling tasks such
      * as async retry attempts and timeout task.
      */
-    private ScheduledExecutorService resolveScheduledExecutorService() {
-        return Executors.newScheduledThreadPool(5, new ThreadFactoryBuilder()
-            .threadNamePrefix("sdk-ScheduledExecutor").build());
+    private ScheduledExecutorService resolveScheduledExecutorService(SdkClientConfiguration config) {
+        Supplier<ScheduledExecutorService> defaultScheduledExecutor = () -> {
+            ScheduledExecutorService executor = Executors.newScheduledThreadPool(5, new ThreadFactoryBuilder()
+                .threadNamePrefix("sdk-ScheduledExecutor").build());
+
+            return executor;
+        };            
+
+        return Optional.ofNullable(config.option(SCHEDULED_EXECUTOR_SERVICE))
+            .orElseGet(defaultScheduledExecutor);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -358,6 +358,10 @@ public final class ClientOverrideConfiguration
          * Configure the scheduled executor service that should be used for scheduling tasks such as async retry attempts
          * and timeout task.
          *
+         * <p>
+         * <b>The SDK will not automatically close the executor when the client is closed. It is the responsibility of the
+         * user to manually close the executor once all clients utilizing it have been closed.</b>
+         *
          * @see ClientOverrideConfiguration#scheduledExecutorService()
          */
         Builder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ToBuilderIgnoreField;
@@ -62,6 +63,7 @@ public final class ClientOverrideConfiguration
     private final String defaultProfileName;
     private final List<MetricPublisher> metricPublishers;
     private final ExecutionAttributes executionAttributes;
+    private final ScheduledExecutorService scheduledExecutorService;
 
     /**
      * Initialize this configuration. Private to require use of {@link #builder()}.
@@ -77,6 +79,7 @@ public final class ClientOverrideConfiguration
         this.defaultProfileName = builder.defaultProfileName();
         this.metricPublishers = Collections.unmodifiableList(new ArrayList<>(builder.metricPublishers()));
         this.executionAttributes = ExecutionAttributes.unmodifiableExecutionAttributes(builder.executionAttributes());
+        this.scheduledExecutorService = builder.scheduledExecutorService();
     }
 
     @Override
@@ -92,7 +95,8 @@ public final class ClientOverrideConfiguration
             .defaultProfileFile(defaultProfileFile)
             .defaultProfileName(defaultProfileName)
             .executionAttributes(executionAttributes)
-            .metricPublishers(metricPublishers);
+            .metricPublishers(metricPublishers)
+            .scheduledExecutorService(scheduledExecutorService);
     }
 
     /**
@@ -139,6 +143,14 @@ public final class ClientOverrideConfiguration
      */
     public List<ExecutionInterceptor> executionInterceptors() {
         return executionInterceptors;
+    }
+
+    /**
+     * The optional scheduled executor service that should be used for scheduling tasks such as async retry attempts
+     * and timeout task.
+     */
+    public Optional<ScheduledExecutorService> scheduledExecutorService() {
+        return Optional.ofNullable(scheduledExecutorService);
     }
 
     /**
@@ -226,6 +238,7 @@ public final class ClientOverrideConfiguration
                 .add("advancedOptions", advancedOptions)
                 .add("profileFile", defaultProfileFile)
                 .add("profileName", defaultProfileName)
+                .add("scheduledExecutorService", scheduledExecutorService)
                 .build();
     }
 
@@ -337,6 +350,16 @@ public final class ClientOverrideConfiguration
         Builder addExecutionInterceptor(ExecutionInterceptor executionInterceptor);
 
         List<ExecutionInterceptor> executionInterceptors();
+
+        /**
+         * Configure the scheduled executor service that should be used for scheduling tasks such as async retry attempts
+         * and timeout task.
+         *
+         * @see ClientOverrideConfiguration#scheduledExecutorService()
+         */
+        Builder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService);
+
+        ScheduledExecutorService scheduledExecutorService();        
 
         /**
          * Configure an advanced override option. These values are used very rarely, and the majority of SDK customers can ignore
@@ -499,6 +522,7 @@ public final class ClientOverrideConfiguration
         private String defaultProfileName;
         private List<MetricPublisher> metricPublishers = new ArrayList<>();
         private ExecutionAttributes.Builder executionAttributes = ExecutionAttributes.builder();
+        private ScheduledExecutorService scheduledExecutorService;
 
         @Override
         public Builder headers(Map<String, List<String>> headers) {
@@ -559,6 +583,18 @@ public final class ClientOverrideConfiguration
         @Override
         public List<ExecutionInterceptor> executionInterceptors() {
             return Collections.unmodifiableList(executionInterceptors);
+        }
+
+        @Override
+        public ScheduledExecutorService scheduledExecutorService()
+        {
+            return scheduledExecutorService;
+        }
+
+        @Override
+        public Builder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+            this.scheduledExecutorService = scheduledExecutorService;
+            return this;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -148,6 +148,9 @@ public final class ClientOverrideConfiguration
     /**
      * The optional scheduled executor service that should be used for scheduling tasks such as async retry attempts
      * and timeout task.
+     * <p>
+     * <b>The SDK will not automatically close the executor when the client is closed. It is the responsibility of the
+     * user to manually close the executor once all clients utilizing it have been closed.</b>
      */
     public Optional<ScheduledExecutorService> scheduledExecutorService() {
         return Optional.ofNullable(scheduledExecutorService);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
@@ -79,6 +79,7 @@ import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.ScheduledExecutorUtils.UnmanagedScheduledExecutorService;
 import software.amazon.awssdk.utils.StringInputStream;
 
 /**
@@ -171,7 +172,7 @@ public class DefaultClientBuilderTest {
         assertThat(builderOverrideConfig.metricPublishers()).isEqualTo(metricPublishers);
         assertThat(builderOverrideConfig.executionAttributes().getAttributes()).isEqualTo(executionAttributes.getAttributes());
         assertThat(builderOverrideConfig.advancedOption(ENDPOINT_OVERRIDDEN_OVERRIDE)).isEqualTo(Optional.of(Boolean.TRUE));
-        assertThat(builderOverrideConfig.scheduledExecutorService()).isEqualTo(scheduledExecutorService);
+        assertThat(builderOverrideConfig.scheduledExecutorService().get()).isEqualTo(scheduledExecutorService);
     }
 
     @Test
@@ -276,7 +277,9 @@ public class DefaultClientBuilderTest {
         assertThat(config.option(METRIC_PUBLISHERS)).contains(metricPublisher);
         assertThat(config.option(EXECUTION_ATTRIBUTES).getAttribute(execAttribute)).isEqualTo("value");
         assertThat(config.option(ENDPOINT_OVERRIDDEN)).isEqualTo(Boolean.TRUE);
-        assertThat(config.option(SCHEDULED_EXECUTOR_SERVICE)).isEqualTo(scheduledExecutorService);
+        UnmanagedScheduledExecutorService customScheduledExecutorService =
+            (UnmanagedScheduledExecutorService) config.option(SCHEDULED_EXECUTOR_SERVICE);
+        assertThat(customScheduledExecutorService.scheduledExecutorService()).isEqualTo(scheduledExecutorService);
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
@@ -38,6 +38,7 @@ import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_
 import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_FILE_SUPPLIER;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_NAME;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.RETRY_POLICY;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.SCHEDULED_EXECUTOR_SERVICE;
 import static software.amazon.awssdk.core.internal.SdkInternalTestAdvancedClientOption.ENDPOINT_OVERRIDDEN_OVERRIDE;
 
 import java.beans.BeanInfo;
@@ -52,6 +53,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -132,6 +135,7 @@ public class DefaultClientBuilderTest {
                                              .type(ProfileFile.Type.CONFIGURATION)
                                              .build();
         String profileName = "name";
+        ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
 
         ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()
             .executionInterceptors(interceptors)
@@ -148,6 +152,7 @@ public class DefaultClientBuilderTest {
             .metricPublishers(metricPublishers)
             .executionAttributes(executionAttributes)
             .putAdvancedOption(ENDPOINT_OVERRIDDEN_OVERRIDE, Boolean.TRUE)
+            .scheduledExecutorService(scheduledExecutorService)
             .build();
 
         TestClientBuilder builder = testClientBuilder().overrideConfiguration(overrideConfig);
@@ -166,6 +171,7 @@ public class DefaultClientBuilderTest {
         assertThat(builderOverrideConfig.metricPublishers()).isEqualTo(metricPublishers);
         assertThat(builderOverrideConfig.executionAttributes().getAttributes()).isEqualTo(executionAttributes.getAttributes());
         assertThat(builderOverrideConfig.advancedOption(ENDPOINT_OVERRIDDEN_OVERRIDE)).isEqualTo(Optional.of(Boolean.TRUE));
+        assertThat(builderOverrideConfig.scheduledExecutorService()).isEqualTo(scheduledExecutorService);
     }
 
     @Test
@@ -189,6 +195,7 @@ public class DefaultClientBuilderTest {
         assertThat(builderOverrideConfig.metricPublishers()).isEmpty();
         assertThat(builderOverrideConfig.executionAttributes().getAttributes()).isEmpty();
         assertThat(builderOverrideConfig.advancedOption(ENDPOINT_OVERRIDDEN_OVERRIDE)).isEmpty();
+        assertThat(builderOverrideConfig.scheduledExecutorService()).isEmpty();
     }
 
     @Test
@@ -198,6 +205,7 @@ public class DefaultClientBuilderTest {
         interceptors.add(interceptor);
 
         RetryPolicy retryPolicy = RetryPolicy.builder().build();
+        ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
 
         Map<String, List<String>> headers = new HashMap<>();
         List<String> headerValues = new ArrayList<>();
@@ -247,6 +255,7 @@ public class DefaultClientBuilderTest {
             .metricPublishers(metricPublishers)
             .executionAttributes(executionAttributes)
             .putAdvancedOption(ENDPOINT_OVERRIDDEN_OVERRIDE, Boolean.TRUE)
+            .scheduledExecutorService(scheduledExecutorService)
             .build();
 
         SdkClientConfiguration config =
@@ -267,6 +276,7 @@ public class DefaultClientBuilderTest {
         assertThat(config.option(METRIC_PUBLISHERS)).contains(metricPublisher);
         assertThat(config.option(EXECUTION_ATTRIBUTES).getAttribute(execAttribute)).isEqualTo("value");
         assertThat(config.option(ENDPOINT_OVERRIDDEN)).isEqualTo(Boolean.TRUE);
+        assertThat(config.option(SCHEDULED_EXECUTOR_SERVICE)).isEqualTo(scheduledExecutorService);
     }
 
     @Test

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResourceManagementTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResourceManagementTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -81,6 +83,16 @@ public class ResourceManagementTest {
 
         verify(executor, never()).shutdown();
         verify(executor, never()).shutdownNow();
+    }
+
+    @Test
+    public void scheduledExecutorFromBuilderNotShutdown() {
+        ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
+
+        asyncClientBuilder().overrideConfiguration(c -> c.scheduledExecutorService(scheduledExecutorService)).build().close();
+
+        verify(scheduledExecutorService, never()).shutdown();
+        verify(scheduledExecutorService, never()).shutdownNow();
     }
 
     public ProtocolRestJsonClientBuilder syncClientBuilder() {

--- a/utils/src/main/java/software/amazon/awssdk/utils/ScheduledExecutorUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ScheduledExecutorUtils.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import static software.amazon.awssdk.utils.Validate.paramNotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+
+/**
+ * Utilities that make it easier to create, use and destroy
+ * {@link ScheduledExecutor}s.
+ */
+@SdkProtectedApi
+public final class ScheduledExecutorUtils {
+    private ScheduledExecutorUtils() {
+    }
+
+    /**
+     * Wrap a scheduled executor in a type that cannot be closed, or shut down.
+     */
+    public static ScheduledExecutorService unmanagedScheduledExecutor(ScheduledExecutorService executor) {
+        return new UnmanagedScheduledExecutorService(executor);
+    }
+
+    /**
+     * Wrapper around {@link ScheduledExecutorService} to prevent it from being
+     * closed. Used when the customer provides
+     * a custom scheduled executor service in which case they are responsible for
+     * the lifecycle of it.
+     */
+    @SdkTestInternalApi
+    public static final class UnmanagedScheduledExecutorService implements ScheduledExecutorService {
+
+        private final ScheduledExecutorService delegate;
+
+        UnmanagedScheduledExecutorService(ScheduledExecutorService delegate) {
+            this.delegate = paramNotNull(delegate, "ScheduledExecutorService");
+        }
+
+        public ScheduledExecutorService scheduledExecutorService() {
+            return delegate;
+        }
+
+        @Override
+        public void shutdown() {
+            // Do nothing, this executor service is managed by the customer.
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return delegate.isShutdown();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return delegate.awaitTermination(timeout, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            return delegate.schedule(command, delay, unit);
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            return delegate.schedule(callable, delay, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+                TimeUnit unit) {
+            return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return delegate.isTerminated();
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            return delegate.submit(task);
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            return delegate.submit(task, result);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            return delegate.submit(task);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+            return delegate.invokeAll(tasks);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException {
+            return delegate.invokeAll(tasks, timeout, unit);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+                throws InterruptedException, ExecutionException {
+            return delegate.invokeAny(tasks);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            return delegate.invokeAny(tasks, timeout, unit);
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            delegate.execute(command);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Customer should be able to use their own ThreadPool and reuse it accros multiple clients.

https://github.com/aws/aws-sdk-java-v2/issues/1690

## Modifications
Introduce new client config methods to allow to override `SCHEDULED_EXECUTOR_SERVICE` option. It is optional and when not provided will default to the actual code that create a new ThreadPool for each clients

## Testing
Unit tests ensure the override is applied on the client configuration.
I also tested in a private project by setting api call timeout to actually create new thread on the custom thread pool.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
