### PR TITLE
Bump aws-crt to 0.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.15</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.21.17</awscrt.version>
+        <awscrt.version>0.22.1</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>


### PR DESCRIPTION
Bump aws-crt to 0.22.1 that has support for streaming with unknown content length #139