### PR TITLE
Add IdentityProviderConfiguration implementation

### DIFF
--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/IdentityProviderConfiguration.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/IdentityProviderConfiguration.java
@@ -16,8 +16,10 @@
 package software.amazon.awssdk.http.auth.spi;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.internal.DefaultIdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.utils.builder.SdkBuilder;
 
 /**
  * The identity providers configured in the SDK.
@@ -33,4 +35,23 @@ public interface IdentityProviderConfiguration {
      * Retrieve an identity provider for the provided identity type.
      */
     <T extends Identity> IdentityProvider<T> identityProvider(Class<T> identityType);
+
+    /**
+     * Get a new builder for creating a {@link IdentityProviderConfiguration}.
+     */
+    static Builder builder() {
+        return DefaultIdentityProviderConfiguration.builder();
+    }
+
+    /**
+     * A builder for a {@link IdentityProviderConfiguration}.
+     */
+    interface Builder extends SdkBuilder<Builder, IdentityProviderConfiguration> {
+
+        /**
+         * Add the {@link IdentityProvider} for a given type. If a provider of that type, as determined by {@link
+         * IdentityProvider#identityType()} is already added, it will be replaced.
+         */
+        <T extends Identity> Builder putIdentityProvider(IdentityProvider<T> identityProvider);
+    }
 }

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/IdentityProviderConfiguration.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/IdentityProviderConfiguration.java
@@ -19,7 +19,8 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.auth.spi.internal.DefaultIdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
-import software.amazon.awssdk.utils.builder.SdkBuilder;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * The identity providers configured in the SDK.
@@ -28,8 +29,8 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
  * configured on the SDK.
  */
 @SdkPublicApi
-@FunctionalInterface
-public interface IdentityProviderConfiguration {
+public interface IdentityProviderConfiguration extends ToCopyableBuilder<IdentityProviderConfiguration.Builder,
+    IdentityProviderConfiguration> {
 
     /**
      * Retrieve an identity provider for the provided identity type.
@@ -46,7 +47,7 @@ public interface IdentityProviderConfiguration {
     /**
      * A builder for a {@link IdentityProviderConfiguration}.
      */
-    interface Builder extends SdkBuilder<Builder, IdentityProviderConfiguration> {
+    interface Builder extends CopyableBuilder<Builder, IdentityProviderConfiguration> {
 
         /**
          * Add the {@link IdentityProvider} for a given type. If a provider of that type, as determined by {@link

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultIdentityProviderConfiguration.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultIdentityProviderConfiguration.java
@@ -43,6 +43,11 @@ public final class DefaultIdentityProviderConfiguration implements IdentityProvi
     }
 
     @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    @Override
     public String toString() {
         return ToString.builder("IdentityProviderConfiguration")
                        .add("identityProviders", identityProviders)
@@ -51,6 +56,13 @@ public final class DefaultIdentityProviderConfiguration implements IdentityProvi
 
     private static final class BuilderImpl implements Builder {
         private final Map<Class<?>, IdentityProvider<?>> identityProviders = new HashMap<>();
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(DefaultIdentityProviderConfiguration identityProviders) {
+            this.identityProviders.putAll(identityProviders.identityProviders);
+        }
 
         @Override
         public <T extends Identity> Builder putIdentityProvider(IdentityProvider<T> identityProvider) {

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultIdentityProviderConfiguration.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultIdentityProviderConfiguration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.spi.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public final class DefaultIdentityProviderConfiguration implements IdentityProviderConfiguration {
+
+    private final Map<Class<?>, IdentityProvider<?>> identityProviders;
+
+    private DefaultIdentityProviderConfiguration(BuilderImpl builder) {
+        this.identityProviders = new HashMap<>(builder.identityProviders);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public <T extends Identity> IdentityProvider<T> identityProvider(Class<T> identityType) {
+        return (IdentityProvider<T>) identityProviders.get(identityType);
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("IdentityProviderConfiguration")
+                       .add("identityProviders", identityProviders)
+                       .build();
+    }
+
+    private static final class BuilderImpl implements Builder {
+        private final Map<Class<?>, IdentityProvider<?>> identityProviders = new HashMap<>();
+
+        @Override
+        public <T extends Identity> Builder putIdentityProvider(IdentityProvider<T> identityProvider) {
+            Validate.paramNotNull(identityProvider, "identityProvider");
+            identityProviders.put(identityProvider.identityType(), identityProvider);
+            return this;
+        }
+
+        public IdentityProviderConfiguration build() {
+            return new DefaultIdentityProviderConfiguration(this);
+        }
+    }
+}

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/IdentityProviderConfigurationTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/IdentityProviderConfigurationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.spi;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
+import software.amazon.awssdk.identity.spi.TokenIdentity;
+
+class IdentityProviderConfigurationTest {
+
+    @Test
+    public void builder_empty_builds() {
+        assertNotNull(IdentityProviderConfiguration.builder().build());
+    }
+
+    @Test
+    public void identityProvider_canBeRetrieved() {
+        IdentityProvider<AwsCredentialsIdentity> awsCredentialsProvider = new AwsCredentialsProvider();
+        IdentityProviderConfiguration identityProviders =
+            IdentityProviderConfiguration.builder().putIdentityProvider(awsCredentialsProvider).build();
+        assertSame(awsCredentialsProvider, identityProviders.identityProvider(AwsCredentialsIdentity.class));
+    }
+
+    @Test
+    public void identityProvider_withUnknownType_returnsNull() {
+        IdentityProvider<AwsCredentialsIdentity> awsCredentialsProvider = new AwsCredentialsProvider();
+        IdentityProviderConfiguration identityProviders =
+            IdentityProviderConfiguration.builder().putIdentityProvider(awsCredentialsProvider).build();
+        assertNull(identityProviders.identityProvider(TokenIdentity.class));
+    }
+
+    @Test
+    public void identityProvider_withSubType_returnsAppropriateSubType() {
+        IdentityProvider<AwsCredentialsIdentity> awsCredentialsProvider = new AwsCredentialsProvider();
+        IdentityProvider<AwsSessionCredentialsIdentity> awsSessionCredentialsProvider = new AwsSessionCredentialsProvider();
+        IdentityProviderConfiguration identityProviders =
+            IdentityProviderConfiguration.builder()
+                                         .putIdentityProvider(awsCredentialsProvider)
+                                         .putIdentityProvider(awsSessionCredentialsProvider)
+                                         .build();
+
+        assertSame(awsCredentialsProvider, identityProviders.identityProvider(AwsCredentialsIdentity.class));
+        assertSame(awsSessionCredentialsProvider, identityProviders.identityProvider(AwsSessionCredentialsIdentity.class));
+    }
+
+    @Test
+    public void identityProvider_withOnlySubType_returnsNullForParentType() {
+        IdentityProvider<AwsSessionCredentialsIdentity> awsSessionCredentialsProvider = new AwsSessionCredentialsProvider();
+        IdentityProviderConfiguration identityProviders =
+            IdentityProviderConfiguration.builder()
+                                         .putIdentityProvider(awsSessionCredentialsProvider)
+                                         .build();
+
+        assertNull(identityProviders.identityProvider(AwsCredentialsIdentity.class));
+    }
+
+    private static final class AwsCredentialsProvider implements IdentityProvider<AwsCredentialsIdentity> {
+
+        @Override
+        public Class<AwsCredentialsIdentity> identityType() {
+            return AwsCredentialsIdentity.class;
+        }
+
+        @Override
+        public CompletableFuture<? extends AwsCredentialsIdentity> resolveIdentity(ResolveIdentityRequest request) {
+            return null;
+        }
+    }
+
+    private static final class AwsSessionCredentialsProvider implements IdentityProvider<AwsSessionCredentialsIdentity> {
+
+        @Override
+        public Class<AwsSessionCredentialsIdentity> identityType() {
+            return AwsSessionCredentialsIdentity.class;
+        }
+
+        @Override
+        public CompletableFuture<? extends AwsSessionCredentialsIdentity> resolveIdentity(ResolveIdentityRequest request) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Only an interface for IdentityProviderConfiguration was added earlier. Need a default implementation and builder.

## Modifications
<!--- Describe your changes in detail -->
Add Builder to the interface and a default internal implementation.

IdentityProviderConfiguration would initially be setup for a client, but we'd want to allow individual request to override its identity provider, so we would need to be able to copy the IdentityProviderConfiguration to mutate. So made it implement ToCopyableBuilder. This meant `@FunctionalInterface` needed to be dropped.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests.
