### PR TITLE
Skip signing for smithy.api#noAuth

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -161,10 +161,6 @@ public class SigningStage implements RequestToRequestPipeline {
     private boolean shouldSign(SelectedAuthScheme<?> selectedAuthScheme) {
         // TODO: Should this string be a constant somewhere. Similar logic is used in AuthSchemeInterceptors.
         return "smithy.api#noAuth".equals(selectedAuthScheme.authSchemeOption().schemeId());
-
-        // Hmm, these would be equivalent too:
-        // return selectedAuthScheme.identityProvider() == null;
-        // return selectedAuthScheme.signer() == null;
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -62,6 +62,7 @@ public class SigningStage implements RequestToRequestPipeline {
     @Override
     public SdkHttpFullRequest execute(SdkHttpFullRequest request, RequestExecutionContext context) throws Exception {
         InterruptMonitor.checkInterrupted();
+        // TODO: Add unit tests for SRA signing logic.
         if (context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME) != null) {
             return sraSignRequest(request, context);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The SRA logic to sign should be skipped when the selected auth scheme after auth resolution is the schemeId that represents no authentication.

## Modifications
<!--- Describe your changes in detail -->
Add condition to check for smithy.api#noAuth
