### PR TITLE
Improve Http2 ping timeout logic

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-6454991.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-6454991.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "akidambisrinivasan",
+    "description": "Improve HTTP2/PING timeout logic. Improvements are to reset the ack timers on incoming data packets because it supports liveness of the connection. Also avoiding premature timeouts due to delays in flushing or scheduling."
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/HttpClientApiCallTimeoutTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/HttpClientApiCallTimeoutTest.java
@@ -56,6 +56,8 @@ public class HttpClientApiCallTimeoutTest {
 
     private AmazonSyncHttpClient httpClient;
 
+    private final static int EPSILON_MILLIS = 10;
+
     @Before
     public void setup() {
         httpClient = testClientBuilder()
@@ -70,7 +72,7 @@ public class HttpClientApiCallTimeoutTest {
                     .willReturn(aResponse().withStatus(200).withBody("{}")));
 
         assertThatThrownBy(() -> requestBuilder().execute(combinedSyncResponseHandler(
-            superSlowResponseHandler(API_CALL_TIMEOUT.toMillis()), null)))
+            superSlowResponseHandler(API_CALL_TIMEOUT.toMillis() + EPSILON_MILLIS), null)))
             .isInstanceOf(ApiCallTimeoutException.class);
     }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandler.java
@@ -41,6 +41,11 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
     private static final NettyClientLogger log = NettyClientLogger.getLogger(Http2PingHandler.class);
     private static final Http2PingFrame DEFAULT_PING_FRAME = new DefaultHttp2PingFrame(0);
 
+    /**
+     * Time limit in ms for delays that results in a warning message being printed.
+     */
+    private final long delayWarningTimeLimitMs;
+
     private final long pingTimeoutMillis;
 
     private ScheduledFuture<?> periodicPing;
@@ -49,6 +54,7 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
 
     public Http2PingHandler(int pingTimeoutMillis) {
         this.pingTimeoutMillis = pingTimeoutMillis;
+        delayWarningTimeLimitMs = Math.min(100, pingTimeoutMillis / 10);
     }
 
     @Override
@@ -62,7 +68,7 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
         if (protocol == Protocol.HTTP2 && periodicPing == null) {
             periodicPing = ctx.channel()
                               .eventLoop()
-                              .scheduleAtFixedRate(() -> doPeriodicPing(ctx.channel()), 0, pingTimeoutMillis, MILLISECONDS);
+                              .schedule(() -> doPeriodicPing(ctx.channel()), 0, MILLISECONDS);
         }
     }
 
@@ -79,8 +85,8 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, Http2PingFrame frame) {
+        log.debug(ctx.channel(), () -> "Received PING from channel, ack=" + frame.ack());
         if (frame.ack()) {
-            log.debug(ctx.channel(), () -> "Received PING ACK from channel " + ctx.channel());
             lastPingAckTime = System.currentTimeMillis();
         } else {
             ctx.fireChannelRead(frame);
@@ -89,22 +95,48 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
 
     private void doPeriodicPing(Channel channel) {
         if (lastPingAckTime <= lastPingSendTime - pingTimeoutMillis) {
+            log.warn(channel, () -> "PING timeout occurred");
             long timeSinceLastPingSend = System.currentTimeMillis() - lastPingSendTime;
             channelIsUnhealthy(channel, new PingFailedException("Server did not respond to PING after " +
                                                                 timeSinceLastPingSend + "ms (limit: " +
                                                                 pingTimeoutMillis + "ms)"));
         } else {
+            log.debug(channel, () -> "Sending HTTP2/PING frame");
+            long scheduleTime = lastPingSendTime == 0 ? 0 : System.currentTimeMillis() - lastPingSendTime;
+            if (scheduleTime - pingTimeoutMillis > delayWarningTimeLimitMs) {
+                log.warn(channel, () -> "PING timer scheduled after " + scheduleTime + "ms");
+            }
             sendPing(channel);
         }
     }
 
     private void sendPing(Channel channel) {
+        long writeMs = System.currentTimeMillis();
         channel.writeAndFlush(DEFAULT_PING_FRAME).addListener(res -> {
             if (!res.isSuccess()) {
                 log.debug(channel, () -> "Failed to write and flush PING frame to connection", res.cause());
                 channelIsUnhealthy(channel, new PingFailedException("Failed to send PING to the service", res.cause()));
             } else {
+                log.debug(channel, () -> "Successfully flushed PING frame to connection");
                 lastPingSendTime = System.currentTimeMillis();
+                long flushTime = lastPingSendTime - writeMs;
+                if (flushTime > delayWarningTimeLimitMs) {
+                    log.warn(channel, () -> "Flushing PING frame took " + flushTime + "ms");
+                }
+                // ping frame was flushed to the socket, schedule to send the next ping now to avoid premature timeout.
+                //
+                // Scenario we want to avoid is shown below (NOTE: ptm - pingTimeoutMillis, Wx - Write Ping x,
+                // Fx - Flush Ping x, Rx - Receive ack x, T -Timeout)
+                // When timer is scheduled periodically, even though ack2 comes < ptm after being flushed to the socket, we
+                // will still timeout at 2ptm.
+                // 0          1ptm       2ptm       3ptm
+                // |----------|----------|----------|-------> time
+                // W1F1 R1    W2      F2 T  R2
+                // When timer is scheduled after flushing, we allow time for ack to come back and don't prematurely timeout.
+                // 0            ptm1               ptm2
+                // |-|----------|------|----------|-----------> time
+                // W1F1 R1      W2     F2   R2    W3
+                periodicPing = channel.eventLoop().schedule(() -> doPeriodicPing(channel), pingTimeoutMillis, MILLISECONDS);
             }
         });
     }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/PingTimeoutTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/PingTimeoutTest.java
@@ -99,23 +99,37 @@ public class PingTimeoutTest {
         netty = null;
     }
 
+    /**
+     * Default ping timeout value is 5000ms, so when the channel has no activity including
+     * no data packets received or ping acks received for the timeout value, the connection
+     * will be closed. During connection setup for testing, there will be Setting frame and
+     * the SettingsAck frame exchanged which counts as activity on the channel, so the channel
+     * should timeout during the second interval which is 10 seconds.
+     */
     @Test
-    public void pingHealthCheck_null_shouldThrowExceptionAfter5Sec() {
+    public void pingHealthCheck_null_shouldThrowExceptionAfter10Sec() {
         Instant a = Instant.now();
         assertThatThrownBy(() -> makeRequest(null).join())
             .hasMessageContaining("An error occurred on the connection")
             .hasCauseInstanceOf(IOException.class)
             .hasRootCauseInstanceOf(PingFailedException.class);
-        assertThat(Duration.between(a, Instant.now())).isBetween(Duration.ofSeconds(5), Duration.ofSeconds(7));
+        assertThat(Duration.between(a, Instant.now())).isBetween(Duration.ofSeconds(10), Duration.ofSeconds(12));
     }
 
+    /**
+     * Test when ping timeout value is 10,000ms. When the channel has no activity including
+     * no data packets received or ping acks received for the timeout value, the connection
+     * will be closed. During connection setup for testing, there will be Setting frame and
+     * the SettingsAck frame exchanged which counts as activity on the channel, so the channel
+     * should timeout during the second interval which is 10 seconds.
+     */
     @Test
     public void pingHealthCheck_10sec_shouldThrowExceptionAfter10Secs() {
         Instant a = Instant.now();
         assertThatThrownBy(() -> makeRequest(Duration.ofSeconds(10)).join()).hasCauseInstanceOf(IOException.class)
                                                                             .hasMessageContaining("An error occurred on the connection")
                                                                             .hasRootCauseInstanceOf(PingFailedException.class);
-        assertThat(Duration.between(a, Instant.now())).isBetween(Duration.ofSeconds(10), Duration.ofSeconds(12));
+        assertThat(Duration.between(a, Instant.now())).isBetween(Duration.ofSeconds(20), Duration.ofSeconds(22));
     }
 
     @Test

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/PingTimeoutTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/PingTimeoutTest.java
@@ -117,19 +117,19 @@ public class PingTimeoutTest {
     }
 
     /**
-     * Test when ping timeout value is 10,000ms. When the channel has no activity including
+     * Test when ping timeout value is 3000ms. When the channel has no activity including
      * no data packets received or ping acks received for the timeout value, the connection
-     * will be closed. During connection setup for testing, there will be Setting frame and
+     * will be closed. During connection setup for testing, there will be Settings frame and
      * the SettingsAck frame exchanged which counts as activity on the channel, so the channel
-     * should timeout during the second interval which is 10 seconds.
+     * should timeout during the second interval which is 6 seconds.
      */
     @Test
-    public void pingHealthCheck_10sec_shouldThrowExceptionAfter10Secs() {
+    public void pingHealthCheck_3sec_shouldThrowExceptionAfter6Secs() {
         Instant a = Instant.now();
-        assertThatThrownBy(() -> makeRequest(Duration.ofSeconds(10)).join()).hasCauseInstanceOf(IOException.class)
+        assertThatThrownBy(() -> makeRequest(Duration.ofSeconds(3)).join()).hasCauseInstanceOf(IOException.class)
                                                                             .hasMessageContaining("An error occurred on the connection")
                                                                             .hasRootCauseInstanceOf(PingFailedException.class);
-        assertThat(Duration.between(a, Instant.now())).isBetween(Duration.ofSeconds(20), Duration.ofSeconds(22));
+        assertThat(Duration.between(a, Instant.now())).isBetween(Duration.ofSeconds(6), Duration.ofSeconds(8));
     }
 
     @Test

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/ServerNotRespondingTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/ServerNotRespondingTest.java
@@ -54,6 +54,7 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,8 +115,9 @@ public class ServerNotRespondingTest {
         // First request should succeed
         firstRequest.join();
 
-        // Wait for Ping to close the connection
-        Thread.sleep(200);
+        // Wait for Ping to close the connection, it takes 2 * healthCheckPingPeriod (200ms)
+        // to identify a silent connection to be closed.
+        Thread.sleep(400);
         server.notRespondOnFirstChannel = false;
         sendGetRequest().join();
         assertThat(server.h2ConnectionCount.get()).isEqualTo(2);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
@@ -158,10 +158,11 @@ public class Http2PingHandlerTest {
     }
 
     @Test
-    public void nonAckPingsResultInOneChannelException() {
+    public void nonAckPingsDoesNotResultInOneChannelException() {
         PipelineExceptionCatcher catcher = new PipelineExceptionCatcher();
         EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher);
 
+        // As long as there is data coming into the channel the ping will not time out.
         channel.eventLoop().scheduleAtFixedRate(() -> channel.writeInbound(new DefaultHttp2PingFrame(0, false)),
                                                 0, FAST_CHECKER_DURATION_MILLIS, TimeUnit.MILLISECONDS);
 
@@ -170,8 +171,7 @@ public class Http2PingHandlerTest {
             channel.runPendingTasks();
         }
 
-        assertThat(catcher.caughtExceptions).hasSize(1);
-        assertThat(catcher.caughtExceptions.get(0)).isInstanceOf(IOException.class);
+        assertThat(catcher.caughtExceptions).hasSize(0);
     }
 
     @Test

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
@@ -330,7 +330,6 @@ public class Http2PingHandlerTest {
     }
 
     private static final class PingResponder extends ChannelOutboundHandlerAdapter {
-
         private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
         private Runnable respondCallback;
         private long callbackDelayMillis;
@@ -339,6 +338,7 @@ public class Http2PingHandlerTest {
             this.respondCallback = respondCallback;
             this.callbackDelayMillis = delay;
         }
+
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             if (msg instanceof Http2PingFrame) {
@@ -350,11 +350,12 @@ public class Http2PingHandlerTest {
     }
 
     private static final class DelayingWriter extends ChannelOutboundHandlerAdapter {
-
         private final long sleepMillis;
+
         DelayingWriter(long sleepMillis) {
             this.sleepMillis = sleepMillis;
         }
+
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             log.debug(ctx.channel(), () -> " Writing " + msg + " delayed by " + sleepMillis);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
@@ -33,14 +33,21 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey;
+import software.amazon.awssdk.http.nio.netty.internal.utils.NettyClientLogger;
 
 public class Http2PingHandlerTest {
+    private static final NettyClientLogger log = NettyClientLogger.getLogger(Http2PingHandler.class);
+
     private static final int FAST_CHECKER_DURATION_MILLIS = 100;
 
     private Http2PingHandler fastChecker;
@@ -109,15 +116,21 @@ public class Http2PingHandlerTest {
     }
 
     @Test
-    public void ignoredPingsResultInOneChannelException() throws InterruptedException {
+    public void schedulingDelayDoesNotCausePingTimeout() throws InterruptedException {
         PipelineExceptionCatcher catcher = new PipelineExceptionCatcher();
-        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher);
-        
-        Thread.sleep(FAST_CHECKER_DURATION_MILLIS);
+        PingResponder pingResponder = new PingResponder();
+        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher, pingResponder);
+
+        pingResponder.setCallback(() -> channel.writeInbound(new DefaultHttp2PingFrame(0, true)),
+                                  (long)(FAST_CHECKER_DURATION_MILLIS / 10) /* send ack 10ms after getting ping */);
+
         channel.runPendingTasks();
 
-        assertThat(catcher.caughtExceptions).hasSize(1);
-        assertThat(catcher.caughtExceptions.get(0)).isInstanceOf(IOException.class);
+        // cause a scheduling delay for the timer to run
+        Thread.sleep(FAST_CHECKER_DURATION_MILLIS * 2);
+        channel.runPendingTasks();
+
+        assertThat(catcher.caughtExceptions).hasSize(0);
     }
 
     @Test
@@ -214,6 +227,51 @@ public class Http2PingHandlerTest {
         assertThat(channel.runScheduledPendingTasks()).isEqualTo(-1L);
     }
 
+    @Test
+    public void delayedPingFlushDoesntTerminateConnectionPrematurely() {
+        Logger.getLogger("").setLevel(Level.ALL);
+
+        PipelineExceptionCatcher catcher = new PipelineExceptionCatcher();
+        PingResponder pingResponder = new PingResponder();
+        DelayingWriter delayingWriter = new DelayingWriter((long)(FAST_CHECKER_DURATION_MILLIS * 1.5));
+
+        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher, pingResponder, delayingWriter);
+
+        pingResponder.setCallback(() -> channel.writeInbound(new DefaultHttp2PingFrame(0, true)),
+                                  FAST_CHECKER_DURATION_MILLIS / 10 /* send ack in 10 ms after getting ping*/);
+
+        Instant runEnd = Instant.now().plus(1, SECONDS);
+        while (Instant.now().isBefore(runEnd)) {
+            channel.runPendingTasks();
+            assertThat(catcher.caughtExceptions).isEmpty();
+        }
+    }
+
+    @Test
+    public void delayedPingAckTerminatesConnection() {
+        Logger.getLogger("").setLevel(Level.ALL);
+
+        PipelineExceptionCatcher catcher = new PipelineExceptionCatcher();
+        PingResponder pingResponder = new PingResponder();
+        DelayingWriter delayingWriter = new DelayingWriter((long)(FAST_CHECKER_DURATION_MILLIS * 1.5));
+
+        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher, pingResponder, delayingWriter);
+
+        pingResponder.setCallback(() -> channel.writeInbound(new DefaultHttp2PingFrame(0, true)),
+                                  (long)(FAST_CHECKER_DURATION_MILLIS * 1.5) /* send a late ack to trigger timeout */);
+
+        Instant runEnd = Instant.now().plus(1, SECONDS);
+        while (Instant.now().isBefore(runEnd)) {
+            channel.runPendingTasks();
+            if (!catcher.caughtExceptions.isEmpty()) {
+                break;
+            }
+        }
+
+        assertThat(catcher.caughtExceptions).hasSize(1);
+        assertThat(catcher.caughtExceptions.get(0)).isInstanceOf(PingFailedException.class);
+    }
+
     private static final class PingReadCatcher extends SimpleChannelInboundHandler<Http2PingFrame> {
         private final List<Http2PingFrame> caughtPings = Collections.synchronizedList(new ArrayList<>());
 
@@ -237,6 +295,46 @@ public class Http2PingHandlerTest {
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             promise.setFailure(new IOException("Failed!"));
+        }
+    }
+
+    private static final class PingResponder extends ChannelOutboundHandlerAdapter {
+
+        private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        private Runnable respondCallback;
+        private long callbackDelayMillis;
+
+        void setCallback(Runnable respondCallback, long delay) {
+            this.respondCallback = respondCallback;
+            this.callbackDelayMillis = delay;
+        }
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            if (msg instanceof Http2PingFrame) {
+                log.debug(ctx.channel(), () -> "OutgoingPingCatcher Received ping " + msg);
+                scheduler.schedule(respondCallback, callbackDelayMillis, TimeUnit.MILLISECONDS);
+            }
+            ctx.write(msg, promise);
+        }
+    }
+
+    private static final class DelayingWriter extends ChannelOutboundHandlerAdapter {
+
+        private final long sleepMillis;
+        DelayingWriter(long sleepMillis) {
+            this.sleepMillis = sleepMillis;
+        }
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            log.debug(ctx.channel(), () -> " Writing " + msg + " delayed by " + sleepMillis);
+            try {
+                Thread.sleep(sleepMillis);
+            } catch (InterruptedException e) {
+
+            }
+            log.debug(ctx.channel(), () -> " Continuing write of " + msg);
+
+            ctx.write(msg, promise);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Current PING timeout logic doesnt work well when there are delays in scheduling or flushing to socket.
```
Scenario we want to avoid is shown below (NOTE: ptm - pingTimeoutMillis, Wx - Write Ping x, Fx - Flush Ping x, Rx - Receive ack x, T -Timeout)

When timer is scheduled periodically, even though ack2 comes < ptm after being flushed to the socket, we
will still timeout at 2ptm.        
 0          1ptm       2ptm       3ptm
|----------|----------|----------|-------> time
W1F1 R1    W2      F2 T  R2
When timer is scheduled after flushing, we allow time for ack to come back and not prematurely timeout.
0            ptm1               ptm2
|-|----------|------|----------|-----------> time
 W1F1 R1      W2     F2   R2    W3
```
The change prevents premature closing of the HTTP2 connection. With this change, it will detect dead connections which are otherwise not detected due to inactivity while tolerating scheduling and flushing delays.

## Modifications
There are two modifications in this patch:
1. The callback to send the next ping is scheduled when the ping write is flushed, so it accounts for delays in flushing (because that delay doesnt mean the connection is dead)
2. And reset the ackReceivedTime for any data packet received not just ACK. That way if the channel has been seeing data, it is not really dead and it would be safe to wait for ACK for longer.

## Testing
Added 3 unit tests and modified one:
1. Add unit test to ensure that when there is a delay in writing to socket, if the ACK doesnt come within pingTimeoutMillis, the code still executes timeout logic and terminates the connection, but if it does come, resets the timer and continues pinging.
2. If there is a scheduling delay, it does not execute timeout. For scheduling delay, the system of jvm is unable to catchup and will do so slowly, the true issue that needs to be fixed is by addressing the slowness not timing out the connection.
3. When data packets are received, it represents activity which can be used to extend the timer for which the connection must be inactive.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
