### PR TITLE
Remove unnecessary AwsRequestOverrideConfiguration.Builder accessor

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsRequestOverrideConfiguration.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsRequestOverrideConfiguration.java
@@ -32,9 +32,9 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
 public final class AwsRequestOverrideConfiguration extends RequestOverrideConfiguration {
     private final IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider;
 
-    private AwsRequestOverrideConfiguration(Builder builder) {
+    private AwsRequestOverrideConfiguration(BuilderImpl builder) {
         super(builder);
-        this.credentialsProvider = builder.credentialsIdentityProvider();
+        this.credentialsProvider = builder.awsCredentialsProvider;
     }
 
     /**
@@ -127,14 +127,10 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
          * @param credentialsProvider The {@link IdentityProvider<? extends AwsCredentialsIdentity>}.
          * @return This object for chaining.
          */
-        // review TODO: Should this be named credentialsIdentityProvider for symmetry with the "get" method
         default Builder credentialsProvider(IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider) {
             throw new UnsupportedOperationException();
         }
 
-        // review TODO: Not sure why the builder should have a public getter. Currently it was called from constructor of
-        //  AwsRequestOverrideConfiguration. But it is private and should probably take BuilderImpl. Still can't remove this
-        //  method, but maybe can avoid adding credentialsIdentityProvider() to Builder.
         /**
          * Return the optional {@link AwsCredentialsProvider} that will provide credentials to be used to authenticate this
          * request.
@@ -142,14 +138,6 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
          * @return The optional {@link AwsCredentialsProvider}.
          */
         AwsCredentialsProvider credentialsProvider();
-
-        /**
-         * Return the optional {@link IdentityProvider<? extends AwsCredentialsIdentity>} that will provide credentials to be
-         * used to authenticate this request.
-         *
-         * @return The optional {@link IdentityProvider<? extends AwsCredentialsIdentity>}.
-         */
-        IdentityProvider<? extends AwsCredentialsIdentity> credentialsIdentityProvider();
 
         @Override
         AwsRequestOverrideConfiguration build();
@@ -180,11 +168,6 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
         @Override
         public AwsCredentialsProvider credentialsProvider() {
             return CredentialUtils.toCredentialsProvider(awsCredentialsProvider);
-        }
-
-        @Override
-        public IdentityProvider<? extends AwsCredentialsIdentity> credentialsIdentityProvider() {
-            return awsCredentialsProvider;
         }
 
         @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Address some old TODOs that didn't get addressed in initial [PR](https://github.com/aws/aws-sdk-java-v2/pull/3829/files#diff-64c4b71af1009af4b25f032c5ec51eb1f301192d7c57281f0171590eb591b1d6)

## Modifications
<!--- Describe your changes in detail -->
The Builder interface had a `credentialsProvider()` accessor method which doesn't make sense for a Builder. But since it is `@SdkPublicApi` that one cannot be removed. However, removing the newly added `credentialsIdentityProvider()` and instead using the BuilderImpl in the constructor gives direct access to the private builder.awsCredentialsProvider without an interface accessor method.

Also keeping the same name `credentialsProvider` for the overloaded setter that takes the new type (instead of `credentialsIdentityProvider`. We have followed the same pattern in other places where we accept the identity types.