### PR TITLE
ddb-enhanced: adds EnhancedType parameters to static builder methods of StaticTableSchema and StaticImmutableTableSchema.

### DIFF
--- a/.changes/next-release/feature-DynamoDBEnhancedClient-270c65a.json
+++ b/.changes/next-release/feature-DynamoDBEnhancedClient-270c65a.json
@@ -1,0 +1,6 @@
+{
+    "category": "DynamoDB Enhanced Client", 
+    "contributor": "bmaizels", 
+    "type": "feature", 
+    "description": "Add EnhancedType parameters to static builder methods of StaticTableSchema and StaticImmitableTableSchema"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/TableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/TableSchema.java
@@ -54,6 +54,18 @@ public interface TableSchema<T> {
     }
 
     /**
+     * Returns a builder for the {@link StaticTableSchema} implementation of this interface which allows all attributes,
+     * tags and table structure to be directly declared in the builder.
+     *
+     * @param itemType The {@link EnhancedType} of the item this {@link TableSchema} will map records to.
+     * @param <T> The type of the item this {@link TableSchema} will map records to.
+     * @return A newly initialized {@link StaticTableSchema.Builder}.
+     */
+    static <T> StaticTableSchema.Builder<T> builder(EnhancedType<T> itemType) {
+        return StaticTableSchema.builder(itemType);
+    }
+
+    /**
      * Returns a builder for the {@link StaticImmutableTableSchema} implementation of this interface which allows all
      * attributes, tags and table structure to be directly declared in the builder.
      *
@@ -67,6 +79,22 @@ public interface TableSchema<T> {
     static <T, B> StaticImmutableTableSchema.Builder<T, B> builder(Class<T> immutableItemClass,
                                                                    Class<B> immutableBuilderClass) {
         return StaticImmutableTableSchema.builder(immutableItemClass, immutableBuilderClass);
+    }
+
+    /**
+     * Returns a builder for the {@link StaticImmutableTableSchema} implementation of this interface which allows all
+     * attributes, tags and table structure to be directly declared in the builder.
+     *
+     * @param immutableItemType The {@link EnhancedType} of the immutable item this {@link TableSchema} will map records to.
+     * @param immutableBuilderType The {@link EnhancedType} of the class that can be used to construct immutable items this
+     *                             {@link TableSchema} maps records to.
+     * @param <T> The type of the immutable item this {@link TableSchema} will map records to.
+     * @param <B> The type of the builder used by this {@link TableSchema} to construct immutable items with.
+     * @return A newly initialized {@link StaticImmutableTableSchema.Builder}
+     */
+    static <T, B> StaticImmutableTableSchema.Builder<T, B> builder(EnhancedType<T> immutableItemType,
+                                                                   EnhancedType<B> immutableBuilderType) {
+        return StaticImmutableTableSchema.builder(immutableItemType, immutableBuilderType);
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/ImmutableAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/ImmutableAttribute.java
@@ -93,6 +93,19 @@ public final class ImmutableAttribute<T, B, R> {
 
     /**
      * Constructs a new builder for this class using supplied types.
+     * @param itemType The {@link EnhancedType} of the immutable item that this attribute composes.
+     * @param builderType The {@link EnhancedType} of the builder for the immutable item that this attribute composes.
+     * @param attributeType A {@link EnhancedType} that represents the type of the value this attribute stores.
+     * @return A new typed builder for an attribute.
+     */
+    public static <T, B, R> Builder<T, B, R> builder(EnhancedType<T> itemType,
+                                                     EnhancedType<B> builderType,
+                                                     EnhancedType<R> attributeType) {
+        return new Builder<>(attributeType);
+    }
+
+    /**
+     * Constructs a new builder for this class using supplied types.
      * @param itemClass The class of the item that this attribute composes.
      * @param builderClass The class of the builder for the immutable item that this attribute composes.
      * @param attributeClass A class that represents the type of the value this attribute stores.

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttribute.java
@@ -69,7 +69,17 @@ public final class StaticAttribute<T, R> {
      * @return A new typed builder for an attribute.
      */
     public static <T, R> Builder<T, R> builder(Class<T> itemClass, EnhancedType<R> attributeType) {
-        return new Builder<>(itemClass, attributeType);
+        return new Builder<>(EnhancedType.of(itemClass), attributeType);
+    }
+
+    /**
+     * Constructs a new builder for this class using supplied types.
+     * @param itemType The {@link EnhancedType} of the item that this attribute composes.
+     * @param attributeType A {@link EnhancedType} that represents the type of the value this attribute stores.
+     * @return A new typed builder for an attribute.
+     */
+    public static <T, R> Builder<T, R> builder(EnhancedType<T> itemType, EnhancedType<R> attributeType) {
+        return new Builder<>(itemType, attributeType);
     }
 
     /**
@@ -79,7 +89,7 @@ public final class StaticAttribute<T, R> {
      * @return A new typed builder for an attribute.
      */
     public static <T, R> Builder<T, R> builder(Class<T> itemClass, Class<R> attributeClass) {
-        return new Builder<>(itemClass, EnhancedType.of(attributeClass));
+        return new Builder<>(EnhancedType.of(itemClass), EnhancedType.of(attributeClass));
     }
 
     /**
@@ -146,8 +156,8 @@ public final class StaticAttribute<T, R> {
     public static final class Builder<T, R> {
         private final ImmutableAttribute.Builder<T, T, R> delegateBuilder;
 
-        private Builder(Class<T> itemClass, EnhancedType<R> type) {
-            this.delegateBuilder = ImmutableAttribute.builder(itemClass, itemClass, type);
+        private Builder(EnhancedType<T> itemType, EnhancedType<R> type) {
+            this.delegateBuilder = ImmutableAttribute.builder(itemType, itemType, type);
         }
 
         private Builder(ImmutableAttribute.Builder<T, T, R> delegateBuilder) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticImmutableTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticImmutableTableSchema.java
@@ -210,7 +210,7 @@ public final class StaticImmutableTableSchema<T, B> implements TableSchema<T> {
         this.newBuilderSupplier = builder.newBuilderSupplier;
         this.buildItemFunction = builder.buildItemFunction;
         this.tableMetadata = tableMetadataBuilder.build();
-        this.itemType = EnhancedType.of(builder.itemClass);
+        this.itemType = builder.itemType;
     }
 
     /**
@@ -220,7 +220,18 @@ public final class StaticImmutableTableSchema<T, B> implements TableSchema<T> {
      * @return A newly initialized builder
      */
     public static <T, B> Builder<T, B> builder(Class<T> itemClass, Class<B> builderClass) {
-        return new Builder<>(itemClass, builderClass);
+        return new Builder<>(EnhancedType.of(itemClass), EnhancedType.of(builderClass));
+    }
+
+    /**
+     * Creates a builder for a {@link StaticImmutableTableSchema} typed to specific immutable data item class.
+     * @param itemType The {@link EnhancedType} of the immutable data item class object that the
+     *                 {@link StaticImmutableTableSchema} is to map to.
+     * @param builderType The builder {@link EnhancedType} that can be used to construct instances of the immutable data item.
+     * @return A newly initialized builder
+     */
+    public static <T, B> Builder<T, B> builder(EnhancedType<T> itemType, EnhancedType<B> builderType) {
+        return new Builder<>(itemType, builderType);
     }
 
     /**
@@ -230,8 +241,8 @@ public final class StaticImmutableTableSchema<T, B> implements TableSchema<T> {
      */
     @NotThreadSafe
     public static final class Builder<T, B> {
-        private final Class<T> itemClass;
-        private final Class<B> builderClass;
+        private final EnhancedType<T> itemType;
+        private final EnhancedType<B> builderType;
         private final List<ResolvedImmutableAttribute<T, B>> additionalAttributes = new ArrayList<>();
         private final List<FlattenedMapper<T, B, ?>> flattenedMappers = new ArrayList<>();
 
@@ -242,9 +253,9 @@ public final class StaticImmutableTableSchema<T, B> implements TableSchema<T> {
         private List<AttributeConverterProvider> attributeConverterProviders =
             Collections.singletonList(ConverterProviderResolver.defaultConverterProvider());
 
-        private Builder(Class<T> itemClass, Class<B> builderClass) {
-            this.itemClass = itemClass;
-            this.builderClass = builderClass;
+        private Builder(EnhancedType<T> itemType, EnhancedType<B> builderType) {
+            this.itemType = itemType;
+            this.builderType = builderType;
         }
 
         /**
@@ -285,7 +296,7 @@ public final class StaticImmutableTableSchema<T, B> implements TableSchema<T> {
                                               Consumer<ImmutableAttribute.Builder<T, B, R>> immutableAttribute) {
 
             ImmutableAttribute.Builder<T, B, R> builder =
-                ImmutableAttribute.builder(itemClass, builderClass, attributeType);
+                ImmutableAttribute.builder(itemType, builderType, attributeType);
             immutableAttribute.accept(builder);
             return addAttribute(builder.build());
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchema.java
@@ -75,7 +75,16 @@ public final class StaticTableSchema<T> extends WrappedTableSchema<T, StaticImmu
      * @return A newly initialized builder
      */
     public static <T> Builder<T> builder(Class<T> itemClass) {
-        return new Builder<>(itemClass);
+        return new Builder<>(EnhancedType.of(itemClass));
+    }
+
+    /**
+     * Creates a builder for a {@link StaticTableSchema} typed to specific data item class.
+     * @param itemType The {@link EnhancedType} of the data item class object that the {@link StaticTableSchema} is to map to.
+     * @return A newly initialized builder
+     */
+    public static <T> Builder<T> builder(EnhancedType<T> itemType) {
+        return new Builder<>(itemType);
     }
 
     /**
@@ -85,11 +94,11 @@ public final class StaticTableSchema<T> extends WrappedTableSchema<T, StaticImmu
     @NotThreadSafe
     public static final class Builder<T> {
         private final StaticImmutableTableSchema.Builder<T, T> delegateBuilder;
-        private final Class<T> itemClass;
+        private final EnhancedType<T> itemType;
 
-        private Builder(Class<T> itemClass) {
-            this.delegateBuilder = StaticImmutableTableSchema.builder(itemClass, itemClass);
-            this.itemClass = itemClass;
+        private Builder(EnhancedType<T> itemType) {
+            this.delegateBuilder = StaticImmutableTableSchema.builder(itemType, itemType);
+            this.itemType = itemType;
         }
 
         /**
@@ -130,7 +139,7 @@ public final class StaticTableSchema<T> extends WrappedTableSchema<T, StaticImmu
          */
         public <R> Builder<T> addAttribute(EnhancedType<R> attributeType,
                                            Consumer<StaticAttribute.Builder<T, R>> staticAttribute) {
-            StaticAttribute.Builder<T, R> builder = StaticAttribute.builder(itemClass, attributeType);
+            StaticAttribute.Builder<T, R> builder = StaticAttribute.builder(itemType, attributeType);
             staticAttribute.accept(builder);
             this.delegateBuilder.addAttribute(builder.build().toImmutableAttribute());
             return this;
@@ -142,7 +151,7 @@ public final class StaticTableSchema<T> extends WrappedTableSchema<T, StaticImmu
          */
         public <R> Builder<T> addAttribute(Class<R> attributeClass,
                                            Consumer<StaticAttribute.Builder<T, R>> staticAttribute) {
-            StaticAttribute.Builder<T, R> builder = StaticAttribute.builder(itemClass, attributeClass);
+            StaticAttribute.Builder<T, R> builder = StaticAttribute.builder(itemType, EnhancedType.of(attributeClass));
             staticAttribute.accept(builder);
             this.delegateBuilder.addAttribute(builder.build().toImmutableAttribute());
             return this;

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/TableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/TableSchemaTest.java
@@ -23,6 +23,7 @@ import org.junit.rules.ExpectedException;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.ImmutableTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticImmutableTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.InvalidBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SimpleBean;
@@ -33,8 +34,28 @@ public class TableSchemaTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void builder_constructsStaticTableSchemaBuilder() {
+    public void builder_constructsStaticTableSchemaBuilder_fromClass() {
         StaticTableSchema.Builder<FakeItem> builder = TableSchema.builder(FakeItem.class);
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    public void builder_constructsStaticTableSchemaBuilder_fromEnhancedType() {
+        StaticTableSchema.Builder<FakeItem> builder = TableSchema.builder(EnhancedType.of(FakeItem.class));
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    public void builder_constructsStaticImmutableTableSchemaBuilder_fromClass() {
+        StaticImmutableTableSchema.Builder<SimpleImmutable, SimpleImmutable.Builder> builder =
+            TableSchema.builder(SimpleImmutable.class, SimpleImmutable.Builder.class);
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    public void builder_constructsStaticImmutableTableSchemaBuilder_fromEnhancedType() {
+        StaticImmutableTableSchema.Builder<SimpleImmutable, SimpleImmutable.Builder> builder =
+            TableSchema.builder(EnhancedType.of(SimpleImmutable.class), EnhancedType.of(SimpleImmutable.Builder.class));
         assertThat(builder).isNotNull();
     }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/EntityEnvelopeBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/EntityEnvelopeBean.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
+
+public class EntityEnvelopeBean<T> {
+    private T entity;
+
+    public T getEntity() {
+        return this.entity;
+    }
+
+    public void setEntity(T entity) {
+        this.entity = entity;
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testimmutables/EntityEnvelopeImmutable.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testimmutables/EntityEnvelopeImmutable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testimmutables;
+
+public class EntityEnvelopeImmutable<T> {
+    private final T entity;
+
+    public EntityEnvelopeImmutable(T entity) {
+        this.entity = entity;
+    }
+
+    public T entity() {
+        return this.entity;
+    }
+
+    public static class Builder<T> {
+        private T entity;
+
+        public void setEntity(T entity) {
+            this.entity = entity;
+        }
+
+        public EntityEnvelopeImmutable<T> build() {
+            return new EntityEnvelopeImmutable<>(this.entity);
+        }
+    }
+}
+


### PR DESCRIPTION
Adds `EnhancedType` parameters to static builder methods of `StaticTableSchema` and `StaticImmutableTableSchema`.

## Motivation and Context
This is a QoL change that allows a static `TableSchema` to be constructed for a generic class without forcing you to use the raw-type of the class as the type parameter. For use-cases where you may want to dynamically create a static tableschema around a type that is being passed by a caller, this allows you to do so in a type-safe manner.

There are two workarounds I know about this today:

1. You simply use the raw-class and add extra type checking in the methods that get and set the attributes, and any methods that actually use the TableSchema type in its parameters (which is most operations!). This pushes the onus of ensuring type safety on the caller which is not ideal.
2. You create an enclosed dynamic class that implements a generic interface that can be typed with the capture type. It's then safe to use the raw-type of the dynamic class for your TableSchema, but it does not let you export the TableSchema outside that method without losing its type.

Since this change was simple to make and makes good use of the `EnhancedType` anonymous class pattern that is already supported in the same library, I felt that it was worth making this improvement. We already have prior art in other interfaces in this library that accept `EnhancedType<T>` in place of `Class<T>` too.

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
