### PR TITLE
Fix bug where enum values could not be null

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/EnumAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/EnumAttributeConverter.java
@@ -62,6 +62,9 @@ public class EnumAttributeConverter<T extends Enum<T>> implements AttributeConve
 
     @Override
     public T transformTo(AttributeValue input) {
+        if(input.nul()){
+            return null;
+        }
         Validate.isTrue(input.s() != null, "Cannot convert non-string value to enum.");
         T returnValue = enumValueMap.get(input.s());
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/EnumAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/EnumAttributeConverter.java
@@ -62,7 +62,7 @@ public class EnumAttributeConverter<T extends Enum<T>> implements AttributeConve
 
     @Override
     public T transformTo(AttributeValue input) {
-        if(input.nul()){
+        if(input.nul() != null && input.nul()){
             return null;
         }
         Validate.isTrue(input.s() != null, "Cannot convert non-string value to enum.");


### PR DESCRIPTION
This fixes https://github.com/aws/aws-sdk-java-v2/issues/4043

## Motivation and Context
An enum-field can also be null. This works when saving the enum but fails on read, so currently if you set an enum-field to null you create a record in the database which can not be read again. Also the error message is misleading since the problem is not a wrong type.

## Modifications
When an enum is null the object can still be correctly read from the database. Other types still throw an error as would be expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
