### PR TITLE
Add User Agent Api name for Cross region API calls

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClient.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.s3.internal.crossregion;
 
+import static software.amazon.awssdk.services.s3.internal.crossregion.utils.CrossRegionUtils.updateUserAgentInConfig;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -39,11 +41,14 @@ public final class S3CrossRegionAsyncClient extends DelegatingS3AsyncClient {
 
         Optional<String> bucket = request.getValueForField("Bucket", String.class);
 
+        AwsRequestOverrideConfiguration overrideConfiguration = updateUserAgentInConfig(request);
+        T userAgentUpdatedRequest = (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
+
         if (!bucket.isPresent()) {
-            return operation.apply(request);
+            return operation.apply(userAgentUpdatedRequest);
         }
 
-        return operation.apply(requestWithDecoratedEndpointProvider(request, bucket.get()))
+        return operation.apply(requestWithDecoratedEndpointProvider(userAgentUpdatedRequest, bucket.get()))
                         .whenComplete((r, t) -> handleOperationFailure(t, bucket.get()));
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/utils/CrossRegionUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/utils/CrossRegionUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crossregion.utils;
+
+
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.ApiName;
+import software.amazon.awssdk.services.s3.model.S3Request;
+
+@SdkInternalApi
+public final class CrossRegionUtils {
+    private static final ApiName API_NAME = ApiName.builder().version("cross-region").name("hll").build();
+    private static final Consumer<AwsRequestOverrideConfiguration.Builder> USER_AGENT_APPLIER = b -> b.addApiName(API_NAME);
+
+    private CrossRegionUtils() {
+    }
+
+    public static <T extends S3Request> AwsRequestOverrideConfiguration updateUserAgentInConfig(T request) {
+        AwsRequestOverrideConfiguration overrideConfiguration =
+            request.overrideConfiguration().map(c -> c.toBuilder()
+                                                      .applyMutation(USER_AGENT_APPLIER)
+                                                      .build())
+                   .orElse(AwsRequestOverrideConfiguration.builder()
+                                                          .applyMutation(USER_AGENT_APPLIER)
+                                                          .build());
+        return overrideConfiguration;
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
@@ -100,9 +100,16 @@ class S3CrossRegionAsyncClientTest {
 
     @Test
     void standardOp_crossRegionClient_containUserAgent() {
-        S3AsyncClient crossRegionClient = new S3CrossRegionAsyncClient(s3Client);
+        S3AsyncClient crossRegionClient = clientBuilder().serviceConfiguration(c -> c.crossRegionAccessEnabled(true)).build();
         crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes()).join();
         assertThat(mockAsyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get()).contains("hll/cross-region");
+    }
+
+    @Test
+    void standardOp_simpleClient_doesNotContainCrossRegionUserAgent() {
+        S3AsyncClient crossRegionClient = clientBuilder().serviceConfiguration(c -> c.crossRegionAccessEnabled(false)).build();
+        crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes()).join();
+        assertThat(mockAsyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get()).doesNotContain("hll/cross-region");
     }
 
     private S3AsyncClientBuilder clientBuilder() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
@@ -98,6 +98,13 @@ class S3CrossRegionAsyncClientTest {
         assertThat(captureInterceptor.endpointProvider).isInstanceOf(S3CrossRegionAsyncClient.BucketEndpointProvider.class);
     }
 
+    @Test
+    void standardOp_crossRegionClient_containUserAgent() {
+        S3AsyncClient crossRegionClient = new S3CrossRegionAsyncClient(s3Client);
+        crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes()).join();
+        assertThat(mockAsyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get()).contains("hll/cross-region");
+    }
+
     private S3AsyncClientBuilder clientBuilder() {
         return S3AsyncClient.builder()
                             .httpClient(mockAsyncHttpClient)

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
@@ -104,6 +104,14 @@ class S3CrossRegionSyncClientTest {
         assertThat(mockSyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get()).contains("hll/cross-region");
     }
 
+    @Test
+    void standardOp_simpleClient_doesNotContainCrossRegionUserAgent() {
+        S3Client crossRegionClient = clientBuilder().serviceConfiguration(c -> c.crossRegionAccessEnabled(false)).build();
+        crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));
+        assertThat(mockSyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get())
+            .doesNotContain("hll/cross-region");
+    }
+
     private S3ClientBuilder clientBuilder() {
         return S3Client.builder()
                        .httpClient(mockSyncHttpClient)

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -28,6 +29,7 @@ import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -93,6 +95,13 @@ class S3CrossRegionSyncClientTest {
         S3Client crossRegionClient = clientBuilder().serviceConfiguration(c -> c.crossRegionAccessEnabled(true)).build();
         crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));
         assertThat(captureInterceptor.endpointProvider).isInstanceOf(S3CrossRegionSyncClient.BucketEndpointProvider.class);
+    }
+
+    @Test
+    void standardOp_crossRegionClient_containUserAgent() {
+        S3Client crossRegionClient = clientBuilder().serviceConfiguration(c -> c.crossRegionAccessEnabled(true)).build();
+        crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));
+        assertThat(mockSyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get()).contains("hll/cross-region");
     }
 
     private S3ClientBuilder clientBuilder() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Add User Agent Api name for Cross region API calls
## Modifications
<!--- Describe your changes in detail -->
- Before calling the delgate the request Override config is updated
Final Sample User agent will look like this

```
Optional[aws-sdk-java/2.20.62-SNAPSHOT Mac_OS_X/19.9.1 OpenJDK_128-Bit_Server_VM/11.0.19+7-LTS Java/11.3.19 vendor/Comp_Inc. io/sync http/UNKNOWN cfg/retry-mode/legacy hll/cross-region]

```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Updated Junit
## Screenshots (if appropriate)
