### PR TITLE
Update version in new modules to 2.20.83-SNAPSHOT after merge

### DIFF
--- a/core/http-auth-aws-crt/pom.xml
+++ b/core/http-auth-aws-crt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.20.77-SNAPSHOT</version>
+        <version>2.20.83-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-auth-aws-crt</artifactId>

--- a/core/http-auth-aws/pom.xml
+++ b/core/http-auth-aws/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.20.77-SNAPSHOT</version>
+        <version>2.20.83-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-auth-aws</artifactId>

--- a/core/http-auth-event-stream/pom.xml
+++ b/core/http-auth-event-stream/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.20.77-SNAPSHOT</version>
+        <version>2.20.83-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-auth-event-stream</artifactId>

--- a/core/http-auth-spi/pom.xml
+++ b/core/http-auth-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.20.77-SNAPSHOT</version>
+        <version>2.20.83-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-auth-spi</artifactId>

--- a/core/http-auth/pom.xml
+++ b/core/http-auth/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.20.77-SNAPSHOT</version>
+        <version>2.20.83-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-auth</artifactId>

--- a/core/identity-spi/pom.xml
+++ b/core/identity-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.20.77-SNAPSHOT</version>
+        <version>2.20.83-SNAPSHOT</version>
     </parent>
 
     <artifactId>identity-spi</artifactId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
In the latest merge from master in https://github.com/aws/aws-sdk-java-v2/commit/4504f91e20fb0f424a93999545c8b68f16f21d1b, the version for the new modules in the branch weren't updated.

## Modifications
<!--- Describe your changes in detail -->
Update version in new modules to 2.20.83-SNAPSHOT