### PR TITLE
Revert "Fix leaked futures when executor rejects Runnable"

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-abc1eac.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-abc1eac.json
@@ -1,6 +1,0 @@
-{
-    "type": "bugfix",
-    "category": "AWS SDK for Java v2",
-    "contributor": "",
-    "description": "This update fixes  an issue where CompletableFutures are leaked/never completed when the submission to the FUTURE_COMPLETE_EXECUTOR is rejected.\n\nBy default, the SDK uses `2 * number of cores` (with a maximum of 64), and uses bounded queue of size 1000. In cases where the throughput to the client exceeds the executor's ability to keep up, it would reject executions. Before this change this would lead to leaked futures."
-}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -156,26 +156,15 @@ public final class MakeAsyncHttpRequestStage<OutputT>
             }
         });
 
-        // Attempt to offload the completion of the future returned from this
-        // stage onto the future completion executor
-        CompletableFuture<Response<OutputT>> asyncComplete =
-            responseHandlerFuture.whenCompleteAsync((r, t) -> completeResponseFuture(responseFuture, r, t),
-                                                    futureCompletionExecutor);
-
-        // It's possible the async execution above fails. If so, log a warning,
-        // and just complete it synchronously.
-        asyncComplete.whenComplete((ignored, asyncCompleteError) -> {
-            if (asyncCompleteError != null) {
-                log.debug(() -> String.format("Could not complete the service call future on the provided "
-                                              + "FUTURE_COMPLETION_EXECUTOR. The future will be completed synchronously by thread"
-                                              + " %s. This may be an indication that the executor is being overwhelmed by too"
-                                              + " many requests, and it may negatively affect performance. Consider changing "
-                                              + "the configuration of the executor to accommodate the load through the client.",
-                                  Thread.currentThread().getName()),
-                          asyncCompleteError);
-                responseHandlerFuture.whenComplete((r, t) -> completeResponseFuture(responseFuture, r, t));
+        // Offload the completion of the future returned from this stage onto
+        // the future completion executor
+        responseHandlerFuture.whenCompleteAsync((r, t) -> {
+            if (t == null) {
+                responseFuture.complete(r);
+            } else {
+                responseFuture.completeExceptionally(t);
             }
-        });
+        }, futureCompletionExecutor);
 
         return responseFuture;
     }
@@ -228,14 +217,6 @@ public final class MakeAsyncHttpRequestStage<OutputT>
                                                 timeoutExecutor,
                                                 exceptionSupplier,
                                                 timeoutMillis);
-    }
-
-    private void completeResponseFuture(CompletableFuture<Response<OutputT>> responseFuture, Response<OutputT> r, Throwable t) {
-        if (t == null) {
-            responseFuture.complete(r);
-        } else {
-            responseFuture.completeExceptionally(t);
-        }
     }
 
     /**

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStageTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -32,8 +31,6 @@ import static software.amazon.awssdk.core.internal.util.AsyncResponseHandlerTest
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -50,7 +47,6 @@ import software.amazon.awssdk.core.http.NoopTestRequest;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
-import software.amazon.awssdk.core.internal.http.TransformingAsyncResponseHandler;
 import software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndRequestTimerTestUtils;
 import software.amazon.awssdk.core.internal.util.AsyncResponseHandlerTestUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -154,33 +150,6 @@ public class MakeAsyncHttpRequestStageTest {
             verify(sdkAsyncHttpClient).execute(httpRequestCaptor.capture());
             assertThat(httpRequestCaptor.getValue().metricCollector()).contains(childCollector);
         }
-    }
-
-    @Test
-    public void execute_futureCompletionExecutorRejectsWhenCompleteAsync_futureCompletedSynchronously() {
-        ExecutorService mockExecutor = mock(ExecutorService.class);
-        doThrow(new RejectedExecutionException("Busy")).when(mockExecutor).execute(any(Runnable.class));
-
-        SdkClientConfiguration config =
-            SdkClientConfiguration.builder()
-                .option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, mockExecutor)
-                .option(ASYNC_HTTP_CLIENT, sdkAsyncHttpClient)
-                .build();
-        HttpClientDependencies dependencies = HttpClientDependencies.builder().clientConfiguration(config).build();
-
-        TransformingAsyncResponseHandler mockHandler = mock(TransformingAsyncResponseHandler.class);
-        when(mockHandler.prepare()).thenReturn(CompletableFuture.completedFuture(null));
-
-        stage = new MakeAsyncHttpRequestStage<>(mockHandler, dependencies);
-
-        CompletableFuture<SdkHttpFullRequest> requestFuture = CompletableFuture.completedFuture(
-            ValidSdkObjects.sdkHttpFullRequest().build());
-
-        CompletableFuture executeFuture = stage.execute(requestFuture, requestContext());
-
-        long testThreadId = Thread.currentThread().getId();
-        executeFuture.whenComplete((r, t) -> assertThat(Thread.currentThread().getId()).isEqualTo(testThreadId)).join();
-        verify(mockExecutor).execute(any(Runnable.class));
     }
 
     private HttpClientDependencies clientDependencies(Duration timeout) {


### PR DESCRIPTION
This reverts commit 8e66ceded98648ad932e16e5fc743890e16e5473.

Reverting this for now, found a small issue - should be using handleAsync instead of whenCompleteAsync.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
