### PR TITLE
Paginated methods returning publisher or iterable implement logic in …

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/CommonGeneratorTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/CommonGeneratorTasks.java
@@ -28,6 +28,6 @@ class CommonGeneratorTasks extends CompositeGeneratorTask {
               new ModelClassGeneratorTasks(params),
               new PackageInfoGeneratorTasks(params),
               new BaseExceptionClassGeneratorTasks(params),
-              new ClientOptionsClassGeneratorTasks(params));
+              new CommonInternalGeneratorTasks(params));
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/CommonInternalGeneratorTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/CommonInternalGeneratorTasks.java
@@ -15,26 +15,35 @@
 
 package software.amazon.awssdk.codegen.emitters.tasks;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import software.amazon.awssdk.codegen.emitters.GeneratorTask;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
 import software.amazon.awssdk.codegen.emitters.PoetGeneratorTask;
 import software.amazon.awssdk.codegen.poet.client.SdkClientOptions;
+import software.amazon.awssdk.codegen.poet.common.UserAgentUtilsSpec;
 
-public class ClientOptionsClassGeneratorTasks extends BaseGeneratorTasks {
+public class CommonInternalGeneratorTasks extends BaseGeneratorTasks {
     private final GeneratorTaskParams params;
 
-    public ClientOptionsClassGeneratorTasks(GeneratorTaskParams params) {
+    public CommonInternalGeneratorTasks(GeneratorTaskParams params) {
         super(params);
         this.params = params;
     }
 
     @Override
     protected List<GeneratorTask> createTasks() throws Exception {
-        return Collections.singletonList(
-            new PoetGeneratorTask(clientOptionsDir(), params.getModel().getFileHeader(), new SdkClientOptions(params.getModel()))
-        );
+        return Arrays.asList(createClientOptionTask(), createUserAgentTask());
+    }
+
+    private PoetGeneratorTask createClientOptionTask() {
+        return new PoetGeneratorTask(clientOptionsDir(), params.getModel().getFileHeader(),
+                                         new SdkClientOptions(params.getModel()));
+    }
+
+    private PoetGeneratorTask createUserAgentTask() {
+        return new PoetGeneratorTask(clientOptionsDir(), params.getModel().getFileHeader(),
+                                     new UserAgentUtilsSpec(params.getModel()));
     }
 
     private String clientOptionsDir() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtension.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtension.java
@@ -73,6 +73,10 @@ public class PoetExtension {
                                            + model.getMetadata().getServiceName() + "ServiceClientConfiguration");
     }
 
+    public ClassName getUserAgentClass() {
+        return ClassName.get(model.getMetadata().getFullClientInternalPackageName(), "UserAgentUtils");
+    }
+
     /**
      * @param operationName Name of the operation
      * @return A Poet {@link ClassName} for the response type of a paginated operation in the base service package.

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -24,7 +24,6 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.internal.Constant.EVENT_PUBLISHER_PARAM_NAME;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.addS3ArnableFieldCode;
-import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applyPaginatorUserAgentMethod;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applySignerOverrideMethod;
 import static software.amazon.awssdk.codegen.poet.client.SyncClientClass.getProtocolSpecs;
 
@@ -155,10 +154,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
             .addMethod(protocolSpec.initProtocolFactory(model))
             .addMethod(resolveMetricPublishersMethod());
 
-        if (model.hasPaginators()) {
-            type.addMethod(applyPaginatorUserAgentMethod(poetExtensions, model));
-        }
-
         if (model.containsRequestSigners() || model.containsRequestEventStreams() || hasStreamingV4AuthOperations()) {
             type.addMethod(applySignerOverrideMethod(poetExtensions, model));
             type.addMethod(isSignerOverriddenOnClientMethod());
@@ -196,9 +191,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
     private Stream<MethodSpec> operations(OperationModel opModel) {
         List<MethodSpec> methods = new ArrayList<>();
         methods.add(traditionalMethod(opModel));
-        if (opModel.isPaginated()) {
-            methods.add(paginatedTraditionalMethod(opModel));
-        }
         return methods.stream();
     }
 
@@ -418,14 +410,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
                .endControlFlow();
 
         return builder;
-    }
-
-    @Override
-    protected MethodSpec.Builder paginatedMethodBody(MethodSpec.Builder builder, OperationModel opModel) {
-        return builder.addModifiers(PUBLIC)
-                      .addStatement("return new $T(this, applyPaginatorUserAgent($L))",
-                                    poetExtensions.getResponseClassForPaginatedAsyncOperation(opModel.getOperationName()),
-                                    opModel.getInput().getVariableName());
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
@@ -42,7 +42,6 @@ import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
-import software.amazon.awssdk.codegen.utils.PaginatorUtils;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.utils.Validate;
 
@@ -171,9 +170,6 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
     private Stream<MethodSpec> operations(OperationModel opModel) {
         List<MethodSpec> methods = new ArrayList<>();
         methods.add(traditionalMethod(opModel));
-        if (opModel.isPaginated()) {
-            methods.add(paginatedTraditionalMethod(opModel));
-        }
         return methods.stream();
     }
 
@@ -210,14 +206,6 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
                              parameters.isEmpty() ? "" : additionalParameters);
 
         return builder;
-    }
-
-    @Override
-    protected MethodSpec.Builder paginatedMethodBody(MethodSpec.Builder builder, OperationModel opModel) {
-        String methodName = PaginatorUtils.getPaginatedMethodName(opModel.getMethodName());
-        return builder.addModifiers(PUBLIC)
-                      .addAnnotation(Override.class)
-                      .addStatement("return delegate.$N($N)", methodName, opModel.getInput().getVariableName());
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -21,7 +21,6 @@ import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.addS3ArnableFieldCode;
-import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applyPaginatorUserAgentMethod;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applySignerOverrideMethod;
 
 import com.squareup.javapoet.ClassName;
@@ -34,10 +33,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
-import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
@@ -50,7 +49,6 @@ import software.amazon.awssdk.codegen.poet.client.specs.JsonProtocolSpec;
 import software.amazon.awssdk.codegen.poet.client.specs.ProtocolSpec;
 import software.amazon.awssdk.codegen.poet.client.specs.QueryProtocolSpec;
 import software.amazon.awssdk.codegen.poet.client.specs.XmlProtocolSpec;
-import software.amazon.awssdk.codegen.utils.PaginatorUtils;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
@@ -113,10 +111,6 @@ public class SyncClientClass extends SyncClientInterface {
 
     @Override
     protected void addAdditionalMethods(TypeSpec.Builder type) {
-
-        if (model.hasPaginators()) {
-            type.addMethod(applyPaginatorUserAgentMethod(poetExtensions, model));
-        }
 
         if (model.containsRequestSigners()) {
             type.addMethod(applySignerOverrideMethod(poetExtensions, model));
@@ -210,14 +204,17 @@ public class SyncClientClass extends SyncClientInterface {
         return model.getOperations().values().stream()
                     .filter(o -> !o.hasEventStreamInput())
                     .filter(o -> !o.hasEventStreamOutput())
-                    .map(this::operationMethodSpecs)
-                    .flatMap(List::stream)
+                    .flatMap(this::operations)
                     .collect(Collectors.toList());
     }
 
-    private List<MethodSpec> operationMethodSpecs(OperationModel opModel) {
+    private Stream<MethodSpec> operations(OperationModel opModel) {
         List<MethodSpec> methods = new ArrayList<>();
+        methods.add(traditionalMethod(opModel));
+        return methods.stream();
+    }
 
+    private MethodSpec traditionalMethod(OperationModel opModel) {
         MethodSpec.Builder method = SyncClientInterface.operationMethodSignature(model, opModel)
                                                        .addAnnotation(Override.class)
                                                        .addCode(ClientClassUtils.callApplySignerOverrideMethod(opModel))
@@ -297,34 +294,7 @@ public class SyncClientClass extends SyncClientInterface {
               .addStatement("metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()))")
               .endControlFlow();
 
-        methods.add(method.build());
-
-        methods.addAll(paginatedMethods(opModel));
-
-        return methods;
-    }
-
-    @Override
-    protected List<MethodSpec> paginatedMethods(OperationModel opModel) {
-        List<MethodSpec> paginatedMethodSpecs = new ArrayList<>();
-
-        if (opModel.isPaginated()) {
-            paginatedMethodSpecs.add(SyncClientInterface.operationMethodSignature(model,
-                                                                                  opModel,
-                                                                                  SimpleMethodOverload.PAGINATED,
-                                                                                  PaginatorUtils.getPaginatedMethodName(
-                                                                                      opModel.getMethodName()))
-                                                        .addAnnotation(Override.class)
-                                                        .returns(poetExtensions.getResponseClassForPaginatedSyncOperation(
-                                                            opModel.getOperationName()))
-                                                        .addStatement("return new $T(this, applyPaginatorUserAgent($L))",
-                                                                      poetExtensions.getResponseClassForPaginatedSyncOperation(
-                                                                          opModel.getOperationName()),
-                                                                      opModel.getInput().getVariableName())
-                                                        .build());
-        }
-
-        return paginatedMethodSpecs;
+        return method.build();
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -176,16 +177,6 @@ public class SyncClientInterface implements ClassSpec {
                          .build();
     }
 
-    protected Iterable<MethodSpec> operations() {
-        return model.getOperations().values().stream()
-                    // TODO Sync not supported for event streaming yet. Revisit after sync/async merge
-                    .filter(o -> !o.hasEventStreamInput())
-                    .filter(o -> !o.hasEventStreamOutput())
-                    .map(this::operationMethodSpec)
-                    .flatMap(List::stream)
-                    .collect(toList());
-    }
-
     private MethodSpec serviceMetadata() {
         return MethodSpec.methodBuilder("serviceMetadata")
                          .returns(ServiceMetadata.class)
@@ -194,31 +185,36 @@ public class SyncClientInterface implements ClassSpec {
                          .build();
     }
 
-    private List<MethodSpec> operationMethodSpec(OperationModel opModel) {
+    protected Iterable<MethodSpec> operations() {
+        return model.getOperations().values().stream()
+                    // TODO Sync not supported for event streaming yet. Revisit after sync/async merge
+                    .filter(o -> !o.hasEventStreamInput())
+                    .filter(o -> !o.hasEventStreamOutput())
+                    .flatMap(this::operationsWithVariants)
+                    .collect(toList());
+    }
+
+    private Stream<MethodSpec> operationsWithVariants(OperationModel opModel) {
         List<MethodSpec> methods = new ArrayList<>();
-
-        if (opModel.getInputShape().isSimpleMethod()) {
-            methods.add(simpleMethod(opModel));
-        }
-
-        methods.addAll(operation(opModel));
-
-        methods.addAll(streamingSimpleMethods(opModel));
+        methods.addAll(traditionalMethodWithConsumerVariant(opModel));
+        methods.addAll(overloadedMethods(opModel));
         methods.addAll(paginatedMethods(opModel));
 
         return methods.stream()
                       // Add Deprecated annotation if needed to all overloads
-                      .map(m -> DeprecationUtils.checkDeprecated(opModel, m))
-                      .collect(toList());
+                      .map(m -> DeprecationUtils.checkDeprecated(opModel, m));
     }
 
-    private MethodSpec simpleMethod(OperationModel opModel) {
-        ClassName requestType = ClassName.get(model.getMetadata().getFullModelPackageName(),
-                                              opModel.getInput().getVariableType());
-        return operationSimpleMethodSignature(model, opModel, opModel.getMethodName())
-            .addStatement("return $L($T.builder().build())", opModel.getMethodName(), requestType)
-            .addJavadoc(opModel.getDocs(model, ClientType.SYNC, SimpleMethodOverload.NO_ARG))
-            .build();
+    private List<MethodSpec> traditionalMethodWithConsumerVariant(OperationModel opModel) {
+        List<MethodSpec> methods = new ArrayList<>();
+
+        MethodSpec.Builder builder = operationMethodSignature(model, opModel);
+        MethodSpec method = operationBody(builder, opModel).build();
+        methods.add(method);
+
+        addConsumerMethod(methods, method, SimpleMethodOverload.NORMAL, opModel);
+
+        return methods;
     }
 
     private static MethodSpec.Builder operationBaseSignature(IntermediateModel model,
@@ -242,18 +238,6 @@ public class SyncClientInterface implements ClassSpec {
         streamingMethod(methodBuilder, opModel, responseType);
 
         return methodBuilder;
-    }
-
-    private List<MethodSpec> operation(OperationModel opModel) {
-        List<MethodSpec> methods = new ArrayList<>();
-
-        MethodSpec.Builder builder = operationMethodSignature(model, opModel);
-        MethodSpec method = operationBody(builder, opModel).build();
-        methods.add(method);
-
-        addConsumerMethod(methods, method, SimpleMethodOverload.NORMAL, opModel);
-
-        return methods;
     }
 
     protected MethodSpec.Builder operationBody(MethodSpec.Builder builder, OperationModel opModel) {
@@ -328,8 +312,10 @@ public class SyncClientInterface implements ClassSpec {
     }
 
     protected MethodSpec.Builder paginatedMethodBody(MethodSpec.Builder builder, OperationModel operationModel) {
-        return builder.addModifiers(DEFAULT)
-                      .addStatement("throw new $T()", UnsupportedOperationException.class);
+        return builder.addModifiers(DEFAULT, PUBLIC)
+                      .addStatement("return new $T(this, $L)",
+                                    poetExtensions.getResponseClassForPaginatedSyncOperation(operationModel.getOperationName()),
+                                    operationModel.getInput().getVariableName());
     }
 
     private static void streamingMethod(MethodSpec.Builder methodBuilder, OperationModel opModel, TypeName responseType) {
@@ -344,14 +330,20 @@ public class SyncClientInterface implements ClassSpec {
         }
     }
 
-    private List<MethodSpec> streamingSimpleMethods(OperationModel opModel) {
+    /**
+     * @param opModel Operation to generate simple methods for.
+     * @return All simple method overloads for a given operation.
+     */
+    private List<MethodSpec> overloadedMethods(OperationModel opModel) {
         TypeName responseType = ClassName.get(model.getMetadata().getFullModelPackageName(),
                                               opModel.getReturnType().getReturnType());
         ClassName requestType = ClassName.get(model.getMetadata().getFullModelPackageName(),
                                               opModel.getInput().getVariableType());
 
         List<MethodSpec> simpleMethods = new ArrayList<>();
-
+        if (opModel.getInputShape().isSimpleMethod()) {
+            simpleMethods.add(simpleMethodWithNoArgs(opModel));
+        }
         if (opModel.hasStreamingInput() && opModel.hasStreamingOutput()) {
             MethodSpec simpleMethod = streamingInputOutputFileSimpleMethod(opModel, responseType, requestType);
             simpleMethods.add(simpleMethod);
@@ -376,6 +368,15 @@ public class SyncClientInterface implements ClassSpec {
         }
 
         return simpleMethods;
+    }
+
+    private MethodSpec simpleMethodWithNoArgs(OperationModel opModel) {
+        ClassName requestType = ClassName.get(model.getMetadata().getFullModelPackageName(),
+                                              opModel.getInput().getVariableType());
+        return operationSimpleMethodSignature(model, opModel, opModel.getMethodName())
+            .addStatement("return $L($T.builder().build())", opModel.getMethodName(), requestType)
+            .addJavadoc(opModel.getDocs(model, ClientType.SYNC, SimpleMethodOverload.NO_ARG))
+            .build();
     }
 
     protected void addConsumerMethod(List<MethodSpec> specs, MethodSpec spec, SimpleMethodOverload overload,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/common/UserAgentUtilsSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/common/UserAgentUtilsSpec.java
@@ -23,6 +23,7 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import java.util.function.Consumer;
 import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
@@ -48,6 +49,7 @@ public class UserAgentUtilsSpec implements ClassSpec {
         return TypeSpec.classBuilder(className())
                        .addModifiers(Modifier.PUBLIC)
                        .addAnnotation(PoetUtils.generatedAnnotation())
+                       .addAnnotation(SdkInternalApi.class)
                        .addMethod(privateConstructor())
                        .addMethod(applyUserAgentInfoMethod())
                        .addMethod(applyPaginatorUserAgentMethod())

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/common/UserAgentUtilsSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/common/UserAgentUtilsSpec.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.common;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeVariableName;
+import java.util.function.Consumer;
+import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.PoetExtension;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.core.ApiName;
+import software.amazon.awssdk.core.util.VersionInfo;
+
+public class UserAgentUtilsSpec implements ClassSpec {
+
+    private static final String PAGINATOR_USER_AGENT = "PAGINATED";
+
+    protected final IntermediateModel model;
+    protected final PoetExtension poetExtensions;
+
+    public UserAgentUtilsSpec(IntermediateModel model) {
+        this.model = model;
+        this.poetExtensions = new PoetExtension(model);
+    }
+
+    @Override
+    public TypeSpec poetSpec() {
+        return TypeSpec.classBuilder(className())
+                       .addModifiers(Modifier.PUBLIC)
+                       .addAnnotation(PoetUtils.generatedAnnotation())
+                       .addMethod(privateConstructor())
+                       .addMethod(applyUserAgentInfoMethod())
+                       .addMethod(applyPaginatorUserAgentMethod())
+                       .build();
+    }
+
+    @Override
+    public ClassName className() {
+        return poetExtensions.getUserAgentClass();
+    }
+
+    protected MethodSpec privateConstructor() {
+        return MethodSpec.constructorBuilder()
+                         .addModifiers(Modifier.PRIVATE)
+                         .build();
+    }
+
+    private MethodSpec applyUserAgentInfoMethod() {
+
+        TypeVariableName typeVariableName =
+            TypeVariableName.get("T", poetExtensions.getModelClass(model.getSdkRequestBaseClassName()));
+
+        ParameterizedTypeName parameterizedTypeName = ParameterizedTypeName
+            .get(ClassName.get(Consumer.class), ClassName.get(AwsRequestOverrideConfiguration.Builder.class));
+
+        CodeBlock codeBlock = CodeBlock.builder()
+                                       .addStatement("$T overrideConfiguration =\n"
+                                                     + "            request.overrideConfiguration().map(c -> c.toBuilder()"
+                                                     + ".applyMutation"
+                                                     + "(userAgentApplier).build())\n"
+                                                     + "            .orElse((AwsRequestOverrideConfiguration.builder()"
+                                                     + ".applyMutation"
+                                                     + "(userAgentApplier).build()))", AwsRequestOverrideConfiguration.class)
+                                       .addStatement("return (T) request.toBuilder().overrideConfiguration"
+                                                     + "(overrideConfiguration).build()")
+                                       .build();
+
+        return MethodSpec.methodBuilder("applyUserAgentInfo")
+                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                         .addParameter(typeVariableName, "request")
+                         .addParameter(parameterizedTypeName, "userAgentApplier")
+                         .addTypeVariable(typeVariableName)
+                         .addCode(codeBlock)
+                         .returns(typeVariableName)
+                         .build();
+    }
+
+    private MethodSpec applyPaginatorUserAgentMethod() {
+        TypeVariableName typeVariableName =
+            TypeVariableName.get("T", poetExtensions.getModelClass(model.getSdkRequestBaseClassName()));
+
+        return MethodSpec.methodBuilder("applyPaginatorUserAgent")
+                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                         .addParameter(typeVariableName, "request")
+                         .addTypeVariable(typeVariableName)
+                         .addStatement("return applyUserAgentInfo(request, b -> b.addApiName($T.builder()"
+                                       + ".version($T.SDK_VERSION)"
+                                       + ".name($S)"
+                                       + ".build()))",
+                                       ApiName.class,
+                                       VersionInfo.class,
+                                       PAGINATOR_USER_AGENT)
+                         .returns(typeVariableName)
+                         .build();
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/AsyncResponseClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/AsyncResponseClassSpec.java
@@ -128,7 +128,10 @@ public class AsyncResponseClassSpec extends PaginatorsClassSpec {
                          .addParameter(requestType(), REQUEST_MEMBER)
                          .addParameter(boolean.class, LAST_PAGE_FIELD)
                          .addStatement("this.$L = $L", CLIENT_MEMBER, CLIENT_MEMBER)
-                         .addStatement("this.$L = $L", REQUEST_MEMBER, REQUEST_MEMBER)
+                         .addStatement("this.$L = $T.applyPaginatorUserAgent($L)",
+                                       REQUEST_MEMBER,
+                                       poetExtensions.getUserAgentClass(),
+                                       REQUEST_MEMBER)
                          .addStatement("this.$L = $L", LAST_PAGE_FIELD, LAST_PAGE_FIELD)
                          .addStatement("this.$L = new $L()", NEXT_PAGE_FETCHER_MEMBER, nextPageFetcherClassName())
                          .build();
@@ -246,4 +249,5 @@ public class AsyncResponseClassSpec extends PaginatorsClassSpec {
                                             .addCode(nextPageMethodBody())
                                             .build());
     }
+
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/SyncResponseClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/SyncResponseClassSpec.java
@@ -104,7 +104,10 @@ public class SyncResponseClassSpec extends PaginatorsClassSpec {
                          .addParameter(getClientInterfaceName(), CLIENT_MEMBER)
                          .addParameter(requestType(), REQUEST_MEMBER)
                          .addStatement("this.$L = $L", CLIENT_MEMBER, CLIENT_MEMBER)
-                         .addStatement("this.$L = $L", REQUEST_MEMBER, REQUEST_MEMBER)
+                         .addStatement("this.$L = $T.applyPaginatorUserAgent($L)",
+                                       REQUEST_MEMBER,
+                                       poetExtensions.getUserAgentClass(),
+                                       REQUEST_MEMBER)
                          .addStatement("this.$L = new $L()", NEXT_PAGE_FETCHER_MEMBER, nextPageFetcherClassName())
                 .build();
     }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/common/UserAgentClassSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/common/UserAgentClassSpecTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.ClientTestModels;
+import software.amazon.awssdk.codegen.poet.common.UserAgentUtilsSpec;
+
+public class UserAgentClassSpecTest {
+
+    @Test
+    public void testGeneratedResponseForSyncOperations() {
+        ClassSpec useragentspec = new UserAgentUtilsSpec(ClientTestModels.restJsonServiceModels());
+        assertThat(useragentspec, generatesTo("test-user-agent-class.java"));
+    }
+
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
@@ -41,8 +41,6 @@ import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationR
 import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher;
 import software.amazon.awssdk.utils.Validate;
 
 @Generated("software.amazon.awssdk:codegen")
@@ -335,84 +333,6 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     }
 
     /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
-     * SDK will internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
-     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
-     * failures only after you start streaming the data. The subscribe method should be called as a request to start
-     * streaming data. For more info, see
-     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
-     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
-     * starting request.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to use the response class:
-     * </p>
-     * 1) Using the subscribe helper method
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
-     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
-     * future.get();
-     * }
-     * </pre>
-     *
-     * 2) Using a custom subscriber
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
-     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse>() {
-     *
-     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
-     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response) { //... };
-     * });}
-     * </pre>
-     *
-     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithResultKeyRequest
-     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
-     *         The CompletableFuture returned by this method can be completed exceptionally with the following
-     *         exceptions.
-     *         <ul>
-     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
-     *         Can be used for catch all scenarios.</li>
-     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
-     *         credentials, etc.</li>
-     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
-     *         of this type.</li>
-     *         </ul>
-     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
-        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
-    }
-
-    /**
      * Some paginated operation without result_key in paginators.json file
      *
      * @param paginatedOperationWithoutResultKeyRequest
@@ -437,84 +357,6 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
         return invokeOperation(paginatedOperationWithoutResultKeyRequest,
                                request -> delegate.paginatedOperationWithoutResultKey(request));
-    }
-
-    /**
-     * Some paginated operation without result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
-     * SDK will internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
-     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
-     * failures only after you start streaming the data. The subscribe method should be called as a request to start
-     * streaming data. For more info, see
-     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
-     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
-     * starting request.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to use the response class:
-     * </p>
-     * 1) Using the subscribe helper method
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
-     * future.get();
-     * }
-     * </pre>
-     *
-     * 2) Using a custom subscriber
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse>() {
-     *
-     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
-     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response) { //... };
-     * });}
-     * </pre>
-     *
-     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithoutResultKeyRequest
-     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
-     *         The CompletableFuture returned by this method can be completed exceptionally with the following
-     *         exceptions.
-     *         <ul>
-     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
-     *         Can be used for catch all scenarios.</li>
-     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
-     *         credentials, etc.</li>
-     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
-     *         of this type.</li>
-     *         </ul>
-     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
-        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
@@ -1,12 +1,9 @@
 package software.amazon.awssdk.services.json;
 
-import java.nio.file.Path;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.ResponseBytes;
-import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -38,8 +35,6 @@ import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationR
 import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable;
 import software.amazon.awssdk.utils.Validate;
 
 @Generated("software.amazon.awssdk:codegen")
@@ -71,11 +66,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
      * @sample JsonClient.APostOperation
      * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
      *      API Documentation</a>
-     *
-     * @deprecated This API is deprecated, use something else
      */
     @Override
-    @Deprecated
     public APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
                                                                                                      AwsServiceException, SdkClientException, JsonException {
         return invokeOperation(aPostOperationRequest, request -> delegate.aPostOperation(request));
@@ -206,28 +198,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
     /**
      * Some paginated operation with result_key in paginators.json file
      *
-     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see #paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey() throws AwsServiceException,
-                                                                                            SdkClientException, JsonException {
-        return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder().build());
-    }
-
-    /**
-     * Some paginated operation with result_key in paginators.json file
-     *
      * @param paginatedOperationWithResultKeyRequest
      * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
      * @throws SdkException
@@ -247,161 +217,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
                                                                                               SdkClientException, JsonException {
         return invokeOperation(paginatedOperationWithResultKeyRequest,
                                request -> delegate.paginatedOperationWithResultKey(request));
-    }
-
-    /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client
-     *             .paginatedOperationWithResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see #paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator() throws AwsServiceException,
-                                                                                                     SdkClientException, JsonException {
-        return paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest.builder().build());
-    }
-
-    /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client
-     *             .paginatedOperationWithResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithResultKeyRequest
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
-                                                                                              SdkClientException, JsonException {
-        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
     }
 
     /**
@@ -426,84 +241,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
                                                                                                     SdkClientException, JsonException {
         return invokeOperation(paginatedOperationWithoutResultKeyRequest,
                                request -> delegate.paginatedOperationWithoutResultKey(request));
-    }
-
-    /**
-     * Some paginated operation without result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client
-     *             .paginatedOperationWithoutResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithoutResultKeyRequest
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithoutResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
-                                                                                                    SdkClientException, JsonException {
-        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
     }
 
     /**
@@ -557,49 +294,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
     }
 
     /**
-     * Invokes the PutOperationWithChecksum operation.
-     *
-     * @param putOperationWithChecksumRequest
-     * @param sourcePath
-     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
-     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
-     *        access to read it then an exception will be thrown. The service documentation for the request content is
-     *        as follows '
-     *        <p>
-     *        Object data.
-     *        </p>
-     *        '
-     * @param destinationPath
-     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
-     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
-     *        The service documentation for the response content is as follows '
-     *        <p>
-     *        Object data.
-     *        </p>
-     *        '.
-     * @return The transformed result of the ResponseTransformer.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PutOperationWithChecksum
-     * @see #putOperationWithChecksum(PutOperationWithChecksumRequest, RequestBody)
-     * @see #putOperationWithChecksum(PutOperationWithChecksumRequest, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PutOperationWithChecksum"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PutOperationWithChecksumResponse putOperationWithChecksum(
-        PutOperationWithChecksumRequest putOperationWithChecksumRequest, Path sourcePath, Path destinationPath)
-        throws AwsServiceException, SdkClientException, JsonException {
-        return putOperationWithChecksum(putOperationWithChecksumRequest, RequestBody.fromFile(sourcePath),
-                                        ResponseTransformer.toFile(destinationPath));
-    }
-
-    /**
      * Some operation with a streaming input
      *
      * @param streamingInputOperationRequest
@@ -630,34 +324,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
                                                                    RequestBody requestBody) throws AwsServiceException, SdkClientException, JsonException {
         return invokeOperation(streamingInputOperationRequest, request -> delegate.streamingInputOperation(request, requestBody));
-    }
-
-    /**
-     * Some operation with a streaming input
-     *
-     * @param streamingInputOperationRequest
-     * @param sourcePath
-     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
-     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
-     *        access to read it then an exception will be thrown. The service documentation for the request content is
-     *        as follows 'This be a stream'
-     * @return Result of the StreamingInputOperation operation returned by the service.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingInputOperation
-     * @see #streamingInputOperation(StreamingInputOperationRequest, RequestBody)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
-                                                                   Path sourcePath) throws AwsServiceException, SdkClientException, JsonException {
-        return streamingInputOperation(streamingInputOperationRequest, RequestBody.fromFile(sourcePath));
     }
 
     /**
@@ -704,41 +370,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
     }
 
     /**
-     * Some operation with streaming input and streaming output
-     *
-     * @param streamingInputOutputOperationRequest
-     * @param sourcePath
-     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
-     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
-     *        access to read it then an exception will be thrown. The service documentation for the request content is
-     *        as follows 'This be a stream'
-     * @param destinationPath
-     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
-     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
-     *        The service documentation for the response content is as follows 'This be a stream'.
-     * @return The transformed result of the ResponseTransformer.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingInputOutputOperation
-     * @see #streamingInputOutputOperation(StreamingInputOutputOperationRequest, RequestBody)
-     * @see #streamingInputOutputOperation(StreamingInputOutputOperationRequest, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public StreamingInputOutputOperationResponse streamingInputOutputOperation(
-        StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, Path sourcePath, Path destinationPath)
-        throws AwsServiceException, SdkClientException, JsonException {
-        return streamingInputOutputOperation(streamingInputOutputOperationRequest, RequestBody.fromFile(sourcePath),
-                                             ResponseTransformer.toFile(destinationPath));
-    }
-
-    /**
      * Some operation with a streaming output
      *
      * @param streamingOutputOperationRequest
@@ -769,89 +400,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
                                request -> delegate.streamingOutputOperation(request, responseTransformer));
     }
 
-    /**
-     * Some operation with a streaming output
-     *
-     * @param streamingOutputOperationRequest
-     * @param destinationPath
-     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
-     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
-     *        The service documentation for the response content is as follows 'This be a stream'.
-     * @return The transformed result of the ResponseTransformer.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingOutputOperation
-     * @see #streamingOutputOperation(StreamingOutputOperationRequest, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public StreamingOutputOperationResponse streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest, Path destinationPath) throws AwsServiceException,
-                                                                                                      SdkClientException, JsonException {
-        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toFile(destinationPath));
-    }
-
-    /**
-     * Some operation with a streaming output
-     *
-     * @param streamingOutputOperationRequest
-     * @return A {@link ResponseInputStream} containing data streamed from service. Note that this is an unmanaged
-     *         reference to the underlying HTTP connection so great care must be taken to ensure all data if fully read
-     *         from the input stream and that it is properly closed. Failure to do so may result in sub-optimal behavior
-     *         and exhausting connections in the connection pool. The unmarshalled response object can be obtained via
-     *         {@link ResponseInputStream#response()}. The service documentation for the response content is as follows
-     *         'This be a stream'.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingOutputOperation
-     * @see #getObject(streamingOutputOperation, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
-                                                                                JsonException {
-        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toInputStream());
-    }
-
-    /**
-     * Some operation with a streaming output
-     *
-     * @param streamingOutputOperationRequest
-     * @return A {@link ResponseBytes} that loads the data streamed from the service into memory and exposes it in
-     *         convenient in-memory representations like a byte buffer or string. The unmarshalled response object can
-     *         be obtained via {@link ResponseBytes#response()}. The service documentation for the response content is
-     *         as follows 'This be a stream'.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingOutputOperation
-     * @see #getObject(streamingOutputOperation, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationAsBytes(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
-                                                                                JsonException {
-        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toBytes());
-    }
 
     /**
      * Creates an instance of {@link JsonUtilities} object with the configuration set on this client.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -23,7 +23,6 @@ import software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransf
 import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionJsonMarshaller;
 import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionPojoSupplier;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkPojoBuilder;
 import software.amazon.awssdk.core.SdkResponse;
@@ -44,7 +43,6 @@ import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
-import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -91,8 +89,6 @@ import software.amazon.awssdk.services.json.model.StreamingOutputOperationRespon
 import software.amazon.awssdk.services.json.model.inputeventstream.DefaultInputEvent;
 import software.amazon.awssdk.services.json.model.inputeventstreamtwo.DefaultInputEventOne;
 import software.amazon.awssdk.services.json.model.inputeventstreamtwo.DefaultInputEventTwo;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher;
 import software.amazon.awssdk.services.json.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.EventStreamOperationRequestMarshaller;
@@ -740,83 +736,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     }
 
     /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
-     * SDK will internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
-     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
-     * failures only after you start streaming the data. The subscribe method should be called as a request to start
-     * streaming data. For more info, see
-     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
-     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
-     * starting request.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to use the response class:
-     * </p>
-     * 1) Using the subscribe helper method
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
-     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
-     * future.get();
-     * }
-     * </pre>
-     *
-     * 2) Using a custom subscriber
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
-     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse>() {
-     *
-     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
-     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response) { //... };
-     * });}
-     * </pre>
-     *
-     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithResultKeyRequest
-     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
-     *         The CompletableFuture returned by this method can be completed exceptionally with the following
-     *         exceptions.
-     *         <ul>
-     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
-     *         Can be used for catch all scenarios.</li>
-     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
-     *         credentials, etc.</li>
-     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
-     *         of this type.</li>
-     *         </ul>
-     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    public PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
-        return new PaginatedOperationWithResultKeyPublisher(this, applyPaginatorUserAgent(paginatedOperationWithResultKeyRequest));
-    }
-
-    /**
      * Some paginated operation without result_key in paginators.json file
      *
      * @param paginatedOperationWithoutResultKeyRequest
@@ -870,84 +789,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
-    }
-
-    /**
-     * Some paginated operation without result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
-     * SDK will internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
-     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
-     * failures only after you start streaming the data. The subscribe method should be called as a request to start
-     * streaming data. For more info, see
-     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
-     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
-     * starting request.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to use the response class:
-     * </p>
-     * 1) Using the subscribe helper method
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
-     * future.get();
-     * }
-     * </pre>
-     *
-     * 2) Using a custom subscriber
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse>() {
-     *
-     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
-     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response) { //... };
-     * });}
-     * </pre>
-     *
-     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithoutResultKeyRequest
-     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
-     *         The CompletableFuture returned by this method can be completed exceptionally with the following
-     *         exceptions.
-     *         <ul>
-     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
-     *         Can be used for catch all scenarios.</li>
-     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
-     *         credentials, etc.</li>
-     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
-     *         of this type.</li>
-     *         </ul>
-     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    public PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
-        return new PaginatedOperationWithoutResultKeyPublisher(this,
-                                                               applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
     }
 
     /**
@@ -1217,15 +1058,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             publishers = Collections.emptyList();
         }
         return publishers;
-    }
-
-    private <T extends JsonRequest> T applyPaginatorUserAgent(T request) {
-        Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
-                                                                                                      .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     private <T extends JsonRequest> T applySignerOverride(T request, Signer signer) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
@@ -5,15 +5,12 @@ import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
@@ -21,7 +18,6 @@ import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.metrics.CoreMetric;
-import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -34,7 +30,6 @@ import software.amazon.awssdk.services.querytojsoncompatible.model.APostOperatio
 import software.amazon.awssdk.services.querytojsoncompatible.model.APostOperationResponse;
 import software.amazon.awssdk.services.querytojsoncompatible.model.InvalidInputException;
 import software.amazon.awssdk.services.querytojsoncompatible.model.QueryToJsonCompatibleException;
-import software.amazon.awssdk.services.querytojsoncompatible.model.QueryToJsonCompatibleRequest;
 import software.amazon.awssdk.services.querytojsoncompatible.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.HostnameValidator;
@@ -163,15 +158,6 @@ final class DefaultQueryToJsonCompatibleAsyncClient implements QueryToJsonCompat
             publishers = Collections.emptyList();
         }
         return publishers;
-    }
-
-    private <T extends QueryToJsonCompatibleRequest> T applyPaginatorUserAgent(T request) {
-        Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
-                                                                                                      .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
@@ -2,13 +2,10 @@ package software.amazon.awssdk.services.querytojsoncompatible;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
@@ -17,7 +14,6 @@ import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.metrics.CoreMetric;
-import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -30,7 +26,6 @@ import software.amazon.awssdk.services.querytojsoncompatible.model.APostOperatio
 import software.amazon.awssdk.services.querytojsoncompatible.model.APostOperationResponse;
 import software.amazon.awssdk.services.querytojsoncompatible.model.InvalidInputException;
 import software.amazon.awssdk.services.querytojsoncompatible.model.QueryToJsonCompatibleException;
-import software.amazon.awssdk.services.querytojsoncompatible.model.QueryToJsonCompatibleRequest;
 import software.amazon.awssdk.services.querytojsoncompatible.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.utils.HostnameValidator;
 import software.amazon.awssdk.utils.Logger;
@@ -112,15 +107,6 @@ final class DefaultQueryToJsonCompatibleClient implements QueryToJsonCompatibleC
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
-    }
-
-    private <T extends QueryToJsonCompatibleRequest> T applyPaginatorUserAgent(T request) {
-        Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
-                                                                                                      .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionJsonMars
 import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionPojoSupplier;
 import software.amazon.awssdk.awscore.eventstream.RestEventStreamAsyncResponseTransformer;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.CredentialType;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkPojoBuilder;
@@ -48,7 +47,6 @@ import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
-import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -98,8 +96,6 @@ import software.amazon.awssdk.services.json.model.StreamingOutputOperationRespon
 import software.amazon.awssdk.services.json.model.inputeventstream.DefaultInputEvent;
 import software.amazon.awssdk.services.json.model.inputeventstreamtwo.DefaultInputEventOne;
 import software.amazon.awssdk.services.json.model.inputeventstreamtwo.DefaultInputEventTwo;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher;
 import software.amazon.awssdk.services.json.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.BearerAuthOperationRequestMarshaller;
@@ -818,83 +814,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     }
 
     /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
-     * SDK will internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
-     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
-     * failures only after you start streaming the data. The subscribe method should be called as a request to start
-     * streaming data. For more info, see
-     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
-     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
-     * starting request.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to use the response class:
-     * </p>
-     * 1) Using the subscribe helper method
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
-     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
-     * future.get();
-     * }
-     * </pre>
-     *
-     * 2) Using a custom subscriber
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
-     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse>() {
-     *
-     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
-     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response) { //... };
-     * });}
-     * </pre>
-     *
-     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithResultKeyRequest
-     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
-     *         The CompletableFuture returned by this method can be completed exceptionally with the following
-     *         exceptions.
-     *         <ul>
-     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
-     *         Can be used for catch all scenarios.</li>
-     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
-     *         credentials, etc.</li>
-     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
-     *         of this type.</li>
-     *         </ul>
-     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    public PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
-        return new PaginatedOperationWithResultKeyPublisher(this, applyPaginatorUserAgent(paginatedOperationWithResultKeyRequest));
-    }
-
-    /**
      * Some paginated operation without result_key in paginators.json file
      *
      * @param paginatedOperationWithoutResultKeyRequest
@@ -948,84 +867,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
-    }
-
-    /**
-     * Some paginated operation without result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
-     * SDK will internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
-     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
-     * failures only after you start streaming the data. The subscribe method should be called as a request to start
-     * streaming data. For more info, see
-     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
-     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
-     * starting request.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to use the response class:
-     * </p>
-     * 1) Using the subscribe helper method
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
-     * future.get();
-     * }
-     * </pre>
-     *
-     * 2) Using a custom subscriber
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse>() {
-     *
-     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
-     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response) { //... };
-     * });}
-     * </pre>
-     *
-     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithoutResultKeyRequest
-     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
-     *         The CompletableFuture returned by this method can be completed exceptionally with the following
-     *         exceptions.
-     *         <ul>
-     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
-     *         Can be used for catch all scenarios.</li>
-     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
-     *         credentials, etc.</li>
-     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
-     *         of this type.</li>
-     *         </ul>
-     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    public PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
-        return new PaginatedOperationWithoutResultKeyPublisher(this,
-                                                               applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
     }
 
     /**
@@ -1394,15 +1235,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             publishers = Collections.emptyList();
         }
         return publishers;
-    }
-
-    private <T extends JsonRequest> T applyPaginatorUserAgent(T request) {
-        Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
-                                                                                                      .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     private <T extends JsonRequest> T applySignerOverride(T request, Signer signer) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -838,7 +838,7 @@ public interface JsonAsyncClient extends AwsClient {
      */
     default PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
-        throw new UnsupportedOperationException();
+        return new PaginatedOperationWithResultKeyPublisher(this, paginatedOperationWithResultKeyRequest);
     }
 
     /**
@@ -1056,7 +1056,7 @@ public interface JsonAsyncClient extends AwsClient {
      */
     default PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
-        throw new UnsupportedOperationException();
+        return new PaginatedOperationWithoutResultKeyPublisher(this, paginatedOperationWithoutResultKeyRequest);
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -10,7 +10,6 @@ import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.CredentialType;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -27,7 +26,6 @@ import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
-import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -63,8 +61,6 @@ import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationR
 import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable;
 import software.amazon.awssdk.services.json.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.BearerAuthOperationRequestMarshaller;
@@ -460,84 +456,6 @@ final class DefaultJsonClient implements JsonClient {
     }
 
     /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client
-     *             .paginatedOperationWithResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithResultKeyRequest
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
-                                                                                              SdkClientException, JsonException {
-        return new PaginatedOperationWithResultKeyIterable(this, applyPaginatorUserAgent(paginatedOperationWithResultKeyRequest));
-    }
-
-    /**
      * Some paginated operation without result_key in paginators.json file
      *
      * @param paginatedOperationWithoutResultKeyRequest
@@ -582,85 +500,6 @@ final class DefaultJsonClient implements JsonClient {
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
-    }
-
-    /**
-     * Some paginated operation without result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client
-     *             .paginatedOperationWithoutResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithoutResultKeyRequest
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithoutResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
-                                                                                                    SdkClientException, JsonException {
-        return new PaginatedOperationWithoutResultKeyIterable(this,
-                                                              applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
     }
 
     /**
@@ -947,15 +786,6 @@ final class DefaultJsonClient implements JsonClient {
     @Override
     public JsonUtilities utilities() {
         return JsonUtilities.create(param1, param2, param3);
-    }
-
-    private <T extends JsonRequest> T applyPaginatorUserAgent(T request) {
-        Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
-                                                                                                      .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     private <T extends JsonRequest> T applySignerOverride(T request, Signer signer) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -394,27 +394,6 @@ public interface JsonClient extends AwsClient {
     /**
      * Some paginated operation with result_key in paginators.json file
      *
-     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see #paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey() throws AwsServiceException,
-                                                                                             SdkClientException, JsonException {
-        return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder().build());
-    }
-
-    /**
-     * Some paginated operation with result_key in paginators.json file
-     *
      * @param paginatedOperationWithResultKeyRequest
      * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
      * @throws SdkException
@@ -461,6 +440,27 @@ public interface JsonClient extends AwsClient {
         throws AwsServiceException, SdkClientException, JsonException {
         return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder()
                                                                                      .applyMutation(paginatedOperationWithResultKeyRequest).build());
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see #paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey() throws AwsServiceException,
+                                                                                             SdkClientException, JsonException {
+        return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder().build());
     }
 
     /**
@@ -613,7 +613,7 @@ public interface JsonClient extends AwsClient {
     default PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
-        throw new UnsupportedOperationException();
+        return new PaginatedOperationWithResultKeyIterable(this, paginatedOperationWithResultKeyRequest);
     }
 
     /**
@@ -825,7 +825,7 @@ public interface JsonClient extends AwsClient {
     default PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
-        throw new UnsupportedOperationException();
+        return new PaginatedOperationWithoutResultKeyIterable(this, paginatedOperationWithoutResultKeyRequest);
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-user-agent-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-user-agent-class.java
@@ -1,0 +1,27 @@
+package software.amazon.awssdk.services.json.internal;
+
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.ApiName;
+import software.amazon.awssdk.core.util.VersionInfo;
+import software.amazon.awssdk.services.json.model.JsonRequest;
+
+@Generated("software.amazon.awssdk:codegen")
+public class UserAgentUtils {
+    private UserAgentUtils() {
+    }
+
+    public static <T extends JsonRequest> T applyUserAgentInfo(T request,
+                                                               Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier) {
+        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
+                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
+                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
+        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
+    }
+
+    public static <T extends JsonRequest> T applyPaginatorUserAgent(T request) {
+        return applyUserAgentInfo(request,
+                                  b -> b.addApiName(ApiName.builder().version(VersionInfo.SDK_VERSION).name("PAGINATED").build()));
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyIterable.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyIterable.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.core.pagination.sync.SyncPageFetcher;
 import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient;
+import software.amazon.awssdk.services.jsonprotocoltests.internal.UserAgentUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.jsonprotocoltests.model.SimpleStruct;
@@ -83,7 +84,7 @@ public class PaginatedOperationWithResultKeyIterable implements SdkIterable<Pagi
     public PaginatedOperationWithResultKeyIterable(JsonProtocolTestsClient client,
                                                    PaginatedOperationWithResultKeyRequest firstRequest) {
         this.client = client;
-        this.firstRequest = firstRequest;
+        this.firstRequest = UserAgentUtils.applyPaginatorUserAgent(firstRequest);
         this.nextPageFetcher = new PaginatedOperationWithResultKeyResponseFetcher();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPublisher.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPublisher.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.core.pagination.async.PaginatedItemsPublisher;
 import software.amazon.awssdk.core.pagination.async.ResponsesSubscription;
 import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsAsyncClient;
+import software.amazon.awssdk.services.jsonprotocoltests.internal.UserAgentUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.jsonprotocoltests.model.SimpleStruct;
@@ -90,7 +91,7 @@ public class PaginatedOperationWithResultKeyPublisher implements SdkPublisher<Pa
     private PaginatedOperationWithResultKeyPublisher(JsonProtocolTestsAsyncClient client,
                                                      PaginatedOperationWithResultKeyRequest firstRequest, boolean isLastPage) {
         this.client = client;
-        this.firstRequest = firstRequest;
+        this.firstRequest = UserAgentUtils.applyPaginatorUserAgent(firstRequest);
         this.isLastPage = isLastPage;
         this.nextPageFetcher = new PaginatedOperationWithResultKeyResponseFetcher();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyIterable.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyIterable.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.core.pagination.sync.SyncPageFetcher;
 import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient;
+import software.amazon.awssdk.services.jsonprotocoltests.internal.UserAgentUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyResponse;
 
@@ -79,7 +80,7 @@ public class PaginatedOperationWithoutResultKeyIterable implements SdkIterable<P
     public PaginatedOperationWithoutResultKeyIterable(JsonProtocolTestsClient client,
                                                       PaginatedOperationWithoutResultKeyRequest firstRequest) {
         this.client = client;
-        this.firstRequest = firstRequest;
+        this.firstRequest = UserAgentUtils.applyPaginatorUserAgent(firstRequest);
         this.nextPageFetcher = new PaginatedOperationWithoutResultKeyResponseFetcher();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPublisher.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPublisher.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.core.pagination.async.AsyncPageFetcher;
 import software.amazon.awssdk.core.pagination.async.ResponsesSubscription;
 import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsAsyncClient;
+import software.amazon.awssdk.services.jsonprotocoltests.internal.UserAgentUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyResponse;
 
@@ -85,7 +86,7 @@ public class PaginatedOperationWithoutResultKeyPublisher implements SdkPublisher
     private PaginatedOperationWithoutResultKeyPublisher(JsonProtocolTestsAsyncClient client,
                                                         PaginatedOperationWithoutResultKeyRequest firstRequest, boolean isLastPage) {
         this.client = client;
-        this.firstRequest = firstRequest;
+        this.firstRequest = UserAgentUtils.applyPaginatorUserAgent(firstRequest);
         this.isLastPage = isLastPage;
         this.nextPageFetcher = new PaginatedOperationWithoutResultKeyResponseFetcher();
     }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingAsyncClientTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingAsyncClientTest.java
@@ -85,7 +85,6 @@ public class DelegatingAsyncClientTest {
         validateIsDecorated();
     }
 
-    //TODO: handle paginated calls - the paginated publisher calls should also be decorated
     @Test
     public void paginatedOp_Request_publisherResponse_delegatingClient_DoesNotIntercept() throws Exception {
         PaginatedOperationWithResultKeyPublisher publisher =
@@ -94,7 +93,7 @@ public class DelegatingAsyncClientTest {
                                                                                                             .build());
         CompletableFuture<Void> future = publisher.subscribe(PaginatedOperationWithResultKeyResponse::items);
         future.get();
-        assertThat(mockAsyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+        validateIsDecorated();
     }
 
     @Test
@@ -103,7 +102,7 @@ public class DelegatingAsyncClientTest {
             decoratingClient.paginatedOperationWithResultKeyPaginator(r -> r.nextToken("token").build());
         CompletableFuture<Void> future = publisher.subscribe(PaginatedOperationWithResultKeyResponse::items);
         future.get();
-        assertThat(mockAsyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+        validateIsDecorated();
     }
 
     private void validateIsDecorated() {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingSyncClientTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/delegatingclients/DelegatingSyncClientTest.java
@@ -89,23 +89,22 @@ public class DelegatingSyncClientTest {
         validateIsDecorated();
     }
 
-    //TODO: handle paginated calls - the paginated publisher calls should also be decorated
     @Test
-    public void paginatedOp_Request_publisherResponse_delegatingClient_DoesNotIntercept() throws Exception {
+    public void paginatedOp_Request_publisherResponse_delegatingClient_SuccessfullyIntercepts() {
         PaginatedOperationWithResultKeyIterable iterable =
             decoratingClient.paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest.builder()
                                                                                                             .nextToken("token")
                                                                                                             .build());
         iterable.forEach(PaginatedOperationWithResultKeyResponse::items);
-        assertThat(mockSyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+        validateIsDecorated();
     }
 
     @Test
-    public void paginatedOp_ConsumerRequest_publisherResponse_delegatingClient_DoesNotIntercept() throws Exception {
+    public void paginatedOp_ConsumerRequest_publisherResponse_delegatingClient_SuccessfullyIntercepts() {
         PaginatedOperationWithResultKeyIterable iterable =
             decoratingClient.paginatedOperationWithResultKeyPaginator(r -> r.nextToken("token").build());
         iterable.forEach(PaginatedOperationWithResultKeyResponse::items);
-        assertThat(mockSyncHttpClient.getLastRequest().headers().get(INTERCEPTED_HEADER)).isNull();
+        validateIsDecorated();
     }
 
     private void validateIsDecorated() {


### PR DESCRIPTION
…interface instead of throwing unsupported exception

## Motivation and Context
For paginated API operations, the service client interfaces contain a version that returns a publisher (async) or iterable (sync). The default implementation of all methods at interface level throws an unsupported exception and is overridden by any implementing client. However, because these operation versions do not truly execute backend calls, they are difficult to handle when you have a delegating client that can intercept API calls. This PR moves the logic of creating a publisher/iterable from the default (base) client to the interface, and removes these paginating method versions from the implementing clients. The refactoring enables delegating clients to provide an instance of themselves to the publisher/iterable constructor, which closes the intercepting loop for delegating clients.

## Modifications
- Moves the `applyPaginatorUserAgent` method to a separate class that is referenced by each publisher/iterable
- Moves the instance creation of a new publisher/iterable to the sync/async interfaces
- Removes any paginator methods that return publisher/iterable from implementing classes. 
- Refactors the operation logic in client codegen to increase the similarity and therefore the understanding of the code between sync/async and interface/class/abstract class implementations.

