### PR TITLE
Adds account ID as a built-in endpoint parameter

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/BuiltInParameter.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/BuiltInParameter.java
@@ -23,6 +23,7 @@ public enum BuiltInParameter {
     AWS_USE_DUAL_STACK,
     AWS_USE_FIPS,
     SDK_ENDPOINT,
+    AWS_AUTH_ACCOUNT_ID,
     AWS_STS_USE_GLOBAL_ENDPOINT,
     AWS_S3_FORCE_PATH_STYLE,
     AWS_S3_ACCELERATE,
@@ -43,6 +44,8 @@ public enum BuiltInParameter {
                 return AWS_USE_FIPS;
             case "sdk::endpoint":
                 return SDK_ENDPOINT;
+            case "aws::auth::accountid":
+                return AWS_AUTH_ACCOUNT_ID;
             case "aws::sts::useglobalendpoint":
                 return AWS_STS_USE_GLOBAL_ENDPOINT;
             case "aws::s3::forcepathstyle":

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -170,6 +170,9 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
                 case SDK_ENDPOINT:
                     builtInFn = "endpointBuiltIn";
                     break;
+                case AWS_AUTH_ACCOUNT_ID:
+                    builtInFn = "accountIdBuiltIn";
+                    break;
                 case AWS_S3_USE_GLOBAL_ENDPOINT:
                     builtInFn = "useGlobalEndpointBuiltIn";
                     break;

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
@@ -40,6 +40,10 @@ public final class AwsEndpointProviderUtils {
         return executionAttributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED);
     }
 
+    public static String accountIdBuiltIn(ExecutionAttributes executionAttributes) {
+        return executionAttributes.getAttribute(AwsExecutionAttribute.AWS_AUTH_ACCOUNT_ID);
+    }
+
     /**
      * Returns the endpoint set on the client. Note that this strips off the query part of the URI because the endpoint
      * rules library, e.g. {@code ParseURL} will return an exception if the URI it parses has query parameters.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
@@ -16,6 +16,10 @@
       "type": "boolean",
       "builtIn": "AWS::UseFIPS"
     },
+    "awsAccountId": {
+      "type": "String",
+      "builtIn": "AWS::Auth::AccountId"
+    },
     "endpointId": {
       "type": "string"
     },

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -16,6 +16,8 @@ public final class QueryEndpointParams {
 
     private final Boolean useFIPSEndpoint;
 
+    private final String awsAccountId;
+
     private final String endpointId;
 
     private final Boolean defaultTrueParam;
@@ -34,6 +36,7 @@ public final class QueryEndpointParams {
         this.region = builder.region;
         this.useDualStackEndpoint = builder.useDualStackEndpoint;
         this.useFIPSEndpoint = builder.useFIPSEndpoint;
+        this.awsAccountId = builder.awsAccountId;
         this.endpointId = builder.endpointId;
         this.defaultTrueParam = builder.defaultTrueParam;
         this.defaultStringParam = builder.defaultStringParam;
@@ -57,6 +60,10 @@ public final class QueryEndpointParams {
 
     public Boolean useFipsEndpoint() {
         return useFIPSEndpoint;
+    }
+
+    public String awsAccountId() {
+        return awsAccountId;
     }
 
     public String endpointId() {
@@ -95,6 +102,8 @@ public final class QueryEndpointParams {
 
         Builder useFipsEndpoint(Boolean useFIPSEndpoint);
 
+        Builder awsAccountId(String awsAccountId);
+
         Builder endpointId(String endpointId);
 
         Builder defaultTrueParam(Boolean defaultTrueParam);
@@ -119,6 +128,8 @@ public final class QueryEndpointParams {
         private Boolean useDualStackEndpoint;
 
         private Boolean useFIPSEndpoint;
+
+        private String awsAccountId;
 
         private String endpointId;
 
@@ -149,6 +160,12 @@ public final class QueryEndpointParams {
         @Override
         public Builder useFipsEndpoint(Boolean useFIPSEndpoint) {
             this.useFIPSEndpoint = useFIPSEndpoint;
+            return this;
+        }
+
+        @Override
+        public Builder awsAccountId(String awsAccountId) {
+            this.awsAccountId = awsAccountId;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -38,6 +38,9 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         if (params.useFipsEndpoint() != null) {
             paramsMap.put(Identifier.of("useFIPSEndpoint"), Value.fromBool(params.useFipsEndpoint()));
         }
+        if (params.awsAccountId() != null) {
+            paramsMap.put(Identifier.of("awsAccountId"), Value.fromStr(params.awsAccountId()));
+        }
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
         }
@@ -297,6 +300,9 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                     .addParameter(
                         Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
                                  .required(false).builtIn("AWS::UseFIPS").build())
+                    .addParameter(
+                        Parameter.builder().name("awsAccountId").type(ParameterType.fromValue("String"))
+                                 .required(false).builtIn("AWS::Auth::AccountId").build())
                     .addParameter(
                         Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
                                  .required(false).build())

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -55,6 +55,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
         builder.region(AwsEndpointProviderUtils.regionBuiltIn(executionAttributes));
         builder.useDualStackEndpoint(AwsEndpointProviderUtils.dualStackEnabledBuiltIn(executionAttributes));
         builder.useFipsEndpoint(AwsEndpointProviderUtils.fipsEnabledBuiltIn(executionAttributes));
+        builder.awsAccountId(AwsEndpointProviderUtils.accountIdBuiltIn(executionAttributes));
         setClientContextParams(builder, executionAttributes);
         setContextParams(builder, executionAttributes.getAttribute(AwsExecutionAttribute.OPERATION_NAME), context.request());
         setStaticContextParams(builder, executionAttributes.getAttribute(AwsExecutionAttribute.OPERATION_NAME));

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsExecutionAttribute.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsExecutionAttribute.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.regions.Region;
  * AWS-specific attributes attached to the execution. This information is available to {@link ExecutionInterceptor}s.
  */
 @SdkPublicApi
-public final class AwsExecutionAttribute extends SdkExecutionAttribute {
+public final class  AwsExecutionAttribute extends SdkExecutionAttribute {
     /**
      * The AWS {@link Region} the client was configured with. This is not always same as the
      * {@link AwsSignerExecutionAttribute#SIGNING_REGION} for global services like IAM.
@@ -57,6 +57,12 @@ public final class AwsExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<Boolean> USE_GLOBAL_ENDPOINT =
         new ExecutionAttribute<>("UseGlobalEndpoint");
+
+    /**
+     * The AWS account ID associated with the identity resolved for this request.
+     */
+    public static final ExecutionAttribute<String> AWS_AUTH_ACCOUNT_ID =
+        new ExecutionAttribute<>("AwsAuthAccountId");
 
     private AwsExecutionAttribute() {
     }


### PR DESCRIPTION
## Motivation and Context
Adds identity-sourced account ID as a built-in endpoint rule parameter

## Modifications
Codegen changes that modify the endpoint rule, the parameter resolution and the endpoint resolver interceptor. 
For now, the account ID is retrieved from an AWS execution attribute - this may change in later PRs. 