### PR TITLE
Fixes memory leak by closing wrapper input stream

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-2fd347e.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-2fd347e.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "martinKindall", 
+    "type": "bugfix", 
+    "description": "Added missing close() handler for the AwsUnsignedChunkedEncodingInputStream class. This fixes a memory leak that occured when creating request bodies from files."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/io/AwsUnsignedChunkedEncodingInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/io/AwsUnsignedChunkedEncodingInputStream.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.internal.io;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -123,6 +124,16 @@ public class AwsUnsignedChunkedEncodingInputStream extends AwsChunkedEncodingInp
                 .append(BinaryUtils.toBase64(calculatedChecksum))
                 .append(CRLF);
         return chunkHeader.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+
+        InputStream stream = this.getWrappedInputStream();
+        if (stream != null) {
+            stream.close();
+        }
     }
 
     public static final class Builder extends AwsChunkedEncodingInputStream.Builder<Builder> {


### PR DESCRIPTION
## Motivation and Context
https://github.com/aws/aws-sdk-java-v2/issues/4001

## Modifications
Fixes memory leak by closing wrapper input stream in AWSUnsignedChunkedEncodingInputStream class.

## Testing
The included tests were tested running the unit tests of that module with ./mvnw package
Testing environment

Java version: 1.8.0_361, vendor: Oracle Corporation
OS name: "windows 10", version: "10.0", arch: "amd64"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
