### PR TITLE
Adds accountId to STS credentials providers

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -44,18 +44,17 @@ public final class AwsBasicCredentials implements AwsCredentials {
      * This should be accessed via {@link AnonymousCredentialsProvider#resolveCredentials()}.
      */
     @SdkInternalApi
-    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().build();
+    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().validateCredentials(Boolean.FALSE).build();
 
     private final String accessKeyId;
     private final String secretAccessKey;
-
     private final String accountId;
 
     private AwsBasicCredentials(Builder builder) {
         this.accessKeyId = trimToNull(builder.accessKeyId);
         this.secretAccessKey = trimToNull(builder.secretAccessKey);
 
-        if (builder.validateCredentials) {
+        if (Boolean.TRUE.equals(builder.validateCredentials)) {
             Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
             Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
         }
@@ -75,7 +74,6 @@ public final class AwsBasicCredentials implements AwsCredentials {
     public static AwsBasicCredentials create(String accessKeyId, String secretAccessKey) {
         return builder().accessKeyId(accessKeyId)
                         .secretAccessKey(secretAccessKey)
-                        .validateCredentials(true)
                         .build();
     }
 
@@ -95,6 +93,9 @@ public final class AwsBasicCredentials implements AwsCredentials {
         return secretAccessKey;
     }
 
+    /**
+     * Retrieve the AWS account id associated with this credentials identity, if found.
+     */
     @Override
     public Optional<String> accountId() {
         return Optional.ofNullable(accountId);
@@ -135,24 +136,36 @@ public final class AwsBasicCredentials implements AwsCredentials {
         private String accessKeyId;
         private String secretAccessKey;
         private String accountId;
-        private boolean validateCredentials;
+        private Boolean validateCredentials = Boolean.TRUE;
 
+        /**
+         * The AWS access key, used to identify the user interacting with services.
+         */
         public Builder accessKeyId(String accessKeyId) {
             this.accessKeyId = accessKeyId;
             return this;
         }
 
+        /**
+         * The AWS secret access key, used to authenticate the user interacting with services.
+         */
         public Builder secretAccessKey(String secretAccessKey) {
             this.secretAccessKey = secretAccessKey;
             return this;
         }
 
+        /**
+         * The AWS account id associated with this credentials identity.
+         */
         public Builder accountId(String accountId) {
             this.accountId = accountId;
             return this;
         }
 
-        public Builder validateCredentials(boolean validateCredentials) {
+        /**
+         * Whether this class should verify that accessKeyId and secretAccessKey are not null.
+         */
+        Builder validateCredentials(Boolean validateCredentials) {
             this.validateCredentials = validateCredentials;
             return this;
         }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -44,7 +44,7 @@ public final class AwsBasicCredentials implements AwsCredentials {
      * This should be accessed via {@link AnonymousCredentialsProvider#resolveCredentials()}.
      */
     @SdkInternalApi
-    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().validateCredentials(Boolean.FALSE).build();
+    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().validateCredentials(false).build();
 
     private final String accessKeyId;
     private final String secretAccessKey;
@@ -54,11 +54,23 @@ public final class AwsBasicCredentials implements AwsCredentials {
         this.accessKeyId = trimToNull(builder.accessKeyId);
         this.secretAccessKey = trimToNull(builder.secretAccessKey);
 
-        if (Boolean.TRUE.equals(builder.validateCredentials)) {
+        if (builder.validateCredentials) {
             Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
             Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
         }
         this.accountId = builder.accountId;
+    }
+
+    /**
+     * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
+     */
+    protected AwsBasicCredentials(String accessKeyId, String secretAccessKey) {
+        this(builder().accessKeyId(accessKeyId)
+                      .secretAccessKey(secretAccessKey)
+                      .validateCredentials(true));
     }
 
     public static Builder builder() {
@@ -136,7 +148,7 @@ public final class AwsBasicCredentials implements AwsCredentials {
         private String accessKeyId;
         private String secretAccessKey;
         private String accountId;
-        private Boolean validateCredentials = Boolean.TRUE;
+        private boolean validateCredentials = true;
 
         /**
          * The AWS access key, used to identify the user interacting with services.

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.auth.credentials;
 import static software.amazon.awssdk.utils.StringUtils.trimToNull;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -25,8 +26,8 @@ import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * Provides access to the AWS credentials used for accessing services: AWS access key ID and secret access key. These
- * credentials are used to securely sign requests to services (e.g., AWS services) that use them for authentication.
+ * Provides access to the AWS credentials used for accessing services: AWS access key ID and secret access key. These credentials
+ * are used to securely sign requests to services (e.g., AWS services) that use them for authentication.
  *
  * <p>For more details on AWS access keys, see:
  * <a href="https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys">
@@ -39,43 +40,43 @@ import software.amazon.awssdk.utils.Validate;
 public final class AwsBasicCredentials implements AwsCredentials {
     /**
      * A set of AWS credentials without an access key or secret access key, indicating that anonymous access should be used.
-     *
+     * <p>
      * This should be accessed via {@link AnonymousCredentialsProvider#resolveCredentials()}.
      */
     @SdkInternalApi
-    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = new AwsBasicCredentials(null, null, false);
+    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().build();
 
     private final String accessKeyId;
     private final String secretAccessKey;
 
-    /**
-     * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
-     *
-     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
-     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
-     */
-    protected AwsBasicCredentials(String accessKeyId, String secretAccessKey) {
-        this(accessKeyId, secretAccessKey, true);
-    }
+    private final String accountId;
 
-    private AwsBasicCredentials(String accessKeyId, String secretAccessKey, boolean validateCredentials) {
-        this.accessKeyId = trimToNull(accessKeyId);
-        this.secretAccessKey = trimToNull(secretAccessKey);
+    private AwsBasicCredentials(Builder builder) {
+        this.accessKeyId = trimToNull(builder.accessKeyId);
+        this.secretAccessKey = trimToNull(builder.secretAccessKey);
 
-        if (validateCredentials) {
+        if (builder.validateCredentials) {
             Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
             Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
         }
+        this.accountId = builder.accountId;
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
      * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
      *
-     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
+     * @param accessKeyId     The AWS access key, used to identify the user interacting with AWS.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
-     * */
+     */
     public static AwsBasicCredentials create(String accessKeyId, String secretAccessKey) {
-        return new AwsBasicCredentials(accessKeyId, secretAccessKey);
+        return builder().accessKeyId(accessKeyId)
+                        .secretAccessKey(secretAccessKey)
+                        .validateCredentials(true)
+                        .build();
     }
 
     /**
@@ -95,9 +96,15 @@ public final class AwsBasicCredentials implements AwsCredentials {
     }
 
     @Override
+    public Optional<String> accountId() {
+        return Optional.ofNullable(accountId);
+    }
+
+    @Override
     public String toString() {
         return ToString.builder("AwsCredentials")
                        .add("accessKeyId", accessKeyId)
+                       .add("accountId", accountId)
                        .build();
     }
 
@@ -111,7 +118,8 @@ public final class AwsBasicCredentials implements AwsCredentials {
         }
         AwsBasicCredentials that = (AwsBasicCredentials) o;
         return Objects.equals(accessKeyId, that.accessKeyId) &&
-               Objects.equals(secretAccessKey, that.secretAccessKey);
+               Objects.equals(secretAccessKey, that.secretAccessKey) &&
+               Objects.equals(accountId, that.accountId().orElse(null));
     }
 
     @Override
@@ -119,6 +127,38 @@ public final class AwsBasicCredentials implements AwsCredentials {
         int hashCode = 1;
         hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
+        hashCode = 31 * hashCode + Objects.hashCode(accountId);
         return hashCode;
+    }
+
+    public static final class Builder {
+        private String accessKeyId;
+        private String secretAccessKey;
+        private String accountId;
+        private boolean validateCredentials;
+
+        public Builder accessKeyId(String accessKeyId) {
+            this.accessKeyId = accessKeyId;
+            return this;
+        }
+
+        public Builder secretAccessKey(String secretAccessKey) {
+            this.secretAccessKey = secretAccessKey;
+            return this;
+        }
+
+        public Builder accountId(String accountId) {
+            this.accountId = accountId;
+            return this;
+        }
+
+        public Builder validateCredentials(boolean validateCredentials) {
+            this.validateCredentials = validateCredentials;
+            return this;
+        }
+
+        public AwsBasicCredentials build() {
+            return new AwsBasicCredentials(this);
+        }
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.auth.credentials;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Immutable;
@@ -36,12 +37,14 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
     private final String secretAccessKey;
     private final String sessionToken;
     private final String accountId;
+    private final Instant expiration;
 
     private AwsSessionCredentials(Builder builder) {
         this.accessKeyId = Validate.paramNotNull(builder.accessKeyId, "accessKey");
         this.secretAccessKey = Validate.paramNotNull(builder.secretAccessKey, "secretKey");
         this.sessionToken = Validate.paramNotNull(builder.sessionToken, "sessionToken");
         this.accountId = builder.accountId;
+        this.expiration = builder.expiration;
     }
 
     public static Builder builder() {
@@ -80,6 +83,10 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         return Optional.ofNullable(accountId);
     }
 
+    public Optional<Instant> expiration() {
+        return Optional.ofNullable(expiration);
+    }
+
     @Override
     public String toString() {
         return ToString.builder("AwsSessionCredentials")
@@ -101,7 +108,8 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         return Objects.equals(accessKeyId, that.accessKeyId) &&
                Objects.equals(secretAccessKey, that.secretAccessKey) &&
                Objects.equals(sessionToken, that.sessionToken) &&
-               Objects.equals(accountId, that.accountId().orElse(null));
+               Objects.equals(accountId, that.accountId().orElse(null)) &&
+               Objects.equals(expiration, that.expiration().orElse(null));
     }
 
     @Override
@@ -111,6 +119,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
         hashCode = 31 * hashCode + Objects.hashCode(sessionToken());
         hashCode = 31 * hashCode + Objects.hashCode(accountId);
+        hashCode = 31 * hashCode + Objects.hashCode(expiration);
         return hashCode;
     }
 
@@ -119,6 +128,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         private String secretAccessKey;
         private String sessionToken;
         private String accountId;
+        private Instant expiration;
 
         public Builder accessKeyId(String accessKeyId) {
             this.accessKeyId = accessKeyId;
@@ -137,6 +147,11 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
 
         public Builder accountId(String accountId) {
             this.accountId = accountId;
+            return this;
+        }
+
+        public Builder expiration(Instant expiration) {
+            this.expiration = expiration;
             return this;
         }
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.auth.credentials;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
@@ -34,11 +35,17 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
     private final String accessKeyId;
     private final String secretAccessKey;
     private final String sessionToken;
+    private final String accountId;
 
-    private AwsSessionCredentials(String accessKey, String secretKey, String sessionToken) {
-        this.accessKeyId = Validate.paramNotNull(accessKey, "accessKey");
-        this.secretAccessKey = Validate.paramNotNull(secretKey, "secretKey");
-        this.sessionToken = Validate.paramNotNull(sessionToken, "sessionToken");
+    private AwsSessionCredentials(Builder builder) {
+        this.accessKeyId = Validate.paramNotNull(builder.accessKeyId, "accessKey");
+        this.secretAccessKey = Validate.paramNotNull(builder.secretAccessKey, "secretKey");
+        this.sessionToken = Validate.paramNotNull(builder.sessionToken, "sessionToken");
+        this.accountId = builder.accountId;
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -50,7 +57,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
      * received temporary permission to access some resource.
      */
     public static AwsSessionCredentials create(String accessKey, String secretKey, String sessionToken) {
-        return new AwsSessionCredentials(accessKey, secretKey, sessionToken);
+        return builder().accessKeyId(accessKey).secretAccessKey(secretKey).sessionToken(sessionToken).build();
     }
 
     @Override
@@ -69,9 +76,15 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
     }
 
     @Override
+    public Optional<String> accountId() {
+        return Optional.ofNullable(accountId);
+    }
+
+    @Override
     public String toString() {
         return ToString.builder("AwsSessionCredentials")
                        .add("accessKeyId", accessKeyId())
+                       .add("accountId", accountId)
                        .build();
     }
 
@@ -87,7 +100,8 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         AwsSessionCredentials that = (AwsSessionCredentials) o;
         return Objects.equals(accessKeyId, that.accessKeyId) &&
                Objects.equals(secretAccessKey, that.secretAccessKey) &&
-               Objects.equals(sessionToken, that.sessionToken);
+               Objects.equals(sessionToken, that.sessionToken) &&
+               Objects.equals(accountId, that.accountId().orElse(null));
     }
 
     @Override
@@ -96,6 +110,38 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
         hashCode = 31 * hashCode + Objects.hashCode(sessionToken());
+        hashCode = 31 * hashCode + Objects.hashCode(accountId);
         return hashCode;
+    }
+
+    public static final class Builder {
+        private String accessKeyId;
+        private String secretAccessKey;
+        private String sessionToken;
+        private String accountId;
+
+        public Builder accessKeyId(String accessKeyId) {
+            this.accessKeyId = accessKeyId;
+            return this;
+        }
+
+        public Builder secretAccessKey(String secretAccessKey) {
+            this.secretAccessKey = secretAccessKey;
+            return this;
+        }
+
+        public Builder sessionToken(String sessionToken) {
+            this.sessionToken = sessionToken;
+            return this;
+        }
+
+        public Builder accountId(String accountId) {
+            this.accountId = accountId;
+            return this;
+        }
+
+        public AwsSessionCredentials build() {
+            return new AwsSessionCredentials(this);
+        }
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
@@ -71,15 +71,21 @@ public final class CredentialUtils {
         // identity-spi defines 2 known types - AwsCredentialsIdentity and a sub-type AwsSessionCredentialsIdentity
         if (awsCredentialsIdentity instanceof AwsSessionCredentialsIdentity) {
             AwsSessionCredentialsIdentity awsSessionCredentialsIdentity = (AwsSessionCredentialsIdentity) awsCredentialsIdentity;
-            return AwsSessionCredentials.create(awsSessionCredentialsIdentity.accessKeyId(),
-                                                awsSessionCredentialsIdentity.secretAccessKey(),
-                                                awsSessionCredentialsIdentity.sessionToken());
+            return AwsSessionCredentials.builder()
+                                        .accessKeyId(awsSessionCredentialsIdentity.accessKeyId())
+                                        .secretAccessKey(awsSessionCredentialsIdentity.secretAccessKey())
+                                        .sessionToken(awsSessionCredentialsIdentity.sessionToken())
+                                        .accountId(awsSessionCredentialsIdentity.accountId().orElse(null))
+                                        .build();
         }
         if (isAnonymous(awsCredentialsIdentity)) {
             return AwsBasicCredentials.ANONYMOUS_CREDENTIALS;
         }
-        return AwsBasicCredentials.create(awsCredentialsIdentity.accessKeyId(),
-                                          awsCredentialsIdentity.secretAccessKey());
+        return AwsBasicCredentials.builder()
+                                  .accessKeyId(awsCredentialsIdentity.accessKeyId())
+                                  .secretAccessKey(awsCredentialsIdentity.secretAccessKey())
+                                  .accountId(awsCredentialsIdentity.accountId().orElse(null))
+                                  .build();
     }
 
     /**

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 public class StaticCredentialsProviderTest {
     @Test
     public void getAwsCredentials_ReturnsSameCredentials() throws Exception {
-        final AwsCredentials credentials = new AwsBasicCredentials("akid", "skid");
+        final AwsCredentials credentials = AwsBasicCredentials.create("akid", "skid");
         final AwsCredentials actualCredentials =
                 StaticCredentialsProvider.create(credentials).resolveCredentials();
         assertEquals(credentials, actualCredentials);

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/AwsSessionCredentialsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/AwsSessionCredentialsTest.java
@@ -16,23 +16,74 @@
 package software.amazon.awssdk.auth.credentials.internal;
 
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.internal.DefaultAwsSessionCredentialsIdentity;
 
 public class AwsSessionCredentialsTest {
 
+    private static final String ACCESS_KEY_ID = "accessKeyId";
+    private static final String SECRET_ACCESS_KEY = "secretAccessKey";
+    private static final String SESSION_TOKEN = "sessionToken";
+    private static final String ACCOUNT_ID = "accountId";
 
     @Test
-    public void equalsHashCode() {
-        AwsSessionCredentials credentials =
-            AwsSessionCredentials.create("test", "key", "sessionToken");
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(DefaultAwsSessionCredentialsIdentity.class)
+                      .verify();
+    }
 
-        AwsSessionCredentials anotherCredentials =
-            AwsSessionCredentials.create("test", "key", "sessionToken");
-        assertThat(credentials).isEqualTo(anotherCredentials);
-        assertThat(credentials.hashCode()).isEqualTo(anotherCredentials.hashCode());
+    @Test
+    public void emptyBuilder_ThrowsException() {
+        assertThrows(NullPointerException.class, () -> AwsSessionCredentialsIdentity.builder().build());
+    }
+
+    @Test
+    public void builderMissingSessionToken_ThrowsException() {
+        assertThrows(NullPointerException.class, () -> AwsSessionCredentialsIdentity.builder()
+                                                                                    .accessKeyId(ACCESS_KEY_ID)
+                                                                                    .secretAccessKey(SECRET_ACCESS_KEY)
+                                                                                    .build());
+    }
+
+    @Test
+    public void builderMissingAccessKeyId_ThrowsException() {
+        assertThrows(NullPointerException.class, () -> AwsSessionCredentialsIdentity.builder()
+                                                                                    .secretAccessKey(SECRET_ACCESS_KEY)
+                                                                                    .sessionToken(SESSION_TOKEN)
+                                                                                    .build());
+    }
+
+    @Test
+    public void create_isSuccessful() {
+        AwsSessionCredentialsIdentity identity = AwsSessionCredentialsIdentity.create(ACCESS_KEY_ID,
+                                                                                      SECRET_ACCESS_KEY,
+                                                                                      SESSION_TOKEN);
+        assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
+        assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
+        assertEquals(SESSION_TOKEN, identity.sessionToken());
+        assertFalse(identity.accountId().isPresent());
+    }
+
+    @Test
+    public void build_isSuccessful() {
+        AwsSessionCredentialsIdentity identity = AwsSessionCredentialsIdentity.builder()
+                                                                              .accessKeyId(ACCESS_KEY_ID)
+                                                                              .secretAccessKey(SECRET_ACCESS_KEY)
+                                                                              .sessionToken(SESSION_TOKEN)
+                                                                              .accountId(ACCOUNT_ID)
+                                                                              .build();
+        assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
+        assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
+        assertEquals(SESSION_TOKEN, identity.sessionToken());
+        assertTrue(identity.accountId().isPresent());
+        assertEquals(ACCOUNT_ID, identity.accountId().get());
     }
 
 }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsSessionCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsSessionCredentialsIdentity.java
@@ -32,14 +32,10 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
 
 
     private DefaultAwsSessionCredentialsIdentity(Builder builder) {
-        this.accessKeyId = builder.accessKeyId;
-        this.secretAccessKey = builder.secretAccessKey;
-        this.sessionToken = builder.sessionToken;
+        this.accessKeyId = Validate.paramNotNull(builder.accessKeyId, "accessKeyId");
+        this.secretAccessKey = Validate.paramNotNull(builder.secretAccessKey, "secretAccessKey");
+        this.sessionToken = Validate.paramNotNull(builder.sessionToken, "sessionToken");
         this.accountId = builder.accountId;
-
-        Validate.paramNotNull(accessKeyId, "accessKeyId");
-        Validate.paramNotNull(secretAccessKey, "secretAccessKey");
-        Validate.paramNotNull(sessionToken, "sessionToken");
     }
 
     public static AwsSessionCredentialsIdentity.Builder builder() {
@@ -86,7 +82,7 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
         return Objects.equals(accessKeyId, that.accessKeyId()) &&
                Objects.equals(secretAccessKey, that.secretAccessKey()) &&
                Objects.equals(sessionToken, that.sessionToken()) &&
-                Objects.equals(accountId, that.accountId().orElse(null));
+               Objects.equals(accountId, that.accountId().orElse(null));
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -635,8 +635,6 @@
                             <!-- Moving the interface methods to new SRA super interfaces causes japicmp to complain -->
                             <exclude>software.amazon.awssdk.auth.credentials.AwsCredentials</exclude>
                             <exclude>software.amazon.awssdk.auth.token.credentials.SdkToken</exclude>
-                            <!-- Removed protected ctor, not used according to internal code usage search -->
-                            <exclude>software.amazon.awssdk.auth.credentials.AwsBasicCredentials</exclude>
                         </excludes>
 
                         <ignoreMissingOldVersion>true</ignoreMissingOldVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,8 @@
                             <!-- Moving the interface methods to new SRA super interfaces causes japicmp to complain -->
                             <exclude>software.amazon.awssdk.auth.credentials.AwsCredentials</exclude>
                             <exclude>software.amazon.awssdk.auth.token.credentials.SdkToken</exclude>
+                            <!-- Removed protected ctor, not used according to internal code usage search -->
+                            <exclude>software.amazon.awssdk.auth.credentials.AwsBasicCredentials</exclude>
                         </excludes>
 
                         <ignoreMissingOldVersion>true</ignoreMissingOldVersion>

--- a/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
+++ b/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
@@ -178,6 +178,7 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
         assertThat(awsCredentials.accessKeyId()).isNotBlank();
         assertThat(awsCredentials.secretAccessKey()).isNotBlank();
+        assertThat(awsCredentials.accountId()).isPresent();
         ((SdkAutoCloseable) awsCredentialsProvider).close();
     }
 
@@ -210,6 +211,7 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
             assertThat(awsCredentials.accessKeyId()).isNotBlank();
             assertThat(awsCredentials.secretAccessKey()).isNotBlank();
+            assertThat(awsCredentials.accountId()).isPresent();
             ((SdkAutoCloseable) awsCredentialsProvider).close();
         });
     }
@@ -247,6 +249,7 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
                 assertThat(awsCredentials.accessKeyId()).isNotBlank();
                 assertThat(awsCredentials.secretAccessKey()).isNotBlank();
+                assertThat(awsCredentials.accountId()).isPresent();
                 ((SdkAutoCloseable) awsCredentialsProvider).close();
             });
         } finally {

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
@@ -31,11 +31,19 @@ final class SessionCredentialsHolder {
     private final AwsSessionCredentials sessionCredentials;
     private final Date sessionCredentialsExpiration;
 
-    SessionCredentialsHolder(Credentials credentials) {
-        this.sessionCredentials = AwsSessionCredentials.create(credentials.accessKeyId(),
-                                                            credentials.secretAccessKey(),
-                                                            credentials.sessionToken());
+    SessionCredentialsHolder(Builder b) {
+        Credentials credentials = b.credentials;
+        this.sessionCredentials = AwsSessionCredentials.builder()
+                                                       .accessKeyId(credentials.accessKeyId())
+                                                       .secretAccessKey(credentials.secretAccessKey())
+                                                       .sessionToken(credentials.sessionToken())
+                                                       .accountId(b.accountId)
+                                                       .build();
         this.sessionCredentialsExpiration = Date.from(credentials.expiration());
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     public AwsSessionCredentials getSessionCredentials() {
@@ -44,5 +52,30 @@ final class SessionCredentialsHolder {
 
     public Date getSessionCredentialsExpiration() {
         return sessionCredentialsExpiration;
+    }
+
+    public static class Builder {
+        private Credentials credentials;
+        private Date expiration;
+        private String accountId;
+
+        public Builder credentials(Credentials credentials) {
+            this.credentials = credentials;
+            return this;
+        }
+
+        public Builder expiration(Date expiration) {
+            this.expiration = expiration;
+            return this;
+        }
+
+        public Builder accountId(String accountId) {
+            this.accountId = accountId;
+            return this;
+        }
+
+        public SessionCredentialsHolder build() {
+            return new SessionCredentialsHolder(this);
+        }
     }
 }

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.sts.auth;
 
+import java.time.Instant;
 import java.util.Date;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
@@ -29,7 +30,7 @@ import software.amazon.awssdk.services.sts.model.Credentials;
 final class SessionCredentialsHolder {
 
     private final AwsSessionCredentials sessionCredentials;
-    private final Date sessionCredentialsExpiration;
+    private final Instant sessionCredentialsExpiration;
 
     SessionCredentialsHolder(Builder b) {
         Credentials credentials = b.credentials;
@@ -39,7 +40,7 @@ final class SessionCredentialsHolder {
                                                        .sessionToken(credentials.sessionToken())
                                                        .accountId(b.accountId)
                                                        .build();
-        this.sessionCredentialsExpiration = Date.from(credentials.expiration());
+        this.sessionCredentialsExpiration = credentials.expiration();
     }
 
     public static Builder builder() {
@@ -50,7 +51,7 @@ final class SessionCredentialsHolder {
         return sessionCredentials;
     }
 
-    public Date getSessionCredentialsExpiration() {
+    public Instant getSessionCredentialsExpiration() {
         return sessionCredentialsExpiration;
     }
 

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.services.sts.auth;
 
 import java.time.Instant;
-import java.util.Date;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -28,7 +27,6 @@ import software.amazon.awssdk.services.sts.model.Credentials;
 @SdkInternalApi
 @ThreadSafe
 final class SessionCredentialsHolder {
-
     private final AwsSessionCredentials sessionCredentials;
     private final Instant sessionCredentialsExpiration;
 
@@ -57,16 +55,10 @@ final class SessionCredentialsHolder {
 
     public static class Builder {
         private Credentials credentials;
-        private Date expiration;
         private String accountId;
 
         public Builder credentials(Credentials credentials) {
             this.credentials = credentials;
-            return this;
-        }
-
-        public Builder expiration(Date expiration) {
-            this.expiration = expiration;
             return this;
         }
 

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
@@ -15,12 +15,16 @@
 
 package software.amazon.awssdk.services.sts.auth;
 
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.accountIdFromArn;
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.fromStsCredentials;
+
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
@@ -65,14 +69,11 @@ public final class StsAssumeRoleCredentialsProvider
     }
 
     @Override
-    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
+    protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleRequest assumeRoleRequest = assumeRoleRequestSupplier.get();
         Validate.notNull(assumeRoleRequest, "Assume role request must not be null.");
         AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(assumeRoleRequest);
-        return SessionCredentialsHolder.builder()
-                                       .credentials(assumeRoleResponse.credentials())
-                                       .accountId(accountIdFromArn(assumeRoleResponse.assumedRoleUser()))
-                                       .build();
+        return fromStsCredentials(assumeRoleResponse.credentials(), accountIdFromArn(assumeRoleResponse.assumedRoleUser()));
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -65,10 +65,14 @@ public final class StsAssumeRoleCredentialsProvider
     }
 
     @Override
-    protected Credentials getUpdatedCredentials(StsClient stsClient) {
+    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleRequest assumeRoleRequest = assumeRoleRequestSupplier.get();
         Validate.notNull(assumeRoleRequest, "Assume role request must not be null.");
-        return stsClient.assumeRole(assumeRoleRequest).credentials();
+        AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(assumeRoleRequest);
+        return SessionCredentialsHolder.builder()
+                                       .credentials(assumeRoleResponse.credentials())
+                                       .accountId(accountIdFromArn(assumeRoleResponse.assumedRoleUser()))
+                                       .build();
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
-import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlResponse;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -66,10 +66,14 @@ public final class StsAssumeRoleWithSamlCredentialsProvider
     }
 
     @Override
-    protected Credentials getUpdatedCredentials(StsClient stsClient) {
+    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithSamlRequest assumeRoleWithSamlRequest = assumeRoleWithSamlRequestSupplier.get();
         Validate.notNull(assumeRoleWithSamlRequest, "Assume role with saml request must not be null.");
-        return stsClient.assumeRoleWithSAML(assumeRoleWithSamlRequest).credentials();
+        AssumeRoleWithSamlResponse assumeRoleResponse = stsClient.assumeRoleWithSAML(assumeRoleWithSamlRequest);
+        return SessionCredentialsHolder.builder()
+                                       .credentials(assumeRoleResponse.credentials())
+                                       .accountId(accountIdFromArn(assumeRoleResponse.assumedRoleUser()))
+                                       .build();
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -15,12 +15,16 @@
 
 package software.amazon.awssdk.services.sts.auth;
 
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.accountIdFromArn;
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.fromStsCredentials;
+
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlResponse;
@@ -66,14 +70,11 @@ public final class StsAssumeRoleWithSamlCredentialsProvider
     }
 
     @Override
-    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
+    protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithSamlRequest assumeRoleWithSamlRequest = assumeRoleWithSamlRequestSupplier.get();
         Validate.notNull(assumeRoleWithSamlRequest, "Assume role with saml request must not be null.");
         AssumeRoleWithSamlResponse assumeRoleResponse = stsClient.assumeRoleWithSAML(assumeRoleWithSamlRequest);
-        return SessionCredentialsHolder.builder()
-                                       .credentials(assumeRoleResponse.credentials())
-                                       .accountId(accountIdFromArn(assumeRoleResponse.assumedRoleUser()))
-                                       .build();
+        return fromStsCredentials(assumeRoleResponse.credentials(), accountIdFromArn(assumeRoleResponse.assumedRoleUser()));
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
-import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -67,10 +67,14 @@ public final class StsAssumeRoleWithWebIdentityCredentialsProvider
     }
 
     @Override
-    protected Credentials getUpdatedCredentials(StsClient stsClient) {
+    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithWebIdentityRequest request = assumeRoleWithWebIdentityRequest.get();
         notNull(request, "AssumeRoleWithWebIdentityRequest can't be null");
-        return stsClient.assumeRoleWithWebIdentity(request).credentials();
+        AssumeRoleWithWebIdentityResponse assumeRoleResponse = stsClient.assumeRoleWithWebIdentity(request);
+        return SessionCredentialsHolder.builder()
+                                       .credentials(assumeRoleResponse.credentials())
+                                       .accountId(accountIdFromArn(assumeRoleResponse.assumedRoleUser()))
+                                       .build();
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sts.auth;
 
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.accountIdFromArn;
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.fromStsCredentials;
 import static software.amazon.awssdk.utils.Validate.notNull;
 
 import java.util.function.Consumer;
@@ -23,6 +25,7 @@ import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
@@ -67,14 +70,11 @@ public final class StsAssumeRoleWithWebIdentityCredentialsProvider
     }
 
     @Override
-    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
+    protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithWebIdentityRequest request = assumeRoleWithWebIdentityRequest.get();
         notNull(request, "AssumeRoleWithWebIdentityRequest can't be null");
         AssumeRoleWithWebIdentityResponse assumeRoleResponse = stsClient.assumeRoleWithWebIdentity(request);
-        return SessionCredentialsHolder.builder()
-                                       .credentials(assumeRoleResponse.credentials())
-                                       .accountId(accountIdFromArn(assumeRoleResponse.assumedRoleUser()))
-                                       .build();
+        return fromStsCredentials(assumeRoleResponse.credentials(), accountIdFromArn(assumeRoleResponse.assumedRoleUser()));
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
@@ -87,7 +87,7 @@ abstract class StsCredentialsProvider implements AwsCredentialsProvider, SdkAuto
      */
     private RefreshResult<SessionCredentialsHolder> updateSessionCredentials() {
         SessionCredentialsHolder credentials = getUpdatedCredentials(stsClient);
-        Instant actualTokenExpiration = credentials.getSessionCredentialsExpiration().toInstant();
+        Instant actualTokenExpiration = credentials.getSessionCredentialsExpiration();
 
         return RefreshResult.builder(credentials)
                             .staleTime(actualTokenExpiration.minus(staleTime))

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
@@ -83,6 +83,7 @@ public class StsGetFederationTokenCredentialsProvider
                   .orElse(null);
     }
 
+    @Override
     public String toString() {
         return ToString.builder("StsGetFederationTokenCredentialsProvider")
                        .add("refreshRequest", getFederationTokenRequest)

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
@@ -15,11 +15,14 @@
 
 package software.amazon.awssdk.services.sts.auth;
 
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.fromStsCredentials;
+
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.endpoints.internal.Arn;
 import software.amazon.awssdk.services.sts.model.FederatedUser;
@@ -66,12 +69,9 @@ public class StsGetFederationTokenCredentialsProvider
     }
 
     @Override
-    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
+    protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         GetFederationTokenResponse federationToken = stsClient.getFederationToken(getFederationTokenRequest);
-        return SessionCredentialsHolder.builder()
-                                       .credentials(federationToken.credentials())
-                                       .accountId(accountIdFromArn(federationToken.federatedUser()))
-                                       .build();
+        return fromStsCredentials(federationToken.credentials(), accountIdFromArn(federationToken.federatedUser()));
     }
 
     private String accountIdFromArn(FederatedUser federatedUser) {

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
@@ -21,8 +21,8 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.model.Credentials;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenRequest;
+import software.amazon.awssdk.services.sts.model.GetSessionTokenResponse;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -64,8 +64,11 @@ public class StsGetSessionTokenCredentialsProvider
     }
 
     @Override
-    protected Credentials getUpdatedCredentials(StsClient stsClient) {
-        return stsClient.getSessionToken(getSessionTokenRequest).credentials();
+    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
+        GetSessionTokenResponse sessionToken = stsClient.getSessionToken(getSessionTokenRequest);
+        return SessionCredentialsHolder.builder()
+                                       .credentials(sessionToken.credentials())
+                                       .build();
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
@@ -15,11 +15,14 @@
 
 package software.amazon.awssdk.services.sts.auth;
 
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.fromStsCredentials;
+
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenRequest;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenResponse;
@@ -64,11 +67,9 @@ public class StsGetSessionTokenCredentialsProvider
     }
 
     @Override
-    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
+    protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         GetSessionTokenResponse sessionToken = stsClient.getSessionToken(getSessionTokenRequest);
-        return SessionCredentialsHolder.builder()
-                                       .credentials(sessionToken.credentials())
-                                       .build();
+        return fromStsCredentials(sessionToken.credentials());
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sts.auth;
 
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.accountIdFromArn;
+import static software.amazon.awssdk.services.sts.internal.StsAuthUtils.fromStsCredentials;
 import static software.amazon.awssdk.utils.StringUtils.trim;
 import static software.amazon.awssdk.utils.Validate.notNull;
 
@@ -25,6 +27,7 @@ import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.internal.WebIdentityTokenCredentialProperties;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -140,14 +143,12 @@ public final class StsWebIdentityTokenFileCredentialsProvider
     }
 
     @Override
-    protected SessionCredentialsHolder getUpdatedCredentials(StsClient stsClient) {
+    protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithWebIdentityRequest request = assumeRoleWithWebIdentityRequest.get();
         notNull(request, "AssumeRoleWithWebIdentityRequest can't be null");
         AssumeRoleWithWebIdentityResponse assumeRoleWithWebIdentityResponse = stsClient.assumeRoleWithWebIdentity(request);
-        return SessionCredentialsHolder.builder()
-                                       .credentials(assumeRoleWithWebIdentityResponse.credentials())
-                                       .accountId(accountIdFromArn(assumeRoleWithWebIdentityResponse.assumedRoleUser()))
-                                       .build();
+        return fromStsCredentials(assumeRoleWithWebIdentityResponse.credentials(),
+                                  accountIdFromArn(assumeRoleWithWebIdentityResponse.assumedRoleUser()));
     }
 
     @Override

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
@@ -28,7 +28,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.internal.WebIdentityTokenCredentialProperties;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.endpoints.internal.Arn;
 import software.amazon.awssdk.services.sts.internal.AssumeRoleWithWebIdentityRequestSupplier;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
@@ -147,9 +147,7 @@ public final class StsWebIdentityTokenFileCredentialsProvider
         AssumeRoleWithWebIdentityResponse assumeRoleWithWebIdentityResponse = stsClient.assumeRoleWithWebIdentity(request);
         return SessionCredentialsHolder.builder()
                                        .credentials(assumeRoleWithWebIdentityResponse.credentials())
-                                       .accountId(Arn.parse(assumeRoleWithWebIdentityResponse.assumedRoleUser().arn())
-                                                     .map(Arn::accountId)
-                                                     .orElse(null))
+                                       .accountId(accountIdFromArn(assumeRoleWithWebIdentityResponse.assumedRoleUser()))
                                        .build();
     }
 

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsAuthUtils.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsAuthUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.sts.endpoints.internal.Arn;
+import software.amazon.awssdk.services.sts.model.AssumedRoleUser;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+@SdkInternalApi
+public final class StsAuthUtils {
+
+    private StsAuthUtils() {
+    }
+
+    public static String accountIdFromArn(AssumedRoleUser assumedRoleUser) {
+        if (assumedRoleUser == null) {
+            return null;
+        }
+        return Arn.parse(assumedRoleUser.arn())
+                  .map(Arn::accountId)
+                  .orElse(null);
+    }
+
+    public static AwsSessionCredentials fromStsCredentials(Credentials credentials) {
+        return fromStsCredentials(credentials, null);
+    }
+
+    public static AwsSessionCredentials fromStsCredentials(Credentials credentials, String accountId) {
+        return AwsSessionCredentials.builder()
+                                    .accessKeyId(credentials.accessKeyId())
+                                    .secretAccessKey(credentials.secretAccessKey())
+                                    .sessionToken(credentials.sessionToken())
+                                    .accountId(accountId)
+                                    .expiration(credentials.expiration())
+                                    .build();
+    }
+}

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProviderTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.sts.auth;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.AssumedRoleUser;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 /**
@@ -32,7 +33,10 @@ public class StsAssumeRoleCredentialsProviderTest extends StsCredentialsProvider
 
     @Override
     protected AssumeRoleResponse getResponse(Credentials credentials) {
-        return AssumeRoleResponse.builder().credentials(credentials).build();
+        return AssumeRoleResponse.builder()
+                                 .credentials(credentials)
+                                 .assumedRoleUser(AssumedRoleUser.builder().arn(ARN).build())
+                                 .build();
     }
 
     @Override

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithSamlCredentialsProvider.Builder;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlResponse;
+import software.amazon.awssdk.services.sts.model.AssumedRoleUser;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 /**
@@ -35,7 +36,10 @@ public class StsAssumeRoleWithSamlCredentialsProviderTest
 
     @Override
     protected AssumeRoleWithSamlResponse getResponse(Credentials credentials) {
-        return AssumeRoleWithSamlResponse.builder().credentials(credentials).build();
+        return AssumeRoleWithSamlResponse.builder()
+                                         .credentials(credentials)
+                                         .assumedRoleUser(AssumedRoleUser.builder().arn(ARN).build())
+                                         .build();
     }
 
     @Override

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProviderTest.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithWebIdentityCredentialsProvider.Builder;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
+import software.amazon.awssdk.services.sts.model.AssumedRoleUser;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 /**
@@ -34,7 +35,10 @@ public class StsAssumeRoleWithWebIdentityCredentialsProviderTest
 
     @Override
     protected AssumeRoleWithWebIdentityResponse getResponse(Credentials credentials) {
-        return AssumeRoleWithWebIdentityResponse.builder().credentials(credentials).build();
+        return AssumeRoleWithWebIdentityResponse.builder()
+                                                .credentials(credentials)
+                                                .assumedRoleUser(AssumedRoleUser.builder().arn(ARN).build())
+                                                .build();
     }
 
     @Override

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.endpoints.internal.Arn;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 /**
@@ -38,6 +39,8 @@ import software.amazon.awssdk.services.sts.model.Credentials;
  */
 @ExtendWith(MockitoExtension.class)
 public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
+
+    protected static final String ARN = "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0e9801d129EXAMPLE";
     @Mock
     protected StsClient stsClient;
 
@@ -102,7 +105,6 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
         Credentials credentials = Credentials.builder().accessKeyId("a").secretAccessKey("b").sessionToken("c").expiration(credentialsExpirationDate).build();
         RequestT request = getRequest();
         ResponseT response = getResponse(credentials);
-
         when(callClient(stsClient, request)).thenReturn(response);
 
         StsCredentialsProvider.BaseBuilder<?, ? extends StsCredentialsProvider> credentialsProviderBuilder = createCredentialsProviderBuilder(request);
@@ -129,6 +131,10 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
                 assertThat(providedCredentials.accessKeyId()).isEqualTo("a");
                 assertThat(providedCredentials.secretAccessKey()).isEqualTo("b");
                 assertThat(providedCredentials.sessionToken()).isEqualTo("c");
+                if (!(credentialsProvider instanceof StsGetSessionTokenCredentialsProvider)) {
+                    assertThat(providedCredentials.accountId().isPresent());
+                    assertThat(providedCredentials.accountId().get()).isEqualTo("123456789012");
+                }
             }
         }
     }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProviderTest.java
@@ -17,7 +17,9 @@ package software.amazon.awssdk.services.sts.auth;
 
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetFederationTokenCredentialsProvider.Builder;
+import software.amazon.awssdk.services.sts.model.AssumedRoleUser;
 import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.FederatedUser;
 import software.amazon.awssdk.services.sts.model.GetFederationTokenRequest;
 import software.amazon.awssdk.services.sts.model.GetFederationTokenResponse;
 
@@ -34,7 +36,10 @@ public class StsGetFederationTokenCredentialsProviderTest
 
     @Override
     protected GetFederationTokenResponse getResponse(Credentials credentials) {
-        return GetFederationTokenResponse.builder().credentials(credentials).build();
+        return GetFederationTokenResponse.builder()
+                                         .credentials(credentials)
+                                         .federatedUser(FederatedUser.builder().arn(ARN).build())
+                                         .build();
     }
 
     @Override

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProviderTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sts.auth;
 
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider.Builder;
+import software.amazon.awssdk.services.sts.model.AssumedRoleUser;
 import software.amazon.awssdk.services.sts.model.Credentials;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenRequest;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenResponse;
@@ -34,7 +35,9 @@ public class StsGetSessionTokenCredentialsProviderTest
 
     @Override
     protected GetSessionTokenResponse getResponse(Credentials credentials) {
-        return GetSessionTokenResponse.builder().credentials(credentials).build();
+        return GetSessionTokenResponse.builder()
+                                      .credentials(credentials)
+                                      .build();
     }
 
     @Override

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialsProviderBaseTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialsProviderBaseTest.java
@@ -29,13 +29,14 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider.Builder;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
+import software.amazon.awssdk.services.sts.model.AssumedRoleUser;
 import software.amazon.awssdk.services.sts.model.Credentials;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.IoUtils;
 
 /**
- * Validate the functionality of {@link StsWebIdentityTokenFileCredentialsProvider}. Inherits tests from {@link
- * StsCredentialsProviderTestBase}.
+ * Validate the functionality of {@link StsWebIdentityTokenFileCredentialsProvider}. Inherits tests from
+ * {@link StsCredentialsProviderTestBase}.
  */
 public class StsWebIdentityTokenCredentialsProviderBaseTest
     extends StsCredentialsProviderTestBase<AssumeRoleWithWebIdentityRequest, AssumeRoleWithWebIdentityResponse> {
@@ -44,7 +45,7 @@ public class StsWebIdentityTokenCredentialsProviderBaseTest
 
 
     @BeforeEach
-    public   void setUp() {
+    public void setUp() {
         String webIdentityTokenPath = Paths.get("src/test/resources/token.jwt").toAbsolutePath().toString();
         ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_ROLE_ARN.environmentVariable(), "someRole");
         ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE.environmentVariable(), webIdentityTokenPath);
@@ -52,7 +53,7 @@ public class StsWebIdentityTokenCredentialsProviderBaseTest
     }
 
     @AfterEach
-    public void cleanUp(){
+    public void cleanUp() {
         ENVIRONMENT_VARIABLE_HELPER.reset();
     }
 
@@ -64,7 +65,10 @@ public class StsWebIdentityTokenCredentialsProviderBaseTest
 
     @Override
     protected AssumeRoleWithWebIdentityResponse getResponse(Credentials credentials) {
-        return AssumeRoleWithWebIdentityResponse.builder().credentials(credentials).build();
+        return AssumeRoleWithWebIdentityResponse.builder()
+                                                .credentials(credentials)
+                                                .assumedRoleUser(AssumedRoleUser.builder().arn(ARN).build())
+                                                .build();
     }
 
     @Override

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/endpoint-rule-set.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/endpoint-rule-set.json
@@ -27,6 +27,11 @@
             "documentation": "Override the endpoint used to send this request",
             "type": "String"
         },
+        "awsAccountId": {
+            "type": "String",
+            "builtIn": "AWS::Auth::AccountId",
+            "required": false
+        },
         "StaticStringParam": {
             "type": "String",
             "required": false

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AccountIdParameterTests.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AccountIdParameterTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.endpointproviders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.awscore.AwsExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersClient;
+import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJsonEndpointProvidersEndpointParams;
+import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJsonEndpointProvidersEndpointProvider;
+
+public class AccountIdParameterTests {
+
+    private static RestJsonEndpointProvidersEndpointProvider mockEndpointProvider;
+    private static SdkHttpClient mockHttpClient;
+
+    @BeforeAll
+    public static void setup() {
+        mockEndpointProvider = mock(RestJsonEndpointProvidersEndpointProvider.class);
+        mockHttpClient = mock(SdkHttpClient.class);
+        when(mockHttpClient.clientName()).thenReturn("MockHttpClient");
+        when(mockHttpClient.prepareRequest(any())).thenThrow(new RuntimeException("boom"));
+        when(mockEndpointProvider.resolveEndpoint(any(RestJsonEndpointProvidersEndpointParams.class)))
+            .thenReturn(CompletableFuture.completedFuture(Endpoint.builder()
+                                                                  .url(URI.create("https://my-service.com"))
+                                                                  .build()));
+    }
+
+    @Test
+    public void accountId_isResolvedToValue_whenEndpointResolverIsCalled_NOTWORKING() {
+        CapturingInterceptor executionAttributeCaptor = new CapturingInterceptor();
+        RestJsonEndpointProvidersClient client =
+            RestJsonEndpointProvidersClient.builder()
+                                           .endpointProvider(mockEndpointProvider)
+                                           .httpClient(mockHttpClient)
+                                           .region(Region.US_WEST_2)
+                                           .credentialsProvider(credentialsWithAccountId())
+                                           .overrideConfiguration(c -> c.addExecutionInterceptor(executionAttributeCaptor))
+                                           .build();
+
+        assertThatThrownBy(() -> client.operationWithNoInputOrOutput(r -> {})).hasMessageContaining("boom");
+
+
+        ArgumentCaptor<RestJsonEndpointProvidersEndpointParams> paramsCaptor = ArgumentCaptor.forClass(RestJsonEndpointProvidersEndpointParams.class);
+        verify(mockEndpointProvider).resolveEndpoint(paramsCaptor.capture());
+
+        assertThat(executionAttributeCaptor.accountIdBeforeMarshalling()).isNotNull();
+
+        RestJsonEndpointProvidersEndpointParams resolvedEndpointParams = paramsCaptor.getValue();
+        // TODO: this assertion should test for a non-null value after core logic is re-ordered
+        assertThat(resolvedEndpointParams.awsAccountId()).isNull();
+    }
+
+    private static AwsCredentialsProvider credentialsWithAccountId() {
+        return () -> AwsSessionCredentials.builder()
+                                          .accessKeyId("akid")
+                                          .secretAccessKey("skid")
+                                          .sessionToken("token")
+                                          .accountId("accountId")
+                                          .build();
+    }
+
+    private static class CapturingInterceptor implements ExecutionInterceptor {
+        String accountId;
+
+        public String accountIdBeforeMarshalling() {
+            return accountId;
+        }
+
+        @Override
+        public void beforeMarshalling(Context.BeforeMarshalling context, ExecutionAttributes executionAttributes) {
+            this.accountId = executionAttributes.getAttribute(AwsExecutionAttribute.AWS_AUTH_ACCOUNT_ID);
+        }
+    };
+
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AccountIdParameterTests.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AccountIdParameterTests.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
-import org.junit.Test;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;


### PR DESCRIPTION
## Motivation and Context
STS provides accountId in the ARN of the assumedRoleUser included in its response objects. This PR extracts that accountId, if present, and adds it to the credentials identity. 

Resolving credentials end-to-end should work once credentials are resolved before the endpoint.

## Modifications
- Added accountId to `AwsBasicCredentials` and `AwsSessionCredentials` since the credentials providers use those classes. 
- Modified STS providers to find accountId in the response and add it to the returned credentials

## Testing
Added codegen classes test to verify that the accountId is available to the endpoint resolution logic. Because we currently resolve the endpoint before we resolve credentials, this test is not working. 
