### PR TITLE
Request compression interceptor and non-streaming compression

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -77,6 +77,7 @@ import software.amazon.awssdk.core.internal.interceptor.AsyncRequestBodyHttpChec
 import software.amazon.awssdk.core.internal.interceptor.HttpChecksumInHeaderInterceptor;
 import software.amazon.awssdk.core.internal.interceptor.HttpChecksumRequiredInterceptor;
 import software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor;
+import software.amazon.awssdk.core.internal.interceptor.RequestCompressionInterceptor;
 import software.amazon.awssdk.core.internal.interceptor.SyncHttpChecksumInTrailerInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
@@ -444,6 +445,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
      */
     private List<ExecutionInterceptor> sdkInterceptors() {
         return Collections.unmodifiableList(Arrays.asList(
+            new RequestCompressionInterceptor(),
             new HttpChecksumRequiredInterceptor(),
             new SyncHttpChecksumInTrailerInterceptor(),
             new HttpChecksumValidationInterceptor(),

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/CompressionType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/CompressionType.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.compression;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.internal.compression.GzipCompressor;
+import software.amazon.awssdk.utils.internal.EnumUtils;
+
+/**
+ * The supported compression algorithms for operations with the requestCompression trait. Each supported algorithm will have an
+ * {@link Compressor} implementation.
+ */
+@SdkInternalApi
+public enum CompressionType {
+
+    GZIP("gzip"),
+
+    UNKNOWN_TO_SDK_VERSION(null);
+
+    private static final Map<String, CompressionType> VALUE_MAP = EnumUtils.uniqueIndex(
+        CompressionType.class, CompressionType::toString);
+
+    private final String value;
+
+    CompressionType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Maps the {@link CompressionType} to its corresponding {@link Compressor}.
+     * TODO: Update mappings here when additional compressors are supported in the future
+     */
+    public Compressor compressor() {
+        if (value == null) {
+            return null;
+        }
+        if (value.equals("gzip")) {
+            return new GzipCompressor();
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    /**
+     * Use this in place of valueOf to convert the raw string into the enum value.
+     *
+     * @param value
+     *        real value
+     * @return SupportedEncodings corresponding to the value
+     */
+    public static CompressionType fromValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return VALUE_MAP.getOrDefault(value, UNKNOWN_TO_SDK_VERSION);
+    }
+
+    /**
+     * Use this in place of {@link #values()} to return a {@link Set} of all values known to the SDK. This will return
+     * all known enum values except {@link #UNKNOWN_TO_SDK_VERSION}.
+     *
+     * @return a {@link Set} of known {@link CompressionType}s
+     */
+    public static Set<CompressionType> knownValues() {
+        Set<CompressionType> knownValues = EnumSet.allOf(CompressionType.class);
+        knownValues.remove(UNKNOWN_TO_SDK_VERSION);
+        return knownValues;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/CompressionType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/CompressionType.java
@@ -19,7 +19,6 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.internal.compression.GzipCompressor;
 import software.amazon.awssdk.utils.internal.EnumUtils;
 
 /**
@@ -40,20 +39,6 @@ public enum CompressionType {
 
     CompressionType(String value) {
         this.value = value;
-    }
-
-    /**
-     * Maps the {@link CompressionType} to its corresponding {@link Compressor}.
-     * TODO: Update mappings here when additional compressors are supported in the future
-     */
-    public Compressor compressor() {
-        if (value == null) {
-            return null;
-        }
-        if (value.equals("gzip")) {
-            return new GzipCompressor();
-        }
-        return null;
     }
 
     @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
@@ -52,7 +52,8 @@ public interface Compressor {
             case GZIP:
                 return new GzipCompressor();
             default:
-                return null;
+                throw new IllegalArgumentException("The compresssion type " + compressionType + "does not have an implemenation"
+                                                   + " of Compressor.");
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
@@ -15,11 +15,11 @@
 
 package software.amazon.awssdk.core.compression;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.internal.compression.GzipCompressor;
 import software.amazon.awssdk.core.internal.interceptor.RequestCompressionInterceptor;
 
 /**
@@ -28,23 +28,31 @@ import software.amazon.awssdk.core.internal.interceptor.RequestCompressionInterc
 @SdkPublicApi
 public interface Compressor {
 
-    /*
+    /**
      * The compression algorithm type.
      */
-    String contentType();
+    String compressorType();
 
-    /*
+    /**
      * Compress content of fixed length.
      */
-    byte[] compress(byte[] content);
+    byte[] compress(InputStream inputStream);
 
-    /*
-     * Compress a sync stream.
-     */
-    InputStream compressSyncStream(InputStream inputStream) throws IOException;
-
-    /*
+    /**
      * Compress an async stream.
      */
-    Publisher<ByteBuffer> compressAsyncStream(InputStream inputStream);
+    Publisher<ByteBuffer> compressAsyncStream(Publisher<ByteBuffer> publisher);
+
+    /**
+     * Maps the {@link CompressionType} to its corresponding {@link Compressor}.
+     * TODO: Update mappings here when additional compressors are supported in the future
+     */
+    static Compressor forCompressorType(CompressionType compressionType) {
+        switch (compressionType) {
+            case GZIP:
+                return new GzipCompressor();
+            default:
+                return null;
+        }
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.compression;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.internal.interceptor.RequestCompressionInterceptor;
+
+/**
+ * Interface for compressors to be used by {@link RequestCompressionInterceptor} to compress requests.
+ */
+@SdkPublicApi
+public interface Compressor {
+
+    /*
+     * The compression algorithm type.
+     */
+    String contentType();
+
+    /*
+     * Compress content of fixed length.
+     */
+    byte[] compress(byte[] content);
+
+    /*
+     * Compress a sync stream.
+     */
+    InputStream compressSyncStream(InputStream inputStream) throws IOException;
+
+    /*
+     * Compress an async stream.
+     */
+    Publisher<ByteBuffer> compressAsyncStream(InputStream inputStream);
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
@@ -34,9 +34,9 @@ public interface Compressor {
     String compressorType();
 
     /**
-     * Compress content of fixed length.
+     * Compress an {@link InputStream}.
      */
-    byte[] compress(InputStream inputStream);
+    InputStream compress(InputStream inputStream);
 
     /**
      * Compress an async stream.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.compression;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.zip.GZIPOutputStream;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.compression.Compressor;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+@SdkInternalApi
+public class GzipCompressor implements Compressor {
+
+    private static final String CONTENT_TYPE = "gzip";
+
+    @Override
+    public String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public byte[] compress(byte[] content) {
+        try {
+            ByteArrayOutputStream compressedOutputStream = new ByteArrayOutputStream();
+            GZIPOutputStream gzipOutputStream = new GZIPOutputStream(compressedOutputStream);
+            gzipOutputStream.write(content);
+            gzipOutputStream.close();
+
+            return compressedOutputStream.toByteArray();
+        } catch (IOException e) {
+            throw SdkClientException.create(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public InputStream compressSyncStream(InputStream inputStream) {
+        //TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Publisher<ByteBuffer> compressAsyncStream(InputStream inputStream) {
+        //TODO
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.internal.compression;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,7 +38,7 @@ public final class GzipCompressor implements Compressor {
     }
 
     @Override
-    public byte[] compress(InputStream inputStream) {
+    public InputStream compress(InputStream inputStream) {
         try {
             byte[] content = IoUtils.toByteArray(inputStream);
             ByteArrayOutputStream compressedOutputStream = new ByteArrayOutputStream();
@@ -45,7 +46,7 @@ public final class GzipCompressor implements Compressor {
             gzipOutputStream.write(content);
             gzipOutputStream.close();
 
-            return compressedOutputStream.toByteArray();
+            return new ByteArrayInputStream(compressedOutputStream.toByteArray());
         } catch (IOException e) {
             throw SdkClientException.create(e.getMessage(), e);
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
@@ -24,20 +24,22 @@ import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.compression.Compressor;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.utils.IoUtils;
 
 @SdkInternalApi
-public class GzipCompressor implements Compressor {
+public final class GzipCompressor implements Compressor {
 
-    private static final String CONTENT_TYPE = "gzip";
+    private static final String COMPRESSOR_TYPE = "gzip";
 
     @Override
-    public String contentType() {
-        return CONTENT_TYPE;
+    public String compressorType() {
+        return COMPRESSOR_TYPE;
     }
 
     @Override
-    public byte[] compress(byte[] content) {
+    public byte[] compress(InputStream inputStream) {
         try {
+            byte[] content = IoUtils.toByteArray(inputStream);
             ByteArrayOutputStream compressedOutputStream = new ByteArrayOutputStream();
             GZIPOutputStream gzipOutputStream = new GZIPOutputStream(compressedOutputStream);
             gzipOutputStream.write(content);
@@ -50,13 +52,7 @@ public class GzipCompressor implements Compressor {
     }
 
     @Override
-    public InputStream compressSyncStream(InputStream inputStream) {
-        //TODO
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Publisher<ByteBuffer> compressAsyncStream(InputStream inputStream) {
+    public Publisher<ByteBuffer> compressAsyncStream(Publisher<ByteBuffer> publisher) {
         //TODO
         throw new UnsupportedOperationException();
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/RequestCompressionInterceptor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/RequestCompressionInterceptor.java
@@ -164,7 +164,7 @@ public class RequestCompressionInterceptor implements ExecutionInterceptor {
     private static boolean resolveRequestCompressionEnabled(Context.ModifyHttpRequest context,
                                                             ExecutionAttributes executionAttributes) {
 
-        if (context.request().overrideConfiguration().get().requestCompressionConfiguration() != null
+        if (context.request().overrideConfiguration().isPresent()
             && context.request().overrideConfiguration().get().requestCompressionConfiguration().isPresent()) {
             Boolean requestCompressionEnabled = context.request().overrideConfiguration().get()
                                                        .requestCompressionConfiguration().get()

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/RequestCompressionInterceptor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/RequestCompressionInterceptor.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.interceptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.compression.CompressionType;
+import software.amazon.awssdk.core.compression.Compressor;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Interceptor to handles compression of requests whose operations are marked with the "requestCompression" C2J trait.
+ * Compression of payload will be completed prior to checksum calculation. The Content-Encoding header will be updated
+ * accordingly.
+ */
+@SdkInternalApi
+public class RequestCompressionInterceptor implements ExecutionInterceptor {
+
+    private static final int DEFAULT_MIN_COMPRESSION_SIZE = 10_240;
+    private static final int MIN_COMPRESSION_SIZE_LIMIT = 10_485_760;
+    private static final Supplier<ProfileFile> PROFILE_FILE = ProfileFile::defaultProfileFile;
+    private static final String PROFILE_NAME = ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow();
+
+    @Override
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        if (!shouldCompress(context, executionAttributes)) {
+            return context.httpRequest();
+        }
+        if (executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION).isStreaming()) {
+            return updateContentEncodingHeader(context.httpRequest(), executionAttributes);
+        }
+
+        Compressor compressor = resolveCompressionType(executionAttributes);
+        SdkHttpFullRequest sdkHttpFullRequest = (SdkHttpFullRequest) context.httpRequest();
+        try {
+            InputStream inputStream = sdkHttpFullRequest.contentStreamProvider().get().newStream();
+            byte[] compressedBytes = compressor.compress(IoUtils.toByteArray(inputStream));
+            SdkHttpRequest sdkHttpRequest =
+                sdkHttpFullRequest.toBuilder()
+                                  .contentStreamProvider(() -> new ByteArrayInputStream(compressedBytes))
+                                  .build();
+            sdkHttpRequest = updateContentEncodingHeader(sdkHttpRequest, executionAttributes);
+            return updateContentLengthHeader(sdkHttpRequest);
+        } catch (IOException e) {
+            throw SdkClientException.create(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Optional<RequestBody> modifyHttpContent(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        if (!context.requestBody().isPresent() || !shouldCompress(context, executionAttributes)) {
+            return context.requestBody();
+        }
+
+        RequestBody requestBody = context.requestBody().get();
+        Compressor compressor = resolveCompressionType(executionAttributes);
+
+        // TODO - Sync streaming compression implementation
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<AsyncRequestBody> modifyAsyncHttpContent(Context.ModifyHttpRequest context,
+                                                             ExecutionAttributes executionAttributes) {
+        if (!context.asyncRequestBody().isPresent() || !shouldCompress(context, executionAttributes)) {
+            return context.asyncRequestBody();
+        }
+
+        AsyncRequestBody asyncRequestBody = context.asyncRequestBody().get();
+        Compressor compressor = resolveCompressionType(executionAttributes);
+
+        // TODO - Async streaming compression implementation
+        throw new UnsupportedOperationException();
+    }
+
+    private static boolean shouldCompress(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        if (executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION) == null) {
+            return false;
+        }
+        if (resolveCompressionType(executionAttributes) == null) {
+            return false;
+        }
+        if (!resolveRequestCompressionEnabled(context, executionAttributes)) {
+            return false;
+        }
+        if (executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION).isStreaming()) {
+            return true;
+        }
+        SdkHttpFullRequest sdkHttpFullRequest = (SdkHttpFullRequest) context.httpRequest();
+        if (!sdkHttpFullRequest.contentStreamProvider().isPresent()) {
+            return false;
+        }
+        return isRequestSizeWithinThreshold(context, executionAttributes);
+    }
+
+    private static SdkHttpRequest updateContentEncodingHeader(SdkHttpRequest sdkHttpRequest,
+                                                             ExecutionAttributes executionAttributes) {
+        Compressor compressor = resolveCompressionType(executionAttributes);
+        if (sdkHttpRequest.firstMatchingHeader("Content-encoding").isPresent()) {
+            return sdkHttpRequest.copy(r -> r.appendHeader("Content-encoding", compressor.contentType()));
+        }
+
+        return sdkHttpRequest.copy(r -> r.putHeader("Content-encoding", compressor.contentType()));
+    }
+
+    private static SdkHttpRequest updateContentLengthHeader(SdkHttpRequest sdkHttpRequest) {
+        SdkHttpFullRequest sdkHttpFullRequest = (SdkHttpFullRequest) sdkHttpRequest;
+        InputStream inputStream = sdkHttpFullRequest.contentStreamProvider().get().newStream();
+        try {
+            byte[] bytes = IoUtils.toByteArray(inputStream);
+            String length = String.valueOf(bytes.length);
+            return sdkHttpRequest.copy(r -> r.putHeader("Content-Length", length));
+        } catch (IOException e) {
+            throw SdkClientException.create(e.getMessage(), e);
+        }
+    }
+
+    private static Compressor resolveCompressionType(ExecutionAttributes executionAttributes) {
+        List<String> encodings =
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION).getEncodings();
+
+        for (String encoding: encodings) {
+            CompressionType compressionType = CompressionType.fromValue(encoding.toLowerCase(Locale.ROOT));
+            if (compressionType == CompressionType.UNKNOWN_TO_SDK_VERSION) {
+                continue;
+            }
+            return compressionType.compressor();
+        }
+        return null;
+    }
+
+    private static boolean resolveRequestCompressionEnabled(Context.ModifyHttpRequest context,
+                                                            ExecutionAttributes executionAttributes) {
+
+        if (context.request().overrideConfiguration().get().requestCompressionConfiguration() != null
+            && context.request().overrideConfiguration().get().requestCompressionConfiguration().isPresent()) {
+            Boolean requestCompressionEnabled = context.request().overrideConfiguration().get()
+                                                       .requestCompressionConfiguration().get()
+                                                       .requestCompressionEnabled();
+            if (requestCompressionEnabled != null) {
+                return requestCompressionEnabled;
+            }
+        }
+
+        if (executionAttributes.getAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION) != null) {
+            Boolean requestCompressionEnabled = executionAttributes.getAttribute(
+                SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION).requestCompressionEnabled();
+            if (requestCompressionEnabled != null) {
+                return requestCompressionEnabled;
+            }
+        }
+
+        if (SdkSystemSetting.AWS_DISABLE_REQUEST_COMPRESSION.getBooleanValue().isPresent()) {
+            return !SdkSystemSetting.AWS_DISABLE_REQUEST_COMPRESSION.getBooleanValue().get();
+        }
+
+        Optional<Boolean> profileSetting =
+            PROFILE_FILE.get()
+                        .profile(PROFILE_NAME)
+                        .flatMap(p -> p.booleanProperty(ProfileProperty.DISABLE_REQUEST_COMPRESSION));
+        if (profileSetting.isPresent()) {
+            return !profileSetting.get();
+        }
+
+        return true;
+    }
+
+    private static boolean isRequestSizeWithinThreshold(Context.ModifyHttpRequest context,
+                                                        ExecutionAttributes executionAttributes) {
+        int minimumCompressionThreshold = resolveMinCompressionSize(context, executionAttributes);
+        validateMinCompressionSizeInput(minimumCompressionThreshold);
+
+        SdkHttpFullRequest sdkHttpFullRequest = (SdkHttpFullRequest) context.httpRequest();
+        long contentLength = Long.parseLong(sdkHttpFullRequest.firstMatchingHeader("Content-Length").orElse("0"));
+        return contentLength >= minimumCompressionThreshold;
+    }
+
+    private static int resolveMinCompressionSize(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+
+        if (context.request().overrideConfiguration().isPresent()
+            && context.request().overrideConfiguration().get().requestCompressionConfiguration().isPresent()) {
+            Integer minCompressionSize = context.request().overrideConfiguration().get()
+                                                .requestCompressionConfiguration().get()
+                                                .minimumCompressionThresholdInBytes();
+            if (minCompressionSize != null) {
+                return minCompressionSize;
+            }
+        }
+
+        if (executionAttributes.getAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION) != null) {
+            Integer minCompressionSize = executionAttributes.getAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION)
+                                                            .minimumCompressionThresholdInBytes();
+            if (minCompressionSize != null) {
+                return minCompressionSize;
+            }
+        }
+
+        if (SdkSystemSetting.AWS_REQUEST_MIN_COMPRESSION_SIZE_BYTES.getIntegerValue().isPresent()) {
+            return SdkSystemSetting.AWS_REQUEST_MIN_COMPRESSION_SIZE_BYTES.getIntegerValue().get();
+        }
+
+        Optional<String> profileSetting =
+            PROFILE_FILE.get()
+                        .profile(PROFILE_NAME)
+                        .flatMap(p -> p.property(ProfileProperty.REQUEST_MIN_COMPRESSION_SIZE_BYTES));
+        if (profileSetting.isPresent()) {
+            return Integer.parseInt(profileSetting.get());
+        }
+
+        return DEFAULT_MIN_COMPRESSION_SIZE;
+    }
+
+    private static void validateMinCompressionSizeInput(int minCompressionSize) {
+        if (!(minCompressionSize >= 0 && minCompressionSize <= MIN_COMPRESSION_SIZE_LIMIT)) {
+            throw SdkClientException.create("The minimum compression size must be non-negative with a maximum value of "
+                                               + "10485760.", new IllegalArgumentException());
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding request compression interceptor to handle compression, and implementing non-streaming compression.
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
Added CompressionType enum for supported encodings, Compressor interface and GzipCompressor implementation. 

## Testing
<!--- Please describe in detail how you tested your changes -->
To add tests once streaming compression is implemented.

Was able to send compressed PutMetricData request to CloudWatch successfully
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
