### PR TITLE
Fix bug about wrong part size number in CopyObjectHelper

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-5d8e168.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-5d8e168.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix an issue where the optimal number of parts calculated could be higher than 10,000"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelper.java
@@ -130,7 +130,7 @@ public final class CopyObjectHelper {
                                Long contentLength,
                                CompletableFuture<CopyObjectResponse> returnFuture,
                                String uploadId) {
-        long optimalPartSize = calculateOptimalPartSizeForCopy(partSizeInBytes);
+        long optimalPartSize = calculateOptimalPartSizeForCopy(contentLength);
 
         int partCount = determinePartCount(contentLength, optimalPartSize);
 


### PR DESCRIPTION
In `CopyObjectHelper` the method `calculateOptimalPartSizeForCopy(long contentLengthOfSource)` expect the content length of the whole object to copy, but is passed the part size instead. This PR is to fix that issue, now it is passed the content length so that the part size can be automatically adjusted if the total number of parts would exceed 10,000.