### PR TITLE
Adds S3CrossRegion clients and codegen for retrieving bucket name

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/AwsGeneratorTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/AwsGeneratorTasks.java
@@ -27,6 +27,7 @@ public class AwsGeneratorTasks extends CompositeGeneratorTask {
               new PaginatorsGeneratorTasks(params),
               new EventStreamGeneratorTasks(params),
               new WaitersGeneratorTasks(params),
-              new EndpointProviderTasks(params));
+              new EndpointProviderTasks(params),
+              new ServiceSpecificGeneratorTasks(params));
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/ServiceSpecificGeneratorTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/ServiceSpecificGeneratorTasks.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.emitters.tasks;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.codegen.emitters.GeneratorTask;
+import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
+import software.amazon.awssdk.codegen.poet.service.s3.BucketRequestParameterSpec;
+
+/**
+ * Common generator tasks.
+ */
+class ServiceSpecificGeneratorTasks extends BaseGeneratorTasks {
+
+    ServiceSpecificGeneratorTasks(GeneratorTaskParams dependencies) {
+        super(dependencies);
+    }
+
+    @Override
+    protected List<GeneratorTask> createTasks() throws Exception {
+        List<GeneratorTask> generatorTasks = new ArrayList<>();
+        if (isS3CrossRegionEnabled()) {
+            generatorTasks.add(createS3RequestParameterTask());
+        }
+        return generatorTasks;
+    }
+
+    private GeneratorTask createS3RequestParameterTask() throws IOException {
+        return createPoetGeneratorTask(new BucketRequestParameterSpec(model));
+    }
+
+    private boolean isS3CrossRegionEnabled() {
+        return "s3".equalsIgnoreCase(model.getMetadata().getServiceName()) &&
+               (model.getCustomizationConfig().isDelegateAsyncClientClass() ||
+                model.getCustomizationConfig().isDelegateSyncClientClass());
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/service/s3/BucketRequestParameterSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/service/s3/BucketRequestParameterSpec.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.service.s3;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.util.Map;
+import java.util.Optional;
+import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.PoetExtension;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.core.SdkRequest;
+
+public class BucketRequestParameterSpec implements ClassSpec {
+    private final IntermediateModel model;
+    private final PoetExtension poetExtension;
+
+    public BucketRequestParameterSpec(IntermediateModel model) {
+        this.model = model;
+        this.poetExtension = new PoetExtension(model);
+    }
+
+    @Override
+    public TypeSpec poetSpec() {
+        TypeSpec.Builder b = PoetUtils.createClassBuilder(className())
+                                      .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                                      .addAnnotation(SdkInternalApi.class);
+        b.addMethod(setParams());
+
+        return b.build();
+    }
+
+    @Override
+    public ClassName className() {
+        return ClassName.get(getPackage(),
+                             model.getMetadata().getServiceName() + "BucketRequestParams");
+    }
+
+    private String getPackage() {
+        return model.getMetadata().getFullClientInternalPackageName();
+    }
+
+    private MethodSpec setParams() {
+        Map<String, OperationModel> operations = model.getOperations();
+
+        MethodSpec.Builder b = MethodSpec.methodBuilder("bucketName")
+                                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                                         .addParameter(SdkRequest.class, "request")
+                                         .returns(ParameterizedTypeName.get(Optional.class, String.class));
+
+        operations.forEach((n, m) -> {
+            Optional<MemberModel> bucketContextParam = bucketContextParam(m);
+            bucketContextParam.ifPresent(bucket -> b.addCode(addBucketParamStatement(bucket, requestClassName(m))));
+        });
+
+        b.addStatement("return Optional.empty()");
+
+        return b.build();
+    }
+
+    private CodeBlock addBucketParamStatement(MemberModel bucketMember, ClassName requestClassName) {
+        CodeBlock.Builder b = CodeBlock.builder();
+        b.beginControlFlow("if (request instanceof $T)", requestClassName);
+        b.addStatement("return Optional.of((($T) request).$N())", requestClassName, bucketMember.getFluentGetterMethodName());
+        b.endControlFlow();
+        return b.build();
+    }
+
+    private ClassName requestClassName(OperationModel opModel) {
+        String requestClassName = model.getNamingStrategy().getRequestClassName(opModel.getOperationName());
+        return poetExtension.getModelClass(requestClassName);
+    }
+
+    private Optional<MemberModel> bucketContextParam(OperationModel opModel) {
+        return opModel.getInputShape().getMembers().stream()
+                      .filter(m -> m.getContextParam() != null &&
+                                   "bucket".equalsIgnoreCase(m.getContextParam().getName())).findFirst();
+    }
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
@@ -77,15 +77,6 @@ public abstract class AwsServiceClientConfiguration extends SdkServiceClientConf
         Builder region(Region region);
 
         @Override
-        Builder overrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration);
-
-        @Override
-        Builder endpointOverride(URI endpointOverride);
-
-        @Override
-        Builder endpointProvider(EndpointProvider endpointProvider);
-
-        @Override
         AwsServiceClientConfiguration build();
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crossregion;
+
+import java.util.Optional;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.internal.S3BucketRequestParams;
+import software.amazon.awssdk.services.s3.model.S3Request;
+
+@SdkInternalApi
+public final class S3CrossRegionAsyncClient extends DelegatingS3AsyncClient {
+
+    public S3CrossRegionAsyncClient(S3AsyncClient s3Client) {
+        super(s3Client);
+    }
+
+    @Override
+    protected <T extends S3Request, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
+        Optional<String> bucket = S3BucketRequestParams.bucketName(request);
+
+        if (!bucket.isPresent()) {
+            return operation.apply(request);
+        }
+
+        //TODO: add modifyRequest logic
+        return operation.apply(request);
+    }
+
+    private void handleOperationFailure(Throwable t, String bucket) {
+        //TODO: handle failure case
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClient.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crossregion;
+
+import java.util.Optional;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.s3.DelegatingS3Client;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.internal.S3BucketRequestParams;
+import software.amazon.awssdk.services.s3.model.S3Request;
+
+@SdkInternalApi
+public final class S3CrossRegionSyncClient extends DelegatingS3Client {
+
+    public S3CrossRegionSyncClient(S3Client s3Client) {
+        super(s3Client);
+    }
+
+    @Override
+    protected <T extends S3Request, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
+        Optional<String> bucket = S3BucketRequestParams.bucketName(request);
+
+        if (bucket.isPresent()) {
+            try {
+                operation.apply(request); //TODO: add modifyRequest logic
+            } catch (Exception e) {
+                handleOperationFailure(e, bucket.get());
+            }
+        }
+
+        return operation.apply(request);
+    }
+
+    private void handleOperationFailure(Throwable t, String bucket) {
+        //TODO: handle failure case
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Adds a new cross region client that extends DelegatingS3Client and can decorate the s3 client. It needs the value of the request bucket parameter, so this PR provides that value. 

## Modifications
Added codegen for retrieving bucket parameter from any S3 API that supports it.

## Testing
`S3BucketRequestParams` generates to 

~~~
@Generated("software.amazon.awssdk:codegen")
@SdkInternalApi
public final class S3BucketRequestParams {
    public static Optional<String> bucketName(SdkRequest request) {
        if (request instanceof AbortMultipartUploadRequest) {
            return Optional.of(((AbortMultipartUploadRequest) request).bucket());
        }
        if (request instanceof CompleteMultipartUploadRequest) {
            return Optional.of(((CompleteMultipartUploadRequest) request).bucket());
        }
        if (request instanceof CopyObjectRequest) {
            return Optional.of(((CopyObjectRequest) request).destinationBucket());
        }
        ...
        return Optional.empty();
}
~~~