### PR TITLE
Change uses of RetryPolicy to RetryStrategy

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -130,6 +130,11 @@ public class CustomizationConfig {
      */
     private String customRetryPolicy;
 
+    /**
+     * Custom Retry strategy
+     */
+    private String customRetryStrategy;
+
     private boolean skipSyncClientGeneration;
 
     /**
@@ -416,8 +421,16 @@ public class CustomizationConfig {
         return customRetryPolicy;
     }
 
+    public String getCustomRetryStrategy() {
+        return customRetryStrategy;
+    }
+
     public void setCustomRetryPolicy(String customRetryPolicy) {
         this.customRetryPolicy = customRetryPolicy;
+    }
+
+    public void setCustomRetryStrategy(String customRetryStrategy) {
+        this.customRetryStrategy = customRetryStrategy;
     }
 
     public boolean isSkipSyncClientGeneration() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
@@ -205,6 +205,10 @@ public final class IntermediateModel {
         return customizationConfig.getCustomRetryPolicy();
     }
 
+    public String getCustomRetryStrategy() {
+        return customizationConfig.getCustomRetryStrategy();
+    }
+
     public String getSdkModeledExceptionBaseFqcn() {
         return String.format("%s.%s",
                              metadata.getFullModelPackageName(),

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -342,6 +342,12 @@ public class BaseClientBuilderClass implements ClassSpec {
                             PoetUtils.classNameFromFqcn(model.getCustomizationConfig().getCustomRetryPolicy()));
         }
 
+        if (StringUtils.isNotBlank(model.getCustomizationConfig().getCustomRetryStrategy())) {
+            builder.addCode(".option($1T.RETRY_STRATEGY, $2T.resolveRetryStrategy(config))",
+                            SdkClientOption.class,
+                            PoetUtils.classNameFromFqcn(model.getCustomizationConfig().getCustomRetryStrategy()));
+        }
+
         if (StringUtils.isNotBlank(clientConfigClassName)) {
             builder.addCode(".option($T.SERVICE_CONFIGURATION, finalServiceConfig)", SdkClientOption.class);
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import software.amazon.MyServiceHttpConfig;
 import software.amazon.MyServiceRetryPolicy;
+import software.amazon.MyServiceRetryStrategy;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
@@ -126,6 +127,7 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                      .option(AwsClientOption.FIPS_ENDPOINT_ENABLED, finalServiceConfig.fipsModeEnabled())
                      .option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
                      .option(SdkClientOption.RETRY_POLICY, MyServiceRetryPolicy.resolveRetryPolicy(config))
+                     .option(SdkClientOption.RETRY_STRATEGY, MyServiceRetryStrategy.resolveRetryStrategy(config))
                      .option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig).build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
@@ -10,6 +10,7 @@
       "hasFipsProperty": true
     },
     "customRetryPolicy": "software.amazon.MyServiceRetryPolicy",
+    "customRetryStrategy": "software.amazon.MyServiceRetryStrategy",
     "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
     "blacklistedSimpleMethods" : [
         "eventStreamOperation"

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
@@ -14,6 +14,7 @@
       "hasAccelerateModeEnabledProperty":true
     },
     "customRetryPolicy": "software.amazon.MyServiceRetryPolicy",
+    "customRetryStrategy": "software.amazon.MyServiceRetryStrategy",
     "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
     "blacklistedSimpleMethods" : [
         "eventStreamOperation"

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -372,28 +372,8 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
             }
         }
 
-        RetryMode retryMode = RetryMode.resolver()
-                                       .profileFile(config.option(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                       .profileName(config.option(SdkClientOption.PROFILE_NAME))
-                                       .defaultRetryMode(config.option(SdkClientOption.DEFAULT_RETRY_MODE))
-                                       .resolve();
-        return AwsRetryPolicy.forRetryMode(retryMode);
-        // TODO: fixme This will be changed like this to pick the configured retry strategy
-        // if no retry policy is configured.
-        /*
-        RetryPolicy policy = config.option(SdkClientOption.RETRY_POLICY);
-
-        if (policy != null) {
-            if (policy.additionalRetryConditionsAllowed()) {
-                return AwsRetryPolicy.addRetryConditions(policy);
-            } else {
-                return policy;
-            }
-        }
-
         // If we don't have a configured retry policy we will use the configured retry strategy instead.
         return null;
-         */
     }
 
     private RetryStrategy<?, ?> resolveAwsRetryStrategy(SdkClientConfiguration config) {

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultsModeTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultsModeTest.java
@@ -23,6 +23,7 @@ import static software.amazon.awssdk.awscore.client.config.AwsAdvancedClientOpti
 import static software.amazon.awssdk.awscore.client.config.AwsClientOption.DEFAULTS_MODE;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.DEFAULT_RETRY_MODE;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.RETRY_POLICY;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.RETRY_STRATEGY;
 import static software.amazon.awssdk.regions.ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT;
 
 import java.time.Duration;
@@ -36,6 +37,7 @@ import software.amazon.awssdk.awscore.internal.defaultsmode.AutoDefaultsModeDisc
 import software.amazon.awssdk.awscore.internal.defaultsmode.DefaultsModeConfiguration;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
@@ -75,7 +77,7 @@ public class DefaultsModeTest {
             .build();
 
         assertThat(client.clientConfiguration.option(DEFAULTS_MODE)).isEqualTo(DefaultsMode.LEGACY);
-        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(RetryMode.defaultRetryMode());
+        assertThat(SdkDefaultRetryStrategy.retryMode(client.clientConfiguration.option(RETRY_STRATEGY))).isEqualTo(RetryMode.defaultRetryMode());
         assertThat(client.clientConfiguration.option(DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT)).isNull();
     }
 
@@ -97,7 +99,7 @@ public class DefaultsModeTest {
 
         AttributeMap attributes = DefaultsModeConfiguration.defaultConfig(targetMode);
 
-        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(attributes.get(DEFAULT_RETRY_MODE));
+        assertThat(SdkDefaultRetryStrategy.retryMode(client.clientConfiguration.option(RETRY_STRATEGY))).isEqualTo(attributes.get(DEFAULT_RETRY_MODE));
         assertThat(client.clientConfiguration.option(DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT)).isEqualTo("regional");
     }
 
@@ -119,7 +121,7 @@ public class DefaultsModeTest {
 
         AttributeMap attributes = DefaultsModeConfiguration.defaultConfig(targetMode);
 
-        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(attributes.get(DEFAULT_RETRY_MODE));
+        assertThat(SdkDefaultRetryStrategy.retryMode(client.clientConfiguration.option(RETRY_STRATEGY))).isEqualTo(attributes.get(DEFAULT_RETRY_MODE));
     }
 
     @Test

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retries/api/RetryStrategy.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retries/api/RetryStrategy.java
@@ -84,6 +84,13 @@ public interface RetryStrategy<
     RecordSuccessResponse recordSuccess(RecordSuccessRequest request);
 
     /**
+     * Returns the maximum numbers attempts that this retry policy will allow.
+     *
+     * @return the maximum numbers attempts that this retry policy will allow.
+     */
+    int maxAttempts();
+
+    /**
      * Create a new {@link Builder} with the current configuration.
      *
      * <p>This is useful for modifying the strategy's behavior, like conditions or max retries.

--- a/core/retries-api/src/test/java/software/amazon/awssdk/retries/api/RetryStrategyBuilderTest.java
+++ b/core/retries-api/src/test/java/software/amazon/awssdk/retries/api/RetryStrategyBuilderTest.java
@@ -177,9 +177,15 @@ class RetryStrategyBuilderTest {
         }
 
         @Override
+        public int maxAttempts() {
+            return 0;
+        }
+
+        @Override
         public BuilderToTestDefaults toBuilder() {
             return null;
         }
+
     }
 
 }

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -139,6 +139,11 @@ public abstract class BaseRetryStrategy<
     }
 
     @Override
+    public int maxAttempts() {
+        return maxAttempts;
+    }
+
+    @Override
     public abstract B toBuilder();
 
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -358,22 +358,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
     }
 
     private RetryPolicy resolveRetryPolicy(SdkClientConfiguration config) {
-        RetryPolicy policy = config.option(SdkClientOption.RETRY_POLICY);
-        if (policy != null) {
-            return policy;
-        }
-
-        RetryMode retryMode = RetryMode.resolver()
-                                       .profileFile(config.option(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                       .profileName(config.option(SdkClientOption.PROFILE_NAME))
-                                       .defaultRetryMode(config.option(SdkClientOption.DEFAULT_RETRY_MODE))
-                                       .resolve();
-        return RetryPolicy.forRetryMode(retryMode);
-        // TODO: fixme This will be changed like this to pick the configured retry strategy
-        // if no retry policy is configured.
-        /*
         return config.option(SdkClientOption.RETRY_POLICY);
-        */
     }
 
     private RetryStrategy<?, ?> resolveRetryStrategy(SdkClientConfiguration config) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOptionValidation.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOptionValidation.java
@@ -46,8 +46,6 @@ public class SdkClientOptionValidation {
 
         require("overrideConfiguration.additionalHttpHeaders", c.option(SdkClientOption.ADDITIONAL_HTTP_HEADERS));
         require("overrideConfiguration.executionInterceptors", c.option(SdkClientOption.EXECUTION_INTERCEPTORS));
-        // TODO: fixme, this will be removed as retryPolicy will be optional
-        require("overrideConfiguration.retryPolicy", c.option(SdkClientOption.RETRY_POLICY));
         require("overrideConfiguration.retryStrategy", c.option(SdkClientOption.RETRY_STRATEGY));
 
         require("overrideConfiguration.advancedOption[USER_AGENT_PREFIX]",

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage2.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage2.java
@@ -28,12 +28,14 @@ import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestToResponsePipeline;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper2;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
 
 /**
  * Wrapper around the pipeline for a single request to provide retry, clock-skew and request throttling functionality.
  */
 @SdkInternalApi
 public final class RetryableStage2<OutputT> implements RequestToResponsePipeline<OutputT> {
+    private static final String RETRY_AFTER_HEADER = "Retry-After";
     private final RequestPipeline<SdkHttpFullRequest, Response<OutputT>> requestPipeline;
     private final HttpClientDependencies dependencies;
 
@@ -54,8 +56,13 @@ public final class RetryableStage2<OutputT> implements RequestToResponsePipeline
                 Response<OutputT> response = executeRequest(retryableStageHelper, context);
                 retryableStageHelper.recordAttemptSucceeded();
                 return response;
-            } catch (SdkException | IOException e) {
-                retryableStageHelper.setLastException(e);
+            } catch (SdkExceptionWithRetryAfterHint | SdkException | IOException e) {
+                Throwable throwable = e;
+                if (e instanceof SdkExceptionWithRetryAfterHint) {
+                    SdkExceptionWithRetryAfterHint wrapper = (SdkExceptionWithRetryAfterHint) e;
+                    throwable = wrapper.cause();
+                }
+                retryableStageHelper.setLastException(throwable);
                 Duration suggestedDelay = suggestedDelay(e);
                 Optional<Duration> backoffDelay = retryableStageHelper.tryRefreshToken(suggestedDelay);
                 if (backoffDelay.isPresent()) {
@@ -70,6 +77,10 @@ public final class RetryableStage2<OutputT> implements RequestToResponsePipeline
     }
 
     private Duration suggestedDelay(Exception e) {
+        if (e instanceof SdkExceptionWithRetryAfterHint) {
+            SdkExceptionWithRetryAfterHint except = (SdkExceptionWithRetryAfterHint) e;
+            return Duration.ofSeconds(except.retryAfter());
+        }
         return Duration.ZERO;
     }
 
@@ -83,8 +94,52 @@ public final class RetryableStage2<OutputT> implements RequestToResponsePipeline
         retryableStageHelper.setLastResponse(response.httpResponse());
         if (!response.isSuccess()) {
             retryableStageHelper.adjustClockIfClockSkew(response);
-            throw response.exception();
+            throw responseException(response);
         }
         return response;
+    }
+
+    private RuntimeException responseException(Response<OutputT> response) {
+        Optional<Integer> optionalRetryAfter = retryAfter(response.httpResponse());
+        if (optionalRetryAfter.isPresent()) {
+            return new SdkExceptionWithRetryAfterHint(optionalRetryAfter.get(), response.exception());
+        }
+        return response.exception();
+    }
+
+    private Optional<Integer> retryAfter(SdkHttpFullResponse response) {
+        Optional<String> optionalRetryAfterHeader = response.firstMatchingHeader(RETRY_AFTER_HEADER);
+        if (optionalRetryAfterHeader.isPresent()) {
+            String retryAfterHeader = optionalRetryAfterHeader.get();
+            try {
+                return Optional.of(Integer.parseInt(retryAfterHeader));
+            } catch (NumberFormatException e) {
+                // Ignore and fallback to returning empty.
+            }
+        }
+        return Optional.empty();
+    }
+
+    // This probably should go directly into SdkException
+    static class SdkExceptionWithRetryAfterHint extends RuntimeException {
+        private final SdkException cause;
+        private final int seconds;
+
+        SdkExceptionWithRetryAfterHint(int seconds, SdkException cause) {
+            this.seconds = seconds;
+            this.cause = cause;
+        }
+
+        public int retryAfter() {
+            return seconds;
+        }
+
+        public SdkException cause() {
+            return cause;
+        }
+
+        public int seconds() {
+            return seconds;
+        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper2.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper2.java
@@ -173,10 +173,9 @@ public final class RetryableStageHelper2 {
      * Retrieve the request to send to the service, including any detailed retry information headers.
      */
     public SdkHttpFullRequest requestToSend() {
-        // TODO: fixme, we don't longer have this information handy we need to change the interface to access it.
-        int maxAllowedRetries = 3;
         return request.toBuilder()
-                      .putHeader(SDK_RETRY_INFO_HEADER, "attempt=" + attemptNumber + "; max=" + maxAllowedRetries)
+                      .putHeader(SDK_RETRY_INFO_HEADER, "attempt=" + attemptNumber
+                                                        + "; max=" + retryStrategy().maxAttempts())
                       .build();
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/RetryPolicyAdapter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/RetryPolicyAdapter.java
@@ -78,6 +78,11 @@ public final class RetryPolicyAdapter implements RetryStrategy<RetryPolicyAdapte
     }
 
     @Override
+    public int maxAttempts() {
+        return retryPolicy.numRetries() + 1;
+    }
+
+    @Override
     public Builder toBuilder() {
         return new Builder(this);
     }

--- a/services/dynamodb/pom.xml
+++ b/services/dynamodb/pom.xml
@@ -63,6 +63,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-api</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>sts</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
@@ -33,6 +33,6 @@
     "listWebACLs",
     "listXssMatchSets"
   ],
-  "customRetryPolicy" : "software.amazon.awssdk.services.dynamodb.DynamoDbRetryPolicy",
+  "customRetryStrategy" : "software.amazon.awssdk.services.dynamodb.DynamoDbRetryPolicy",
   "enableEndpointDiscoveryMethodRequired": true
 }

--- a/test/codegen-generated-classes-test/pom.xml
+++ b/test/codegen-generated-classes-test/pom.xml
@@ -121,6 +121,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-api</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>netty-nio-client</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/AsyncCoreMetricsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/AsyncCoreMetricsTest.java
@@ -72,7 +72,8 @@ public class AsyncCoreMetricsTest extends BaseAsyncCoreMetricsTest {
                                             .region(Region.US_WEST_2)
                                             .credentialsProvider(mockCredentialsProvider)
                                             .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                            .overrideConfiguration(c -> c.addMetricPublisher(mockPublisher).retryPolicy(b -> b.numRetries(MAX_RETRIES)))
+                                            .overrideConfiguration(c -> c.addMetricPublisher(mockPublisher)
+                                                                         .retryStrategy(b -> b.maxAttempts(MAX_ATTEMPTS)))
                                             .build();
 
         when(mockCredentialsProvider.resolveCredentials()).thenAnswer(invocation -> {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/AsyncEventStreamingCoreMetricsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/AsyncEventStreamingCoreMetricsTest.java
@@ -61,7 +61,7 @@ public class AsyncEventStreamingCoreMetricsTest extends BaseAsyncCoreMetricsTest
                                             .credentialsProvider(mockCredentialsProvider)
                                             .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                             .overrideConfiguration(c -> c.addMetricPublisher(mockPublisher)
-                                                                         .retryPolicy(b -> b.numRetries(MAX_RETRIES)))
+                                                                         .retryStrategy(b -> b.maxAttempts(MAX_ATTEMPTS)))
                                             .build();
 
         when(mockCredentialsProvider.resolveCredentials()).thenAnswer(invocation -> {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/AsyncStreamingCoreMetricsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/AsyncStreamingCoreMetricsTest.java
@@ -59,7 +59,8 @@ public class AsyncStreamingCoreMetricsTest extends BaseAsyncCoreMetricsTest {
                                             .region(Region.US_WEST_2)
                                             .credentialsProvider(mockCredentialsProvider)
                                             .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                            .overrideConfiguration(c -> c.addMetricPublisher(mockPublisher).retryPolicy(b -> b.numRetries(MAX_RETRIES)))
+                                            .overrideConfiguration(c -> c.addMetricPublisher(mockPublisher)
+                                                                         .retryStrategy(b -> b.maxAttempts(MAX_ATTEMPTS)))
                                             .build();
 
         when(mockCredentialsProvider.resolveCredentials()).thenAnswer(invocation -> {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/BaseAsyncCoreMetricsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/async/BaseAsyncCoreMetricsTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.metrics.async;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -23,18 +24,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.internal.metrics.SdkErrorType;
+import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.http.HttpMetric;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricPublisher;
@@ -46,6 +49,7 @@ public abstract class BaseAsyncCoreMetricsTest {
     private static final String REQUEST_ID = "req-id";
     private static final String EXTENDED_REQUEST_ID = "extended-id";
     static final int MAX_RETRIES = 2;
+    static final int MAX_ATTEMPTS = MAX_RETRIES + 1;
     public static final Duration FIXED_DELAY = Duration.ofMillis(500);
 
     @Test
@@ -97,7 +101,8 @@ public abstract class BaseAsyncCoreMetricsTest {
 
         MetricCollection capturedCollection = collectionCaptor.getValue();
         verifyFailedApiCallCollection(capturedCollection);
-        assertThat(capturedCollection.children()).hasSize(MAX_RETRIES + 1);
+        assertThat(capturedCollection.children()).hasSize(MAX_ATTEMPTS);
+        WireMock.verify(MAX_ATTEMPTS, anyRequestedFor(anyUrl()));
 
         capturedCollection.children().forEach(requestMetrics -> {
             assertThat(requestMetrics.metricValues(HttpMetric.HTTP_STATUS_CODE))
@@ -159,6 +164,8 @@ public abstract class BaseAsyncCoreMetricsTest {
             .containsExactly(REQUEST_ID);
         assertThat(requestMetrics.metricValues(CoreMetric.AWS_EXTENDED_REQUEST_ID))
             .containsExactly(EXTENDED_REQUEST_ID);
+        assertThat(requestMetrics.metricValues(CoreMetric.BACKOFF_DELAY_DURATION).size())
+            .isGreaterThan(0);
         assertThat(requestMetrics.metricValues(CoreMetric.BACKOFF_DELAY_DURATION).get(0))
             .isGreaterThanOrEqualTo(Duration.ZERO);
         assertThat(requestMetrics.metricValues(CoreMetric.SERVICE_CALL_DURATION).get(0))
@@ -173,6 +180,8 @@ public abstract class BaseAsyncCoreMetricsTest {
             .containsExactly(REQUEST_ID);
         assertThat(attemptCollection.metricValues(CoreMetric.AWS_EXTENDED_REQUEST_ID))
             .containsExactly(EXTENDED_REQUEST_ID);
+        assertThat(attemptCollection.metricValues(CoreMetric.BACKOFF_DELAY_DURATION).size())
+            .isGreaterThanOrEqualTo(1);
         assertThat(attemptCollection.metricValues(CoreMetric.BACKOFF_DELAY_DURATION).get(0))
             .isGreaterThanOrEqualTo(Duration.ZERO);
         assertThat(attemptCollection.metricValues(CoreMetric.SIGNING_DURATION).get(0))

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/AsyncRetryHeaderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/AsyncRetryHeaderTest.java
@@ -31,7 +31,7 @@ public class AsyncRetryHeaderTest extends RetryHeaderTestSuite<MockAsyncHttpClie
     public AsyncRetryHeaderTest() {
         super(new MockAsyncHttpClient());
         client = ProtocolRestJsonAsyncClient.builder()
-                                            .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
+                                            .overrideConfiguration(c -> c.retryStrategy(RetryMode.STANDARD))
                                             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                             .region(Region.US_EAST_1)
                                             .endpointOverride(URI.create("http://localhost"))

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ClientRetryModeTestSuite.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ClientRetryModeTestSuite.java
@@ -48,7 +48,8 @@ public abstract class ClientRetryModeTestSuite<ClientT, BuilderT extends AwsClie
     @Test
     public void legacyRetryModeIsFourAttempts() {
         stubThrottlingResponse();
-        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryPolicy(RetryMode.LEGACY)).build();
+        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryStrategy(RetryMode.LEGACY))
+                                        .build();
         assertThatThrownBy(() -> callAllTypes(client)).isInstanceOf(SdkException.class);
         verifyRequestCount(4);
     }
@@ -56,7 +57,7 @@ public abstract class ClientRetryModeTestSuite<ClientT, BuilderT extends AwsClie
     @Test
     public void standardRetryModeIsThreeAttempts() {
         stubThrottlingResponse();
-        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryPolicy(RetryMode.STANDARD)).build();
+        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD)).build();
         assertThatThrownBy(() -> callAllTypes(client)).isInstanceOf(SdkException.class);
         verifyRequestCount(3);
     }
@@ -80,8 +81,7 @@ public abstract class ClientRetryModeTestSuite<ClientT, BuilderT extends AwsClie
         stubThrottlingResponse();
 
         ExecutorService executor = Executors.newFixedThreadPool(51);
-        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryPolicy(RetryMode.LEGACY)).build();
-
+        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryStrategy(RetryMode.LEGACY)).build();
         for (int i = 0; i < 51; ++i) {
             executor.execute(() -> assertThatThrownBy(() -> callAllTypes(client)).isInstanceOf(SdkException.class));
         }
@@ -97,7 +97,7 @@ public abstract class ClientRetryModeTestSuite<ClientT, BuilderT extends AwsClie
         stubThrottlingResponse();
 
         ExecutorService executor = Executors.newFixedThreadPool(51);
-        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryPolicy(RetryMode.STANDARD)).build();
+        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD)).build();
 
         for (int i = 0; i < 51; ++i) {
             executor.execute(() -> assertThatThrownBy(() -> callAllTypes(client)).isInstanceOf(SdkException.class));

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/RetryHeaderTestSuite.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/RetryHeaderTestSuite.java
@@ -82,10 +82,8 @@ public abstract class RetryHeaderTestSuite<T extends MockHttpClient> {
         assertThat(requests).hasSize(2);
         assertThat(retryComponent(requests.get(0), "attempt")).isEqualTo("1");
         assertThat(retryComponent(requests.get(1), "attempt")).isEqualTo("2");
-        /* TODO: fixme, we do not set the max field correctly at the moment
         assertThat(retryComponent(requests.get(0), "max")).isEqualTo("3");
         assertThat(retryComponent(requests.get(1), "max")).isEqualTo("3");
-         */
     }
 
     private String invocationId(SdkHttpRequest request) {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/SyncRetryHeaderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/SyncRetryHeaderTest.java
@@ -29,7 +29,7 @@ public class SyncRetryHeaderTest extends RetryHeaderTestSuite<MockSyncHttpClient
     public SyncRetryHeaderTest() {
         super(new MockSyncHttpClient());
         client = ProtocolRestJsonClient.builder()
-            .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
+            .overrideConfiguration(c -> c.retryStrategy(RetryMode.STANDARD))
                                          .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
                                                                                                                           "skid")))
                                          .region(Region.US_EAST_1)

--- a/test/protocol-tests/pom.xml
+++ b/test/protocol-tests/pom.xml
@@ -118,6 +118,16 @@
             <artifactId>endpoints-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-api</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
@@ -33,10 +33,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
 import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
@@ -85,7 +85,7 @@ public class AsyncResponseThreadingTest {
                                        .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                        .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                        .asyncConfiguration(c -> c.advancedOption(FUTURE_COMPLETION_EXECUTOR, mockExecutor))
-                                       .overrideConfiguration(o -> o.retryPolicy(RetryPolicy.none()))
+                                       .overrideConfiguration(o -> o.retryStrategy(AwsRetryStrategy.none()))
                                        .build();
 
         assertThatThrownBy(() ->
@@ -107,7 +107,7 @@ public class AsyncResponseThreadingTest {
                                        .region(Region.US_WEST_1)
                                        .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                        .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
-                                       .overrideConfiguration(o -> o.retryPolicy(RetryPolicy.none()))
+                                       .overrideConfiguration(o -> o.retryStrategy(AwsRetryStrategy.none()))
                                        .asyncConfiguration(c -> c.advancedOption(FUTURE_COMPLETION_EXECUTOR, mockExecutor))
                                        .build();
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/clockskew/ClockSkewAdjustmentTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/clockskew/ClockSkewAdjustmentTest.java
@@ -205,7 +205,7 @@ public class ClockSkewAdjustmentTest {
                                     .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                     .region(Region.US_EAST_1)
                                     .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                    .overrideConfiguration(c -> c.retryPolicy(r -> r.numRetries(retryCount)))
+                                    .overrideConfiguration(c -> c.retryStrategy(r -> r.maxAttempts(retryCount + 1)))
                                     .build();
     }
 
@@ -214,7 +214,7 @@ public class ClockSkewAdjustmentTest {
                                          .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                          .region(Region.US_EAST_1)
                                          .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                         .overrideConfiguration(c -> c.retryPolicy(r -> r.numRetries(retryCount)))
+                                         .overrideConfiguration(c -> c.retryStrategy(r -> r.maxAttempts(retryCount + 1)))
                                          .build();
     }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/connection/SyncClientConnectionInterruptionTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/connection/SyncClientConnectionInterruptionTest.java
@@ -32,14 +32,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.metrics.MetricCollection;
@@ -151,7 +150,9 @@ class SyncClientConnectionInterruptionTest {
         stubPostRequest("/2016-03-11/allTypes", aResponse().withFixedDelay(responseDelay), SAMPLE_BODY);
         ExceptionInThreadRun exception = new ExceptionInThreadRun();
         ProtocolRestJsonClient client =
-            getClient(httpClient, Duration.ofMillis(10)).overrideConfiguration(o -> o.retryPolicy(RetryPolicy.none())).build();
+            getClient(httpClient, Duration.ofMillis(10))
+                .overrideConfiguration(o -> o.retryStrategy(AwsRetryStrategy.none()))
+                .build();
         unInterruptedSleep(100);
         // We need to creat a separate thread to interrupt it externally.
         Thread leaseWaitingThread = new Thread(() -> {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AsyncAwsJsonRetryTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AsyncAwsJsonRetryTest.java
@@ -30,7 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocoljsonrpc.ProtocolJsonRpcAsyncClient;
 import software.amazon.awssdk.services.protocoljsonrpc.model.AllTypesRequest;
@@ -127,7 +127,7 @@ public class AsyncAwsJsonRetryTest {
     }
 
     @Test
-    public void retryPolicyNone_shouldNotRetry() {
+    public void retryStrategyNone_shouldNotRetry() {
         stubFor(post(urlEqualTo(PATH))
                     .inScenario("retry at 500")
                     .whenScenarioStateIs(Scenario.STARTED)
@@ -149,7 +149,7 @@ public class AsyncAwsJsonRetryTest {
                                                                                                                        "skid")))
                                       .region(Region.US_EAST_1)
                                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                      .overrideConfiguration(c -> c.retryPolicy(RetryPolicy.none()))
+                                      .overrideConfiguration(c -> c.retryStrategy(AwsRetryStrategy.none()))
                                       .build();
 
         assertThatThrownBy(() -> clientWithNoRetry.allTypes(AllTypesRequest.builder().build()).join())

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AwsJsonRetryTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AwsJsonRetryTest.java
@@ -30,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocoljsonrpc.ProtocolJsonRpcClient;
@@ -126,7 +127,7 @@ public class AwsJsonRetryTest {
     }
 
     @Test
-    public void retryPolicyNone_shouldNotRetry() {
+    public void retryStrategyNone_shouldNotRetry() {
         stubFor(post(urlEqualTo(PATH))
                     .inScenario("retry at 500")
                     .whenScenarioStateIs(Scenario.STARTED)
@@ -148,7 +149,7 @@ public class AwsJsonRetryTest {
                                                                                                                   "skid")))
                                  .region(Region.US_EAST_1)
                                  .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                 .overrideConfiguration(c -> c.retryPolicy(RetryPolicy.none()))
+                                 .overrideConfiguration(c -> c.retryStrategy(AwsRetryStrategy.none()))
                                  .build();
 
         assertThatThrownBy(() -> clientWithNoRetry.allTypes(AllTypesRequest.builder().build())).isInstanceOf(ProtocolJsonRpcException.class);

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/async/AsyncApiCallAttemptsTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/async/AsyncApiCallAttemptsTimeoutTest.java
@@ -28,13 +28,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.protocol.tests.timeout.BaseApiCallAttemptTimeoutTest;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
 import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationRequest;
@@ -59,7 +60,7 @@ public class AsyncApiCallAttemptsTimeoutTest extends BaseApiCallAttemptTimeoutTe
                                             .httpClient(mockClient)
                                             .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                             .overrideConfiguration(b -> b.apiCallAttemptTimeout(API_CALL_ATTEMPT_TIMEOUT)
-                                                                         .retryPolicy(RetryPolicy.none()))
+                                                                         .retryStrategy(AwsRetryStrategy.none()))
                                             .build();
 
         clientWithRetry = ProtocolRestJsonAsyncClient.builder()
@@ -67,9 +68,11 @@ public class AsyncApiCallAttemptsTimeoutTest extends BaseApiCallAttemptTimeoutTe
                                                      .httpClient(mockClient)
                                                      .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                                      .overrideConfiguration(b -> b.apiCallAttemptTimeout(API_CALL_ATTEMPT_TIMEOUT)
-                                                                                  .retryPolicy(RetryPolicy.builder()
-                                                                                                          .numRetries(1)
-                                                                                                          .build()))
+                                                                                  .retryStrategy(AwsRetryStrategy.standardRetryStrategy()
+                                                                                                                 .toBuilder()
+                                                                                                                 .backoffStrategy(BackoffStrategy.retryImmediately())
+                                                                                                                 .maxAttempts(2)
+                                                                                                                 .build()))
                                                      .build();
 
     }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/async/AsyncApiCallTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/async/AsyncApiCallTimeoutTest.java
@@ -27,12 +27,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
-import software.amazon.awssdk.core.retry.RetryPolicy;
-import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
 import software.amazon.awssdk.protocol.tests.timeout.BaseApiCallTimeoutTest;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
 import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
 import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
@@ -57,17 +57,18 @@ public class AsyncApiCallTimeoutTest extends BaseApiCallTimeoutTest {
                                             .httpClient(mockClient)
                                             .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                             .overrideConfiguration(b -> b.apiCallTimeout(TIMEOUT)
-                                                                         .retryPolicy(RetryPolicy.none()))
+                                                                         .retryStrategy(AwsRetryStrategy.none()))
                                             .build();
 
         clientWithRetry = ProtocolRestJsonAsyncClient.builder()
                                                      .region(Region.US_WEST_1)
                                                      .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                                      .overrideConfiguration(b -> b.apiCallTimeout(TIMEOUT)
-                                                                                  .retryPolicy(RetryPolicy.builder()
-                                                                                                          .backoffStrategy(BackoffStrategy.none())
-                                                                                                          .numRetries(1)
-                                                                                                          .build()))
+                                                                                 .retryStrategy(AwsRetryStrategy.standardRetryStrategy()
+                                                                                                                .toBuilder()
+                                                                                                                .backoffStrategy(BackoffStrategy.retryImmediately())
+                                                                                                                .maxAttempts(2)
+                                                                                                                .build()))
                                                      .httpClient(mockClient)
                                                      .build();
     }
@@ -136,7 +137,7 @@ public class AsyncApiCallTimeoutTest extends BaseApiCallTimeoutTest {
                                           .httpClient(mockClient)
                                           .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                           .overrideConfiguration(b -> b.apiCallTimeout(TIMEOUT)
-                                                                       .retryPolicy(RetryPolicy.none()))
+                                                                       .retryStrategy(AwsRetryStrategy.none()))
                                           .build();
     }
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncApiCallAttemptTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncApiCallAttemptTimeoutTest.java
@@ -24,11 +24,12 @@ import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.protocol.tests.timeout.BaseApiCallAttemptTimeoutTest;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
 import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
 import software.amazon.awssdk.testutils.service.http.MockHttpClient;
@@ -53,7 +54,7 @@ public class SyncApiCallAttemptTimeoutTest extends BaseApiCallAttemptTimeoutTest
                                        .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                        .overrideConfiguration(
                                            b -> b.apiCallAttemptTimeout(API_CALL_ATTEMPT_TIMEOUT)
-                                                 .retryPolicy(RetryPolicy.none()))
+                                                 .retryStrategy(AwsRetryStrategy.none()))
                                        .build();
 
         clientWithRetry = ProtocolRestJsonClient.builder()
@@ -62,9 +63,11 @@ public class SyncApiCallAttemptTimeoutTest extends BaseApiCallAttemptTimeoutTest
                                                 .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                                 .overrideConfiguration(
                                                     b -> b.apiCallAttemptTimeout(API_CALL_ATTEMPT_TIMEOUT)
-                                                          .retryPolicy(RetryPolicy.builder()
-                                                                                  .numRetries(1)
-                                                                                  .build()))
+                                                          .retryStrategy(AwsRetryStrategy.standardRetryStrategy()
+                                                                                         .toBuilder()
+                                                                                         .backoffStrategy(BackoffStrategy.retryImmediately())
+                                                                                         .maxAttempts(2)
+                                                                                         .build()))
                                                 .build();
 
     }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncApiCallTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncApiCallTimeoutTest.java
@@ -26,12 +26,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
-import software.amazon.awssdk.core.retry.RetryPolicy;
-import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.protocol.tests.timeout.BaseApiCallTimeoutTest;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
 import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
 import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
@@ -58,7 +58,7 @@ public class SyncApiCallTimeoutTest extends BaseApiCallTimeoutTest {
                                        .httpClient(mockClient)
                                        .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                        .overrideConfiguration(b -> b.apiCallTimeout(TIMEOUT)
-                                                                    .retryPolicy(RetryPolicy.none()))
+                                                                    .retryStrategy(AwsRetryStrategy.none()))
                                        .build();
 
         clientWithRetry = ProtocolRestJsonClient.builder()
@@ -66,10 +66,11 @@ public class SyncApiCallTimeoutTest extends BaseApiCallTimeoutTest {
                                                 .httpClient(mockClient)
                                                 .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                                 .overrideConfiguration(b -> b.apiCallTimeout(TIMEOUT)
-                                                                             .retryPolicy(RetryPolicy.builder()
-                                                                                                     .backoffStrategy(BackoffStrategy.none())
-                                                                                                     .numRetries(1)
-                                                                                                     .build()))
+                                                    .retryStrategy(AwsRetryStrategy.standardRetryStrategy()
+                                                                       .toBuilder()
+                                                                       .backoffStrategy(BackoffStrategy.retryImmediately())
+                                                                       .maxAttempts(2)
+                                                                       .build()))
                                                 .build();
     }
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncStreamingOperationApiCallAttemptTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncStreamingOperationApiCallAttemptTimeoutTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.protocol.tests.timeout.sync;
 
 import java.time.Duration;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
 import software.amazon.awssdk.core.retry.RetryPolicy;
@@ -32,6 +33,7 @@ public class SyncStreamingOperationApiCallAttemptTimeoutTest extends BaseSyncStr
 
     @Override
     ClientOverrideConfiguration clientOverrideConfiguration() {
-        return ClientOverrideConfiguration.builder().apiCallAttemptTimeout(Duration.ofMillis(TIMEOUT)).retryPolicy(RetryPolicy.none()).build();
+        return ClientOverrideConfiguration.builder().apiCallAttemptTimeout(Duration.ofMillis(TIMEOUT))
+            .retryStrategy(AwsRetryStrategy.none()).build();
     }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncStreamingOperationApiCallTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/sync/SyncStreamingOperationApiCallTimeoutTest.java
@@ -16,9 +16,9 @@
 package software.amazon.awssdk.protocol.tests.timeout.sync;
 
 import java.time.Duration;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 
 /**
  * A set of tests to test ApiCallTimeout for synchronous streaming operations because they are tricky.
@@ -34,7 +34,7 @@ public class SyncStreamingOperationApiCallTimeoutTest extends BaseSyncStreamingT
     ClientOverrideConfiguration clientOverrideConfiguration() {
         return ClientOverrideConfiguration.builder()
                                           .apiCallTimeout(Duration.ofMillis(TIMEOUT))
-                                          .retryPolicy(RetryPolicy.none())
+                                          .retryStrategy(AwsRetryStrategy.none())
                                           .build();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Update all the places that use `RetryPolicy` to use `RetryStrategy` instead.

## Modifications
<!--- Describe your changes in detail -->

## Testing

The same battery of tests that were in place for `RetryPolicy` should now pass with `RetryStrategy`.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
