### PR TITLE
Fix leaked futures when executor rejects Runnable

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-abc1eac.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-abc1eac.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "This update fixes  an issue where CompletableFutures are leaked/never completed when the submission to the FUTURE_COMPLETE_EXECUTOR is rejected.\n\nBy default, the SDK uses `2 * number of cores` (with a maximum of 64), and uses bounded queue of size 1000. In cases where the throughput to the client exceeds the executor's ability to keep up, it would reject executions. Before this change this would lead to leaked futures."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -156,15 +156,26 @@ public final class MakeAsyncHttpRequestStage<OutputT>
             }
         });
 
-        // Offload the completion of the future returned from this stage onto
-        // the future completion executor
-        responseHandlerFuture.whenCompleteAsync((r, t) -> {
-            if (t == null) {
-                responseFuture.complete(r);
-            } else {
-                responseFuture.completeExceptionally(t);
+        // Attempt to offload the completion of the future returned from this
+        // stage onto the future completion executor
+        CompletableFuture<Response<OutputT>> asyncComplete =
+            responseHandlerFuture.whenCompleteAsync((r, t) -> completeResponseFuture(responseFuture, r, t),
+                                                    futureCompletionExecutor);
+
+        // It's possible the async execution above fails. If so, log a warning,
+        // and just complete it synchronously.
+        asyncComplete.whenComplete((ignored, asyncCompleteError) -> {
+            if (asyncCompleteError != null) {
+                log.debug(() -> String.format("Could not complete the service call future on the provided "
+                                              + "FUTURE_COMPLETION_EXECUTOR. The future will be completed synchronously by thread"
+                                              + " %s. This may be an indication that the executor is being overwhelmed by too"
+                                              + " many requests, and it may negatively affect performance. Consider changing "
+                                              + "the configuration of the executor to accommodate the load through the client.",
+                                  Thread.currentThread().getName()),
+                          asyncCompleteError);
+                responseHandlerFuture.whenComplete((r, t) -> completeResponseFuture(responseFuture, r, t));
             }
-        }, futureCompletionExecutor);
+        });
 
         return responseFuture;
     }
@@ -217,6 +228,14 @@ public final class MakeAsyncHttpRequestStage<OutputT>
                                                 timeoutExecutor,
                                                 exceptionSupplier,
                                                 timeoutMillis);
+    }
+
+    private void completeResponseFuture(CompletableFuture<Response<OutputT>> responseFuture, Response<OutputT> r, Throwable t) {
+        if (t == null) {
+            responseFuture.complete(r);
+        } else {
+            responseFuture.completeExceptionally(t);
+        }
     }
 
     /**


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This commit fixes  an issue where CompletableFutures are leaked/never completed when the submission to the FUTURE_COMPLETE_EXECUTOR is rejected.

By default, the SDK uses `2 * number of cores` (with a maximum of 64), and uses bounded queue of size 1000. In cases where the throughput to the client exceeds the executor's ability to keep up, it would reject executions, and previously, this would lead to leaked futures.

## Modifications
<!--- Describe your changes in detail -->

## Testing
 - Unit tests.
 - Integ tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
