### PR TITLE
Contains Ignorecase Check for ProfileCredentials property keys read from ~/.aws/credentials file.

### DIFF
--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.profiles;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -193,7 +192,7 @@ public final class Profile implements ToCopyableBuilder<Profile.Builder, Profile
         public Builder properties(Map<String, String> properties) {
             Map<String, String> keyCaseInsensitiveMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             keyCaseInsensitiveMap.putAll(properties);
-            //TODO: Why LinkedHashMap being used here, should we really consider insertion order?
+            //Why LinkedHashMap being used here, should we really consider insertion order?
             this.properties = Collections.unmodifiableMap(keyCaseInsensitiveMap);
             return this;
         }

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.SystemSetting;
 import software.amazon.awssdk.utils.ToString;
@@ -190,7 +191,10 @@ public final class Profile implements ToCopyableBuilder<Profile.Builder, Profile
 
         @Override
         public Builder properties(Map<String, String> properties) {
-            this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+            Map<String, String> keyCaseInsensitiveMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            keyCaseInsensitiveMap.putAll(properties);
+            //TODO: Why LinkedHashMap being used here, should we really consider insertion order?
+            this.properties = Collections.unmodifiableMap(keyCaseInsensitiveMap);
             return this;
         }
 

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
@@ -73,6 +73,22 @@ public class ProfileFileTest {
     }
 
     @Test
+    public void profilesCanContainPropertiesWithMixedCase() {
+        Map<String, Profile> profiles = profiles(profile("foo", property("name", "value")));
+        assertThat(configFileProfiles("[profile foo]\n" +
+                                      "Name = value"))
+            .isEqualTo(profiles);
+
+        profiles.forEach((s, profile) -> {
+            assertThat(s).isEqualTo("foo");
+            assertThat(profile.properties().containsKey("NAME")).isTrue();
+            assertThat(profile.properties().containsKey("Name")).isTrue();
+            assertThat(profile.properties().containsKey("naMe")).isTrue();
+            assertThat(profile.properties().containsKey("name")).isTrue();
+        });
+    }
+
+    @Test
     public void windowsStyleLineEndingsAreSupported() {
         assertThat(configFileProfiles("[profile foo]\r\n" +
                                       "name = value"))


### PR DESCRIPTION
## Motivation and Context
There is no guarantee that every developer machine having profile configured with lower case property keys.
For example in our case, we are using some python reusable script to setup ~/.aws/credentials file, it actually creates file as below

````
[default]
AWS_ACCESS_KEY_ID=   
AWS_SECRET_ACCESS_KEY=   
AWS_SESSION_TOKEN=
````  

Due property keys are in upper case, **ProfileCredentialsUtil.java @Line 143 and 147** is failing due to case sensitive check with containsKey of properties map object.

## Modifications
Storing profile credential data as `TreeMap` with `String.CASE_INSENSITIVE_ORDER`, it actually doesn't alter any property key-values, but while checking contains key, it considers case insensitivity.

Changes to file: `software.amazon.awssdk.profiles.Profile.java#BuilderImpl.java`  @Line 194.

## Testing
Maven build passed locally.
Validated through sample java application with updated SDK changes.
Added UT to validate actual change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
