### PR TITLE
Adds cross region client logic for decorating endpoint provider

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingSyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingSyncClientClass.java
@@ -148,9 +148,7 @@ public class DelegatingSyncClientClass extends SyncClientInterface {
         String methodName = PaginatorUtils.getPaginatedMethodName(opModel.getMethodName());
         return builder.addModifiers(PUBLIC)
                       .addAnnotation(Override.class)
-                      .addStatement("return invokeOperation($N, request -> delegate.$N(request))",
-                                    opModel.getInput().getVariableName(),
-                                    methodName);
+                      .addStatement("return delegate.$N($N)", methodName, opModel.getInput().getVariableName());
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
@@ -409,8 +409,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
-        return invokeOperation(paginatedOperationWithResultKeyRequest,
-                               request -> delegate.paginatedOperationWithResultKeyPaginator(request));
+        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
     }
 
     /**
@@ -515,8 +514,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
-        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
-                               request -> delegate.paginatedOperationWithoutResultKeyPaginator(request));
+        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
     }
 
     /**
@@ -677,7 +675,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
         return this.delegate;
     }
 
-    protected <T extends JsonRequest, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
+    protected <T extends JsonRequest, ReturnT> CompletableFuture<ReturnT> invokeOperation(T request,
+                                                                                          Function<T, CompletableFuture<ReturnT>> operation) {
         return operation.apply(request);
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
@@ -401,8 +401,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
-        return invokeOperation(paginatedOperationWithResultKeyRequest,
-                               request -> delegate.paginatedOperationWithResultKeyPaginator(request));
+        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
     }
 
     /**
@@ -504,8 +503,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
-        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
-                               request -> delegate.paginatedOperationWithoutResultKeyPaginator(request));
+        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
     }
 
     /**

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
@@ -17,31 +17,82 @@ package software.amazon.awssdk.services.s3.internal.crossregion;
 
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointParams;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.model.S3Request;
 
 @SdkInternalApi
 public final class S3CrossRegionAsyncClient extends DelegatingS3AsyncClient {
-
     public S3CrossRegionAsyncClient(S3AsyncClient s3Client) {
         super(s3Client);
     }
 
     @Override
-    protected <T extends S3Request, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
-        Optional<String> bucket = request.getValueForField("bucket", String.class);
+    protected <T extends S3Request, ReturnT> CompletableFuture<ReturnT>
+    invokeOperation(T request,
+                    Function<T, CompletableFuture<ReturnT>> operation) {
+
+        Optional<String> bucket = request.getValueForField("Bucket", String.class);
 
         if (!bucket.isPresent()) {
             return operation.apply(request);
         }
 
-        //TODO: add modifyRequest logic
-        return operation.apply(request);
+        return operation.apply(requestWithDecoratedEndpointProvider(request, bucket.get()))
+                        .whenComplete((r, t) -> handleOperationFailure(t, bucket.get()));
     }
 
     private void handleOperationFailure(Throwable t, String bucket) {
         //TODO: handle failure case
+    }
+
+    //Cannot avoid unchecked cast without upstream changes to supply builder function
+    @SuppressWarnings("unchecked")
+    private <T extends S3Request> T requestWithDecoratedEndpointProvider(T request, String bucket) {
+        return (T) request.toBuilder()
+                          .overrideConfiguration(getOrCreateConfigWithEndpointProvider(request, bucket))
+                          .build();
+    }
+
+    //TODO: optimize shared sync/async code
+    private AwsRequestOverrideConfiguration getOrCreateConfigWithEndpointProvider(S3Request request,
+                                                                                  String bucket) {
+
+        AwsRequestOverrideConfiguration requestOverrideConfiguration =
+            request.overrideConfiguration().orElseGet(() -> AwsRequestOverrideConfiguration.builder().build());
+
+        EndpointProvider delegateEndpointProvider =
+            requestOverrideConfiguration.endpointProvider().orElseGet(() -> serviceClientConfiguration().endpointProvider().get());
+
+        return requestOverrideConfiguration.toBuilder()
+                                           .endpointProvider(BucketEndpointProvider.create((S3EndpointProvider) delegateEndpointProvider, bucket))
+                                           .build();
+    }
+
+    //TODO: add cross region logic
+    static final class BucketEndpointProvider implements S3EndpointProvider {
+        private final S3EndpointProvider delegate;
+        private final String bucket;
+
+        private BucketEndpointProvider(S3EndpointProvider delegate, String bucket) {
+            this.delegate = delegate;
+            this.bucket = bucket;
+        }
+
+        public static BucketEndpointProvider create(S3EndpointProvider delegate, String bucket) {
+            return new BucketEndpointProvider(delegate, bucket);
+        }
+
+        @Override
+        public CompletableFuture<Endpoint> resolveEndpoint(S3EndpointParams endpointParams) {
+            return delegate.resolveEndpoint(endpointParams);
+        }
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
@@ -16,12 +16,11 @@
 package software.amazon.awssdk.services.s3.internal.crossregion;
 
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.endpoints.Endpoint;
-import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.endpoints.S3EndpointParams;
@@ -36,8 +35,7 @@ public final class S3CrossRegionAsyncClient extends DelegatingS3AsyncClient {
 
     @Override
     protected <T extends S3Request, ReturnT> CompletableFuture<ReturnT>
-    invokeOperation(T request,
-                    Function<T, CompletableFuture<ReturnT>> operation) {
+            invokeOperation(T request, Function<T, CompletableFuture<ReturnT>> operation) {
 
         Optional<String> bucket = request.getValueForField("Bucket", String.class);
 
@@ -62,18 +60,16 @@ public final class S3CrossRegionAsyncClient extends DelegatingS3AsyncClient {
     }
 
     //TODO: optimize shared sync/async code
-    private AwsRequestOverrideConfiguration getOrCreateConfigWithEndpointProvider(S3Request request,
-                                                                                  String bucket) {
-
-        AwsRequestOverrideConfiguration requestOverrideConfiguration =
+    private AwsRequestOverrideConfiguration getOrCreateConfigWithEndpointProvider(S3Request request, String bucket) {
+        AwsRequestOverrideConfiguration requestOverrideConfig =
             request.overrideConfiguration().orElseGet(() -> AwsRequestOverrideConfiguration.builder().build());
 
-        EndpointProvider delegateEndpointProvider =
-            requestOverrideConfiguration.endpointProvider().orElseGet(() -> serviceClientConfiguration().endpointProvider().get());
+        S3EndpointProvider delegateEndpointProvider = (S3EndpointProvider)
+            requestOverrideConfig.endpointProvider().orElseGet(() -> serviceClientConfiguration().endpointProvider().get());
 
-        return requestOverrideConfiguration.toBuilder()
-                                           .endpointProvider(BucketEndpointProvider.create((S3EndpointProvider) delegateEndpointProvider, bucket))
-                                           .build();
+        return requestOverrideConfig.toBuilder()
+                                    .endpointProvider(BucketEndpointProvider.create(delegateEndpointProvider, bucket))
+                                    .build();
     }
 
     //TODO: add cross region logic

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClient.java
@@ -16,26 +16,33 @@
 package software.amazon.awssdk.services.s3.internal.crossregion;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.DelegatingS3Client;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointParams;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.model.S3Request;
 
 @SdkInternalApi
 public final class S3CrossRegionSyncClient extends DelegatingS3Client {
-
     public S3CrossRegionSyncClient(S3Client s3Client) {
         super(s3Client);
     }
 
     @Override
     protected <T extends S3Request, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
-        Optional<String> bucket = request.getValueForField("bucket", String.class);
+
+        Optional<String> bucket = request.getValueForField("Bucket", String.class);
 
         if (bucket.isPresent()) {
             try {
-                operation.apply(request); //TODO: add modifyRequest logic
+                return operation.apply(requestWithDecoratedEndpointProvider(request, bucket.get()));
             } catch (Exception e) {
                 handleOperationFailure(e, bucket.get());
             }
@@ -46,5 +53,46 @@ public final class S3CrossRegionSyncClient extends DelegatingS3Client {
 
     private void handleOperationFailure(Throwable t, String bucket) {
         //TODO: handle failure case
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends S3Request> T requestWithDecoratedEndpointProvider(T request, String bucket) {
+        return (T) request.toBuilder()
+                          .overrideConfiguration(getOrCreateConfigWithEndpointProvider(request, bucket))
+                          .build();
+    }
+
+    //TODO: optimize shared sync/async code
+    private AwsRequestOverrideConfiguration getOrCreateConfigWithEndpointProvider(S3Request request,
+                                                                                  String bucket) {
+
+        AwsRequestOverrideConfiguration requestOverrideConfiguration =
+            request.overrideConfiguration().orElseGet(() -> AwsRequestOverrideConfiguration.builder().build());
+
+        EndpointProvider delegateEndpointProvider =
+            requestOverrideConfiguration.endpointProvider().orElseGet(() -> serviceClientConfiguration().endpointProvider().get());
+
+        return requestOverrideConfiguration.toBuilder()
+                                           .endpointProvider(BucketEndpointProvider.create((S3EndpointProvider) delegateEndpointProvider, bucket))
+                                           .build();
+    }
+
+    static final class BucketEndpointProvider implements S3EndpointProvider {
+        private final S3EndpointProvider delegate;
+        private final String bucket;
+
+        private BucketEndpointProvider(S3EndpointProvider delegate, String bucket) {
+            this.delegate = delegate;
+            this.bucket = bucket;
+        }
+
+        public static BucketEndpointProvider create(S3EndpointProvider delegate, String bucket) {
+            return new BucketEndpointProvider(delegate, bucket);
+        }
+
+        @Override
+        public CompletableFuture<Endpoint> resolveEndpoint(S3EndpointParams endpointParams) {
+            return delegate.resolveEndpoint(endpointParams);
+        }
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crossregion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.endpoints.EndpointProvider;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.endpoints.internal.DefaultS3EndpointProvider;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.utils.StringInputStream;
+
+class S3CrossRegionAsyncClientTest {
+
+    private static final String RESPONSE = "<Res>response</Res>";
+    private static final String BUCKET = "bucket";
+    private static final String KEY = "key";
+    private static final String TOKEN = "token";
+
+    private final MockAsyncHttpClient mockAsyncHttpClient = new MockAsyncHttpClient();
+    private CaptureInterceptor captureInterceptor;
+    private S3AsyncClient s3Client;
+
+    @BeforeEach
+    public void before() {
+        mockAsyncHttpClient.stubNextResponse(
+            HttpExecuteResponse.builder()
+                               .response(SdkHttpResponse.builder().statusCode(200).build())
+                               .responseBody(AbortableInputStream.create(new StringInputStream(RESPONSE)))
+                               .build());
+
+        captureInterceptor = new CaptureInterceptor();
+        s3Client = S3AsyncClient.builder()
+                                .httpClient(mockAsyncHttpClient)
+                                .endpointOverride(URI.create("http://localhost"))
+                                .overrideConfiguration(c -> c.addExecutionInterceptor(captureInterceptor))
+                                .build();
+    }
+
+    @Test
+    public void standardOp_crossRegionClient_noOverrideConfig_SuccessfullyIntercepts() {
+        S3AsyncClient crossRegionClient = new S3CrossRegionAsyncClient(s3Client);
+        crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes());
+        assertThat(captureInterceptor.endpointProvider).isInstanceOf(S3CrossRegionAsyncClient.BucketEndpointProvider.class);
+    }
+
+    @Test
+    public void standardOp_crossRegionClient_existingOverrideConfig_SuccessfullyIntercepts() {
+        S3AsyncClient crossRegionClient = new S3CrossRegionAsyncClient(s3Client);
+        GetObjectRequest request = GetObjectRequest.builder()
+                                                   .bucket(BUCKET)
+                                                   .key(KEY)
+                                                   .overrideConfiguration(o -> o.putHeader("someheader", "somevalue"))
+                                                   .build();
+        crossRegionClient.getObject(request, AsyncResponseTransformer.toBytes());
+        assertThat(captureInterceptor.endpointProvider).isInstanceOf(S3CrossRegionAsyncClient.BucketEndpointProvider.class);
+        assertThat(mockAsyncHttpClient.getLastRequest().headers().get("someheader")).isNotNull();
+    }
+
+    //TODO: handle paginated calls - the paginated publisher calls should also be decorated
+    @Test
+    public void paginatedOp_crossRegionClient_DoesNotIntercept() throws Exception {
+        S3AsyncClient crossRegionClient = new S3CrossRegionAsyncClient(s3Client);
+        ListObjectsV2Publisher publisher =
+            crossRegionClient.listObjectsV2Paginator(r -> r.bucket(BUCKET).continuationToken(TOKEN).build());
+        CompletableFuture<Void> future = publisher.subscribe(ListObjectsV2Response::contents);
+        future.get();
+        assertThat(captureInterceptor.endpointProvider).isInstanceOf(DefaultS3EndpointProvider.class);
+    }
+
+    private static final class CaptureInterceptor implements ExecutionInterceptor {
+
+        private EndpointProvider endpointProvider;
+
+        @Override
+        public void beforeMarshalling(Context.BeforeMarshalling context, ExecutionAttributes executionAttributes) {
+            endpointProvider = executionAttributes.getAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER);
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crossregion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.endpoints.EndpointProvider;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.endpoints.internal.DefaultS3EndpointProvider;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+import software.amazon.awssdk.utils.StringInputStream;
+
+class S3CrossRegionSyncClientTest {
+
+    private static final String RESPONSE = "<Res>response</Res>";
+    private static final String BUCKET = "bucket";
+    private static final String KEY = "key";
+    private static final String TOKEN = "token";
+
+    private final MockSyncHttpClient mockSyncHttpClient = new MockSyncHttpClient();
+    private CaptureInterceptor captureInterceptor;
+    private S3Client s3Client;
+
+    @BeforeEach
+    public void before() {
+        mockSyncHttpClient.stubNextResponse(
+            HttpExecuteResponse.builder()
+                               .response(SdkHttpResponse.builder().statusCode(200).build())
+                               .responseBody(AbortableInputStream.create(new StringInputStream(RESPONSE)))
+                               .build());
+
+        captureInterceptor = new CaptureInterceptor();
+        s3Client = S3Client.builder()
+                           .httpClient(mockSyncHttpClient)
+                           .endpointOverride(URI.create("http://localhost"))
+                           .overrideConfiguration(c -> c.addExecutionInterceptor(captureInterceptor))
+                           .build();
+    }
+
+    @Test
+    public void standardOp_crossRegionClient_noOverrideConfig_SuccessfullyIntercepts() {
+        S3Client crossRegionClient = new S3CrossRegionSyncClient(s3Client);
+        crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));
+        assertThat(captureInterceptor.endpointProvider).isInstanceOf(S3CrossRegionSyncClient.BucketEndpointProvider.class);
+    }
+
+    @Test
+    public void standardOp_crossRegionClient_existingOverrideConfig_SuccessfullyIntercepts() {
+        S3Client crossRegionClient = new S3CrossRegionSyncClient(s3Client);
+        GetObjectRequest request = GetObjectRequest.builder()
+                                                   .bucket(BUCKET)
+                                                   .key(KEY)
+                                                   .overrideConfiguration(o -> o.putHeader("someheader", "somevalue"))
+                                                   .build();
+        crossRegionClient.getObject(request);
+        assertThat(captureInterceptor.endpointProvider).isInstanceOf(S3CrossRegionSyncClient.BucketEndpointProvider.class);
+        assertThat(mockSyncHttpClient.getLastRequest().headers().get("someheader")).isNotNull();
+    }
+
+    //TODO: handle paginated calls - the paginated publisher calls should also be decorated
+    @Test
+    public void paginatedOp_crossRegionClient_DoesNotIntercept() throws Exception {
+        S3Client crossRegionClient = new S3CrossRegionSyncClient(s3Client);
+        ListObjectsV2Iterable iterable =
+            crossRegionClient.listObjectsV2Paginator(r -> r.bucket(BUCKET).continuationToken(TOKEN).build());
+        iterable.forEach(ListObjectsV2Response::contents);
+        assertThat(captureInterceptor.endpointProvider).isInstanceOf(DefaultS3EndpointProvider.class);
+    }
+
+    private static final class CaptureInterceptor implements ExecutionInterceptor {
+
+        private EndpointProvider endpointProvider;
+
+        @Override
+        public void beforeMarshalling(Context.BeforeMarshalling context, ExecutionAttributes executionAttributes) {
+            endpointProvider = executionAttributes.getAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER);
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/customization.config
@@ -20,5 +20,7 @@
         "REQUEST_ID": "x-foobar-id"
     },
     "skipEndpointTestGeneration": true,
-    "requiredTraitValidationEnabled": true
+    "requiredTraitValidationEnabled": true,
+    "delegateAsyncClientClass": true,
+    "delegateSyncClientClass": true
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
@@ -256,6 +256,20 @@
         "requestUri":"/2016-03-11/queryParameterOperation/{PathParam}"
       },
       "input":{"shape":"QueryParameterOperationRequest"}
+    },
+    "PaginatedOperationWithResultKey": {
+      "name": "PaginatedOperationWithResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithResultKeyResponse"
+      },
+      "documentation": "Some paginated operation with result_key in paginators.json file"
     }
   },
   "shapes":{
@@ -616,6 +630,33 @@
       "type":"structure",
       "members":{
       }
+    },
+    "PaginatedOperationWithResultKeyRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "String",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "Items": {
+          "shape": "ListOfSimpleStructs",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
     },
     "RecursiveListType":{
       "type":"list",

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
@@ -256,20 +256,6 @@
         "requestUri":"/2016-03-11/queryParameterOperation/{PathParam}"
       },
       "input":{"shape":"QueryParameterOperationRequest"}
-    },
-    "PaginatedOperationWithResultKey": {
-      "name": "PaginatedOperationWithResultKey",
-      "http": {
-        "method": "POST",
-        "requestUri": "/"
-      },
-      "input": {
-        "shape": "PaginatedOperationWithResultKeyRequest"
-      },
-      "output": {
-        "shape": "PaginatedOperationWithResultKeyResponse"
-      },
-      "documentation": "Some paginated operation with result_key in paginators.json file"
     }
   },
   "shapes":{
@@ -630,33 +616,6 @@
       "type":"structure",
       "members":{
       }
-    },
-    "PaginatedOperationWithResultKeyRequest": {
-      "type": "structure",
-      "members": {
-        "NextToken": {
-          "shape": "String",
-          "documentation": "<p>Token for the next set of results</p>"
-        },
-        "MaxResults": {
-          "shape": "String",
-          "documentation": "<p>Maximum number of results in a single page</p>"
-        }
-      }
-    },
-    "PaginatedOperationWithResultKeyResponse": {
-      "type": "structure",
-      "members": {
-        "NextToken": {
-          "shape": "String",
-          "documentation": "<p>Token for the next set of results</p>"
-        },
-        "Items": {
-          "shape": "ListOfSimpleStructs",
-          "documentation": "<p>Maximum number of results in a single page</p>"
-        }
-      },
-      "documentation": "<p>Response type of a single page</p>"
     },
     "RecursiveListType":{
       "type":"list",

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingAsyncClientTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingAsyncClientTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.delegatingclients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.protocolrestjson.DelegatingProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonRequest;
+import software.amazon.awssdk.services.protocolrestjson.paginators.PaginatedOperationWithResultKeyPublisher;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.utils.StringInputStream;
+
+public class DelegatingAsyncClientTest {
+
+    private static final String INTERCEPTED_HEADER = "intercepted-header";
+    private static final String INTERCEPTED_HEADER_VALUE = "intercepted-value";
+    private static final String RESPONSE = "response";
+
+    MockAsyncHttpClient mockAsyncHttpClient = new MockAsyncHttpClient();
+    ProtocolRestJsonAsyncClient defaultClient = ProtocolRestJsonAsyncClient.builder()
+                                                                           .httpClient(mockAsyncHttpClient)
+                                                                           .endpointOverride(URI.create("http://localhost"))
+                                                                           .build();
+    ProtocolRestJsonAsyncClient decoratingClient = new DecoratingClient(defaultClient);
+
+    @BeforeEach
+    public void before() {
+        mockAsyncHttpClient.stubNextResponse(
+            HttpExecuteResponse.builder()
+                               .response(SdkHttpResponse.builder().statusCode(200).build())
+                               .responseBody(AbortableInputStream.create(new StringInputStream(RESPONSE)))
+                               .build());
+    }
+
+    @Test
+    public void standardOp_Request_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.allTypes(AllTypesRequest.builder().stringMember("test").build()).join();
+        validateIsDecorated();
+    }
+
+    @Test
+    public void standardOp_ConsumerRequest_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.allTypes(r -> r.stringMember("test")).join();
+        validateIsDecorated();
+    }
+
+    @Test
+    public void paginatedOp_Request_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.paginatedOperationWithResultKey(
+            PaginatedOperationWithResultKeyRequest.builder().nextToken("token").build())
+                        .join();
+        validateIsDecorated();
+    }
+
+    @Test
+    public void paginatedOp_ConsumerRequest_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.paginatedOperationWithResultKey(r -> r.nextToken("token")).join();
+        validateIsDecorated();
+    }
+
+    //TODO: handle paginated calls - the paginated publisher calls should also be decorated
+    @Test
+    public void paginatedOp_Request_publisherResponse_delegatingClient_DoesNotIntercept() throws Exception {
+        PaginatedOperationWithResultKeyPublisher publisher =
+            decoratingClient.paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest.builder()
+                                                                                                            .nextToken("token")
+                                                                                                            .build());
+        CompletableFuture<Void> future = publisher.subscribe(PaginatedOperationWithResultKeyResponse::items);
+        future.get();
+        assertThat(mockAsyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+    }
+
+    @Test
+    public void paginatedOp_ConsumerRequest_publisherResponse_delegatingClient_DoesNotIntercept() throws Exception {
+        PaginatedOperationWithResultKeyPublisher publisher =
+            decoratingClient.paginatedOperationWithResultKeyPaginator(r -> r.nextToken("token").build());
+        CompletableFuture<Void> future = publisher.subscribe(PaginatedOperationWithResultKeyResponse::items);
+        future.get();
+        assertThat(mockAsyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+    }
+
+    private void validateIsDecorated() {
+        SdkHttpRequest lastRequest = mockAsyncHttpClient.getLastRequest();
+        assertThat(lastRequest.headers().get(INTERCEPTED_HEADER)).isNotNull();
+        assertThat(lastRequest.headers().get(INTERCEPTED_HEADER).get(0)).isEqualTo(INTERCEPTED_HEADER_VALUE);
+    }
+
+    private static final class DecoratingClient extends DelegatingProtocolRestJsonAsyncClient {
+
+        DecoratingClient(ProtocolRestJsonAsyncClient client) {
+            super(client);
+        }
+
+        @Override
+        protected <T extends ProtocolRestJsonRequest, ReturnT> CompletableFuture<ReturnT>
+        invokeOperation(T request, Function<T, CompletableFuture<ReturnT>> operation) {
+            return operation.apply(decorateRequest(request));
+        }
+
+        @SuppressWarnings("unchecked")
+        private <T extends ProtocolRestJsonRequest> T decorateRequest(T request) {
+            AwsRequestOverrideConfiguration alin = AwsRequestOverrideConfiguration.builder()
+                                                                                  .putHeader(INTERCEPTED_HEADER, INTERCEPTED_HEADER_VALUE)
+                                                                                  .build();
+            return (T) request.toBuilder()
+                              .overrideConfiguration(alin)
+                              .build();
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingSyncClientTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingSyncClientTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.delegatingclients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.protocolrestjson.DelegatingProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.DelegatingProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonRequest;
+import software.amazon.awssdk.services.protocolrestjson.paginators.PaginatedOperationWithResultKeyIterable;
+import software.amazon.awssdk.services.protocolrestjson.paginators.PaginatedOperationWithResultKeyPublisher;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+import software.amazon.awssdk.utils.StringInputStream;
+
+public class DelegatingSyncClientTest {
+
+    private static final String INTERCEPTED_HEADER = "intercepted-header";
+    private static final String INTERCEPTED_HEADER_VALUE = "intercepted-value";
+    private static final String RESPONSE = "response";
+
+    MockSyncHttpClient mockSyncHttpClient = new MockSyncHttpClient();
+    ProtocolRestJsonClient defaultClient = ProtocolRestJsonClient.builder()
+                                                                 .httpClient(mockSyncHttpClient)
+                                                                 .endpointOverride(URI.create("http://localhost"))
+                                                                 .build();
+    ProtocolRestJsonClient decoratingClient = new DecoratingClient(defaultClient);
+
+    @BeforeEach
+    public void before() {
+        mockSyncHttpClient.stubNextResponse(
+            HttpExecuteResponse.builder()
+                               .response(SdkHttpResponse.builder().statusCode(200).build())
+                               .responseBody(AbortableInputStream.create(new StringInputStream(RESPONSE)))
+                               .build());
+    }
+
+    @Test
+    public void standardOp_Request_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.allTypes(AllTypesRequest.builder().stringMember("test").build());
+        validateIsDecorated();
+    }
+
+    @Test
+    public void standardOp_ConsumerRequest_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.allTypes(r -> r.stringMember("test"));
+        validateIsDecorated();
+    }
+
+    @Test
+    public void paginatedOp_Request_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder()
+                                                                                               .nextToken("token")
+                                                                                               .build());
+        validateIsDecorated();
+    }
+
+    @Test
+    public void paginatedOp_ConsumerRequest_standardFutureResponse_delegatingClient_SuccessfullyIntercepts() {
+        decoratingClient.paginatedOperationWithResultKey(r -> r.nextToken("token"));
+        validateIsDecorated();
+    }
+
+    //TODO: handle paginated calls - the paginated publisher calls should also be decorated
+    @Test
+    public void paginatedOp_Request_publisherResponse_delegatingClient_DoesNotIntercept() throws Exception {
+        PaginatedOperationWithResultKeyIterable iterable =
+            decoratingClient.paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest.builder()
+                                                                                                            .nextToken("token")
+                                                                                                            .build());
+        iterable.forEach(PaginatedOperationWithResultKeyResponse::items);
+        assertThat(mockSyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+    }
+
+    @Test
+    public void paginatedOp_ConsumerRequest_publisherResponse_delegatingClient_DoesNotIntercept() throws Exception {
+        PaginatedOperationWithResultKeyIterable iterable =
+            decoratingClient.paginatedOperationWithResultKeyPaginator(r -> r.nextToken("token").build());
+        iterable.forEach(PaginatedOperationWithResultKeyResponse::items);
+        assertThat(mockSyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+    }
+
+    private void validateIsDecorated() {
+        SdkHttpRequest lastRequest = mockSyncHttpClient.getLastRequest();
+        assertThat(lastRequest.headers().get(INTERCEPTED_HEADER)).isNotNull();
+        assertThat(lastRequest.headers().get(INTERCEPTED_HEADER).get(0)).isEqualTo(INTERCEPTED_HEADER_VALUE);
+    }
+
+    private static final class DecoratingClient extends DelegatingProtocolRestJsonClient {
+
+        DecoratingClient(ProtocolRestJsonClient client) {
+            super(client);
+        }
+
+        @Override
+        protected <T extends ProtocolRestJsonRequest, ReturnT> ReturnT
+        invokeOperation(T request, Function<T, ReturnT> operation) {
+            return operation.apply(decorateRequest(request));
+        }
+
+        @SuppressWarnings("unchecked")
+        private <T extends ProtocolRestJsonRequest> T decorateRequest(T request) {
+            AwsRequestOverrideConfiguration alin = AwsRequestOverrideConfiguration.builder()
+                                                                                  .putHeader(INTERCEPTED_HEADER,
+                                                                                             INTERCEPTED_HEADER_VALUE)
+                                                                                  .build();
+            return (T) request.toBuilder()
+                              .overrideConfiguration(alin)
+                              .build();
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Adds the structure and signatures for the new cross region client to be able to successfully decorate the existing S3 client with an override config containing a decorated endpoint provider. 

## Modifications
- Changes the signature of `invokeOperation` (back) to `CompletableFuture`, which is necessary in order to use nonblocking I/O
- Modifies paginated methods that return `Publisher` or `Iterable` to NOT use `invokeOperation` in the abstract delegating clients, i.e. back to originating behavior. The correct place to intercept these calls is when each page is called which will be handled by a later PR. 
- Adds the logic of modifying the request and correctly creating/overriding the RequestOverrideConfig to the cross region client
- Adds a `BucketEndpointProvider` that will contain the cross-region logic (separate PR).

**NOTE**: There is an unchecked cast back to `T` after the request has been modified, due to two contributing factors:
1. The `toBuilder` method returns an S3 request and the type is lost. 
2. The override config method is present on the subtype (T) and on the Aws-level request, but not on the S3 request. 

Adding the override config then returns an Aws request builder. It's not possible to give the compiler enough information to deduce that the request is a T, and we cannot modify the request hierarchy due to backwards compatibility reasons. However, because we control the generation of the subtypes like `GetObjectRequest` etc, we know that the cast is safe. 

## Testing
- Codegen functional testing to verify the delegating client functionality
- S3 functional testing to verify override functionality.