### PR TITLE
Add AuthScheme sub-interfaces

### DIFF
--- a/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtS3V4aHttpAuthScheme.java
+++ b/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtS3V4aHttpAuthScheme.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.crt;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.HttpAuthScheme;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * The <a href="https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4-trait">aws.auth#sigv4</a>
+ * auth scheme, which uses a {@link AwsCredentialsIdentity} and {@link AwsCrtV4aHttpSigner}.
+ */
+@SdkPublicApi
+public interface AwsCrtS3V4aHttpAuthScheme extends HttpAuthScheme<AwsCredentialsIdentity> {
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return "aws.auth#sigv4";
+    }
+
+    /**
+     * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    /**
+     * Retrieve the {@link AwsCrtV4aHttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    default AwsCrtV4aHttpSigner signer() {
+        return AwsCrtV4aHttpSigner.create();
+    }
+}

--- a/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtS3V4aHttpAuthScheme.java
+++ b/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtS3V4aHttpAuthScheme.java
@@ -51,4 +51,12 @@ public interface AwsCrtS3V4aHttpAuthScheme extends HttpAuthScheme<AwsCredentials
     default AwsCrtV4aHttpSigner signer() {
         return AwsCrtV4aHttpSigner.create();
     }
+
+    /**
+     * Get a default implementation of a {@link AwsCrtS3V4aHttpAuthScheme}
+     */
+    static AwsCrtS3V4aHttpAuthScheme create() {
+        return new AwsCrtS3V4aHttpAuthScheme() {
+        };
+    }
 }

--- a/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtV4aHttpAuthScheme.java
+++ b/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtV4aHttpAuthScheme.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.crt;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.HttpAuthScheme;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * The <a href="https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4-trait">aws.auth#sigv4</a>
+ * auth scheme, which uses a {@link AwsCredentialsIdentity} and {@link AwsCrtV4aHttpSigner}.
+ */
+@SdkPublicApi
+public interface AwsCrtV4aHttpAuthScheme extends HttpAuthScheme<AwsCredentialsIdentity> {
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return "aws.auth#sigv4";
+    }
+
+    /**
+     * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    /**
+     * Retrieve the {@link AwsCrtV4aHttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    default AwsCrtV4aHttpSigner signer() {
+        return AwsCrtV4aHttpSigner.create();
+    }
+}

--- a/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtV4aHttpAuthScheme.java
+++ b/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/AwsCrtV4aHttpAuthScheme.java
@@ -51,4 +51,12 @@ public interface AwsCrtV4aHttpAuthScheme extends HttpAuthScheme<AwsCredentialsId
     default AwsCrtV4aHttpSigner signer() {
         return AwsCrtV4aHttpSigner.create();
     }
+
+    /**
+     * Get a default implementation of a {@link AwsCrtV4aHttpAuthScheme}
+     */
+    static AwsCrtV4aHttpAuthScheme create() {
+        return new AwsCrtV4aHttpAuthScheme() {
+        };
+    }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsS3V4HttpAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsS3V4HttpAuthScheme.java
@@ -51,4 +51,12 @@ public interface AwsS3V4HttpAuthScheme extends HttpAuthScheme<AwsCredentialsIden
     default AwsS3V4HttpSigner signer() {
         return AwsS3V4HttpSigner.create();
     }
+
+    /**
+     * Get a default implementation of a {@link AwsS3V4HttpAuthScheme}
+     */
+    static AwsS3V4HttpAuthScheme create() {
+        return new AwsS3V4HttpAuthScheme() {
+        };
+    }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsS3V4HttpAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsS3V4HttpAuthScheme.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.HttpAuthScheme;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * The <a href="https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4-trait">aws.auth#sigv4</a>
+ * auth scheme, which uses a {@link AwsCredentialsIdentity} and {@link AwsS3V4HttpSigner}.
+ */
+@SdkPublicApi
+public interface AwsS3V4HttpAuthScheme extends HttpAuthScheme<AwsCredentialsIdentity> {
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return "aws.auth#sigv4";
+    }
+
+    /**
+     * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    /**
+     * Retrieve the {@link AwsS3V4HttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    default AwsS3V4HttpSigner signer() {
+        return AwsS3V4HttpSigner.create();
+    }
+}

--- a/core/http-auth-event-stream/src/main/java/software/amazon/awssdk/http/auth/eventstream/AwsV4EventStreamHttpAuthScheme.java
+++ b/core/http-auth-event-stream/src/main/java/software/amazon/awssdk/http/auth/eventstream/AwsV4EventStreamHttpAuthScheme.java
@@ -51,4 +51,12 @@ public interface AwsV4EventStreamHttpAuthScheme extends HttpAuthScheme<AwsCreden
     default AwsV4EventStreamHttpSigner signer() {
         return AwsV4EventStreamHttpSigner.create();
     }
+
+    /**
+     * Get a default implementation of a {@link AwsV4EventStreamHttpAuthScheme}
+     */
+    static AwsV4EventStreamHttpAuthScheme create() {
+        return new AwsV4EventStreamHttpAuthScheme() {
+        };
+    }
 }

--- a/core/http-auth-event-stream/src/main/java/software/amazon/awssdk/http/auth/eventstream/AwsV4EventStreamHttpAuthScheme.java
+++ b/core/http-auth-event-stream/src/main/java/software/amazon/awssdk/http/auth/eventstream/AwsV4EventStreamHttpAuthScheme.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.eventstream;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.HttpAuthScheme;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * The <a href="https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4-trait">aws.auth#sigv4</a>
+ * auth scheme, which uses a {@link AwsCredentialsIdentity} and {@link AwsV4EventStreamHttpSigner}.
+ */
+@SdkPublicApi
+public interface AwsV4EventStreamHttpAuthScheme extends HttpAuthScheme<AwsCredentialsIdentity> {
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return "aws.auth#sigv4";
+    }
+
+    /**
+     * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    /**
+     * Retrieve the {@link AwsV4EventStreamHttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    default AwsV4EventStreamHttpSigner signer() {
+        return AwsV4EventStreamHttpSigner.create();
+    }
+}

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4HttpAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4HttpAuthScheme.java
@@ -51,4 +51,12 @@ public interface AwsV4HttpAuthScheme extends HttpAuthScheme<AwsCredentialsIdenti
     default AwsV4HttpSigner signer() {
         return AwsV4HttpSigner.create();
     }
+
+    /**
+     * Get a default implementation of a {@link AwsV4HttpAuthScheme}
+     */
+    static AwsV4HttpAuthScheme create() {
+        return new AwsV4HttpAuthScheme() {
+        };
+    }
 }

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4HttpAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4HttpAuthScheme.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.HttpAuthScheme;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * The <a href="https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4-trait">aws.auth#sigv4</a>
+ * auth scheme, which uses a {@link AwsCredentialsIdentity} and {@link AwsV4HttpSigner}.
+ */
+@SdkPublicApi
+public interface AwsV4HttpAuthScheme extends HttpAuthScheme<AwsCredentialsIdentity> {
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return "aws.auth#sigv4";
+    }
+
+    /**
+     * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    /**
+     * Retrieve the {@link AwsV4HttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    default AwsV4HttpSigner signer() {
+        return AwsV4HttpSigner.create();
+    }
+}

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4QueryHttpAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4QueryHttpAuthScheme.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.HttpAuthScheme;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * The <a href="https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4-trait">aws.auth#sigv4</a>
+ * auth scheme, which uses a {@link AwsCredentialsIdentity} and {@link AwsV4QueryHttpSigner}.
+ */
+@SdkPublicApi
+public interface AwsV4QueryHttpAuthScheme extends HttpAuthScheme<AwsCredentialsIdentity> {
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return "aws.auth#sigv4";
+    }
+
+    /**
+     * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    /**
+     * Retrieve the {@link AwsV4QueryHttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    default AwsV4QueryHttpSigner signer() {
+        return AwsV4QueryHttpSigner.create();
+    }
+}

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4QueryHttpAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4QueryHttpAuthScheme.java
@@ -51,4 +51,12 @@ public interface AwsV4QueryHttpAuthScheme extends HttpAuthScheme<AwsCredentialsI
     default AwsV4QueryHttpSigner signer() {
         return AwsV4QueryHttpSigner.create();
     }
+
+    /**
+     * Get a default implementation of a {@link AwsV4QueryHttpAuthScheme}
+     */
+    static AwsV4QueryHttpAuthScheme create() {
+        return new AwsV4QueryHttpAuthScheme() {
+        };
+    }
 }

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerHttpAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerHttpAuthScheme.java
@@ -51,4 +51,12 @@ public interface BearerHttpAuthScheme extends HttpAuthScheme<TokenIdentity> {
     default BearerHttpSigner signer() {
         return BearerHttpSigner.create();
     }
+
+    /**
+     * Get a default implementation of a {@link BearerHttpAuthScheme}
+     */
+    static BearerHttpAuthScheme create() {
+        return new BearerHttpAuthScheme() {
+        };
+    }
 }

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerHttpAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerHttpAuthScheme.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.HttpAuthScheme;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.TokenIdentity;
+
+/**
+ * The <a href="https://smithy.io/2.0/spec/authentication-traits.html#httpbearerauth-trait">smithy.api#httpBearerAuth</a>
+ * auth scheme, which uses a {@link TokenIdentity} and {@link BearerHttpSigner}.
+ */
+@SdkPublicApi
+public interface BearerHttpAuthScheme extends HttpAuthScheme<TokenIdentity> {
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return "smithy.api#httpBearerAuth";
+    }
+
+    /**
+     * Retrieve the {@link TokenIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<TokenIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(TokenIdentity.class);
+    }
+
+    /**
+     * Retrieve the {@link BearerHttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    default BearerHttpSigner signer() {
+        return BearerHttpSigner.create();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
Added AuthScheme sub-interfaces. All methods have default implementation. So for the default class, just created anonymous inner class within `create()`. I think, this can be moved to a named class if/when we want to later.

There is no `public interface AnonymousAuthScheme extends HttpAuthScheme<Void> {` as noted in the design doc. HttpAuthScheme's generic type is defined as `<T extends Identity>`, so `Void` can't be used. I think we may not need an actual sub-type of this interface for the anonymous use case.

**Note**: There will be some upcoming refactoring - dropping Http from some type names, moving the S3 specific interfaces to s3 module and possibly combining some signers. But those will happen separately, and signers and AuthScheme will be updated at the same time later. So want to get initial version of all the AuthSchemes interfaces in atleast, so other logic can refer to them.