### PR TITLE
Add auth scheme params based on endpoint params

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -231,6 +231,16 @@ public class CustomizationConfig {
      */
     private boolean requiredTraitValidationEnabled = false;
 
+    /**
+     * Whether to generate auth scheme params based on endpoint params.
+     */
+    private boolean enableEndpointAuthSchemeParams = false;
+
+    /**
+     * List of endpoint params to be used for the auth scheme params
+     */
+    private List<String> allowedEndpointAuthSchemeParams = new ArrayList<>();
+
     private CustomizationConfig() {
     }
 
@@ -607,5 +617,21 @@ public class CustomizationConfig {
 
     public void setRequiredTraitValidationEnabled(boolean requiredTraitValidationEnabled) {
         this.requiredTraitValidationEnabled = requiredTraitValidationEnabled;
+    }
+
+    public void setEnableEndpointAuthSchemeParams(boolean enableEndpointAuthSchemeParams) {
+        this.enableEndpointAuthSchemeParams = enableEndpointAuthSchemeParams;
+    }
+
+    public boolean isEnableEndpointAuthSchemeParams() {
+        return enableEndpointAuthSchemeParams;
+    }
+
+    public void setAllowedEndpointAuthSchemeParams(List<String> allowedEndpointAuthSchemeParams) {
+        this.allowedEndpointAuthSchemeParams = allowedEndpointAuthSchemeParams;
+    }
+
+    public List<String> getAllowedEndpointAuthSchemeParams() {
+        return this.allowedEndpointAuthSchemeParams;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
@@ -18,16 +18,22 @@ package software.amazon.awssdk.codegen.poet.auth.scheme;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.utils.AuthUtils;
 import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
 
 public final class AuthSchemeSpecUtils {
     private final IntermediateModel intermediateModel;
+    private final Set<String> allowedEndpointAuthSchemeParams;
 
     public AuthSchemeSpecUtils(IntermediateModel intermediateModel) {
         this.intermediateModel = intermediateModel;
+        this.allowedEndpointAuthSchemeParams = Collections.unmodifiableSet(
+            new HashSet<>(intermediateModel.getCustomizationConfig().getAllowedEndpointAuthSchemeParams()));
     }
 
     private String basePackage() {
@@ -50,6 +56,10 @@ public final class AuthSchemeSpecUtils {
         return ClassName.get(internalPackage(), "Default" + parametersInterfaceName().simpleName());
     }
 
+    public ClassName parametersDefaultBuilderImplName() {
+        return ClassName.get(internalPackage(), "Default" + parametersInterfaceName().simpleName());
+    }
+
     public ClassName providerInterfaceName() {
         return ClassName.get(basePackage(), intermediateModel.getMetadata().getServiceName() + "AuthSchemeProvider");
     }
@@ -66,4 +76,15 @@ public final class AuthSchemeSpecUtils {
         return AuthUtils.usesAwsAuth(intermediateModel);
     }
 
+    public String paramMethodName(String name) {
+        return intermediateModel.getNamingStrategy().getVariableName(name);
+    }
+
+    public boolean generateEndpointBasedParams() {
+        return intermediateModel.getCustomizationConfig().isEnableEndpointAuthSchemeParams();
+    }
+
+    public boolean includeParam(String name) {
+        return allowedEndpointAuthSchemeParams.contains(name);
+    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/DefaultAuthSchemeParamsSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/DefaultAuthSchemeParamsSpec.java
@@ -19,22 +19,29 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
-import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import java.lang.reflect.Type;
-import java.util.Optional;
+import java.util.Map;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.Validate;
 
 public class DefaultAuthSchemeParamsSpec implements ClassSpec {
+
+    private final IntermediateModel intermediateModel;
     private final AuthSchemeSpecUtils authSchemeSpecUtils;
+    private final EndpointRulesSpecUtils endpointRulesSpecUtils;
 
     public DefaultAuthSchemeParamsSpec(IntermediateModel intermediateModel) {
+        this.intermediateModel = intermediateModel;
         this.authSchemeSpecUtils = new AuthSchemeSpecUtils(intermediateModel);
+        this.endpointRulesSpecUtils = new EndpointRulesSpecUtils(intermediateModel);
     }
 
     @Override
@@ -45,15 +52,15 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
     @Override
     public TypeSpec poetSpec() {
         TypeSpec.Builder b = PoetUtils.createClassBuilder(className())
-                              .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                              .addAnnotation(SdkInternalApi.class)
-                              .addSuperinterface(authSchemeSpecUtils.parametersInterfaceName())
-                              .addMethod(constructor())
-                              .addMethod(builderMethod())
-                              .addType(builderImplSpec());
+                                      .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                                      .addAnnotation(SdkInternalApi.class)
+                                      .addSuperinterface(authSchemeSpecUtils.parametersInterfaceName())
+                                      .addMethod(constructor())
+                                      .addMethod(builderMethod())
+                                      .addType(builderImplSpec());
 
         addFieldsAndAccessors(b);
-
+        addToBuilder(b);
         return b.build();
     }
 
@@ -67,7 +74,29 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
         if (authSchemeSpecUtils.usesSigV4()) {
             b.addStatement("this.region = builder.region");
         }
+
+        if (authSchemeSpecUtils.generateEndpointBasedParams()) {
+            parameters().forEach((name, model) -> {
+                if (authSchemeSpecUtils.includeParam(name)) {
+                    String fieldName = authSchemeSpecUtils.paramMethodName(name);
+                    boolean isRequired = isParamRequired(model);
+                    if (isRequired) {
+                        b.addStatement("this.$1N = $2T.paramNotNull(builder.$1N, $1S)",
+                                       fieldName, Validate.class);
+                    } else {
+                        b.addStatement("this.$1N = builder.$1N", fieldName);
+                    }
+
+                }
+            });
+        }
+
         return b.build();
+    }
+
+    private boolean isParamRequired(ParameterModel model) {
+        Boolean isRequired = model.isRequired();
+        return (isRequired != null && isRequired) || model.getDefault() != null;
     }
 
     private MethodSpec builderMethod() {
@@ -83,6 +112,7 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
                                      .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
                                      .addSuperinterface(authSchemeSpecUtils.parametersInterfaceBuilderInterfaceName());
 
+        addBuilderConstructors(b);
         addBuilderFieldsAndSetter(b);
 
         b.addMethod(MethodSpec.methodBuilder("build")
@@ -93,6 +123,27 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
                               .build());
 
         return b.build();
+    }
+
+    private void addBuilderConstructors(TypeSpec.Builder b) {
+        b.addMethod(MethodSpec.constructorBuilder()
+                              .build());
+
+        MethodSpec.Builder builderFromInstance = MethodSpec.constructorBuilder()
+                                                           .addParameter(className(), "params");
+
+        builderFromInstance.addStatement("this.operation = params.operation");
+        if (authSchemeSpecUtils.usesSigV4()) {
+            builderFromInstance.addStatement("this.region = params.region");
+        }
+        if (authSchemeSpecUtils.generateEndpointBasedParams()) {
+            parameters().forEach((name, model) -> {
+                if (authSchemeSpecUtils.includeParam(name)) {
+                    builderFromInstance.addStatement("this.$1N = params.$1N", endpointRulesSpecUtils.variableName(name));
+                }
+            });
+        }
+        b.addMethod(builderFromInstance.build());
     }
 
     private void addFieldsAndAccessors(TypeSpec.Builder b) {
@@ -108,34 +159,64 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
                               .build());
 
         if (authSchemeSpecUtils.usesSigV4()) {
-            b.addField(FieldSpec.builder(String.class, "region")
+            b.addField(FieldSpec.builder(Region.class, "region")
                                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                                 .build());
 
             b.addMethod(MethodSpec.methodBuilder("region")
                                   .addModifiers(Modifier.PUBLIC)
                                   .addAnnotation(Override.class)
-                                  .returns(ParameterizedTypeName.get(Optional.class, String.class))
-                                  .addStatement("return region == null ? Optional.empty() : Optional.of(region)")
+                                  .returns(Region.class)
+                                  .addStatement("return region")
                                   .build());
         }
+
+        if (authSchemeSpecUtils.generateEndpointBasedParams()) {
+            parameters().forEach((name, model) -> {
+                if (authSchemeSpecUtils.includeParam(name)) {
+                    b.addField(endpointRulesSpecUtils.parameterClassField(name, model));
+                    b.addMethod(endpointRulesSpecUtils.parameterClassAccessorMethod(name, model)
+                                                      .toBuilder()
+                                                      .addAnnotation(Override.class)
+                                                      .build());
+                }
+            });
+        }
+    }
+
+    private void addToBuilder(TypeSpec.Builder b) {
+        b.addMethod(MethodSpec.methodBuilder("toBuilder")
+                              .addModifiers(Modifier.PUBLIC)
+                              .addAnnotation(Override.class)
+                              .returns(authSchemeSpecUtils.parametersInterfaceBuilderInterfaceName())
+                              .addStatement("return new $T(this)", builderClassName())
+                              .build());
     }
 
     private void addBuilderFieldsAndSetter(TypeSpec.Builder b) {
         b.addField(FieldSpec.builder(String.class, "operation")
                             .addModifiers(Modifier.PRIVATE)
                             .build());
-        b.addMethod(builderSetterMethod("operation", String.class));
+        b.addMethod(builderSetterMethod("operation", TypeName.get(String.class)));
 
         if (authSchemeSpecUtils.usesSigV4()) {
-            b.addField(FieldSpec.builder(String.class, "region")
+            b.addField(FieldSpec.builder(Region.class, "region")
                                 .addModifiers(Modifier.PRIVATE)
                                 .build());
-            b.addMethod(builderSetterMethod("region", String.class));
+            b.addMethod(builderSetterMethod("region", TypeName.get(Region.class)));
+        }
+
+        if (authSchemeSpecUtils.generateEndpointBasedParams()) {
+            parameters().forEach((name, model) -> {
+                if (authSchemeSpecUtils.includeParam(name)) {
+                    b.addField(endpointRulesSpecUtils.parameterBuilderFieldSpec(name, model));
+                    b.addMethod(endpointRulesSpecUtils.parameterBuilderSetterMethod(className(), name, model));
+                }
+            });
         }
     }
 
-    private MethodSpec builderSetterMethod(String field, Type type) {
+    private MethodSpec builderSetterMethod(String field, TypeName type) {
         return MethodSpec.methodBuilder(field)
                          .addModifiers(Modifier.PUBLIC)
                          .addAnnotation(Override.class)
@@ -148,5 +229,9 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
 
     private ClassName builderClassName() {
         return className().nestedClass("Builder");
+    }
+
+    private Map<String, ParameterModel> parameters() {
+        return intermediateModel.getEndpointRuleSetModel().getParameters();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointParametersClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointParametersClassSpec.java
@@ -15,24 +15,17 @@
 
 package software.amazon.awssdk.codegen.poet.rules;
 
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.jr.stree.JrsBoolean;
-import com.fasterxml.jackson.jr.stree.JrsString;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeSpec;
 import java.util.Map;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
-import software.amazon.awssdk.codegen.model.rules.endpoints.BuiltInParameter;
 import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
-import software.amazon.awssdk.regions.Region;
 
 public class EndpointParametersClassSpec implements ClassSpec {
     private final IntermediateModel intermediateModel;
@@ -56,8 +49,8 @@ public class EndpointParametersClassSpec implements ClassSpec {
                                       .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
         parameters().forEach((name, model) -> {
-            b.addField(fieldSpec(name, model).toBuilder().addModifiers(Modifier.FINAL).build());
-            b.addMethod(accessorMethod(name, model));
+            b.addField(endpointRulesSpecUtils.parameterClassField(name, model));
+            b.addMethod(endpointRulesSpecUtils.parameterClassAccessorMethod(name, model));
         });
 
         return b.build();
@@ -73,7 +66,7 @@ public class EndpointParametersClassSpec implements ClassSpec {
                                          .addModifiers(Modifier.PUBLIC);
 
         parameters().forEach((name, model) -> {
-            b.addMethod(setterMethodDeclaration(name, model));
+            b.addMethod(endpointRulesSpecUtils.parameterBuilderSetterMethodDeclaration(className(), name, model));
         });
 
         b.addMethod(MethodSpec.methodBuilder("build")
@@ -90,8 +83,8 @@ public class EndpointParametersClassSpec implements ClassSpec {
                                      .addSuperinterface(builderInterfaceName());
 
         parameters().forEach((name, model) -> {
-            b.addField(fieldSpec(name, model).toBuilder().initializer(defaultValueCode(model)).build());
-            b.addMethod(builderSetterMethod(name, model));
+            b.addField(endpointRulesSpecUtils.parameterBuilderFieldSpec(name, model));
+            b.addMethod(endpointRulesSpecUtils.parameterBuilderSetterMethod(className(), name, model));
         });
 
         b.addMethod(MethodSpec.methodBuilder("build")
@@ -118,51 +111,6 @@ public class EndpointParametersClassSpec implements ClassSpec {
         return intermediateModel.getEndpointRuleSetModel().getParameters();
     }
 
-    private ParameterSpec parameterSpec(String name, ParameterModel model) {
-        return ParameterSpec.builder(endpointRulesSpecUtils.parameterType(model), variableName(name)).build();
-    }
-
-    private FieldSpec fieldSpec(String name, ParameterModel model) {
-        return FieldSpec.builder(endpointRulesSpecUtils.parameterType(model), variableName(name))
-                        .addModifiers(Modifier.PRIVATE)
-                        .build();
-    }
-
-    private MethodSpec setterMethodDeclaration(String name, ParameterModel model) {
-        MethodSpec.Builder b = paramMethodBuilder(name, model);
-        b.addModifiers(Modifier.ABSTRACT);
-        b.addParameter(parameterSpec(name, model));
-        b.returns(builderInterfaceName());
-        return b.build();
-    }
-
-    private MethodSpec accessorMethod(String name, ParameterModel model) {
-        MethodSpec.Builder b = paramMethodBuilder(name, model);
-        b.returns(endpointRulesSpecUtils.parameterType(model));
-        b.addStatement("return $N", variableName(name));
-        return b.build();
-    }
-
-    private MethodSpec builderSetterMethod(String name, ParameterModel model) {
-        String memberName = variableName(name);
-
-        MethodSpec.Builder b = paramMethodBuilder(name, model)
-            .addAnnotation(Override.class)
-            .addParameter(parameterSpec(name, model))
-            .returns(builderInterfaceName())
-            .addStatement("this.$1N = $1N", memberName);
-
-        TreeNode defaultValue = model.getDefault();
-        if (defaultValue != null) {
-            b.beginControlFlow("if (this.$N == null)", memberName);
-            b.addStatement("this.$N = $L", memberName, defaultValueCode(model));
-            b.endControlFlow();
-        }
-
-        b.addStatement("return this");
-        return b.build();
-    }
-
     private MethodSpec ctor() {
         MethodSpec.Builder b = MethodSpec.constructorBuilder()
                                          .addModifiers(Modifier.PRIVATE)
@@ -185,43 +133,5 @@ public class EndpointParametersClassSpec implements ClassSpec {
 
     private String variableName(String name) {
         return intermediateModel.getNamingStrategy().getVariableName(name);
-    }
-
-    private CodeBlock defaultValueCode(ParameterModel parameterModel) {
-        CodeBlock.Builder b = CodeBlock.builder();
-
-        TreeNode defaultValue = parameterModel.getDefault();
-
-        if (defaultValue == null) {
-            return b.build();
-        }
-
-        switch (defaultValue.asToken()) {
-            case VALUE_STRING:
-                String stringValue = ((JrsString) defaultValue).getValue();
-                if (parameterModel.getBuiltInEnum() == BuiltInParameter.AWS_REGION) {
-                    b.add("$T.of($S)", Region.class, stringValue);
-                } else {
-                    b.add("$S", stringValue);
-                }
-                break;
-            case VALUE_TRUE:
-            case VALUE_FALSE:
-                b.add("$L", ((JrsBoolean) defaultValue).booleanValue());
-                break;
-            default:
-                throw new RuntimeException("Don't know how to set default value for parameter of type "
-                                           + defaultValue.asToken());
-        }
-        return b.build();
-    }
-
-    private MethodSpec.Builder paramMethodBuilder(String name, ParameterModel model) {
-        MethodSpec.Builder b = MethodSpec.methodBuilder(endpointRulesSpecUtils.paramMethodName(name));
-        b.addModifiers(Modifier.PUBLIC);
-        if (model.getDeprecated() != null) {
-            b.addAnnotation(Deprecated.class);
-        }
-        return b;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -20,6 +20,9 @@ import com.fasterxml.jackson.jr.stree.JrsBoolean;
 import com.fasterxml.jackson.jr.stree.JrsString;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.io.IOException;
@@ -32,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
+import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.Metadata;
@@ -206,5 +210,190 @@ public class EndpointRulesSpecUtils {
     public boolean isDeclaredParam(String paramName) {
         Map<String, ParameterModel> parameters = intermediateModel.getEndpointRuleSetModel().getParameters();
         return parameters.containsKey(paramName);
+    }
+
+    /**
+     * Creates a data-class level field for the given parameter. For instance
+     *
+     * <pre>
+     *     private final Region region;
+     * </pre>
+     */
+    public FieldSpec parameterClassField(String name, ParameterModel model) {
+        return parameterFieldSpecBuilder(name, model)
+            .addModifiers(Modifier.PRIVATE)
+            .addModifiers(Modifier.FINAL)
+            .build();
+    }
+
+    /**
+     * Creates a data-class method to access the given parameter. For instance
+     *
+     * <pre>
+     *     public Region region() {…};
+     * </pre>
+     */
+    public MethodSpec parameterClassAccessorMethod(String name, ParameterModel model) {
+        MethodSpec.Builder b = parameterMethodBuilder(name, model);
+        b.returns(parameterType(model));
+        b.addStatement("return $N", variableName(name));
+        return b.build();
+    }
+
+
+    /**
+     * Creates a data-interface method to access the given parameter. For instance
+     *
+     * <pre>
+     *     Region region();
+     * </pre>
+     */
+    public MethodSpec parameterInterfaceAccessorMethod(String name, ParameterModel model) {
+        MethodSpec.Builder b = parameterMethodBuilder(name, model);
+        b.returns(parameterType(model));
+        b.addModifiers(Modifier.ABSTRACT);
+        return b.build();
+    }
+
+    /**
+     * Creates a builder-class level field for the given parameter initialized to its default value when present. For instance
+     *
+     * <pre>
+     *    private Boolean useGlobalEndpoint = false;
+     * </pre>
+     */
+    public FieldSpec parameterBuilderFieldSpec(String name, ParameterModel model) {
+        return parameterFieldSpecBuilder(name, model)
+            .initializer(parameterDefaultValueCode(model))
+            .build();
+    }
+
+    /**
+     * Creates a builder-interface method to set the given parameter. For instance
+     *
+     * <pre>
+     *    Builder region(Region region);
+     * </pre>
+     *
+     */
+    public MethodSpec parameterBuilderSetterMethodDeclaration(ClassName containingClass, String name, ParameterModel model) {
+        MethodSpec.Builder b = parameterMethodBuilder(name, model);
+        b.addModifiers(Modifier.ABSTRACT);
+        b.addParameter(parameterSpec(name, model));
+        b.returns(containingClass.nestedClass("Builder"));
+        return b.build();
+    }
+
+    /**
+     * Creates a builder-class method to set the given parameter. For instance
+     *
+     * <pre>
+     *    public Builder region(Region region) {…};
+     * </pre>
+     */
+    public MethodSpec parameterBuilderSetterMethod(ClassName containingClass, String name, ParameterModel model) {
+        String memberName = variableName(name);
+
+        MethodSpec.Builder b = parameterMethodBuilder(name, model)
+            .addAnnotation(Override.class)
+            .addParameter(parameterSpec(name, model))
+            .returns(containingClass.nestedClass("Builder"))
+            .addStatement("this.$1N = $1N", memberName);
+
+        TreeNode defaultValue = model.getDefault();
+        if (defaultValue != null) {
+            b.beginControlFlow("if (this.$N == null)", memberName);
+            b.addStatement("this.$N = $L", memberName, parameterDefaultValueCode(model));
+            b.endControlFlow();
+        }
+
+        b.addStatement("return this");
+        return b.build();
+    }
+
+    /**
+     * Used internally to create a field for the given parameter. Returns the builder that can be further tailor to be used for
+     * data-classes or for builder-classes.
+     */
+    private FieldSpec.Builder parameterFieldSpecBuilder(String name, ParameterModel model) {
+        return FieldSpec.builder(parameterType(model), variableName(name))
+                        .addModifiers(Modifier.PRIVATE);
+    }
+
+    /**
+     * Used internally to create the spec for a parameter to be used in a method for the given param model. For instance, for
+     * {@code ParameterModel} for {@code Region} it creates this parameter for the builder setter.
+     *
+     * <pre>
+     *    public Builder region(
+     *          Region region // <<--- This
+     *          ) {…};
+     * </pre>
+     */
+    private ParameterSpec parameterSpec(String name, ParameterModel model) {
+        return ParameterSpec.builder(parameterType(model), variableName(name)).build();
+    }
+
+    /**
+     * Used internally to create a accessor method for the given parameter model. Returns the builder that can be further
+     * tailor to be used for data-classes/interfaces and builder-classes/interfaces.
+     */
+    private MethodSpec.Builder parameterMethodBuilder(String name, ParameterModel model) {
+        MethodSpec.Builder b = MethodSpec.methodBuilder(paramMethodName(name));
+        b.addModifiers(Modifier.PUBLIC);
+        if (model.getDeprecated() != null) {
+            b.addAnnotation(Deprecated.class);
+        }
+        return b;
+    }
+
+    /**
+     * Used internally to create the code to initialize the default value modeled for the given parameter. For instance, if the
+     * modeled default for region is "us-east-1", it will create
+     *
+     * <pre>
+     *     Region.of("us-east-1")
+     * </pre>
+     *
+     * and if the modeled default value for a boolean parameter useGlobalEndpoint is "false", it will create
+     *
+     * <pre>
+     *     false
+     * </pre>
+     */
+    private CodeBlock parameterDefaultValueCode(ParameterModel parameterModel) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        TreeNode defaultValue = parameterModel.getDefault();
+
+        if (defaultValue == null) {
+            return b.build();
+        }
+
+        switch (defaultValue.asToken()) {
+            case VALUE_STRING:
+                String stringValue = ((JrsString) defaultValue).getValue();
+                if (parameterModel.getBuiltInEnum() == BuiltInParameter.AWS_REGION) {
+                    b.add("$T.of($S)", Region.class, stringValue);
+                } else {
+                    b.add("$S", stringValue);
+                }
+                break;
+            case VALUE_TRUE:
+            case VALUE_FALSE:
+                b.add("$L", ((JrsBoolean) defaultValue).booleanValue());
+                break;
+            default:
+                throw new RuntimeException("Don't know how to set default value for parameter of type "
+                                           + defaultValue.asToken());
+        }
+        return b.build();
+    }
+
+    /**
+     * Returns the name as a variable name using the intermediate model naming strategy.
+     */
+    public String variableName(String name) {
+        return intermediateModel.getNamingStrategy().getVariableName(name);
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -108,6 +108,29 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel queryServiceModelsEndpointAuthParams() {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/query/service-2.json").getFile());
+        File customizationModel =
+            new File(ClientTestModels.class.getResource("client/c2j/query/customization-endpoint-auth-params.config")
+                                           .getFile());
+        File waitersModel = new File(ClientTestModels.class.getResource("client/c2j/query/waiters-2.json").getFile());
+        File endpointRuleSetModel =
+            new File(ClientTestModels.class.getResource("client/c2j/query/endpoint-rule-set.json").getFile());
+        File endpointTestsModel =
+            new File(ClientTestModels.class.getResource("client/c2j/query/endpoint-tests.json").getFile());
+
+        C2jModels models = C2jModels
+            .builder()
+            .serviceModel(getServiceModel(serviceModel))
+            .customizationConfig(getCustomizationConfig(customizationModel))
+            .waitersModel(getWaiters(waitersModel))
+            .endpointRuleSetModel(getEndpointRuleSet(endpointRuleSetModel))
+            .endpointTestSuiteModel(getEndpointTestSuite(endpointTestsModel))
+            .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     public static IntermediateModel xmlServiceModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/xml/service-2.json").getFile());
         File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/xml/customization.config").getFile());

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecTest.java
@@ -18,33 +18,128 @@ package software.amazon.awssdk.codegen.poet.auth.scheme;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.ClientTestModels;
 
 public class AuthSchemeSpecTest {
 
-    @Test
-    public void authSchemeParams() {
-        ClassSpec authSchemeParams = new AuthSchemeParamsSpec(ClientTestModels.queryServiceModels());
-        assertThat(authSchemeParams, generatesTo("auth-scheme-params.java"));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testCase(TestCase testCase) {
+        ClassSpec classSpec = testCase.classSpecProvider.apply(testCase.modelProvider.get());
+        String expectedFileName = testCase.caseName + "-auth-scheme-" + testCase.outputFileSuffix + ".java";
+        assertThat("Generated class must match " + expectedFileName,
+            classSpec, generatesTo(expectedFileName));
     }
 
-    @Test
-    public void authSchemeProvider() {
-        ClassSpec authSchemeProvider = new AuthSchemeProviderSpec(ClientTestModels.queryServiceModels());
-        assertThat(authSchemeProvider, generatesTo("auth-scheme-provider.java"));
+    static List<TestCase> parameters() {
+        return Arrays.asList(
+            // query
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModels)
+                    .classSpecProvider(AuthSchemeProviderSpec::new)
+                    .caseName("query")
+                    .outputFileSuffix("provider")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModels)
+                    .classSpecProvider(AuthSchemeParamsSpec::new)
+                    .caseName("query")
+                    .outputFileSuffix("params")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModels)
+                    .classSpecProvider(DefaultAuthSchemeProviderSpec::new)
+                    .caseName("query")
+                    .outputFileSuffix("default-provider")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModels)
+                    .classSpecProvider(DefaultAuthSchemeParamsSpec::new)
+                    .caseName("query")
+                    .outputFileSuffix("default-params")
+                    .build(),
+            // query-endpoint-auth-params
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModelsEndpointAuthParams)
+                    .classSpecProvider(AuthSchemeProviderSpec::new)
+                    .caseName("query-endpoint-auth-params")
+                    .outputFileSuffix("provider")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModelsEndpointAuthParams)
+                    .classSpecProvider(AuthSchemeParamsSpec::new)
+                    .caseName("query-endpoint-auth-params")
+                    .outputFileSuffix("params")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModelsEndpointAuthParams)
+                    .classSpecProvider(DefaultAuthSchemeProviderSpec::new)
+                    .caseName("query-endpoint-auth-params")
+                    .outputFileSuffix("default-provider")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::queryServiceModelsEndpointAuthParams)
+                    .classSpecProvider(DefaultAuthSchemeParamsSpec::new)
+                    .caseName("query-endpoint-auth-params")
+                    .outputFileSuffix("default-params")
+                    .build()
+        );
     }
 
-    @Test
-    public void defaultAuthSchemeParams() {
-        ClassSpec defaultAuthSchemeParams = new DefaultAuthSchemeParamsSpec(ClientTestModels.queryServiceModels());
-        assertThat(defaultAuthSchemeParams, generatesTo("default-auth-scheme-params.java"));
-    }
+    static class TestCase {
+        private final Supplier<IntermediateModel> modelProvider;
+        private final Function<IntermediateModel, ClassSpec> classSpecProvider;
+        private final String outputFileSuffix;
+        private final String caseName;
 
-    @Test
-    public void defaultAuthSchemeProvider() {
-        ClassSpec defaultAuthSchemeProvider = new DefaultAuthSchemeProviderSpec(ClientTestModels.queryServiceModels());
-        assertThat(defaultAuthSchemeProvider, generatesTo("default-auth-scheme-provider.java"));
+        TestCase(Builder builder) {
+            this.modelProvider = builder.modelProvider;
+            this.classSpecProvider = builder.classSpecProvider;
+            this.outputFileSuffix = builder.outputFileSuffix;
+            this.caseName = builder.caseName;
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        static class Builder {
+            private Supplier<IntermediateModel> modelProvider;
+            private Function<IntermediateModel, ClassSpec> classSpecProvider;
+            private String outputFileSuffix;
+            private String caseName;
+
+            Builder modelProvider(Supplier<IntermediateModel> modelProvider) {
+                this.modelProvider = modelProvider;
+                return this;
+            }
+
+            Builder classSpecProvider(Function<IntermediateModel, ClassSpec> classSpecProvider) {
+                this.classSpecProvider = classSpecProvider;
+                return this;
+            }
+
+            Builder outputFileSuffix(String outputFileSuffix) {
+                this.outputFileSuffix = outputFileSuffix;
+                return this;
+            }
+
+            Builder caseName(String caseName) {
+                this.caseName = caseName;
+                return this;
+            }
+
+            TestCase build() {
+                return new TestCase(this);
+            }
+        }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-default-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-default-params.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme.internal;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
+import software.amazon.awssdk.utils.Validate;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams {
+    private final String operation;
+
+    private final Region region;
+
+    private DefaultQueryAuthSchemeParams(Builder builder) {
+        this.operation = Validate.paramNotNull(builder.operation, "operation");
+        this.region = builder.region;
+    }
+
+    public static QueryAuthSchemeParams.Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String operation() {
+        return operation;
+    }
+
+    @Override
+    public Region region() {
+        return region;
+    }
+
+    @Override
+    public QueryAuthSchemeParams.Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    private static final class Builder implements QueryAuthSchemeParams.Builder {
+        private String operation;
+
+        private Region region;
+
+        Builder() {
+        }
+
+        Builder(DefaultQueryAuthSchemeParams params) {
+            this.operation = params.operation;
+            this.region = params.region;
+        }
+
+        @Override
+        public Builder operation(String operation) {
+            this.operation = operation;
+            return this;
+        }
+
+        @Override
+        public Builder region(Region region) {
+            this.region = region;
+            return this;
+        }
+
+        @Override
+        public QueryAuthSchemeParams build() {
+            return new DefaultQueryAuthSchemeParams(this);
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-default-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-default-provider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
+import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProvider {
+    private static final DefaultQueryAuthSchemeProvider DEFAULT = new DefaultQueryAuthSchemeProvider();
+
+    private DefaultQueryAuthSchemeProvider() {
+    }
+
+    public static DefaultQueryAuthSchemeProvider create() {
+        return DEFAULT;
+    }
+
+    @Override
+    public List<AuthSchemeOption> resolveAuthScheme(QueryAuthSchemeParams authSchemeParams) {
+        return new ArrayList<>();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-params.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.query.auth.scheme.internal.DefaultQueryAuthSchemeParams;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * The parameters object used to resolve the auth schemes for the Query service.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface QueryAuthSchemeParams extends ToCopyableBuilder<QueryAuthSchemeParams.Builder, QueryAuthSchemeParams> {
+    /**
+     * Get a new builder for creating a {@link QueryAuthSchemeParams}.
+     */
+    static Builder builder() {
+        return DefaultQueryAuthSchemeParams.builder();
+    }
+
+    /**
+     * Returns the operation for which to resolve the auth scheme.
+     */
+    String operation();
+
+    /**
+     * Returns the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
+     */
+    Region region();
+
+    /**
+     * Returns a {@link Builder} to customize the parameters.
+     */
+    Builder toBuilder();
+
+    /**
+     * A builder for a {@link QueryAuthSchemeParams}.
+     */
+    interface Builder extends CopyableBuilder<Builder, QueryAuthSchemeParams> {
+        /**
+         * Set the operation for which to resolve the auth scheme.
+         */
+        Builder operation(String operation);
+
+        /**
+         * Set the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
+         */
+        Builder region(Region region);
+
+        /**
+         * Returns a {@link QueryAuthSchemeParams} object that is created from the properties that have been set on the
+         * builder.
+         */
+        QueryAuthSchemeParams build();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-provider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme;
+
+import java.util.List;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeProvider;
+import software.amazon.awssdk.services.query.auth.scheme.internal.DefaultQueryAuthSchemeProvider;
+
+/**
+ * An auth scheme provider for Query service. The auth scheme provider takes a set of parameters using
+ * {@link QueryAuthSchemeParams}, and resolves a list of {@link AuthSchemeOption} based on the given parameters.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface QueryAuthSchemeProvider extends AuthSchemeProvider {
+    /**
+     * Resolve the auth schemes based on the given set of parameters.
+     */
+    List<AuthSchemeOption> resolveAuthScheme(QueryAuthSchemeParams authSchemeParams);
+
+    /**
+     * Resolve the auth schemes based on the given set of parameters.
+     */
+    default List<AuthSchemeOption> resolveAuthScheme(Consumer<QueryAuthSchemeParams.Builder> consumer) {
+        QueryAuthSchemeParams.Builder builder = QueryAuthSchemeParams.builder();
+        consumer.accept(builder);
+        return resolveAuthScheme(builder.build());
+    }
+
+    /**
+     * Get the default auth scheme provider.
+     */
+    static QueryAuthSchemeProvider defaultProvider() {
+        return DefaultQueryAuthSchemeProvider.create();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-params.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme.internal;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
+import software.amazon.awssdk.utils.Validate;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams {
+    private final String operation;
+
+    private final Region region;
+
+    private final Boolean defaultTrueParam;
+
+    private final String defaultStringParam;
+
+    private final String deprecatedParam;
+
+    private final Boolean booleanContextParam;
+
+    private final String stringContextParam;
+
+    private final String operationContextParam;
+
+    private DefaultQueryAuthSchemeParams(Builder builder) {
+        this.operation = Validate.paramNotNull(builder.operation, "operation");
+        this.region = builder.region;
+        this.defaultTrueParam = Validate.paramNotNull(builder.defaultTrueParam, "defaultTrueParam");
+        this.defaultStringParam = Validate.paramNotNull(builder.defaultStringParam, "defaultStringParam");
+        this.deprecatedParam = builder.deprecatedParam;
+        this.booleanContextParam = builder.booleanContextParam;
+        this.stringContextParam = builder.stringContextParam;
+        this.operationContextParam = builder.operationContextParam;
+    }
+
+    public static QueryAuthSchemeParams.Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String operation() {
+        return operation;
+    }
+
+    @Override
+    public Region region() {
+        return region;
+    }
+
+    @Override
+    public Boolean defaultTrueParam() {
+        return defaultTrueParam;
+    }
+
+    @Override
+    public String defaultStringParam() {
+        return defaultStringParam;
+    }
+
+    @Deprecated
+    @Override
+    public String deprecatedParam() {
+        return deprecatedParam;
+    }
+
+    @Override
+    public Boolean booleanContextParam() {
+        return booleanContextParam;
+    }
+
+    @Override
+    public String stringContextParam() {
+        return stringContextParam;
+    }
+
+    @Override
+    public String operationContextParam() {
+        return operationContextParam;
+    }
+
+    @Override
+    public QueryAuthSchemeParams.Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    private static final class Builder implements QueryAuthSchemeParams.Builder {
+        private String operation;
+
+        private Region region;
+
+        private Boolean defaultTrueParam = true;
+
+        private String defaultStringParam = "hello endpoints";
+
+        private String deprecatedParam;
+
+        private Boolean booleanContextParam;
+
+        private String stringContextParam;
+
+        private String operationContextParam;
+
+        Builder() {
+        }
+
+        Builder(DefaultQueryAuthSchemeParams params) {
+            this.operation = params.operation;
+            this.region = params.region;
+            this.defaultTrueParam = params.defaultTrueParam;
+            this.defaultStringParam = params.defaultStringParam;
+            this.deprecatedParam = params.deprecatedParam;
+            this.booleanContextParam = params.booleanContextParam;
+            this.stringContextParam = params.stringContextParam;
+            this.operationContextParam = params.operationContextParam;
+        }
+
+        @Override
+        public Builder operation(String operation) {
+            this.operation = operation;
+            return this;
+        }
+
+        @Override
+        public Builder region(Region region) {
+            this.region = region;
+            return this;
+        }
+
+        @Override
+        public Builder defaultTrueParam(Boolean defaultTrueParam) {
+            this.defaultTrueParam = defaultTrueParam;
+            if (this.defaultTrueParam == null) {
+                this.defaultTrueParam = true;
+            }
+            return this;
+        }
+
+        @Override
+        public Builder defaultStringParam(String defaultStringParam) {
+            this.defaultStringParam = defaultStringParam;
+            if (this.defaultStringParam == null) {
+                this.defaultStringParam = "hello endpoints";
+            }
+            return this;
+        }
+
+        @Deprecated
+        @Override
+        public Builder deprecatedParam(String deprecatedParam) {
+            this.deprecatedParam = deprecatedParam;
+            return this;
+        }
+
+        @Override
+        public Builder booleanContextParam(Boolean booleanContextParam) {
+            this.booleanContextParam = booleanContextParam;
+            return this;
+        }
+
+        @Override
+        public Builder stringContextParam(String stringContextParam) {
+            this.stringContextParam = stringContextParam;
+            return this;
+        }
+
+        @Override
+        public Builder operationContextParam(String operationContextParam) {
+            this.operationContextParam = operationContextParam;
+            return this;
+        }
+
+        @Override
+        public QueryAuthSchemeParams build() {
+            return new DefaultQueryAuthSchemeParams(this);
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-provider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
+import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProvider {
+    private static final DefaultQueryAuthSchemeProvider DEFAULT = new DefaultQueryAuthSchemeProvider();
+
+    private DefaultQueryAuthSchemeProvider() {
+    }
+
+    public static DefaultQueryAuthSchemeProvider create() {
+        return DEFAULT;
+    }
+
+    @Override
+    public List<AuthSchemeOption> resolveAuthScheme(QueryAuthSchemeParams authSchemeParams) {
+        return new ArrayList<>();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-params.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.query.auth.scheme.internal.DefaultQueryAuthSchemeParams;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * The parameters object used to resolve the auth schemes for the Query service.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface QueryAuthSchemeParams extends ToCopyableBuilder<QueryAuthSchemeParams.Builder, QueryAuthSchemeParams> {
+    /**
+     * Get a new builder for creating a {@link QueryAuthSchemeParams}.
+     */
+    static Builder builder() {
+        return DefaultQueryAuthSchemeParams.builder();
+    }
+
+    /**
+     * Returns the operation for which to resolve the auth scheme.
+     */
+    String operation();
+
+    /**
+     * Returns the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
+     */
+    Region region();
+
+    /**
+     * A param that defauls to true
+     */
+    Boolean defaultTrueParam();
+
+    String defaultStringParam();
+
+    @Deprecated
+    String deprecatedParam();
+
+    Boolean booleanContextParam();
+
+    String stringContextParam();
+
+    String operationContextParam();
+
+    /**
+     * Returns a {@link Builder} to customize the parameters.
+     */
+    Builder toBuilder();
+
+    /**
+     * A builder for a {@link QueryAuthSchemeParams}.
+     */
+    interface Builder extends CopyableBuilder<Builder, QueryAuthSchemeParams> {
+        /**
+         * Set the operation for which to resolve the auth scheme.
+         */
+        Builder operation(String operation);
+
+        /**
+         * Set the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
+         */
+        Builder region(Region region);
+
+        /**
+         * A param that defauls to true
+         */
+        Builder defaultTrueParam(Boolean defaultTrueParam);
+
+        Builder defaultStringParam(String defaultStringParam);
+
+        @Deprecated
+        Builder deprecatedParam(String deprecatedParam);
+
+        Builder booleanContextParam(Boolean booleanContextParam);
+
+        Builder stringContextParam(String stringContextParam);
+
+        Builder operationContextParam(String operationContextParam);
+
+        /**
+         * Returns a {@link QueryAuthSchemeParams} object that is created from the properties that have been set on the
+         * builder.
+         */
+        QueryAuthSchemeParams build();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-provider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.query.auth.scheme;
+
+import java.util.List;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeProvider;
+import software.amazon.awssdk.services.query.auth.scheme.internal.DefaultQueryAuthSchemeProvider;
+
+/**
+ * An auth scheme provider for Query service. The auth scheme provider takes a set of parameters using
+ * {@link QueryAuthSchemeParams}, and resolves a list of {@link AuthSchemeOption} based on the given parameters.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface QueryAuthSchemeProvider extends AuthSchemeProvider {
+    /**
+     * Resolve the auth schemes based on the given set of parameters.
+     */
+    List<AuthSchemeOption> resolveAuthScheme(QueryAuthSchemeParams authSchemeParams);
+
+    /**
+     * Resolve the auth schemes based on the given set of parameters.
+     */
+    default List<AuthSchemeOption> resolveAuthScheme(Consumer<QueryAuthSchemeParams.Builder> consumer) {
+        QueryAuthSchemeParams.Builder builder = QueryAuthSchemeParams.builder();
+        consumer.accept(builder);
+        return resolveAuthScheme(builder.build());
+    }
+
+    /**
+     * Get the default auth scheme provider.
+     */
+    static QueryAuthSchemeProvider defaultProvider() {
+        return DefaultQueryAuthSchemeProvider.create();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization-endpoint-auth-params.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization-endpoint-auth-params.config
@@ -1,0 +1,17 @@
+{
+  "authPolicyActions": {
+    "skip": true
+  },
+  "skipEndpointTests": {
+    "test case 4": "Does not work"
+  },
+  "enableEndpointAuthSchemeParams": true,
+  "allowedEndpointAuthSchemeParams": [
+    "defaultTrueParam",
+    "defaultStringParam",
+    "deprecatedParam",
+    "booleanContextParam",
+    "stringContextParam",
+    "operationContextParam"
+  ]
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
@@ -21,7 +21,8 @@
     },
     "defaultTrueParam": {
       "type": "boolean",
-      "default": true
+        "default": true,
+        "documentation": "A param that defauls to true"
     },
     "defaultStringParam": {
       "type": "string",

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -304,7 +304,8 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                  .required(false).build())
                     .addParameter(
                         Parameter.builder().name("defaultTrueParam").type(ParameterType.fromValue("boolean"))
-                                 .required(false).defaultValue(Value.fromBool(true)).build())
+                                  .required(false).documentation("A param that defauls to true")
+                                  .defaultValue(Value.fromBool(true)).build())
                     .addParameter(
                         Parameter.builder().name("defaultStringParam").type(ParameterType.fromValue("string"))
                                  .required(false).defaultValue(Value.fromStr("hello endpoints")).build())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Add the same set of parameters from the endpoint rules to the auth spec parameters class.

## Note

Supersedes [4053](https://github.com/aws/aws-sdk-java-v2/pull/4053) that got into a messy state after a merge attempt and conflicted with another recent change.

## Code Snippets

This is the generated interface for S3

```java
/*
 * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
 * the License. A copy of the License is located at
 * 
 * http://aws.amazon.com/apache2.0
 * 
 * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 * and limitations under the License.
 */

package software.amazon.awssdk.services.s3.auth.scheme;

import software.amazon.awssdk.annotations.Generated;
import software.amazon.awssdk.annotations.SdkPublicApi;
import software.amazon.awssdk.regions.Region;
import software.amazon.awssdk.services.s3.auth.scheme.internal.DefaultS3AuthSchemeParams;
import software.amazon.awssdk.utils.builder.CopyableBuilder;
import software.amazon.awssdk.utils.builder.ToCopyableBuilder;

/**
 * The parameters object used to resolve the auth schemes for the S3 service.
 */
@Generated("software.amazon.awssdk:codegen")
@SdkPublicApi
public interface S3AuthSchemeParams extends ToCopyableBuilder<S3AuthSchemeParams.Builder, S3AuthSchemeParams> {
    /**
     * Get a new builder for creating a {@link S3AuthSchemeParams}.
     */
    static Builder builder() {
        return DefaultS3AuthSchemeParams.builder();
    }

    /**
     * Returns the operation for which to resolve the auth scheme.
     */
    String operation();

    /**
     * Returns the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
     */
    Region region();

    /**
     * The S3 bucket used to send the request. This is an optional parameter that will be set automatically for
     * operations that are scoped to an S3 bucket.
     */
    String bucket();

    /**
     * When true, force a path-style endpoint to be used where the bucket name is part of the path.
     */
    Boolean forcePathStyle();

    /**
     * When true, use S3 Accelerate. NOTE: Not all regions support S3 accelerate.
     */
    Boolean accelerate();

    /**
     * Whether the global endpoint should be used, rather then the regional endpoint for us-east-1.
     */
    Boolean useGlobalEndpoint();

    /**
     * Internal parameter to use object lambda endpoint for an operation (eg: WriteGetObjectResponse)
     */
    Boolean useObjectLambdaEndpoint();

    /**
     * Whether multi-region access points (MRAP) should be disabled.
     */
    Boolean disableMultiRegionAccessPoints();

    /**
     * When an Access Point ARN is provided and this flag is enabled, the SDK MUST use the ARN's region when
     * constructing the endpoint instead of the client's configured region.
     */
    Boolean useArnRegion();

    /**
     * Returns a {@link Builder} to customize the parameters.
     */
    Builder toBuilder();

    /**
     * A builder for a {@link S3AuthSchemeParams}.
     */
    interface Builder extends CopyableBuilder<Builder, S3AuthSchemeParams> {
        /**
         * Set the operation for which to resolve the auth scheme.
         */
        Builder operation(String operation);

        /**
         * Set the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
         */
        Builder region(Region region);

        /**
         * The S3 bucket used to send the request. This is an optional parameter that will be set automatically for
         * operations that are scoped to an S3 bucket.
         */
        Builder bucket(String bucket);

        /**
         * When true, force a path-style endpoint to be used where the bucket name is part of the path.
         */
        Builder forcePathStyle(Boolean forcePathStyle);

        /**
         * When true, use S3 Accelerate. NOTE: Not all regions support S3 accelerate.
         */
        Builder accelerate(Boolean accelerate);

        /**
         * Whether the global endpoint should be used, rather then the regional endpoint for us-east-1.
         */
        Builder useGlobalEndpoint(Boolean useGlobalEndpoint);

        /**
         * Internal parameter to use object lambda endpoint for an operation (eg: WriteGetObjectResponse)
         */
        Builder useObjectLambdaEndpoint(Boolean useObjectLambdaEndpoint);

        /**
         * Whether multi-region access points (MRAP) should be disabled.
         */
        Builder disableMultiRegionAccessPoints(Boolean disableMultiRegionAccessPoints);

        /**
         * When an Access Point ARN is provided and this flag is enabled, the SDK MUST use the ARN's region when
         * constructing the endpoint instead of the client's configured region.
         */
        Builder useArnRegion(Boolean useArnRegion);

        /**
         * Returns a {@link S3AuthSchemeParams} object that is created from the properties that have been set on the
         * builder.
         */
        S3AuthSchemeParams build();
    }
}
```

With this change to the `customization.config` file

```
diff --git a/services/s3/src/main/resources/codegen-resources/customization.config b/services/s3/src/main/resources/codegen-resources/customization.config
index d09990c54ad..4357a165941 100644
--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -291,5 +291,15 @@
     "software.amazon.awssdk.services.s3.internal.handlers.GetObjectInterceptor",
     "software.amazon.awssdk.services.s3.internal.handlers.CopySourceInterceptor"
   ],
-  "requiredTraitValidationEnabled": true
+  "requiredTraitValidationEnabled": true,
+  "enableEndpointAuthSchemeParams": true,
+   "allowedEndpointAuthSchemeParams": [
+    "Bucket",
+    "ForcePathStyle",
+    "Accelerate",
+    "UseGlobalEndpoint",
+    "UseObjectLambdaEndpoint",
+    "DisableMultiRegionAccessPoints",
+    "UseArnRegion"
+  ]
 }
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
