### PR TITLE
Make ResolveIdentityRequest copyable

### DIFF
--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequest.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequest.java
@@ -19,7 +19,8 @@ import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.identity.spi.internal.DefaultResolveIdentityRequest;
-import software.amazon.awssdk.utils.builder.SdkBuilder;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * A request to resolve an {@link Identity}.
@@ -32,7 +33,7 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
 @SdkPublicApi
 @Immutable
 @ThreadSafe
-public interface ResolveIdentityRequest {
+public interface ResolveIdentityRequest extends ToCopyableBuilder<ResolveIdentityRequest.Builder, ResolveIdentityRequest> {
 
     /**
      * Get a new builder for creating a {@link ResolveIdentityRequest}.
@@ -49,7 +50,7 @@ public interface ResolveIdentityRequest {
     /**
      * A builder for a {@link ResolveIdentityRequest}.
      */
-    interface Builder extends SdkBuilder<Builder, ResolveIdentityRequest> {
+    interface Builder extends CopyableBuilder<Builder, ResolveIdentityRequest> {
 
         /**
          * Set a property that the {@link IdentityProvider} can use while resolving the identity.

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultResolveIdentityRequest.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultResolveIdentityRequest.java
@@ -32,8 +32,8 @@ public final class DefaultResolveIdentityRequest implements ResolveIdentityReque
 
     private final Map<IdentityProperty<?>, Object> properties;
 
-    private DefaultResolveIdentityRequest(Map<IdentityProperty<?>, Object> properties) {
-        this.properties = new HashMap<>(properties);
+    private DefaultResolveIdentityRequest(BuilderImpl builder) {
+        this.properties = new HashMap<>(builder.properties);
     }
 
     public static Builder builder() {
@@ -43,6 +43,11 @@ public final class DefaultResolveIdentityRequest implements ResolveIdentityReque
     @Override
     public <T> T property(IdentityProperty<T> property) {
         return (T) properties.get(property);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
     }
 
     @Override
@@ -73,13 +78,20 @@ public final class DefaultResolveIdentityRequest implements ResolveIdentityReque
     public static final class BuilderImpl implements Builder {
         private final Map<IdentityProperty<?>, Object> properties = new HashMap<>();
 
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(DefaultResolveIdentityRequest resolveIdentityRequest) {
+            this.properties.putAll(resolveIdentityRequest.properties);
+        }
+
         public <T> Builder putProperty(IdentityProperty<T> key, T value) {
             this.properties.put(key, value);
             return this;
         }
 
         public ResolveIdentityRequest build() {
-            return new DefaultResolveIdentityRequest(properties);
+            return new DefaultResolveIdentityRequest(this);
         }
     }
 }

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
@@ -43,4 +43,27 @@ public class ResolveIdentityRequestTest {
                                                                .build();
         assertEquals("value", request.property(property));
     }
+
+    @Test
+    public void putProperty_sameProperty_isReplaced() {
+        IdentityProperty<String> property = IdentityProperty.create(String.class, "key");
+        ResolveIdentityRequest request = ResolveIdentityRequest.builder()
+                                                               .putProperty(property, "value")
+                                                               .putProperty(property, "value2")
+                                                               .build();
+        assertEquals("value2", request.property(property));
+    }
+
+    @Test
+    public void copyBuilder_updateAddProperty_works() {
+        IdentityProperty<String> property1 = IdentityProperty.create(String.class, "key1");
+        ResolveIdentityRequest request = ResolveIdentityRequest.builder()
+                                                               .putProperty(property1, "key1value1")
+                                                               .build();
+
+        IdentityProperty<String> property2 = IdentityProperty.create(String.class, "key2");
+        request = request.copy(builder -> builder.putProperty(property1, "key1value2").putProperty(property2, "key2value1"));
+        assertEquals("key1value2", request.property(property1));
+        assertEquals("key2value1", request.property(property2));
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Helps resolve ambiguity with consumer builder pattern when using IdentityProvider.resolveIdentity. Identified the issue while working on this PR - https://github.com/aws/aws-sdk-java-v2/pull/4111/files#r1232724782

## Modifications
<!--- Describe your changes in detail -->
Make ResolveIdentityRequest copyable

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
added unit tests
