### PR TITLE
Wraps s3 client in cross regional client when enabled

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.awscore.internal.client.ClientComposer;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.traits.PayloadTrait;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -213,12 +214,18 @@ public class CustomizationConfig {
     private boolean delegateSyncClientClass;
 
     /**
-     * Fully qualified name of a class that given the default client instance can return the final client instance,
+     * Fully qualified name of a class that given the default sync client instance can return the final client instance,
      * for instance by decorating the client with specific-purpose implementations of the client interface.
-     * The class should expose one async and one sync public static method that takes an instance of the client class
-     * and the client configuration and returns the same type for the client. See S3 customization.config for an example.
+     * The class should implement the {@link ClientComposer} interface. See S3 customization.config for an example.
      */
-    private String clientComposerFactory;
+    private String syncClientComposer;
+
+    /**
+     * Fully qualified name of a class that given the default async client instance can return the final client instance,
+     * for instance by decorating the client with specific-purpose implementations of the client interface.
+     * The class should implement the {@link ClientComposer} interface. See S3 customization.config for an example.
+     */
+    private String asyncClientComposer;
 
     /**
      * Whether to skip generating endpoint tests from endpoint-tests.json
@@ -569,12 +576,20 @@ public class CustomizationConfig {
         this.delegateAsyncClientClass = delegateAsyncClientClass;
     }
 
-    public String getClientComposerFactory() {
-        return clientComposerFactory;
+    public String getSyncClientComposer() {
+        return syncClientComposer;
     }
 
-    public void setClientComposerFactory(String clientComposerFactory) {
-        this.clientComposerFactory = clientComposerFactory;
+    public void setSyncClientComposer(String syncClientComposer) {
+        this.syncClientComposer = syncClientComposer;
+    }
+
+    public String getAsyncClientComposer() {
+        return asyncClientComposer;
+    }
+
+    public void setAsyncClientComposer(String asyncClientComposer) {
+        this.asyncClientComposer = asyncClientComposer;
     }
 
     public boolean isDelegateSyncClientClass() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -213,6 +213,14 @@ public class CustomizationConfig {
     private boolean delegateSyncClientClass;
 
     /**
+     * Fully qualified name of a class that given the default client instance can return the final client instance,
+     * for instance by decorating the client with specific-purpose implementations of the client interface.
+     * The class should expose one async and one sync public static method that takes an instance of the client class
+     * and the client configuration and returns the same type for the client. See S3 customization.config for an example.
+     */
+    private String clientComposerFactory;
+
+    /**
      * Whether to skip generating endpoint tests from endpoint-tests.json
      */
     private boolean skipEndpointTestGeneration;
@@ -559,6 +567,14 @@ public class CustomizationConfig {
 
     public void setDelegateAsyncClientClass(boolean delegateAsyncClientClass) {
         this.delegateAsyncClientClass = delegateAsyncClientClass;
+    }
+
+    public String getClientComposerFactory() {
+        return clientComposerFactory;
+    }
+
+    public void setClientComposerFactory(String clientComposerFactory) {
+        this.clientComposerFactory = clientComposerFactory;
     }
 
     public boolean isDelegateSyncClientClass() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
@@ -235,6 +235,13 @@ public final class IntermediateModel {
         }
     }
 
+    public Optional<String> clientComposerClassName() {
+        if (customizationConfig.getClientComposerFactory() != null) {
+            return Optional.of(customizationConfig.getClientComposerFactory());
+        }
+        return Optional.empty();
+    }
+
     public String getFileHeader() {
         return FILE_HEADER;
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
@@ -235,9 +235,17 @@ public final class IntermediateModel {
         }
     }
 
-    public Optional<String> clientComposerClassName() {
-        if (customizationConfig.getClientComposerFactory() != null) {
-            return Optional.of(customizationConfig.getClientComposerFactory());
+    public Optional<String> syncClientComposerClassName() {
+        if (customizationConfig.getSyncClientComposer() != null) {
+            return Optional.of(customizationConfig.getSyncClientComposer());
+        }
+        return Optional.empty();
+    }
+
+    public Optional<String> asyncClientComposerClassName() {
+        String asyncClientComposer = customizationConfig.getAsyncClientComposer();
+        if (customizationConfig.getAsyncClientComposer() != null) {
+            return Optional.of(asyncClientComposer);
         }
         return Optional.empty();
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
@@ -24,6 +24,7 @@ import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.awscore.internal.client.ClientComposer;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
@@ -136,9 +137,11 @@ public class AsyncClientBuilderClass implements ClassSpec {
 
         builder.addStatement("$1T client = new $2T(serviceClientConfiguration, clientConfiguration)",
                              clientInterfaceName, clientClassName);
-        if (model.clientComposerClassName().isPresent()) {
-            builder.addStatement("return $T.composeAsync(client, clientConfiguration)",
-                                 PoetUtils.classNameFromFqcn(model.clientComposerClassName().get()));
+        if (model.asyncClientComposerClassName().isPresent()) {
+            builder.addStatement("$1T composer = new $2T()",
+                                 ClientComposer.class,
+                                 PoetUtils.classNameFromFqcn(model.asyncClientComposerClassName().get()));
+            builder.addStatement("return ($T) composer.compose(client, clientConfiguration)", clientInterfaceName);
         } else {
             builder.addStatement("return client");
         }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
@@ -80,7 +80,10 @@ public class AsyncClientBuilderClass implements ClassSpec {
             builder.addMethod(bearerTokenProviderMethod());
         }
 
-        return builder.addMethod(buildClientMethod()).build();
+        builder.addMethod(buildClientMethod());
+        builder.addMethod(initializeServiceClientConfigMethod());
+
+        return builder.build();
     }
 
     private MethodSpec endpointDiscoveryEnabled() {
@@ -120,30 +123,26 @@ public class AsyncClientBuilderClass implements ClassSpec {
     }
 
     private MethodSpec buildClientMethod() {
-        return MethodSpec.methodBuilder("buildClient")
-                         .addAnnotation(Override.class)
-                         .addModifiers(Modifier.PROTECTED, Modifier.FINAL)
-                         .returns(clientInterfaceName)
-                         .addStatement("$T clientConfiguration = super.asyncClientConfiguration()", SdkClientConfiguration.class)
-                         .addStatement("this.validateClientOptions(clientConfiguration)")
-                         .addStatement("$T endpointOverride = null", URI.class)
-                         .addStatement("$T endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER)",
-                                       EndpointProvider.class,
-                                       SdkClientOption.class)
-                         .addCode("if (clientConfiguration.option($T.ENDPOINT_OVERRIDDEN) != null"
-                                  + "&& $T.TRUE.equals(clientConfiguration.option($T.ENDPOINT_OVERRIDDEN))) {"
-                                  + "endpointOverride = clientConfiguration.option($T.ENDPOINT);"
-                                  + "}",
-                                  SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
-                         .addStatement("$T serviceClientConfiguration = $T.builder()"
-                                       + ".overrideConfiguration(overrideConfiguration())"
-                                       + ".region(clientConfiguration.option($T.AWS_REGION))"
-                                       + ".endpointOverride(endpointOverride)"
-                                       + ".endpointProvider(endpointProvider)"
-                                       + ".build()",
-                                       serviceConfigClassName, serviceConfigClassName, AwsClientOption.class)
-                         .addStatement("return new $T(serviceClientConfiguration, clientConfiguration)", clientClassName)
-                         .build();
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("buildClient")
+                                               .addAnnotation(Override.class)
+                                               .addModifiers(Modifier.PROTECTED, Modifier.FINAL)
+                                               .returns(clientInterfaceName)
+                                               .addStatement("$T clientConfiguration = super.asyncClientConfiguration()",
+                                                             SdkClientConfiguration.class)
+                                               .addStatement("this.validateClientOptions(clientConfiguration)")
+                                               .addStatement("$T serviceClientConfiguration = initializeServiceClientConfig"
+                                                             + "(clientConfiguration)",
+                                                             serviceConfigClassName);
+
+        builder.addStatement("$1T client = new $2T(serviceClientConfiguration, clientConfiguration)",
+                             clientInterfaceName, clientClassName);
+        if (model.clientComposerClassName().isPresent()) {
+            builder.addStatement("return $T.composeAsync(client, clientConfiguration)",
+                                 PoetUtils.classNameFromFqcn(model.clientComposerClassName().get()));
+        } else {
+            builder.addStatement("return client");
+        }
+        return builder.build();
     }
 
     private MethodSpec bearerTokenProviderMethod() {
@@ -154,6 +153,29 @@ public class AsyncClientBuilderClass implements ClassSpec {
                          .addStatement("clientConfiguration.option($T.TOKEN_PROVIDER, tokenProvider)",
                                        AwsClientOption.class)
                          .addStatement("return this")
+                         .build();
+    }
+
+    private MethodSpec initializeServiceClientConfigMethod() {
+        return MethodSpec.methodBuilder("initializeServiceClientConfig").addModifiers(Modifier.PRIVATE)
+                         .addParameter(SdkClientConfiguration.class, "clientConfig")
+                         .returns(serviceConfigClassName)
+                         .addStatement("$T endpointOverride = null", URI.class)
+                         .addStatement("$T endpointProvider = clientConfig.option($T.ENDPOINT_PROVIDER)",
+                                       EndpointProvider.class,
+                                       SdkClientOption.class)
+                         .addCode("if (clientConfig.option($T.ENDPOINT_OVERRIDDEN) != null"
+                                  + "&& $T.TRUE.equals(clientConfig.option($T.ENDPOINT_OVERRIDDEN))) {"
+                                  + "endpointOverride = clientConfig.option($T.ENDPOINT);"
+                                  + "}",
+                                  SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
+                         .addStatement("return $T.builder()"
+                                       + ".overrideConfiguration(overrideConfiguration())"
+                                       + ".region(clientConfig.option($T.AWS_REGION))"
+                                       + ".endpointOverride(endpointOverride)"
+                                       + ".endpointProvider(endpointProvider)"
+                                       + ".build()",
+                                       serviceConfigClassName, AwsClientOption.class)
                          .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
@@ -24,6 +24,7 @@ import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.awscore.internal.client.ClientComposer;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
@@ -121,7 +122,6 @@ public class SyncClientBuilderClass implements ClassSpec {
                          .build();
     }
 
-
     private MethodSpec buildClientMethod() {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("buildClient")
                                                .addAnnotation(Override.class)
@@ -136,9 +136,11 @@ public class SyncClientBuilderClass implements ClassSpec {
 
         builder.addStatement("$1T client = new $2T(serviceClientConfiguration, clientConfiguration)",
                              clientInterfaceName, clientClassName);
-        if (model.clientComposerClassName().isPresent()) {
-            builder.addStatement("return $T.composeSync(client, clientConfiguration)",
-                                 PoetUtils.classNameFromFqcn(model.clientComposerClassName().get()));
+        if (model.syncClientComposerClassName().isPresent()) {
+            builder.addStatement("$1T composer = new $2T()",
+                                 ClientComposer.class,
+                                 PoetUtils.classNameFromFqcn(model.syncClientComposerClassName().get()));
+            builder.addStatement("return ($T) composer.compose(client, clientConfiguration)", clientInterfaceName);
         } else {
             builder.addStatement("return client");
         }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
@@ -80,7 +80,10 @@ public class SyncClientBuilderClass implements ClassSpec {
             builder.addMethod(tokenProviderMethodImpl());
         }
 
-        return builder.addMethod(buildClientMethod()).build();
+        builder.addMethod(buildClientMethod());
+        builder.addMethod(initializeServiceClientConfigMethod());
+
+        return builder.build();
     }
 
     private MethodSpec endpointDiscoveryEnabled() {
@@ -120,29 +123,26 @@ public class SyncClientBuilderClass implements ClassSpec {
 
 
     private MethodSpec buildClientMethod() {
-        return MethodSpec.methodBuilder("buildClient")
-                         .addAnnotation(Override.class)
-                         .addModifiers(Modifier.PROTECTED, Modifier.FINAL)
-                         .returns(clientInterfaceName)
-                         .addStatement("$T clientConfiguration = super.syncClientConfiguration()", SdkClientConfiguration.class)
-                         .addStatement("this.validateClientOptions(clientConfiguration)")
-                         .addStatement("$T endpointOverride = null", URI.class)
-                         .addStatement("$T endpointProvider = clientConfiguration.option($T.ENDPOINT_PROVIDER)",
-                                       EndpointProvider.class, SdkClientOption.class)
-                         .addCode("if (clientConfiguration.option($T.ENDPOINT_OVERRIDDEN) != null"
-                                  + "&& $T.TRUE.equals(clientConfiguration.option($T.ENDPOINT_OVERRIDDEN))) {"
-                                  + "endpointOverride = clientConfiguration.option($T.ENDPOINT);"
-                                  + "}",
-                                  SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
-                         .addStatement("$T serviceClientConfiguration = $T.builder()"
-                                       + ".overrideConfiguration(overrideConfiguration())"
-                                       + ".region(clientConfiguration.option($T.AWS_REGION))"
-                                       + ".endpointOverride(endpointOverride)"
-                                       + ".endpointProvider(endpointProvider)"
-                                       + ".build()",
-                                       serviceConfigClassName, serviceConfigClassName, AwsClientOption.class)
-                         .addStatement("return new $T(serviceClientConfiguration, clientConfiguration)", clientClassName)
-                         .build();
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("buildClient")
+                                               .addAnnotation(Override.class)
+                                               .addModifiers(Modifier.PROTECTED, Modifier.FINAL)
+                                               .returns(clientInterfaceName)
+                                               .addStatement("$T clientConfiguration = super.syncClientConfiguration()",
+                                                             SdkClientConfiguration.class)
+                                               .addStatement("this.validateClientOptions(clientConfiguration)")
+                                               .addStatement("$T serviceClientConfiguration = initializeServiceClientConfig"
+                                                             + "(clientConfiguration)",
+                                                             serviceConfigClassName);
+
+        builder.addStatement("$1T client = new $2T(serviceClientConfiguration, clientConfiguration)",
+                             clientInterfaceName, clientClassName);
+        if (model.clientComposerClassName().isPresent()) {
+            builder.addStatement("return $T.composeSync(client, clientConfiguration)",
+                                 PoetUtils.classNameFromFqcn(model.clientComposerClassName().get()));
+        } else {
+            builder.addStatement("return client");
+        }
+        return builder.build();
     }
 
     private MethodSpec tokenProviderMethodImpl() {
@@ -153,6 +153,29 @@ public class SyncClientBuilderClass implements ClassSpec {
                          .addStatement("clientConfiguration.option($T.TOKEN_PROVIDER, tokenProvider)",
                                        AwsClientOption.class)
                          .addStatement("return this")
+                         .build();
+    }
+
+    private MethodSpec initializeServiceClientConfigMethod() {
+        return MethodSpec.methodBuilder("initializeServiceClientConfig").addModifiers(Modifier.PRIVATE)
+                         .addParameter(SdkClientConfiguration.class, "clientConfig")
+                         .returns(serviceConfigClassName)
+                         .addStatement("$T endpointOverride = null", URI.class)
+                         .addStatement("$T endpointProvider = clientConfig.option($T.ENDPOINT_PROVIDER)",
+                                       EndpointProvider.class,
+                                       SdkClientOption.class)
+                         .addCode("if (clientConfig.option($T.ENDPOINT_OVERRIDDEN) != null"
+                                  + "&& $T.TRUE.equals(clientConfig.option($T.ENDPOINT_OVERRIDDEN))) {"
+                                  + "endpointOverride = clientConfig.option($T.ENDPOINT);"
+                                  + "}",
+                                  SdkClientOption.class, Boolean.class, SdkClientOption.class, SdkClientOption.class)
+                         .addStatement("return $T.builder()"
+                                       + ".overrideConfiguration(overrideConfiguration())"
+                                       + ".region(clientConfig.option($T.AWS_REGION))"
+                                       + ".endpointOverride(endpointOverride)"
+                                       + ".endpointProvider(endpointProvider)"
+                                       + ".build()",
+                                       serviceConfigClassName, AwsClientOption.class)
                          .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
@@ -192,7 +192,7 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
         builder.addModifiers(PUBLIC)
                .addAnnotation(Override.class);
 
-        if (builder.parameters.size() < 1) {
+        if (builder.parameters.isEmpty()) {
             throw new IllegalStateException("All client methods must have an argument");
         }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingSyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingSyncClientClass.java
@@ -151,7 +151,7 @@ public class DelegatingSyncClientClass extends SyncClientInterface {
         builder.addModifiers(PUBLIC)
                .addAnnotation(Override.class);
 
-        if (builder.parameters.size() < 1) {
+        if (builder.parameters.isEmpty()) {
             throw new IllegalStateException("All client methods must have an argument");
         }
 

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -146,6 +146,19 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel composedClientJsonServiceModels() {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/rest-json/service-2.json").getFile());
+        File customizationModel =
+            new File(ClientTestModels.class.getResource("client/c2j/composedclient/customization.config").getFile());
+        CustomizationConfig customizationConfig = getCustomizationConfig(customizationModel);
+        C2jModels models = C2jModels.builder()
+                                    .serviceModel(getServiceModel(serviceModel))
+                                    .customizationConfig(customizationConfig)
+                                    .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     public static IntermediateModel internalConfigModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/internalconfig/service-2.json").getFile());
         File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/internalconfig/customization.config").getFile());

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
@@ -69,6 +69,11 @@ public class BuilderClassTest {
     }
 
     @Test
+    public void syncComposedClientBuilderClass() throws Exception {
+        validateComposedClientGeneration(SyncClientBuilderClass::new, "test-composed-sync-client-builder-class.java");
+    }
+
+    @Test
     public void asyncClientBuilderInterface() throws Exception {
         validateGeneration(AsyncClientBuilderInterface::new, "test-async-client-builder-interface.java");
     }
@@ -78,8 +83,18 @@ public class BuilderClassTest {
         validateGeneration(AsyncClientBuilderClass::new, "test-async-client-builder-class.java");
     }
 
+    @Test
+    public void asyncComposedClientBuilderClass() throws Exception {
+        validateComposedClientGeneration(AsyncClientBuilderClass::new, "test-composed-async-client-builder-class.java");
+    }
+
     private void validateGeneration(Function<IntermediateModel, ClassSpec> generatorConstructor, String expectedClassName) {
         assertThat(generatorConstructor.apply(ClientTestModels.restJsonServiceModels()), generatesTo(expectedClassName));
+    }
+
+    private void validateComposedClientGeneration(Function<IntermediateModel, ClassSpec> generatorConstructor,
+                                                  String expectedClassName) {
+        assertThat(generatorConstructor.apply(ClientTestModels.composedClientJsonServiceModels()), generatesTo(expectedClassName));
     }
 
     private void validateBearerAuthGeneration(Function<IntermediateModel, ClassSpec> generatorConstructor,

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/common/UserAgentClassSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/common/UserAgentClassSpecTest.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.codegen.poet.common.UserAgentUtilsSpec;
 public class UserAgentClassSpecTest {
 
     @Test
-    public void testGeneratedResponseForSyncOperations() {
+    void testUserAgentClass() {
         ClassSpec useragentspec = new UserAgentUtilsSpec(ClientTestModels.restJsonServiceModels());
         assertThat(useragentspec, generatesTo("test-user-agent-class.java"));
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
@@ -33,15 +33,20 @@ final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<J
     protected final JsonAsyncClient buildClient() {
         SdkClientConfiguration clientConfiguration = super.asyncClientConfiguration();
         this.validateClientOptions(clientConfiguration);
+        JsonServiceClientConfiguration serviceClientConfiguration = initializeServiceClientConfig(clientConfiguration);
+        JsonAsyncClient client = new DefaultJsonAsyncClient(serviceClientConfiguration, clientConfiguration);
+        return client;
+    }
+
+    private JsonServiceClientConfiguration initializeServiceClientConfig(SdkClientConfiguration clientConfig) {
         URI endpointOverride = null;
-        EndpointProvider endpointProvider = clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER);
-        if (clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN) != null
-            && Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN))) {
-            endpointOverride = clientConfiguration.option(SdkClientOption.ENDPOINT);
+        EndpointProvider endpointProvider = clientConfig.option(SdkClientOption.ENDPOINT_PROVIDER);
+        if (clientConfig.option(SdkClientOption.ENDPOINT_OVERRIDDEN) != null
+            && Boolean.TRUE.equals(clientConfig.option(SdkClientOption.ENDPOINT_OVERRIDDEN))) {
+            endpointOverride = clientConfig.option(SdkClientOption.ENDPOINT);
         }
-        JsonServiceClientConfiguration serviceClientConfiguration = JsonServiceClientConfiguration.builder()
-                                                                                                  .overrideConfiguration(overrideConfiguration()).region(clientConfiguration.option(AwsClientOption.AWS_REGION))
-                                                                                                  .endpointOverride(endpointOverride).endpointProvider(endpointProvider).build();
-        return new DefaultJsonAsyncClient(serviceClientConfiguration, clientConfiguration);
+        return JsonServiceClientConfiguration.builder().overrideConfiguration(overrideConfiguration())
+                                             .region(clientConfig.option(AwsClientOption.AWS_REGION)).endpointOverride(endpointOverride)
+                                             .endpointProvider(endpointProvider).build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-async-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-async-client-builder-class.java
@@ -8,34 +8,35 @@ import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.endpoints.EndpointProvider;
+import software.amazon.awssdk.services.builder.ClientComposerFactory;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
- * Internal implementation of {@link JsonClientBuilder}.
+ * Internal implementation of {@link JsonAsyncClientBuilder}.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
-final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonClientBuilder, JsonClient> implements
-                                                                                                         JsonClientBuilder {
+final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<JsonAsyncClientBuilder, JsonAsyncClient> implements
+                                                                                                                        JsonAsyncClientBuilder {
     @Override
-    public DefaultJsonClientBuilder endpointProvider(JsonEndpointProvider endpointProvider) {
+    public DefaultJsonAsyncClientBuilder endpointProvider(JsonEndpointProvider endpointProvider) {
         clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER, endpointProvider);
         return this;
     }
 
     @Override
-    public DefaultJsonClientBuilder tokenProvider(SdkTokenProvider tokenProvider) {
+    public DefaultJsonAsyncClientBuilder tokenProvider(SdkTokenProvider tokenProvider) {
         clientConfiguration.option(AwsClientOption.TOKEN_PROVIDER, tokenProvider);
         return this;
     }
 
     @Override
-    protected final JsonClient buildClient() {
-        SdkClientConfiguration clientConfiguration = super.syncClientConfiguration();
+    protected final JsonAsyncClient buildClient() {
+        SdkClientConfiguration clientConfiguration = super.asyncClientConfiguration();
         this.validateClientOptions(clientConfiguration);
         JsonServiceClientConfiguration serviceClientConfiguration = initializeServiceClientConfig(clientConfiguration);
-        JsonClient client = new DefaultJsonClient(serviceClientConfiguration, clientConfiguration);
-        return client;
+        JsonAsyncClient client = new DefaultJsonAsyncClient(serviceClientConfiguration, clientConfiguration);
+        return ClientComposerFactory.composeAsync(client, clientConfiguration);
     }
 
     private JsonServiceClientConfiguration initializeServiceClientConfig(SdkClientConfiguration clientConfig) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-async-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-async-client-builder-class.java
@@ -5,10 +5,11 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.awscore.internal.client.ClientComposer;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.endpoints.EndpointProvider;
-import software.amazon.awssdk.services.builder.ClientComposerFactory;
+import software.amazon.awssdk.services.builder.AsyncClientComposer;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
@@ -36,7 +37,8 @@ final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<J
         this.validateClientOptions(clientConfiguration);
         JsonServiceClientConfiguration serviceClientConfiguration = initializeServiceClientConfig(clientConfiguration);
         JsonAsyncClient client = new DefaultJsonAsyncClient(serviceClientConfiguration, clientConfiguration);
-        return ClientComposerFactory.composeAsync(client, clientConfiguration);
+        ClientComposer composer = new AsyncClientComposer();
+        return (JsonAsyncClient) composer.compose(client, clientConfiguration);
     }
 
     private JsonServiceClientConfiguration initializeServiceClientConfig(SdkClientConfiguration clientConfig) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-client-builder-class.java
@@ -5,10 +5,11 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.awscore.internal.client.ClientComposer;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.endpoints.EndpointProvider;
-import software.amazon.awssdk.services.builder.ClientComposerFactory;
+import software.amazon.awssdk.services.builder.SyncClientComposer;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
@@ -36,7 +37,8 @@ final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonCl
         this.validateClientOptions(clientConfiguration);
         JsonServiceClientConfiguration serviceClientConfiguration = initializeServiceClientConfig(clientConfiguration);
         JsonClient client = new DefaultJsonClient(serviceClientConfiguration, clientConfiguration);
-        return ClientComposerFactory.composeSync(client, clientConfiguration);
+        ClientComposer composer = new SyncClientComposer();
+        return (JsonClient) composer.compose(client, clientConfiguration);
     }
 
     private JsonServiceClientConfiguration initializeServiceClientConfig(SdkClientConfiguration clientConfig) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-client-builder-class.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.endpoints.EndpointProvider;
+import software.amazon.awssdk.services.builder.ClientComposerFactory;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
@@ -35,7 +36,7 @@ final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonCl
         this.validateClientOptions(clientConfiguration);
         JsonServiceClientConfiguration serviceClientConfiguration = initializeServiceClientConfig(clientConfiguration);
         JsonClient client = new DefaultJsonClient(serviceClientConfiguration, clientConfiguration);
-        return client;
+        return ClientComposerFactory.composeSync(client, clientConfiguration);
     }
 
     private JsonServiceClientConfiguration initializeServiceClientConfig(SdkClientConfiguration clientConfig) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/composedclient/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/composedclient/customization.config
@@ -1,0 +1,65 @@
+{
+    "authPolicyActions" : {
+        "skip" : true
+    },
+    "presignersFqcn": "software.amazon.awssdk.services.acm.presign.AcmClientPresigners",
+    "serviceSpecificHttpConfig": "software.amazon.MyServiceHttpConfig",
+    "serviceConfig": {
+      "className": "ServiceConfiguration",
+      "hasDualstackProperty": true,
+      "hasFipsProperty": true,
+      "hasUseArnRegionProperty": true,
+      "hasMultiRegionEnabledProperty": true,
+      "hasPathStyleAccessEnabledProperty":true,
+      "hasAccelerateModeEnabledProperty":true
+    },
+    "customRetryPolicy": "software.amazon.TestRetryPolicy",
+    "clientComposerFactory": "software.amazon.awssdk.services.builder.ClientComposerFactory",
+    "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
+    "blacklistedSimpleMethods" : [
+        "eventStreamOperation"
+    ],
+  "utilitiesMethod": {
+    "returnType": "software.amazon.awssdk.services.json.JsonUtilities",
+    "createMethodParams": ["param1", "param2", "param3"]
+  },
+    "additionalBuilderMethods": [
+        {
+          "methodName": "builderOne",
+          "clientType": "ASYNC",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
+          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder",
+          "statement": "builder().build()",
+          "javaDoc": "Create a default builder"
+        },
+        {
+          "methodName": "builderTwo",
+          "clientType": "ASYNC",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilderTwo",
+          "returnType": "software.amazon.awssdk.services.builder.Builder",
+          "statement": "builder2().build()",
+          "javaDoc": "Create a default builder two"
+        },
+
+        {
+          "methodName": "builderThree",
+          "clientType": "SYNC",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
+          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder",
+          "statement": "builder().build()",
+          "javaDoc": "Create a default builder"
+        },
+        {
+          "methodName": "builderFour",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
+          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder",
+          "statement": "builder().build()",
+          "javaDoc": "Create a default builder"
+        }
+    ],
+  "useLegacyEventGenerationScheme": {
+    "EventStream": ["EventOne", "event-two", "eventThree"]
+  },
+  "asyncClientDecoratorClass": true,
+  "syncClientDecoratorClass": true
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/composedclient/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/composedclient/customization.config
@@ -1,9 +1,4 @@
 {
-    "authPolicyActions" : {
-        "skip" : true
-    },
-    "presignersFqcn": "software.amazon.awssdk.services.acm.presign.AcmClientPresigners",
-    "serviceSpecificHttpConfig": "software.amazon.MyServiceHttpConfig",
     "serviceConfig": {
       "className": "ServiceConfiguration",
       "hasDualstackProperty": true,
@@ -13,53 +8,12 @@
       "hasPathStyleAccessEnabledProperty":true,
       "hasAccelerateModeEnabledProperty":true
     },
-    "customRetryPolicy": "software.amazon.TestRetryPolicy",
-    "clientComposerFactory": "software.amazon.awssdk.services.builder.ClientComposerFactory",
-    "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
-    "blacklistedSimpleMethods" : [
-        "eventStreamOperation"
-    ],
-  "utilitiesMethod": {
-    "returnType": "software.amazon.awssdk.services.json.JsonUtilities",
-    "createMethodParams": ["param1", "param2", "param3"]
-  },
-    "additionalBuilderMethods": [
-        {
-          "methodName": "builderOne",
-          "clientType": "ASYNC",
-          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
-          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder",
-          "statement": "builder().build()",
-          "javaDoc": "Create a default builder"
-        },
-        {
-          "methodName": "builderTwo",
-          "clientType": "ASYNC",
-          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilderTwo",
-          "returnType": "software.amazon.awssdk.services.builder.Builder",
-          "statement": "builder2().build()",
-          "javaDoc": "Create a default builder two"
-        },
-
-        {
-          "methodName": "builderThree",
-          "clientType": "SYNC",
-          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
-          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder",
-          "statement": "builder().build()",
-          "javaDoc": "Create a default builder"
-        },
-        {
-          "methodName": "builderFour",
-          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
-          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder",
-          "statement": "builder().build()",
-          "javaDoc": "Create a default builder"
-        }
-    ],
-  "useLegacyEventGenerationScheme": {
-    "EventStream": ["EventOne", "event-two", "eventThree"]
-  },
-  "asyncClientDecoratorClass": true,
-  "syncClientDecoratorClass": true
+    "utilitiesMethod": {
+      "returnType": "software.amazon.awssdk.services.json.JsonUtilities",
+      "createMethodParams": ["param1", "param2", "param3"]
+    },
+    "syncClientComposer": "software.amazon.awssdk.services.builder.SyncClientComposer",
+    "asyncClientComposer": "software.amazon.awssdk.services.builder.AsyncClientComposer",
+    "asyncClientDecoratorClass": true,
+    "syncClientDecoratorClass": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-user-agent-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-user-agent-class.java
@@ -2,12 +2,14 @@ package software.amazon.awssdk.services.json.internal;
 
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.services.json.model.JsonRequest;
 
 @Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
 public class UserAgentUtils {
     private UserAgentUtils() {
     }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/client/ClientComposer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/client/ClientComposer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.internal.client;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+
+@SdkInternalApi
+public interface ClientComposer<T extends AwsClient> {
+    T compose(T base, SdkClientConfiguration clientConfiguration);
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -403,7 +403,6 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
          * Returns value of crossRegionAccessEnabled value set using {@link Builder#crossRegionAccessEnabled(Boolean)}
          */
         Boolean crossRegionAccessEnabled();
-
     }
 
     static final class DefaultS3ServiceConfigurationBuilder implements Builder {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/client/S3AsyncClientComposer.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/client/S3AsyncClientComposer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.internal.client.ClientComposer;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClient;
+import software.amazon.awssdk.utils.ConditionalDecorator;
+
+@SdkInternalApi
+public class S3AsyncClientComposer implements ClientComposer<S3AsyncClient> {
+
+    public S3AsyncClientComposer() {
+    }
+
+    @Override
+    public S3AsyncClient compose(S3AsyncClient base, SdkClientConfiguration clientConfiguration) {
+        List<ConditionalDecorator<S3AsyncClient>> decorators = new ArrayList<>();
+        decorators.add(ConditionalDecorator.create(isCrossRegionEnabledAsync(clientConfiguration),
+                                                   S3CrossRegionAsyncClient::new));
+        return ConditionalDecorator.decorate(base, decorators);
+    }
+
+    private Predicate<S3AsyncClient> isCrossRegionEnabledAsync(SdkClientConfiguration clientConfiguration) {
+        return client -> ((S3Configuration) clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION))
+            .crossRegionAccessEnabled();
+    }
+
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/client/S3ClientComposer.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/client/S3ClientComposer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClient;
+import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionSyncClient;
+import software.amazon.awssdk.utils.ConditionalDecorator;
+
+@SdkInternalApi
+public class S3ClientComposer {
+
+    private S3ClientComposer() {
+    }
+
+    public static S3Client composeSync(S3Client base, SdkClientConfiguration clientConfiguration) {
+        List<ConditionalDecorator<S3Client>> decorators = new ArrayList<>();
+        decorators.add(ConditionalDecorator.create(isCrossRegionEnabledSync(clientConfiguration),
+                                                   S3CrossRegionSyncClient::new));
+        return ConditionalDecorator.decorate(base, decorators);
+    }
+
+    public static S3AsyncClient composeAsync(S3AsyncClient base, SdkClientConfiguration clientConfiguration) {
+        List<ConditionalDecorator<S3AsyncClient>> decorators = new ArrayList<>();
+        decorators.add(ConditionalDecorator.create(isCrossRegionEnabledAsync(clientConfiguration),
+                                                   S3CrossRegionAsyncClient::new));
+        return ConditionalDecorator.decorate(base, decorators);
+    }
+
+    private static Predicate<S3Client> isCrossRegionEnabledSync(SdkClientConfiguration clientConfiguration) {
+        return client -> ((S3Configuration) clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION))
+            .crossRegionAccessEnabled();
+    }
+
+    private static Predicate<S3AsyncClient> isCrossRegionEnabledAsync(SdkClientConfiguration clientConfiguration) {
+        return client -> ((S3Configuration) clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION))
+            .crossRegionAccessEnabled();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/client/S3SyncClientComposer.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/client/S3SyncClientComposer.java
@@ -19,41 +19,29 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.internal.client.ClientComposer;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
-import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClient;
 import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionSyncClient;
 import software.amazon.awssdk.utils.ConditionalDecorator;
 
 @SdkInternalApi
-public class S3ClientComposer {
+public class S3SyncClientComposer implements ClientComposer<S3Client> {
 
-    private S3ClientComposer() {
+    public S3SyncClientComposer() {
     }
 
-    public static S3Client composeSync(S3Client base, SdkClientConfiguration clientConfiguration) {
+    @Override
+    public S3Client compose(S3Client base, SdkClientConfiguration clientConfiguration) {
         List<ConditionalDecorator<S3Client>> decorators = new ArrayList<>();
         decorators.add(ConditionalDecorator.create(isCrossRegionEnabledSync(clientConfiguration),
                                                    S3CrossRegionSyncClient::new));
         return ConditionalDecorator.decorate(base, decorators);
     }
 
-    public static S3AsyncClient composeAsync(S3AsyncClient base, SdkClientConfiguration clientConfiguration) {
-        List<ConditionalDecorator<S3AsyncClient>> decorators = new ArrayList<>();
-        decorators.add(ConditionalDecorator.create(isCrossRegionEnabledAsync(clientConfiguration),
-                                                   S3CrossRegionAsyncClient::new));
-        return ConditionalDecorator.decorate(base, decorators);
-    }
-
-    private static Predicate<S3Client> isCrossRegionEnabledSync(SdkClientConfiguration clientConfiguration) {
-        return client -> ((S3Configuration) clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION))
-            .crossRegionAccessEnabled();
-    }
-
-    private static Predicate<S3AsyncClient> isCrossRegionEnabledAsync(SdkClientConfiguration clientConfiguration) {
+    private Predicate<S3Client> isCrossRegionEnabledSync(SdkClientConfiguration clientConfiguration) {
         return client -> ((S3Configuration) clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION))
             .crossRegionAccessEnabled();
     }

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -275,6 +275,7 @@
   ],
   "delegateAsyncClientClass": true,
   "delegateSyncClientClass": true,
+  "clientComposerFactory": "software.amazon.awssdk.services.s3.internal.client.S3ClientComposer",
   "useGlobalEndpoint": true,
   "interceptors": [
     "software.amazon.awssdk.services.s3.internal.handlers.PutObjectInterceptor",

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -275,7 +275,8 @@
   ],
   "delegateAsyncClientClass": true,
   "delegateSyncClientClass": true,
-  "clientComposerFactory": "software.amazon.awssdk.services.s3.internal.client.S3ClientComposer",
+  "syncClientComposer": "software.amazon.awssdk.services.s3.internal.client.S3SyncClientComposer",
+  "asyncClientComposer": "software.amazon.awssdk.services.s3.internal.client.S3AsyncClientComposer",
   "useGlobalEndpoint": true,
   "interceptors": [
     "software.amazon.awssdk.services.s3.internal.handlers.PutObjectInterceptor",

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/ClientCompositionFactoryTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/ClientCompositionFactoryTest.java
@@ -27,7 +27,8 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
-import software.amazon.awssdk.services.s3.internal.client.S3ClientComposer;
+import software.amazon.awssdk.services.s3.internal.client.S3AsyncClientComposer;
+import software.amazon.awssdk.services.s3.internal.client.S3SyncClientComposer;
 import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClient;
 import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionSyncClient;
 
@@ -36,8 +37,9 @@ public class ClientCompositionFactoryTest {
     @ParameterizedTest
     @MethodSource("syncTestCases")
     void syncClientTest(Consumer<S3Configuration.Builder> s3ConfigSettings, Class<Object> clazz, boolean isClass) {
-        S3Client composedClient = S3ClientComposer.composeSync(S3Client.create(),
-                                                               clientConfigWithServiceConfig(s3ConfigSettings));
+        S3SyncClientComposer composer = new S3SyncClientComposer();
+        S3Client composedClient = composer.compose(S3Client.create(),
+                                                   clientConfigWithServiceConfig(s3ConfigSettings));
         if (isClass) {
             assertThat(composedClient).isInstanceOf(clazz);
         } else {
@@ -48,8 +50,9 @@ public class ClientCompositionFactoryTest {
     @ParameterizedTest
     @MethodSource("asyncTestCases")
     void asyncClientTest(Consumer<S3Configuration.Builder> s3ConfigSettings, Class<Object> clazz, boolean isClass) {
-        S3AsyncClient composedClient = S3ClientComposer.composeAsync(S3AsyncClient.create(),
-                                                                     clientConfigWithServiceConfig(s3ConfigSettings));
+        S3AsyncClientComposer composer = new S3AsyncClientComposer();
+        S3AsyncClient composedClient = composer.compose(S3AsyncClient.create(),
+                                                        clientConfigWithServiceConfig(s3ConfigSettings));
         if (isClass) {
             assertThat(composedClient).isInstanceOf(clazz);
         } else {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/ClientCompositionFactoryTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/ClientCompositionFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.internal.client.S3ClientComposer;
+import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClient;
+import software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionSyncClient;
+
+public class ClientCompositionFactoryTest {
+
+    @ParameterizedTest
+    @MethodSource("syncTestCases")
+    void syncClientTest(Consumer<S3Configuration.Builder> s3ConfigSettings, Class<Object> clazz, boolean isClass) {
+        S3Client composedClient = S3ClientComposer.composeSync(S3Client.create(),
+                                                               clientConfigWithServiceConfig(s3ConfigSettings));
+        if (isClass) {
+            assertThat(composedClient).isInstanceOf(clazz);
+        } else {
+            assertThat(composedClient).isNotInstanceOf(clazz);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("asyncTestCases")
+    void asyncClientTest(Consumer<S3Configuration.Builder> s3ConfigSettings, Class<Object> clazz, boolean isClass) {
+        S3AsyncClient composedClient = S3ClientComposer.composeAsync(S3AsyncClient.create(),
+                                                                     clientConfigWithServiceConfig(s3ConfigSettings));
+        if (isClass) {
+            assertThat(composedClient).isInstanceOf(clazz);
+        } else {
+            assertThat(composedClient).isNotInstanceOf(clazz);
+        }
+    }
+
+    private SdkClientConfiguration clientConfigWithServiceConfig(Consumer<S3Configuration.Builder> s3ConfigSettings) {
+        S3Configuration s3Configuration = S3Configuration.builder().applyMutation(s3ConfigSettings).build();
+        return SdkClientConfiguration.builder().option(SdkClientOption.SERVICE_CONFIGURATION, s3Configuration).build();
+    }
+
+    private static Stream<Arguments> syncTestCases() {
+        return Stream.of(
+            Arguments.of((Consumer<S3Configuration.Builder>) c -> {}, S3CrossRegionSyncClient.class, false),
+            Arguments.of((Consumer<S3Configuration.Builder>) c -> c.crossRegionAccessEnabled(false), S3CrossRegionSyncClient.class, false),
+            Arguments.of((Consumer<S3Configuration.Builder>) c -> c.crossRegionAccessEnabled(true), S3CrossRegionSyncClient.class, true)
+        );
+    }
+
+    private static Stream<Arguments> asyncTestCases() {
+        return Stream.of(
+            Arguments.of((Consumer<S3Configuration.Builder>) c -> {}, S3CrossRegionAsyncClient.class, false),
+            Arguments.of((Consumer<S3Configuration.Builder>) c -> c.crossRegionAccessEnabled(false), S3CrossRegionAsyncClient.class, false),
+            Arguments.of((Consumer<S3Configuration.Builder>) c -> c.crossRegionAccessEnabled(true), S3CrossRegionAsyncClient.class, true)
+        );
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/ConditionalDecorator.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ConditionalDecorator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.utils.internal.DefaultConditionalDecorator;
+
+/**
+ * An interface that defines a class that contains a transform for another type as well as a condition for whether
+ * that transform should be applied.
+ *
+ * @param <T> A type that can be decorated, or transformed, through applying a function.
+ */
+@FunctionalInterface
+@SdkProtectedApi
+public interface ConditionalDecorator<T> {
+
+    default Predicate<T> predicate() {
+        return t -> true;
+    }
+
+
+    UnaryOperator<T> transform();
+
+    static <T> ConditionalDecorator<T> create(Predicate<T> predicate, UnaryOperator<T> transform) {
+        DefaultConditionalDecorator.Builder<T> builder = new DefaultConditionalDecorator.Builder<>();
+        return builder.predicate(predicate).transform(transform).build();
+    }
+
+    /**
+     * This function will transform an initially supplied value with provided transforming, or decorating, functions that are
+     * conditionally and sequentially applied. For each pair of condition and transform: if the condition evaluates to true, the
+     * transform will be applied to the incoming value and the output from the transform is the input to the next transform.
+     * <p>
+     * If the supplied collection is ordered, the function is guaranteed to apply the transforms in the order in which they appear
+     * in the collection.
+     *
+     * @param initialValue The untransformed start value
+     * @param decorators   A list of condition to transform
+     * @param <T>          The type of the value
+     * @return A single transformed value that is the result of applying all transforms evaluated to true
+     */
+    static <T> T decorate(T initialValue, List<ConditionalDecorator<T>> decorators) {
+        return decorators.stream()
+                         .filter(d -> d.predicate().test(initialValue))
+                         .reduce(initialValue,
+                                 (element, decorator) -> decorator.transform().apply(element),
+                                 (el1, el2) -> { throw new IllegalStateException("Should not reach here, combine function not "
+                                                                                 + "needed unless executed in parallel."); });
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/DefaultConditionalDecorator.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/DefaultConditionalDecorator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.internal;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.ConditionalDecorator;
+
+@SdkInternalApi
+public final class DefaultConditionalDecorator<T> implements ConditionalDecorator<T> {
+    private final Predicate<T> predicate;
+    private final UnaryOperator<T> transform;
+
+    DefaultConditionalDecorator(Builder<T> builder) {
+        this.predicate = builder.predicate;
+        this.transform = builder.transform;
+    }
+
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    @Override
+    public Predicate<T> predicate() {
+        return predicate;
+    }
+
+    @Override
+    public UnaryOperator<T> transform() {
+        return transform;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultConditionalDecorator)) {
+            return false;
+        }
+
+        DefaultConditionalDecorator<?> that = (DefaultConditionalDecorator<?>) o;
+
+        if (!Objects.equals(predicate, that.predicate)) {
+            return false;
+        }
+        return Objects.equals(transform, that.transform);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = predicate != null ? predicate.hashCode() : 0;
+        result = 31 * result + (transform != null ? transform.hashCode() : 0);
+        return result;
+    }
+
+    public static final class Builder<T> {
+        private Predicate<T> predicate;
+        private UnaryOperator<T> transform;
+
+        public Builder<T> predicate(Predicate<T> predicate) {
+            this.predicate = predicate;
+            return this;
+        }
+
+        public Builder<T> transform(UnaryOperator<T> transform) {
+            this.transform = transform;
+            return this;
+        }
+
+        public ConditionalDecorator<T> build() {
+            return new DefaultConditionalDecorator<>(this);
+        }
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/ConditionalDecoratorTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/ConditionalDecoratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+public class ConditionalDecoratorTest {
+
+    @Test
+    void basicTransform_directlyCalled_isSuccessful() {
+        ConditionalDecorator<Integer> decorator = ConditionalDecorator.create(i -> true, i -> i + 1);
+        assertThat(decorator.transform().apply(3)).isEqualTo(4);
+    }
+
+    @Test
+    void listOfOrderedTransforms_singleTransformAlwaysTrue_isSuccessful() {
+        ConditionalDecorator<Integer> d1 = ConditionalDecorator.create(i -> true, i -> i + 1);
+        assertThat(ConditionalDecorator.decorate(2, Collections.singletonList(d1))).isEqualTo(3);
+    }
+
+    @Test
+    void listOfOrderedTransforms_alwaysTrue_isSuccessful() {
+        ConditionalDecorator<Integer> d1 = ConditionalDecorator.create(i -> true, i -> i + 1);
+        ConditionalDecorator<Integer> d2 = ConditionalDecorator.create(i -> true, i -> i * 2);
+        assertThat(ConditionalDecorator.decorate(2, Arrays.asList(d1, d2))).isEqualTo(6);
+    }
+
+    @Test
+    void listOfOrderedTransformsInReverse_alwaysTrue_isSuccessful() {
+        ConditionalDecorator<Integer> d1 = ConditionalDecorator.create(i -> true, i -> i + 1);
+        ConditionalDecorator<Integer> d2 = ConditionalDecorator.create(i -> true, i -> i * 2);
+        assertThat(ConditionalDecorator.decorate(2, Arrays.asList(d2, d1))).isEqualTo(5);
+    }
+
+    @Test
+    void listOfOrderedTransforms_onlyAddsEvenNumbers_isSuccessful() {
+        List<ConditionalDecorator<Integer>> decorators =
+            IntStream.range(0, 9)
+                     .<ConditionalDecorator<Integer>>mapToObj(i -> ConditionalDecorator.create(j -> i % 2 == 0,
+                                                                                               j -> j + i))
+                     .collect(Collectors.toList());
+        assertThat(ConditionalDecorator.decorate(0, decorators)).isEqualTo(20);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Users want cross region ability, but do not want or need to know implementation details, they just want to enable the feature. This change modifies the S3 client builder code to check if cross region is enabled and then wraps the regular client in the cross region client and returns it (as an S3Client/S3AsyncClient). 

## Modifications
- Adds a customization flag to point out where the logic for creating a composed S3 client is located
- Changes the builder logic to check the customization flag and if so, call the composing code instead of just returning the client
- Also refactors the builder code to make it more readable
- Adds a decorator utility that can do conditional transforms
- Adds S3 specific logic for creating a list of decorators for client construction and conditions on when to apply them, that are submitted to the decorator utility. Adds the cross region client to the list. 

## Testing
Unit and functional testing.
