### PR TITLE
Make copy of properties map from Builder

### DIFF
--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultSignRequest.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultSignRequest.java
@@ -38,7 +38,7 @@ abstract class DefaultSignRequest<PayloadT, IdentityT extends Identity> implemen
         this.request = Validate.paramNotNull(builder.request, "request");
         this.payload = builder.payload;
         this.identity = Validate.paramNotNull(builder.identity, "identity");
-        this.properties = Collections.unmodifiableMap(builder.properties);
+        this.properties = Collections.unmodifiableMap(new HashMap<>(builder.properties));
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Otherwise, even after build() is called, if more properties are added to the same builder instance, it mutates the built DefaultSignRequest object.

## Modifications
<!--- Describe your changes in detail -->
In constructor of DefaultSignRequest, make copy of the properties map from the Builder.
