### PR TITLE
Switch to handleAsync

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -158,9 +158,12 @@ public final class MakeAsyncHttpRequestStage<OutputT>
 
         // Attempt to offload the completion of the future returned from this
         // stage onto the future completion executor
-        CompletableFuture<Response<OutputT>> asyncComplete =
-            responseHandlerFuture.whenCompleteAsync((r, t) -> completeResponseFuture(responseFuture, r, t),
-                                                    futureCompletionExecutor);
+        CompletableFuture<Void> asyncComplete =
+            responseHandlerFuture.handleAsync((r, t) -> {
+                completeResponseFuture(responseFuture, r, t);
+                return null;
+            },
+            futureCompletionExecutor);
 
         // It's possible the async execution above fails. If so, log a warning,
         // and just complete it synchronously.

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStageTest.java
@@ -16,12 +16,14 @@
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +35,7 @@ import static software.amazon.awssdk.core.internal.util.AsyncResponseHandlerTest
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -58,6 +61,8 @@ import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 import utils.ValidSdkObjects;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -157,7 +162,7 @@ public class MakeAsyncHttpRequestStageTest {
     }
 
     @Test
-    public void execute_futureCompletionExecutorRejectsWhenCompleteAsync_futureCompletedSynchronously() {
+    public void execute_handlerFutureCompletedNormally_futureCompletionExecutorRejectsWhenCompleteAsync_futureCompletedSynchronously() {
         ExecutorService mockExecutor = mock(ExecutorService.class);
         doThrow(new RejectedExecutionException("Busy")).when(mockExecutor).execute(any(Runnable.class));
 
@@ -169,7 +174,8 @@ public class MakeAsyncHttpRequestStageTest {
         HttpClientDependencies dependencies = HttpClientDependencies.builder().clientConfiguration(config).build();
 
         TransformingAsyncResponseHandler mockHandler = mock(TransformingAsyncResponseHandler.class);
-        when(mockHandler.prepare()).thenReturn(CompletableFuture.completedFuture(null));
+        CompletableFuture prepareFuture = new CompletableFuture();
+        when(mockHandler.prepare()).thenReturn(prepareFuture);
 
         stage = new MakeAsyncHttpRequestStage<>(mockHandler, dependencies);
 
@@ -179,8 +185,56 @@ public class MakeAsyncHttpRequestStageTest {
         CompletableFuture executeFuture = stage.execute(requestFuture, requestContext());
 
         long testThreadId = Thread.currentThread().getId();
-        executeFuture.whenComplete((r, t) -> assertThat(Thread.currentThread().getId()).isEqualTo(testThreadId)).join();
+        CompletableFuture afterWhenComplete =
+            executeFuture.whenComplete((r, t) -> assertThat(Thread.currentThread().getId()).isEqualTo(testThreadId));
+
+        prepareFuture.complete(null);
+
+        afterWhenComplete.join();
+
         verify(mockExecutor).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void execute_handlerFutureCompletedExceptionally_doesNotAttemptSynchronousComplete() {
+        String threadNamePrefix = "async-handle-test";
+        ExecutorService mockExecutor = Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder().threadNamePrefix(threadNamePrefix).build());
+
+        SdkClientConfiguration config =
+            SdkClientConfiguration.builder()
+                                  .option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, mockExecutor)
+                                  .option(ASYNC_HTTP_CLIENT, sdkAsyncHttpClient)
+                                  .build();
+        HttpClientDependencies dependencies = HttpClientDependencies.builder().clientConfiguration(config).build();
+
+        TransformingAsyncResponseHandler mockHandler = mock(TransformingAsyncResponseHandler.class);
+        CompletableFuture prepareFuture = spy(new CompletableFuture());
+        when(mockHandler.prepare()).thenReturn(prepareFuture);
+
+        stage = new MakeAsyncHttpRequestStage<>(mockHandler, dependencies);
+
+        CompletableFuture<SdkHttpFullRequest> requestFuture = CompletableFuture.completedFuture(
+            ValidSdkObjects.sdkHttpFullRequest().build());
+
+        CompletableFuture executeFuture = stage.execute(requestFuture, requestContext());
+
+        try {
+            CompletableFuture afterHandle =
+                executeFuture.handle((r, t) -> assertThat(Thread.currentThread().getName()).startsWith(threadNamePrefix));
+
+            prepareFuture.completeExceptionally(new RuntimeException("parse error"));
+
+            afterHandle.join();
+
+            assertThatThrownBy(executeFuture::join)
+                .hasCauseInstanceOf(RuntimeException.class)
+                .hasMessageContaining("parse error");
+
+            verify(prepareFuture, times(0)).whenComplete(any());
+        } finally {
+            mockExecutor.shutdown();
+        }
     }
 
     private HttpClientDependencies clientDependencies(Duration timeout) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Update the fix from #4009.

## Modifications
whenCompleteAsync is incorrect because if the response handler future completes exceptionally, then the returned future will also be completed with that exception which will incorrectly trigger a synchronous completion for the response future.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
