### PR TITLE
[WIP] AWS SDK Cross Version Compatability: env-var `http_proxy` & `https_proxy` support

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-ed33ca1.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-ed33ca1.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "Mythra",
+    "description": "Support checking `http_proxy` & `https_proxy` environment variables for the HTTP clients in tree."
+}

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtConfigurationUtils.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtConfigurationUtils.java
@@ -29,23 +29,26 @@ public final class CrtConfigurationUtils {
     }
 
     public static Optional<HttpProxyOptions> resolveProxy(CrtProxyConfiguration proxyConfiguration,
-                                                          TlsContext tlsContext) {
+                                                          TlsContext tlsContext,
+                                                          String scheme) {
         if (proxyConfiguration == null) {
             return Optional.empty();
         }
 
         HttpProxyOptions clientProxyOptions = new HttpProxyOptions();
 
-        clientProxyOptions.setHost(proxyConfiguration.host());
-        clientProxyOptions.setPort(proxyConfiguration.port());
+        clientProxyOptions.setHost(proxyConfiguration.host(scheme));
+        clientProxyOptions.setPort(proxyConfiguration.port(scheme));
 
-        if ("https".equalsIgnoreCase(proxyConfiguration.scheme())) {
+        if ("https".equalsIgnoreCase(proxyConfiguration.scheme(scheme))) {
             clientProxyOptions.setTlsContext(tlsContext);
         }
 
-        if (proxyConfiguration.username() != null && proxyConfiguration.password() != null) {
-            clientProxyOptions.setAuthorizationUsername(proxyConfiguration.username());
-            clientProxyOptions.setAuthorizationPassword(proxyConfiguration.password());
+        String username = proxyConfiguration.username(scheme);
+        String password = proxyConfiguration.password(scheme);
+        if (username != null && password != null) {
+            clientProxyOptions.setAuthorizationUsername(username);
+            clientProxyOptions.setAuthorizationPassword(password);
             clientProxyOptions.setAuthorizationType(HttpProxyOptions.HttpProxyAuthorizationType.Basic);
         } else {
             clientProxyOptions.setAuthorizationType(HttpProxyOptions.HttpProxyAuthorizationType.None);

--- a/core/crt-core/src/test/java/software/amazon/awssdk/crtcore/CrtConnectionUtilsTest.java
+++ b/core/crt-core/src/test/java/software/amazon/awssdk/crtcore/CrtConnectionUtilsTest.java
@@ -39,8 +39,15 @@ class CrtConnectionUtilsTest {
 
         TlsContext tlsContext = Mockito.mock(TlsContext.class);
 
-        Optional<HttpProxyOptions> httpProxyOptions = CrtConfigurationUtils.resolveProxy(configuration, tlsContext);
+        Optional<HttpProxyOptions> httpProxyOptions = CrtConfigurationUtils.resolveProxy(configuration, tlsContext, "http");
         assertThat(httpProxyOptions).hasValueSatisfying(proxy -> {
+            assertThat(proxy.getTlsContext()).isEqualTo(tlsContext);
+            assertThat(proxy.getAuthorizationPassword()).isEqualTo("bar");
+            assertThat(proxy.getAuthorizationUsername()).isEqualTo("foo");
+            assertThat(proxy.getAuthorizationType()).isEqualTo(HttpProxyOptions.HttpProxyAuthorizationType.Basic);
+        });
+        Optional<HttpProxyOptions> httpsProxyOptions = CrtConfigurationUtils.resolveProxy(configuration, tlsContext, "https");
+        assertThat(httpsProxyOptions).hasValueSatisfying(proxy -> {
             assertThat(proxy.getTlsContext()).isEqualTo(tlsContext);
             assertThat(proxy.getAuthorizationPassword()).isEqualTo("bar");
             assertThat(proxy.getAuthorizationUsername()).isEqualTo("foo");
@@ -51,7 +58,8 @@ class CrtConnectionUtilsTest {
     @Test
     void resolveProxy_emptyProxy_shouldReturnEmpty() {
         TlsContext tlsContext = Mockito.mock(TlsContext.class);
-        assertThat(CrtConfigurationUtils.resolveProxy(null, tlsContext)).isEmpty();
+        assertThat(CrtConfigurationUtils.resolveProxy(null, tlsContext, "http")).isEmpty();
+        assertThat(CrtConfigurationUtils.resolveProxy(null, tlsContext, "https")).isEmpty();
     }
 
     @Test
@@ -61,8 +69,15 @@ class CrtConnectionUtilsTest {
                                                                      .build();
         TlsContext tlsContext = Mockito.mock(TlsContext.class);
 
-        Optional<HttpProxyOptions> httpProxyOptions = CrtConfigurationUtils.resolveProxy(configuration, tlsContext);
+        Optional<HttpProxyOptions> httpProxyOptions = CrtConfigurationUtils.resolveProxy(configuration, tlsContext, "http");
         assertThat(httpProxyOptions).hasValueSatisfying(proxy -> {
+            assertThat(proxy.getTlsContext()).isNull();
+            assertThat(proxy.getAuthorizationPassword()).isNull();
+            assertThat(proxy.getAuthorizationUsername()).isNull();
+            assertThat(proxy.getAuthorizationType()).isEqualTo(HttpProxyOptions.HttpProxyAuthorizationType.None);
+        });
+        Optional<HttpProxyOptions> httpsProxyOptions = CrtConfigurationUtils.resolveProxy(configuration, tlsContext, "https");
+        assertThat(httpsProxyOptions).hasValueSatisfying(proxy -> {
             assertThat(proxy.getTlsContext()).isNull();
             assertThat(proxy.getAuthorizationPassword()).isNull();
             assertThat(proxy.getAuthorizationUsername()).isNull();

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
@@ -16,12 +16,16 @@
 package software.amazon.awssdk.http.apache;
 
 import static software.amazon.awssdk.utils.StringUtils.isEmpty;
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.fetchProxyFromEnvironment;
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.parseNonProxyHostsEnvironment;
 import static software.amazon.awssdk.utils.http.SdkHttpUtils.parseNonProxyHostsProperty;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.ProxySystemSetting;
@@ -29,6 +33,7 @@ import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Configuration that defines how to communicate via an HTTP or HTTPS proxy.
@@ -37,6 +42,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfiguration.Builder, ProxyConfiguration> {
 
     private static final String HTTPS = "https";
+    private static final String HTTP = "http";
     private final URI endpoint;
     private final String username;
     private final String password;
@@ -45,9 +51,9 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
     private final Set<String> nonProxyHosts;
     private final Boolean preemptiveBasicAuthenticationEnabled;
     private final Boolean useSystemPropertyValues;
-    private final String host;
-    private final int port;
-    private final String scheme;
+    private final Boolean useEnvironmentVariables;
+    private final Boolean proxyOverHttp;
+    private final Boolean proxyOverHttps;
 
     /**
      * Initialize this configuration. Private to require use of {@link #builder()}.
@@ -62,58 +68,322 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         this.preemptiveBasicAuthenticationEnabled = builder.preemptiveBasicAuthenticationEnabled == null ? Boolean.FALSE :
                 builder.preemptiveBasicAuthenticationEnabled;
         this.useSystemPropertyValues = builder.useSystemPropertyValues;
-        this.scheme = resolveScheme();
-        this.host = resolveHost(scheme);
-        this.port = resolvePort(scheme);
+        this.useEnvironmentVariables = builder.useEnvironmentVariables;
+        this.proxyOverHttp = builder.proxyOverHttp == null || builder.proxyOverHttp;
+        this.proxyOverHttps = builder.proxyOverHttps == null || builder.proxyOverHttps;
     }
 
     /**
-     * Returns the proxy host name from the configured endpoint if set, else from the "https.proxyHost" or "http.proxyHost" system
-     * property, based on the scheme used, if {@link Builder#useSystemPropertyValues(Boolean)} is set to true.
-     */
-    public String host() {
-        return host;
-    }
-
-    /**
-     * Returns the proxy port from the configured endpoint if set, else from the "https.proxyPort" or "http.proxyPort" system
-     * property, based on the scheme used, if {@link Builder#useSystemPropertyValues(Boolean)} is set to true.
-     * If no value is found in none of the above options, the default value of 0 is returned.
-     */
-    public int port() {
-        return port;
-    }
-
-    /**
-     * Returns the {@link URI#scheme} from the configured endpoint. Otherwise return null.
-     */
-    public String scheme() {
-        return scheme;
-    }
-
-    /**
-     * The username to use when connecting through a proxy.
+     * The proxy host is determined in the following order:
      *
-     * @see Builder#password(String)
-     */
-    public String username() {
-        if (Objects.equals(scheme(), HTTPS)) {
-            return resolveValue(username, ProxySystemSetting.HTTPS_PROXY_USERNAME);
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#endpoint(URI)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyHost</code>,
+     *         or <code>http.proxyHost</code>. If these properties exist, it will return
+     *         the property hostname.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         hostname.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined proxy hostname to connect too.
+     * */
+    public String host(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (endpoint != null) {
+            if (isHttps ? proxyOverHttps : proxyOverHttp) {
+                return endpoint.getHost();
+            }
         }
-        return resolveValue(username, ProxySystemSetting.PROXY_USERNAME);
+
+        if (useSystemPropertyValues) {
+            String hostProperty;
+            if (isHttps) {
+                hostProperty = ProxySystemSetting.HTTPS_PROXY_HOST.getStringValue().orElse(null);
+            } else {
+                hostProperty = ProxySystemSetting.PROXY_HOST.getStringValue().orElse(null);
+            }
+            if (hostProperty != null) {
+                return hostProperty;
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme).map(URL::getHost).orElse(null);
+        }
+
+        return null;
     }
 
     /**
-     * The password to use when connecting through a proxy.
+     * The proxy port is determined in the following order:
      *
-     * @see Builder#password(String)
-     */
-    public String password() {
-
-        if (Objects.equals(scheme(), HTTPS)) {
-            return resolveValue(password, ProxySystemSetting.HTTPS_PROXY_PASSWORD);
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#endpoint(URI)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyPort</code>,
+     *         or <code>http.proxyPort</code>. If these properties exist, it will return
+     *         the property port.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         port.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>0</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined proxy port to connect too.
+     * */
+    public int port(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (endpoint != null) {
+            if (isHttps ? proxyOverHttps : proxyOverHttp) {
+                return endpoint.getPort();
+            }
         }
-        return resolveValue(password, ProxySystemSetting.PROXY_PASSWORD);
+
+        if (useSystemPropertyValues) {
+            int portProperty;
+            if (isHttps) {
+                portProperty = ProxySystemSetting.HTTPS_PROXY_PORT.getStringValue()
+                                                                  .map(Integer::parseInt)
+                                                                  .orElse(0);
+            } else {
+                portProperty = ProxySystemSetting.PROXY_PORT.getStringValue()
+                                                            .map(Integer::parseInt)
+                                                            .orElse(0);
+            }
+            if (portProperty != 0) {
+                return portProperty;
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme).map(url -> {
+                int portAttempted = url.getPort();
+                if (portAttempted == -1) {
+                    return 0;
+                }
+                return portAttempted;
+            }).orElse(0);
+        }
+
+        return 0;
+    }
+
+    /**
+     * The proxy scheme is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *        If a user has manually configured the scheme in the builder through {@link Builder#endpoint(URI)},
+     *        and the user has not explicitly disabled explicit use for <code>connectingToScheme</code>
+     *        through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *        {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>connectingToScheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyHost</code>,
+     *         or <code>http.proxyHost</code>. If these properties exist, it will return
+     *         <code>HTTP</code>.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>connectingToScheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         scheme.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param connectingToScheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined proxy scheme.
+     * */
+    public String scheme(String connectingToScheme) {
+        boolean isHttps = Objects.equals(connectingToScheme, HTTPS);
+        if (endpoint != null) {
+            if (isHttps ? proxyOverHttps : proxyOverHttp) {
+                return endpoint.getScheme();
+            }
+        }
+
+        if (useSystemPropertyValues) {
+            if (isHttps ?
+                    ProxySystemSetting.HTTPS_PROXY_HOST.getStringValue().isPresent() :
+                    ProxySystemSetting.PROXY_HOST.getStringValue().isPresent()) {
+                return HTTP;
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            Optional<URL> proxyToUse = fetchProxyFromEnvironment(connectingToScheme);
+            if (proxyToUse.isPresent()) {
+                return proxyToUse.get().getProtocol();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The proxy username is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#username(String)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyUsername</code>,
+     *         or <code>http.proxyUsername</code>. If these properties exist, it will return
+     *         the property username.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         username if it has one.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined username to authenticate to the proxy with.
+     * */
+    public String username(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (username != null) {
+            if (isHttps ? proxyOverHttps : proxyOverHttp) {
+                return username;
+            }
+        }
+
+        if (useSystemPropertyValues) {
+            Optional<String> usernameProperty;
+            if (isHttps) {
+                usernameProperty = ProxySystemSetting.HTTPS_PROXY_USERNAME.getStringValue();
+            } else {
+                usernameProperty = ProxySystemSetting.PROXY_USERNAME.getStringValue();
+            }
+            if (usernameProperty.isPresent()) {
+                return usernameProperty.get();
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme)
+                .flatMap(SdkHttpUtils::parseUsernameFromUrl)
+                .orElse(null);
+        }
+
+        return null;
+    }
+
+    /**
+     * The proxy password is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#password(String)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyPassword</code>,
+     *         or <code>http.proxyPassword</code>. If these properties exist, it will return
+     *         the property password.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         password if it has one.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined password to authenticate to the proxy with.
+     * */
+    public String password(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (password != null) {
+            if (isHttps ? proxyOverHttps : proxyOverHttp) {
+                return password;
+            }
+        }
+
+        if (useSystemPropertyValues) {
+            Optional<String> passwordProperty;
+            if (Objects.equals(scheme, HTTPS)) {
+                passwordProperty = ProxySystemSetting.HTTPS_PROXY_PASSWORD.getStringValue();
+            } else {
+                passwordProperty = ProxySystemSetting.PROXY_PASSWORD.getStringValue();
+            }
+            if (passwordProperty.isPresent()) {
+                return passwordProperty.get();
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme)
+                .flatMap(SdkHttpUtils::parsePasswordFromUrl)
+                .orElse(null);
+        }
+
+        return null;
     }
 
     /**
@@ -121,8 +391,11 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
      *
      * @see Builder#ntlmDomain(String)
      */
-    public String ntlmDomain() {
-        return ntlmDomain;
+    public String ntlmDomain(String scheme) {
+        if (Objects.equals(scheme, HTTPS) ? proxyOverHttps : proxyOverHttp) {
+            return ntlmDomain;
+        }
+        return null;
     }
 
     /**
@@ -130,20 +403,32 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
      *
      * @see Builder#ntlmWorkstation(String)
      */
-    public String ntlmWorkstation() {
-        return ntlmWorkstation;
+    public String ntlmWorkstation(String scheme) {
+        if (Objects.equals(scheme, HTTPS) ? proxyOverHttps : proxyOverHttp) {
+            return ntlmDomain;
+        }
+        return null;
     }
 
     /**
      * The hosts that the client is allowed to access without going through the proxy.
-     * If the value is not set on the object, the value represent by "http.nonProxyHosts" system property is returned.
-     * If system property is also not set, an unmodifiable empty set is returned.
+     * If the value is not set on the object, the value represent by <code>http.nonProxyHosts</code> system property is returned.
+     * If system property is also not set, or empty we try to load from <code>no_proxy</code> environment variable.
+     * If all are unset, we return an empty set.
      *
      * @see Builder#nonProxyHosts(Set)
      */
     public Set<String> nonProxyHosts() {
-        Set<String> hosts = nonProxyHosts == null && useSystemPropertyValues ? parseNonProxyHostsProperty()
-                                                                             : nonProxyHosts;
+        Set<String> hosts = null;
+        if (nonProxyHosts != null) {
+            hosts = nonProxyHosts;
+        }
+        if (nonProxyHosts == null && useSystemPropertyValues) {
+            hosts = parseNonProxyHostsProperty();
+        }
+        if (nonProxyHosts == null && (hosts == null || hosts.isEmpty()) && useEnvironmentVariables) {
+            hosts = parseNonProxyHostsEnvironment();
+        }
 
         return Collections.unmodifiableSet(hosts != null ? hosts : Collections.emptySet());
     }
@@ -167,7 +452,10 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
                 .ntlmWorkstation(ntlmWorkstation)
                 .nonProxyHosts(nonProxyHosts)
                 .preemptiveBasicAuthenticationEnabled(preemptiveBasicAuthenticationEnabled)
-                .useSystemPropertyValues(useSystemPropertyValues);
+                .useSystemPropertyValues(useSystemPropertyValues)
+                .useEnvironmentVariables(useEnvironmentVariables)
+                .proxyOverHttp(proxyOverHttp)
+                .proxyOverHttps(proxyOverHttps);
     }
 
     /**
@@ -186,51 +474,9 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
                        .add("ntlmWorkstation", ntlmWorkstation)
                        .add("nonProxyHosts", nonProxyHosts)
                        .add("preemptiveBasicAuthenticationEnabled", preemptiveBasicAuthenticationEnabled)
+                       .add("usingEndpointForHttp", proxyOverHttp)
+                       .add("usingEndpointForHttps", proxyOverHttps)
                        .build();
-    }
-
-
-    private String resolveHost(String scheme) {
-        if (endpoint != null) {
-            return endpoint.getHost();
-        }
-
-        if (Objects.equals(scheme, HTTPS)) {
-            return resolveValue(null, ProxySystemSetting.HTTPS_PROXY_HOST);
-        }
-        return resolveValue(null, ProxySystemSetting.PROXY_HOST);
-    }
-
-    private int resolvePort(String scheme) {
-        int port = 0;
-
-        if (endpoint != null) {
-            port = endpoint.getPort();
-        } else if (useSystemPropertyValues) {
-            if (Objects.equals(scheme, HTTPS)) {
-                port = ProxySystemSetting.HTTPS_PROXY_PORT.getStringValue()
-                                                          .map(Integer::parseInt)
-                                                          .orElse(0);
-            } else {
-                port = ProxySystemSetting.PROXY_PORT.getStringValue()
-                                                    .map(Integer::parseInt)
-                                                    .orElse(0);
-            }
-        }
-
-        return port;
-    }
-
-    public String resolveScheme() {
-        return endpoint != null ? endpoint.getScheme() : null;
-    }
-
-    /**
-     * Uses the configuration options, system setting property and returns the final value of the given member.
-     */
-    private String resolveValue(String value, ProxySystemSetting systemSetting) {
-        return value == null && useSystemPropertyValues ? systemSetting.getStringValue().orElse(null)
-                                                        : value;
     }
 
     /**
@@ -285,13 +531,30 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
         /**
          * Option whether to use system property values from {@link ProxySystemSetting} if any of the config options are missing.
-         *
          * This value is set to "true" by default which means SDK will automatically use system property values
          * for options that are not provided during building the {@link ProxyConfiguration} object. To disable this behavior,
          * set this value to "false".
          */
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
+        /**
+         * Option whether to use environment variable values from {@link ProxySystemSetting} if any of the config options are
+         * missing.
+         * This value is set to "true" by default which means SDK will automatically use environment variable values
+         * for options that are not provided during building the {@link ProxyConfiguration} object. To disable this behavior,
+         * set this value to "false".
+         */
+        Builder useEnvironmentVariables(Boolean useEnvironmentVariables);
+
+        /**
+         * Configure whether to attempt to use this proxy for HTTP requests.
+         */
+        Builder proxyOverHttp(Boolean overHttp);
+
+        /**
+         * Configure whether to attempt to use this proxy for HTTPS requests.
+         */
+        Builder proxyOverHttps(Boolean overHttps);
     }
 
     /**
@@ -307,6 +570,9 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         private Set<String> nonProxyHosts;
         private Boolean preemptiveBasicAuthenticationEnabled;
         private Boolean useSystemPropertyValues = Boolean.TRUE;
+        private Boolean useEnvironmentVariables = Boolean.TRUE;
+        private Boolean proxyOverHttp;
+        private Boolean proxyOverHttps;
 
         @Override
         public Builder endpoint(URI endpoint) {
@@ -402,6 +668,36 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
         public void setUseSystemPropertyValues(Boolean useSystemPropertyValues) {
             useSystemPropertyValues(useSystemPropertyValues);
+        }
+
+        @Override
+        public Builder useEnvironmentVariables(Boolean useEnvironmentVariables) {
+            this.useEnvironmentVariables = useEnvironmentVariables;
+            return this;
+        }
+
+        public void setUseEnvironmentVariables(Boolean useEnvironmentVariables) {
+            useEnvironmentVariables(useEnvironmentVariables);
+        }
+
+        @Override
+        public Builder proxyOverHttp(Boolean proxyOverHttp) {
+            this.proxyOverHttp = proxyOverHttp;
+            return this;
+        }
+
+        public void setProxyOverHttp(Boolean shouldProxyOverHttp) {
+            proxyOverHttp(shouldProxyOverHttp);
+        }
+
+        @Override
+        public Builder proxyOverHttps(Boolean proxyOverHttps) {
+            this.proxyOverHttps = proxyOverHttps;
+            return this;
+        }
+
+        public void setProxyOverHttps(Boolean shouldProxyOverHttps) {
+            proxyOverHttps(shouldProxyOverHttps);
         }
 
         @Override

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ProxyConfigurationTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ProxyConfigurationTest.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.http.apache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -23,16 +25,18 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.utils.internal.SystemSettingUtilsTestBackdoor;
 
 public class ProxyConfigurationTest {
-
     @BeforeEach
     public void setup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
         clearProxyProperties();
     }
 
     @AfterAll
     public static void cleanup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
         clearProxyProperties();
     }
 
@@ -45,9 +49,9 @@ public class ProxyConfigurationTest {
 
         ProxyConfiguration config = ProxyConfiguration.builder().useSystemPropertyValues(true).build();
 
-        assertThat(config.host()).isEqualTo(host);
-        assertThat(config.port()).isEqualTo(port);
-        assertThat(config.scheme()).isNull();
+        assertThat(config.host("http")).isEqualTo(host);
+        assertThat(config.port("http")).isEqualTo(port);
+        assertThat(config.scheme("http")).isEqualTo("http");
     }
 
     @Test
@@ -57,25 +61,23 @@ public class ProxyConfigurationTest {
         System.setProperty("https.proxyHost", host);
         System.setProperty("https.proxyPort", Integer.toString(port));
 
-        ProxyConfiguration config = ProxyConfiguration.builder()
-                                                      .endpoint(URI.create("https://foo.com:7777"))
-                                                      .useSystemPropertyValues(true).build();
-
-        assertThat(config.host()).isEqualTo(host);
-        assertThat(config.port()).isEqualTo(port);
-        assertThat(config.scheme()).isEqualTo("https");
+        ProxyConfiguration config = ProxyConfiguration.builder().useSystemPropertyValues(true).build();
+        assertThat(config.host("https")).isEqualTo(host);
+        assertThat(config.port("https")).isEqualTo(port);
+        assertThat(config.scheme("https")).isEqualTo("http");
     }
 
     @Test
     void testEndpointValues_SystemPropertyDisabled() {
-        ProxyConfiguration config = ProxyConfiguration.builder()
-                                                      .endpoint(URI.create("http://localhost:1234"))
-                                                      .useSystemPropertyValues(Boolean.FALSE)
-                                                      .build();
+        String host = "foo.com";
+        int port = 7777;
+        System.setProperty("https.proxyHost", host);
+        System.setProperty("https.proxyPort", Integer.toString(port));
+        ProxyConfiguration config = ProxyConfiguration.builder().useSystemPropertyValues(Boolean.FALSE).build();
 
-        assertThat(config.host()).isEqualTo("localhost");
-        assertThat(config.port()).isEqualTo(1234);
-        assertThat(config.scheme()).isEqualTo("http");
+        assertNull(config.host("http"));
+        assertEquals(0, config.port("http"));
+        assertNull(config.scheme("http"));
     }
 
     @Test
@@ -95,10 +97,10 @@ public class ProxyConfigurationTest {
                                                       .useSystemPropertyValues(Boolean.FALSE)
                                                       .build();
 
-        assertThat(config.host()).isEqualTo("localhost");
-        assertThat(config.port()).isEqualTo(1234);
+        assertThat(config.host("http")).isEqualTo("localhost");
+        assertThat(config.port("http")).isEqualTo(1234);
         assertThat(config.nonProxyHosts()).isEqualTo(nonProxyHosts);
-        assertThat(config.username()).isNull();
+        assertThat(config.username("http")).isNull();
     }
 
     @Test
@@ -117,8 +119,8 @@ public class ProxyConfigurationTest {
                                                       .build();
 
         assertThat(config.nonProxyHosts()).isEqualTo(nonProxyHosts);
-        assertThat(config.host()).isEqualTo("foo.com");
-        assertThat(config.username()).isEqualTo("user");
+        assertThat(config.host("http")).isEqualTo("foo.com");
+        assertThat(config.username("http")).isEqualTo("user");
     }
 
     @Test
@@ -138,8 +140,8 @@ public class ProxyConfigurationTest {
                                                       .build();
 
         assertThat(config.nonProxyHosts()).isEqualTo(nonProxyHosts);
-        assertThat(config.host()).isEqualTo("foo.com");
-        assertThat(config.username()).isEqualTo("user");
+        assertThat(config.host("https")).isEqualTo("foo.com");
+        assertThat(config.username("https")).isEqualTo("user");
     }
 
     @Test
@@ -152,6 +154,168 @@ public class ProxyConfigurationTest {
                               .build();
 
         assertThat(proxyConfiguration.toBuilder()).isNotNull();
+    }
+
+    @Test
+    void testExplicitEndpointOverridesEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@localhost:25565/"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "https://user:pass@localhost:25566/"
+        );
+        ProxyConfiguration proxyConfiguration =
+            ProxyConfiguration.builder()
+                              .endpoint(URI.create("http://example.com:4321"))
+                              .username("mycooluser")
+                              .password("mycoolpass")
+                              .build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.host("https")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(4321);
+        assertThat(proxyConfiguration.port("https")).isEqualTo(4321);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.username("https")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("mycoolpass");
+        assertThat(proxyConfiguration.password("https")).isEqualTo("mycoolpass");
+    }
+
+    @Test
+    void testExplicitPropertiesOverridesEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@localhost:25565/"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "https://user:pass@localhost:25566/"
+        );
+        System.setProperty("http.proxyHost", "example.com");
+        System.setProperty("http.proxyPort", "4321");
+        System.setProperty("http.proxyUser", "mycooluser");
+        System.setProperty("http.proxyPassword", "mycoolpass");
+        System.setProperty("https.proxyHost", "example.com");
+        System.setProperty("https.proxyPort", "4321");
+        System.setProperty("https.proxyUser", "mycooluser");
+        System.setProperty("https.proxyPassword", "mycoolpass");
+
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder().build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.host("https")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(4321);
+        assertThat(proxyConfiguration.port("https")).isEqualTo(4321);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.username("https")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("mycoolpass");
+        assertThat(proxyConfiguration.password("https")).isEqualTo("mycoolpass");
+    }
+
+    @Test
+    void testCanParseEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@localhost:25565/"
+        );
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder().build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("localhost");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(25565);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("https");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("user");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("pass");
+    }
+
+    @Test
+    void testEnvWorksWhenExplicitNotConfigured() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "http://user:pass@localhost:25565/"
+        );
+        ProxyConfiguration proxyConfiguration =
+            ProxyConfiguration.builder()
+                              .endpoint(URI.create("https://example.com:8080"))
+                              .username("insecure")
+                              .password("insecure")
+                              .proxyOverHttps(false)
+                              .build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(8080);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("https");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("insecure");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("insecure");
+
+        assertThat(proxyConfiguration.host("https")).isEqualTo("localhost");
+        assertThat(proxyConfiguration.port("https")).isEqualTo(25565);
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("https")).isEqualTo("user");
+        assertThat(proxyConfiguration.password("https")).isEqualTo("pass");
+    }
+
+    @Test
+    void testCanInferSchemeBasedOnEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@localhost:25565/"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "http://user:pass@localhost:25566/"
+        );
+
+        ProxyConfiguration config = ProxyConfiguration.builder().build();
+        assertThat(config.scheme("http")).isEqualTo("https");
+        assertThat(config.scheme("https")).isEqualTo("http");
+    }
+
+    @Test
+    void testEnvironmentVariableNoProxy() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "no_proxy",
+            "169.254.169.254,test-two.example.com,*.example.com"
+        );
+        // This shouldn't be taken as it isn't being used.
+        System.setProperty("http.nonProxyHosts", "");
+        ProxyConfiguration config = ProxyConfiguration.builder().build();
+
+        assertThat(config.nonProxyHosts()).contains(
+            "test-two.example.com", ".*?.example.com", "169.254.169.254");
+    }
+
+    @Test
+    void testIgnoresEnvironmentWhenToldTo() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "http://user:pass@localhost:25565/index.html"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "https://user:pass@localhost:25566/index.html"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "no_proxy",
+            "localhost,test-two.example.com,*.example.com"
+        );
+        ProxyConfiguration config = ProxyConfiguration.builder().useEnvironmentVariables(false).build();
+
+        assertThat(config.host("http")).isNull();
+        assertThat(config.host("https")).isNull();
+        assertThat(config.port("http")).isEqualTo(0);
+        assertThat(config.port("https")).isEqualTo(0);
+        assertThat(config.username("http")).isNull();
+        assertThat(config.username("https")).isNull();
+        assertThat(config.password("http")).isNull();
+        assertThat(config.password("https")).isNull();
+        assertThat(config.nonProxyHosts()).isEmpty();
+        assertThat(config.scheme("http")).isNull();
     }
 
     private static void clearProxyProperties() {

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlannerTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlannerTest.java
@@ -16,37 +16,116 @@
 package software.amazon.awssdk.http.apache.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Collections;
+import java.net.URI;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.apache.ProxyConfiguration;
+import software.amazon.awssdk.utils.internal.SystemSettingUtilsTestBackdoor;
 
 /**
  * Unit tests for {@link SdkProxyRoutePlanner}.
  */
 public class SdkProxyRoutePlannerTest {
+    private static final HttpHost INSECURE_S3_HOST = new HttpHost("s3.us-west-2.amazonaws.com", 80, "http");
     private static final HttpHost S3_HOST = new HttpHost("s3.us-west-2.amazonaws.com", 443, "https");
+    private static final HttpHost EXAMPLE_HOST = new HttpHost("example.com", 443, "https");
     private static final HttpGet S3_REQUEST = new HttpGet("/my-bucket/my-object");
     private static final HttpClientContext CONTEXT = new HttpClientContext();
 
+    @BeforeEach
+    public void setup() {
+        clearProxyProperties();
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        clearProxyProperties();
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
+    }
+
     @Test
     public void testSetsCorrectSchemeBasedOnProcotol_HTTPS() throws HttpException {
-        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner("localhost", 1234, "https", Collections.emptySet());
+        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner(
+            ProxyConfiguration.builder().endpoint(URI.create("https://localhost:1234")).build()
+        );
 
+        // Routing to an HTTP & HTTPS endpoint should go to the same proxy as
+        // it's been explicitly configured, and by default an explicit proxy
+        // goes to both by default.
         HttpHost proxyHost = planner.determineRoute(S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
         assertEquals("localhost", proxyHost.getHostName());
         assertEquals("https", proxyHost.getSchemeName());
+        assertEquals(1234, proxyHost.getPort());
+        HttpHost insecureProxyHost = planner.determineRoute(INSECURE_S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
+        assertEquals(proxyHost, insecureProxyHost);
     }
 
     @Test
     public void testSetsCorrectSchemeBasedOnProcotol_HTTP() throws HttpException {
-        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner("localhost", 1234, "http", Collections.emptySet());
+        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner(
+            ProxyConfiguration.builder().endpoint(URI.create("http://localhost:1234")).build()
+        );
 
         HttpHost proxyHost = planner.determineRoute(S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
         assertEquals("localhost", proxyHost.getHostName());
         assertEquals("http", proxyHost.getSchemeName());
+        assertEquals(1234, proxyHost.getPort());
+        HttpHost insecureProxyHost = planner.determineRoute(INSECURE_S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
+        assertEquals(proxyHost, insecureProxyHost);
+    }
+
+    @Test
+    public void testCanReturnTwoSeparateProxies() throws HttpException {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride("http_proxy", "https://localhost:1234");
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride("https_proxy", "http://example.com:25565");
+        SdkProxyRoutePlanner envPlanner = new SdkProxyRoutePlanner(ProxyConfiguration.builder()
+                                                                                     .proxyOverHttp(false)
+                                                                                     .proxyOverHttps(false)
+                                                                                     .useSystemPropertyValues(false)
+                                                                                     .build());
+
+        HttpHost proxyHost = envPlanner.determineRoute(S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
+        assertEquals("example.com", proxyHost.getHostName());
+        assertEquals("http", proxyHost.getSchemeName());
+        assertEquals(25565, proxyHost.getPort());
+
+        HttpHost insecureProxyHost = envPlanner.determineRoute(INSECURE_S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
+        assertEquals("localhost", insecureProxyHost.getHostName());
+        assertEquals("https", insecureProxyHost.getSchemeName());
+        assertEquals(1234, insecureProxyHost.getPort());
+    }
+
+    @Test
+    public void testCanIgnoreProxyHost() throws HttpException {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride("http_proxy", "http://localhost:1234");
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride("https_proxy", "http://example.com:1234");
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride("no_proxy", "s3.us-west-2.amazonaws.com");
+        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner(ProxyConfiguration.builder().build());
+
+        assertNull(planner.determineRoute(S3_HOST, S3_REQUEST, CONTEXT).getProxyHost());
+        assertNull(planner.determineRoute(INSECURE_S3_HOST, S3_REQUEST, CONTEXT).getProxyHost());
+        assertNotNull(planner.determineRoute(EXAMPLE_HOST, S3_REQUEST, CONTEXT).getProxyHost());
+    }
+
+    private static void clearProxyProperties() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("http.nonProxyHosts");
+        System.clearProperty("http.proxyUser");
+        System.clearProperty("http.proxyPassword");
+
+        System.clearProperty("https.proxyHost");
+        System.clearProperty("https.proxyPort");
+        System.clearProperty("https.proxyUser");
+        System.clearProperty("https.proxyPassword");
     }
 }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/ProxyConfiguration.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/ProxyConfiguration.java
@@ -115,6 +115,24 @@ public final class ProxyConfiguration extends CrtProxyConfiguration
         @Override
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
+        /**
+         * Option whether to use environment variable values from {@link ProxySystemSetting} if any of the config options are
+         * missing.
+         * This value is set to "true" by default which means SDK will automatically use environment variable values
+         * for options that are not provided during building the {@link CrtProxyConfiguration} object. To disable this behavior,
+         * set this value to "false".
+         */
+        Builder useEnvironmentVariables(Boolean useEnvironmentVariables);
+
+        /**
+         * Configure whether to attempt to use this proxy for HTTP requests.
+         */
+        Builder proxyOverHttp(Boolean overHttp);
+
+        /**
+         * Configure whether to attempt to use this proxy for HTTPS requests.
+         */
+        Builder proxyOverHttps(Boolean overHttps);
 
         @Override
         ProxyConfiguration build();

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -75,9 +75,20 @@ public class AwsCrtHttpClientSpiVerificationTest {
 
     @BeforeClass
     public static void setup() throws Exception {
+        // All requests happen over HTTP, by configuring a proxy for HTTPS requests
+        // we are implicitly testing that requests can only proxy when the scheme
+        // is correct.
         client = AwsCrtAsyncHttpClient.builder()
                                       .connectionHealthConfiguration(b -> b.minimumThroughputInBps(4068L)
                                                                            .minimumThroughputTimeout(Duration.ofSeconds(3)))
+                                      .proxyConfiguration(
+                                          ProxyConfiguration.builder()
+                                                            .host("foobar.com")
+                                                            .port(321)
+                                                            .scheme("https")
+                                                            .proxyOverHttp(false)
+                                                            .build()
+                                      )
                                       .build();
     }
 

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/ProxyConfigurationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/ProxyConfigurationTest.java
@@ -19,12 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URI;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.utils.internal.SystemSettingUtilsTestBackdoor;
 
 /**
  * Tests for {@link ProxyConfiguration}.
@@ -35,14 +35,20 @@ public class ProxyConfigurationTest {
     private static final int TEST_PORT = 7777;
     private static final String TEST_USER = "testuser";
     private static final String TEST_PASSWORD = "123";
+    private static final String ENV_HOST = "bar.com";
+    private static final int ENV_PORT = 9999;
+    private static final String ENV_USER = "env";
+    private static final String ENV_PASSWORD = "321";
 
     @BeforeEach
     public void setup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
         clearProxyProperties();
     }
 
     @AfterAll
     public static void cleanup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
         clearProxyProperties();
     }
 
@@ -56,11 +62,11 @@ public class ProxyConfigurationTest {
         setHttpProxyProperties();
         ProxyConfiguration config = ProxyConfiguration.builder().build();
 
-        assertThat(config.host()).isEqualTo(TEST_HOST);
-        assertThat(config.port()).isEqualTo(TEST_PORT);
-        assertThat(config.username()).isEqualTo(TEST_USER);
-        assertThat(config.password()).isEqualTo(TEST_PASSWORD);
-        assertThat(config.scheme()).isNull();
+        assertThat(config.host("http")).isEqualTo(TEST_HOST);
+        assertThat(config.port("http")).isEqualTo(TEST_PORT);
+        assertThat(config.username("http")).isEqualTo(TEST_USER);
+        assertThat(config.password("http")).isEqualTo(TEST_PASSWORD);
+        assertThat(config.scheme("http")).isEqualTo("http");
     }
 
     @Test
@@ -70,11 +76,11 @@ public class ProxyConfigurationTest {
                                                       .scheme("https")
                                                       .build();
 
-        assertThat(config.host()).isEqualTo(TEST_HOST);
-        assertThat(config.port()).isEqualTo(TEST_PORT);
-        assertThat(config.username()).isEqualTo(TEST_USER);
-        assertThat(config.password()).isEqualTo(TEST_PASSWORD);
-        assertThat(config.scheme()).isEqualTo("https");
+        assertThat(config.host("https")).isEqualTo(TEST_HOST);
+        assertThat(config.port("https")).isEqualTo(TEST_PORT);
+        assertThat(config.username("https")).isEqualTo(TEST_USER);
+        assertThat(config.password("https")).isEqualTo(TEST_PASSWORD);
+        assertThat(config.scheme("https")).isEqualTo("http");
     }
 
     @Test
@@ -82,30 +88,29 @@ public class ProxyConfigurationTest {
         setHttpProxyProperties();
         ProxyConfiguration config = ProxyConfiguration.builder().useSystemPropertyValues(Boolean.TRUE).build();
 
-        assertThat(config.host()).isEqualTo(TEST_HOST);
-        assertThat(config.port()).isEqualTo(TEST_PORT);
-        assertThat(config.username()).isEqualTo(TEST_USER);
-        assertThat(config.password()).isEqualTo(TEST_PASSWORD);
-        assertThat(config.scheme()).isNull();
+        assertThat(config.host("http")).isEqualTo(TEST_HOST);
+        assertThat(config.port("http")).isEqualTo(TEST_PORT);
+        assertThat(config.username("http")).isEqualTo(TEST_USER);
+        assertThat(config.password("http")).isEqualTo(TEST_PASSWORD);
+        assertThat(config.scheme("http")).isEqualTo("http");
     }
 
     @Test
     void build_systemPropertyEnabled_Https() {
         setHttpsProxyProperties();
-        ProxyConfiguration config = ProxyConfiguration.builder()
-                                                      .scheme("https")
-                                                      .useSystemPropertyValues(Boolean.TRUE).build();
+        ProxyConfiguration config = ProxyConfiguration.builder().useSystemPropertyValues(Boolean.TRUE).build();
 
-        assertThat(config.host()).isEqualTo(TEST_HOST);
-        assertThat(config.port()).isEqualTo(TEST_PORT);
-        assertThat(config.username()).isEqualTo(TEST_USER);
-        assertThat(config.password()).isEqualTo(TEST_PASSWORD);
-        assertThat(config.scheme()).isEqualTo("https");
+        assertThat(config.host("https")).isEqualTo(TEST_HOST);
+        assertThat(config.port("https")).isEqualTo(TEST_PORT);
+        assertThat(config.username("https")).isEqualTo(TEST_USER);
+        assertThat(config.password("https")).isEqualTo(TEST_PASSWORD);
+        assertThat(config.scheme("https")).isEqualTo("http");
     }
 
     @Test
     void build_systemPropertyDisabled() {
         setHttpProxyProperties();
+        setHttpsProxyProperties();
         ProxyConfiguration config = ProxyConfiguration.builder()
                                                       .host("localhost")
                                                       .port(8888)
@@ -113,11 +118,16 @@ public class ProxyConfigurationTest {
                                                       .password("password")
                                                       .useSystemPropertyValues(Boolean.FALSE).build();
 
-        assertThat(config.host()).isEqualTo("localhost");
-        assertThat(config.port()).isEqualTo(8888);
-        assertThat(config.username()).isEqualTo("username");
-        assertThat(config.password()).isEqualTo("password");
-        assertThat(config.scheme()).isNull();
+        assertThat(config.host("http")).isEqualTo("localhost");
+        assertThat(config.host("https")).isEqualTo("localhost");
+        assertThat(config.port("http")).isEqualTo(8888);
+        assertThat(config.port("https")).isEqualTo(8888);
+        assertThat(config.username("http")).isEqualTo("username");
+        assertThat(config.username("https")).isEqualTo("username");
+        assertThat(config.password("http")).isEqualTo("password");
+        assertThat(config.password("https")).isEqualTo("password");
+        assertThat(config.scheme("http")).isNull();
+        assertThat(config.scheme("https")).isNull();
     }
 
     @Test
@@ -130,11 +140,110 @@ public class ProxyConfigurationTest {
                                                       .password("password")
                                                       .build();
 
-        assertThat(config.host()).isEqualTo("localhost");
-        assertThat(config.port()).isEqualTo(8888);
-        assertThat(config.username()).isEqualTo("username");
-        assertThat(config.password()).isEqualTo("password");
-        assertThat(config.scheme()).isNull();
+        assertThat(config.host("http")).isEqualTo("localhost");
+        assertThat(config.port("http")).isEqualTo(8888);
+        assertThat(config.username("http")).isEqualTo("username");
+        assertThat(config.password("http")).isEqualTo("password");
+        assertThat(config.scheme("http")).isNull();
+    }
+
+    @Test
+    void testExplicitEndpointOverridesEnvironmentVariables() {
+        setHttpEnvVariables();
+        setHttpsEnvVariables();
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder()
+                                                                  .host("localhost")
+                                                                  .port(8888)
+                                                                  .scheme("http")
+                                                                  .username("username")
+                                                                  .password("password")
+                                                                  .build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("localhost");
+        assertThat(proxyConfiguration.host("https")).isEqualTo("localhost");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(8888);
+        assertThat(proxyConfiguration.port("https")).isEqualTo(8888);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("username");
+        assertThat(proxyConfiguration.username("https")).isEqualTo("username");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("password");
+        assertThat(proxyConfiguration.password("https")).isEqualTo("password");
+    }
+
+    @Test
+    void testExplicitPropertiesOverridesEnvironmentVariables() {
+        setHttpEnvVariables();
+        setHttpsEnvVariables();
+        setHttpProxyProperties();
+        setHttpsProxyProperties();
+
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder().build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo(TEST_HOST);
+        assertThat(proxyConfiguration.host("https")).isEqualTo(TEST_HOST);
+        assertThat(proxyConfiguration.port("http")).isEqualTo(TEST_PORT);
+        assertThat(proxyConfiguration.port("https")).isEqualTo(TEST_PORT);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo(TEST_USER);
+        assertThat(proxyConfiguration.username("https")).isEqualTo(TEST_USER);
+        assertThat(proxyConfiguration.password("http")).isEqualTo(TEST_PASSWORD);
+        assertThat(proxyConfiguration.password("https")).isEqualTo(TEST_PASSWORD);
+    }
+
+    @Test
+    void testCanParseEnvironmentVariables() {
+        setHttpEnvVariables();
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder().build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo(ENV_HOST);
+        assertThat(proxyConfiguration.port("http")).isEqualTo(ENV_PORT);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo(ENV_USER);
+        assertThat(proxyConfiguration.password("http")).isEqualTo(ENV_PASSWORD);
+    }
+
+    @Test
+    void testEnvWorksWhenExplicitNotConfigured() {
+        setHttpsEnvVariables();
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder()
+                                                                 .host(TEST_HOST)
+                                                                 .port(TEST_PORT)
+                                                                 .username(TEST_USER)
+                                                                 .password(TEST_PASSWORD)
+                                                                 .scheme("https")
+                                                                 .proxyOverHttps(false)
+                                                                 .build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo(TEST_HOST);
+        assertThat(proxyConfiguration.port("http")).isEqualTo(TEST_PORT);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("https");
+        assertThat(proxyConfiguration.username("http")).isEqualTo(TEST_USER);
+        assertThat(proxyConfiguration.password("http")).isEqualTo(TEST_PASSWORD);
+
+        assertThat(proxyConfiguration.host("https")).isEqualTo(ENV_HOST);
+        assertThat(proxyConfiguration.port("https")).isEqualTo(ENV_PORT);
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("https")).isEqualTo(ENV_USER);
+        assertThat(proxyConfiguration.password("https")).isEqualTo(ENV_PASSWORD);
+    }
+
+    @Test
+    void testIgnoresEnvironmentWhenToldTo() {
+        setHttpEnvVariables();
+        setHttpsEnvVariables();
+        ProxyConfiguration config = ProxyConfiguration.builder().useEnvironmentVariables(false).build();
+
+        assertThat(config.host("http")).isNull();
+        assertThat(config.host("https")).isNull();
+        assertThat(config.port("http")).isEqualTo(0);
+        assertThat(config.port("https")).isEqualTo(0);
+        assertThat(config.username("http")).isNull();
+        assertThat(config.username("https")).isNull();
+        assertThat(config.password("http")).isNull();
+        assertThat(config.password("https")).isNull();
+        assertThat(config.scheme("http")).isNull();
     }
 
     @Test
@@ -227,6 +336,32 @@ public class ProxyConfigurationTest {
         System.setProperty("https.proxyPort", Integer.toString(TEST_PORT));
         System.setProperty("https.proxyUser", TEST_USER);
         System.setProperty("https.proxyPassword", TEST_PASSWORD);
+    }
+
+    private void setHttpEnvVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            String.format(
+                "http://%s:%s@%s:%d",
+                ENV_USER,
+                ENV_PASSWORD,
+                ENV_HOST,
+                ENV_PORT
+            )
+        );
+    }
+
+    private void setHttpsEnvVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            String.format(
+                "http://%s:%s@%s:%d",
+                ENV_USER,
+                ENV_PASSWORD,
+                ENV_HOST,
+                ENV_PORT
+            )
+        );
     }
 
     private static void clearProxyProperties() {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
@@ -15,10 +15,16 @@
 
 package software.amazon.awssdk.http.nio.netty;
 
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.fetchProxyFromEnvironment;
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.parseNonProxyHostsEnvironment;
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.parseNonProxyHostsProperty;
+
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -26,6 +32,7 @@ import software.amazon.awssdk.utils.ProxySystemSetting;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Proxy configuration for {@link NettyNioAsyncHttpClient}. This class is used to configure an HTTP or HTTPS proxy to be used by
@@ -36,7 +43,11 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 @SdkPublicApi
 public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfiguration.Builder, ProxyConfiguration> {
     private static final String HTTPS = "https";
+    private static final String HTTP = "http";
     private final Boolean useSystemPropertyValues;
+    private final Boolean useEnvironmentVariables;
+    private final Boolean explicitHttp;
+    private final Boolean explicitHttps;
     private final String scheme;
     private final String host;
     private final int port;
@@ -46,12 +57,15 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
     private ProxyConfiguration(BuilderImpl builder) {
         this.useSystemPropertyValues = builder.useSystemPropertyValues;
+        this.useEnvironmentVariables = builder.useEnvironmentVariables;
         this.scheme = builder.scheme;
-        this.host = resolveHost(builder.host);
-        this.port = resolvePort(builder.port);
+        this.host = builder.host;
+        this.port = builder.port;
         this.username = builder.username;
         this.password = builder.password;
         this.nonProxyHosts = builder.nonProxyHosts;
+        this.explicitHttp = builder.explicitHttp == null || builder.explicitHttp;
+        this.explicitHttps = builder.explicitHttps == null || builder.explicitHttps;
     }
 
     public static Builder builder() {
@@ -59,58 +73,338 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
     }
 
     /**
-     * @return The proxy scheme.
-     */
-    public String scheme() {
-        return scheme;
-    }
-
-    /**
-     * @return The proxy host from the configuration if set, else from the "https.proxyHost" or "http.proxyHost" system property,
-     * based on the scheme used, if @link ProxyConfiguration.Builder#useSystemPropertyValues(Boolean)} is set to true
-     */
-    public String host() {
-        return host;
-    }
-
-    /**
-     * @return The proxy port from the configuration if set, else from the "https.proxyPort" or "http.proxyPort" system
-     * property, based on the scheme used, if {@link ProxyConfiguration.Builder#useSystemPropertyValues(Boolean)} is set to true
-     */
-    public int port() {
-        return port;
-    }
-
-    /**
-     * @return The proxy username from the configuration if set, else from the "https.proxyUser" or "http.proxyUser" system
-     * property, based on the scheme used, if {@link ProxyConfiguration.Builder#useSystemPropertyValues(Boolean)} is set to true
+     * The proxy scheme is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *        If a user has manually configured the scheme in the builder through {@link Builder#scheme(String)},
+     *        and the user has not explicitly disabled explicit use for <code>connectingToScheme</code>
+     *        through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *        {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>connectingToScheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyHost</code>,
+     *         or <code>http.proxyHost</code>. If these properties exist, it will return
+     *         <code>HTTP</code>.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>connectingToScheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         scheme.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param connectingToScheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined proxy scheme.
      * */
-    public String username() {
-        if (Objects.equals(scheme(), HTTPS)) {
-            return resolveValue(username, ProxySystemSetting.HTTPS_PROXY_USERNAME);
+    public String scheme(String connectingToScheme) {
+        boolean isHttps = Objects.equals(connectingToScheme, HTTPS);
+        if (scheme != null) {
+            if (isHttps ? explicitHttps : explicitHttp) {
+                return scheme;
+            }
         }
-        return resolveValue(username, ProxySystemSetting.PROXY_USERNAME);
+
+        if (useSystemPropertyValues) {
+            if (isHttps ?
+                    ProxySystemSetting.HTTPS_PROXY_HOST.getStringValue().isPresent() :
+                    ProxySystemSetting.PROXY_HOST.getStringValue().isPresent()) {
+                return HTTP;
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            Optional<URL> proxyToUse = fetchProxyFromEnvironment(connectingToScheme);
+            if (proxyToUse.isPresent()) {
+                return proxyToUse.get().getProtocol();
+            }
+        }
+
+        return null;
     }
 
     /**
-     * @return The proxy password from the configuration if set, else from the "https.proxyPassword" or "http.proxyPassword"
-     * system property, based on the scheme used, if {@link ProxyConfiguration.Builder#useSystemPropertyValues(Boolean)} is set
-     * to true
+     * The proxy host is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#host(String)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyHost</code>,
+     *         or <code>http.proxyHost</code>. If these properties exist, it will return
+     *         the property hostname.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         hostname.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined proxy hostname to connect too.
      * */
-    public String password() {
-        if (Objects.equals(scheme(), HTTPS)) {
-            return resolveValue(password, ProxySystemSetting.HTTPS_PROXY_PASSWORD);
+    public String host(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (host != null) {
+            if (isHttps ? explicitHttps : explicitHttp) {
+                return host;
+            }
         }
-        return resolveValue(password, ProxySystemSetting.PROXY_PASSWORD);
+
+        if (useSystemPropertyValues) {
+            String hostProperty;
+            if (isHttps) {
+                hostProperty = ProxySystemSetting.HTTPS_PROXY_HOST.getStringValue().orElse(null);
+            } else {
+                hostProperty = ProxySystemSetting.PROXY_HOST.getStringValue().orElse(null);
+            }
+            if (hostProperty != null) {
+                return hostProperty;
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme).map(URL::getHost).orElse(null);
+        }
+
+        return null;
     }
 
     /**
-     * @return The set of hosts that should not be proxied. If the value is not set, the value present by "http.nonProxyHost"
-     * system property is returned. If system property is also not set, an unmodifiable empty set is returned.
+     * The proxy port is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#port(int)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyPort</code>,
+     *         or <code>http.proxyPort</code>. If these properties exist, it will return
+     *         the property port.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         port.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>0</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined proxy port to connect too.
+     * */
+    public int port(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (port > 0) {
+            if (isHttps ? explicitHttps : explicitHttp) {
+                return port;
+            }
+        }
+
+        if (useSystemPropertyValues) {
+            int portProperty;
+            if (isHttps) {
+                portProperty = ProxySystemSetting.HTTPS_PROXY_PORT.getStringValue()
+                                                                  .map(Integer::parseInt)
+                                                                  .orElse(0);
+            } else {
+                portProperty = ProxySystemSetting.PROXY_PORT.getStringValue()
+                                                            .map(Integer::parseInt)
+                                                            .orElse(0);
+            }
+            if (portProperty != 0) {
+                return portProperty;
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme).map(url -> {
+                int portAttempted = url.getPort();
+                if (portAttempted == -1) {
+                    return 0;
+                }
+                return portAttempted;
+            }).orElse(0);
+        }
+
+        return 0;
+    }
+
+    /**
+     * The proxy username is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#username(String)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyUsername</code>,
+     *         or <code>http.proxyUsername</code>. If these properties exist, it will return
+     *         the property username.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         username if it has one.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined username to authenticate to the proxy with.
+     * */
+    public String username(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (username != null) {
+            if (isHttps ? explicitHttps : explicitHttp) {
+                return username;
+            }
+        }
+
+        if (useSystemPropertyValues) {
+            Optional<String> usernameProperty;
+            if (isHttps) {
+                usernameProperty = ProxySystemSetting.HTTPS_PROXY_USERNAME.getStringValue();
+            } else {
+                usernameProperty = ProxySystemSetting.PROXY_USERNAME.getStringValue();
+            }
+            if (usernameProperty.isPresent()) {
+                return usernameProperty.get();
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme)
+                .flatMap(SdkHttpUtils::parseUsernameFromUrl)
+                .orElse(null);
+        }
+
+        return null;
+    }
+
+    /**
+     * The proxy password is determined in the following order:
+     *
+     * <ul>
+     *     <li>
+     *         If a user has manually configured the scheme in the builder through {@link Builder#password(String)},
+     *         and the user has not explicitly disabled explicit use for <code>scheme</code>
+     *         through one of the builder interfaces {@link Builder#proxyOverHttp(Boolean)}, or
+     *         {@link Builder#proxyOverHttps(Boolean)}.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useSystemPropertyValues(Boolean)} is set to <code>true</code>
+     *         System properties are checked next. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two system properties <code>https.proxyPassword</code>,
+     *         or <code>http.proxyPassword</code>. If these properties exist, it will return
+     *         the property password.
+     *     </li>
+     *     <li>
+     *         If {@link Builder#useEnvironmentVariables(Boolean)} is set to <code>true</code>
+     *         Environment variables will be checked last. Depending on the <code>scheme</code>
+     *         parameter, it will check one of two environment variables <code>http_proxy</code>, or
+     *         <code>https_proxy</code> (in all lowercase, or all uppercase). If the correct
+     *         environment variable exists, it will parse the URI in this variable, and return it's
+     *         password if it has one.
+     *     </li>
+     *     <li>
+     *         If all else fails <code>null</code> is returned.
+     *     </li>
+     * </ul>
+     *
+     * @param scheme the scheme, or protocol of the URL that we're making a request too.
+     * @return The current determined password to authenticate to the proxy with.
+     * */
+    public String password(String scheme) {
+        boolean isHttps = Objects.equals(scheme, HTTPS);
+        if (password != null) {
+            if (isHttps ? explicitHttps : explicitHttp) {
+                return password;
+            }
+        }
+
+        if (useSystemPropertyValues) {
+            Optional<String> passwordProperty;
+            if (Objects.equals(scheme, HTTPS)) {
+                passwordProperty = ProxySystemSetting.HTTPS_PROXY_PASSWORD.getStringValue();
+            } else {
+                passwordProperty = ProxySystemSetting.PROXY_PASSWORD.getStringValue();
+            }
+            if (passwordProperty.isPresent()) {
+                return passwordProperty.get();
+            }
+        }
+
+        if (useEnvironmentVariables) {
+            return fetchProxyFromEnvironment(scheme)
+                .flatMap(SdkHttpUtils::parsePasswordFromUrl)
+                .orElse(null);
+        }
+
+        return null;
+    }
+
+    /**
+     * The hosts that the client is allowed to access without going through the proxy.
+     * If the value is not set on the object, the value represent by <code>http.nonProxyHosts</code> system property is returned.
+     * If system property is also not set, or empty we try to load from <code>no_proxy</code> environment variable.
+     * If all are unset, we return an empty set.
+     *
+     * @see Builder#nonProxyHosts(Set)
      */
     public Set<String> nonProxyHosts() {
-        Set<String> hosts = nonProxyHosts == null && useSystemPropertyValues ? parseNonProxyHostsProperty()
-                                                                             : nonProxyHosts;
+        Set<String> hosts = null;
+        if (nonProxyHosts != null) {
+            hosts = nonProxyHosts;
+        }
+        if (nonProxyHosts == null && useSystemPropertyValues) {
+            hosts = parseNonProxyHostsProperty();
+        }
+        if (nonProxyHosts == null && (hosts == null || hosts.isEmpty()) && useEnvironmentVariables) {
+            hosts = parseNonProxyHostsEnvironment();
+        }
+
         return Collections.unmodifiableSet(hosts != null ? hosts : Collections.emptySet());
     }
 
@@ -130,24 +424,39 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
             return false;
         }
 
-        if (scheme != null ? !scheme.equals(that.scheme) : that.scheme != null) {
+        if (!Objects.equals(scheme, that.scheme)) {
             return false;
         }
 
-        if (host != null ? !host.equals(that.host) : that.host != null) {
+        if (!Objects.equals(host, that.host)) {
             return false;
         }
 
-        if (username != null ? !username.equals(that.username) : that.username != null) {
+        if (!Objects.equals(username, that.username)) {
             return false;
         }
 
-        if (password != null ? !password.equals(that.password) : that.password != null) {
+        if (!Objects.equals(password, that.password)) {
             return false;
         }
 
-        return nonProxyHosts.equals(that.nonProxyHosts);
+        if (!nonProxyHosts.equals(that.nonProxyHosts)) {
+            return false;
+        }
 
+        if (!Objects.equals(useSystemPropertyValues, that.useSystemPropertyValues)) {
+            return false;
+        }
+
+        if (!Objects.equals(useEnvironmentVariables, that.useEnvironmentVariables)) {
+            return false;
+        }
+
+        if (!Objects.equals(explicitHttp, that.explicitHttp)) {
+            return false;
+        }
+
+        return Objects.equals(explicitHttps, that.explicitHttps);
     }
 
     @Override
@@ -158,6 +467,10 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         result = 31 * result + nonProxyHosts.hashCode();
         result = 31 * result + (username != null ? username.hashCode() : 0);
         result = 31 * result + (password != null ? password.hashCode() : 0);
+        result = 31 * result + (useSystemPropertyValues != null ? useSystemPropertyValues.hashCode() : 0);
+        result = 31 * result + (useEnvironmentVariables != null ? useEnvironmentVariables.hashCode() : 0);
+        result = 31 * result + explicitHttp.hashCode();
+        result = 31 * result + explicitHttps.hashCode();
         return result;
     }
 
@@ -233,32 +546,25 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          */
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
-    }
+        /**
+         * Option whether to use environment variable values from {@link ProxySystemSetting} if any of the config options are
+         * missing.
+         * This value is set to "true" by default which means SDK will automatically use environment variable values
+         * for options that are not provided during building the {@link ProxyConfiguration} object. To disable this behavior,
+         * set this value to "false".
+         */
+        Builder useEnvironmentVariables(Boolean useEnvironmentVariables);
 
-    private String resolveHost(String host) {
-        if (Objects.equals(scheme(), HTTPS)) {
-            return resolveValue(host, ProxySystemSetting.HTTPS_PROXY_HOST);
-        }
-        return resolveValue(host, ProxySystemSetting.PROXY_HOST);
-    }
+        /**
+         * Configure whether to attempt to use this proxy for HTTP requests.
+         */
+        Builder proxyOverHttp(Boolean overHttp);
 
-    private int resolvePort(int port) {
-        if (port == 0 && Boolean.TRUE.equals(useSystemPropertyValues)) {
-            if (Objects.equals(scheme(), HTTPS)) {
-                return ProxySystemSetting.HTTPS_PROXY_PORT.getStringValue().map(Integer::parseInt).orElse(0);
-            }
-            return ProxySystemSetting.PROXY_PORT.getStringValue().map(Integer::parseInt).orElse(0);
-        }
+        /**
+         * Configure whether to attempt to use this proxy for HTTPS requests.
+         */
+        Builder proxyOverHttps(Boolean overHttps);
 
-        return port;
-    }
-
-    /**
-     * Uses the configuration options, system setting property and returns the final value of the given member.
-     */
-    private String resolveValue(String value, ProxySystemSetting systemSetting) {
-        return value == null && Boolean.TRUE.equals(useSystemPropertyValues) ?
-               systemSetting.getStringValue().orElse(null) : value;
     }
 
     private Set<String> parseNonProxyHostsProperty() {
@@ -281,12 +587,16 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         private String password;
         private Set<String> nonProxyHosts;
         private Boolean useSystemPropertyValues = Boolean.TRUE;
+        private Boolean useEnvironmentVariables = Boolean.TRUE;
+        private Boolean explicitHttp;
+        private Boolean explicitHttps;
 
         private BuilderImpl() {
         }
 
         private BuilderImpl(ProxyConfiguration proxyConfiguration) {
             this.useSystemPropertyValues = proxyConfiguration.useSystemPropertyValues;
+            this.useEnvironmentVariables = proxyConfiguration.useEnvironmentVariables;
             this.scheme = proxyConfiguration.scheme;
             this.host = proxyConfiguration.host;
             this.port = proxyConfiguration.port;
@@ -294,6 +604,8 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
                                  new HashSet<>(proxyConfiguration.nonProxyHosts) : null;
             this.username = proxyConfiguration.username;
             this.password = proxyConfiguration.password;
+            this.explicitHttp = proxyConfiguration.explicitHttp;
+            this.explicitHttps = proxyConfiguration.explicitHttps;
         }
 
         @Override
@@ -345,6 +657,36 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
         public void setUseSystemPropertyValues(Boolean useSystemPropertyValues) {
             useSystemPropertyValues(useSystemPropertyValues);
+        }
+
+        @Override
+        public Builder useEnvironmentVariables(Boolean useEnvironmentVariables) {
+            this.useEnvironmentVariables = useEnvironmentVariables;
+            return this;
+        }
+
+        public void setUseEnvironmentVariables(Boolean useEnvironmentVariables) {
+            useEnvironmentVariables(useEnvironmentVariables);
+        }
+
+        @Override
+        public Builder proxyOverHttp(Boolean proxyOverHttp) {
+            this.explicitHttp = proxyOverHttp;
+            return this;
+        }
+
+        public void setProxyOverHttp(Boolean shouldProxyOverHttp) {
+            proxyOverHttp(shouldProxyOverHttp);
+        }
+
+        @Override
+        public Builder proxyOverHttps(Boolean proxyOverHttps) {
+            this.explicitHttps = proxyOverHttps;
+            return this;
+        }
+
+        public void setProxyOverHttps(Boolean shouldProxyOverHttps) {
+            proxyOverHttps(shouldProxyOverHttps);
         }
 
         @Override

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -192,8 +192,11 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
             httpsConnection.setSSLSocketFactory(socketFactory);
         }
 
-        if (proxy.isPresent() && shouldProxyAuthorize()) {
-            connection.addRequestProperty("proxy-authorization", String.format("Basic %s", encodedAuthToken(proxyConfiguration)));
+        String scheme = uri.getScheme();
+        if (proxy.isPresent() && shouldProxyAuthorize(scheme)) {
+            connection.addRequestProperty(
+                "proxy-authorization",
+                String.format("Basic %s", encodedAuthToken(proxyConfiguration, scheme)));
         }
 
         connection.setConnectTimeout(saturatedCast(options.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toMillis()));
@@ -206,23 +209,24 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
      * If a proxy is configured with username+password, then set the proxy-authorization header to authorize ourselves with the
      * proxy
      */
-    private static String encodedAuthToken(ProxyConfiguration proxyConfiguration) {
-
-        String authToken = String.format("%s:%s", proxyConfiguration.username(), proxyConfiguration.password());
+    private static String encodedAuthToken(ProxyConfiguration proxyConfiguration, String scheme) {
+        String authToken = String.format("%s:%s", proxyConfiguration.username(scheme), proxyConfiguration.password(scheme));
         return Base64.getEncoder().encodeToString(authToken.getBytes(StandardCharsets.UTF_8));
     }
 
-    private boolean shouldProxyAuthorize() {
+    private boolean shouldProxyAuthorize(String scheme) {
         return this.proxyConfiguration != null
-               && ! StringUtils.isEmpty(this.proxyConfiguration.username())
-               && ! StringUtils.isEmpty(this.proxyConfiguration.password());
+               && ! StringUtils.isEmpty(this.proxyConfiguration.username(scheme))
+               && ! StringUtils.isEmpty(this.proxyConfiguration.password(scheme));
     }
 
     private Optional<Proxy> determineProxy(URI uri) {
-        if (isProxyEnabled() && isProxyHostIncluded(uri)) {
+        String scheme = uri.getScheme();
+        if (isProxyEnabled(scheme) && isProxyHostIncluded(uri)) {
             return Optional.of(
                 new Proxy(Proxy.Type.HTTP,
-                          InetSocketAddress.createUnresolved(this.proxyConfiguration.host(), this.proxyConfiguration.port())));
+                          InetSocketAddress.createUnresolved(this.proxyConfiguration.host(scheme),
+                                                             this.proxyConfiguration.port(scheme))));
         }
         return Optional.empty();
     }
@@ -233,8 +237,8 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
                                       .noneMatch(uri.getHost().toLowerCase(Locale.getDefault())::matches);
     }
 
-    private boolean isProxyEnabled() {
-        return this.proxyConfiguration != null && this.proxyConfiguration.host() != null;
+    private boolean isProxyEnabled(String scheme) {
+        return this.proxyConfiguration != null && this.proxyConfiguration.host(scheme) != null;
     }
 
     private SSLContext getSslContext(AttributeMap options) {

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/ProxyConfigurationTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/ProxyConfigurationTest.java
@@ -18,29 +18,21 @@ package software.amazon.awssdk.http.urlconnection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
-import java.util.HashSet;
-import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.utils.internal.SystemSettingUtilsTestBackdoor;
 
 public class ProxyConfigurationTest {
-
-    @AfterAll
-    public static void cleanup() {
+    @BeforeEach
+    public void setup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
         clearProxyProperties();
     }
 
-    private static void clearProxyProperties() {
-        System.clearProperty("http.proxyHost");
-        System.clearProperty("http.proxyPort");
-        System.clearProperty("http.nonProxyHosts");
-        System.clearProperty("http.proxyUser");
-        System.clearProperty("http.proxyPassword");
-    }
-
-    @BeforeEach
-    public void setup() {
+    @AfterAll
+    public static void cleanup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
         clearProxyProperties();
     }
 
@@ -53,75 +45,208 @@ public class ProxyConfigurationTest {
 
         ProxyConfiguration config = ProxyConfiguration.builder().useSystemPropertyValues(true).build();
 
-        assertThat(config.host()).isEqualTo(host);
-        assertThat(config.port()).isEqualTo(port);
-        assertThat(config.scheme()).isNull();
+        assertThat(config.host("http")).isEqualTo(host);
+        assertThat(config.port("http")).isEqualTo(port);
+        assertThat(config.scheme("http")).isEqualTo("http");
     }
 
     @Test
-    void testEndpointValues_SystemPropertyDisabled() {
-        ProxyConfiguration config = ProxyConfiguration.builder()
-                                                      .endpoint(URI.create("http://localhost:1234"))
-                                                      .useSystemPropertyValues(Boolean.FALSE)
-                                                      .build();
-
-        assertThat(config.host()).isEqualTo("localhost");
-        assertThat(config.port()).isEqualTo(1234);
-        assertThat(config.scheme()).isEqualTo("http");
-    }
-
-    @Test
-    void testProxyConfigurationWithSystemPropertyDisabled() throws Exception {
-        Set<String> nonProxyHosts = new HashSet<>();
-        nonProxyHosts.add("foo.com");
-
-        // system property should not be used
+    void testEndpointValues_SystemPropertyEnabledOverride() {
         System.setProperty("http.proxyHost", "foo.com");
-        System.setProperty("http.proxyPort", "5555");
-        System.setProperty("http.nonProxyHosts", "bar.com");
+        System.setProperty("http.proxyPort", "7777");
         System.setProperty("http.proxyUser", "user");
+        System.setProperty("http.proxyPassword", "password");
 
         ProxyConfiguration config = ProxyConfiguration.builder()
                                                       .endpoint(URI.create("http://localhost:1234"))
-                                                      .nonProxyHosts(nonProxyHosts)
+                                                      .username("testuser")
+                                                      .password("testpass")
                                                       .useSystemPropertyValues(Boolean.FALSE)
                                                       .build();
 
-        assertThat(config.host()).isEqualTo("localhost");
-        assertThat(config.port()).isEqualTo(1234);
-        assertThat(config.nonProxyHosts()).isEqualTo(nonProxyHosts);
-        assertThat(config.username()).isNull();
-    }
-
-    @Test
-    void testProxyConfigurationWithSystemPropertyEnabled() throws Exception {
-        Set<String> nonProxyHosts = new HashSet<>();
-        nonProxyHosts.add("foo.com");
-
-        // system property should not be used
-        System.setProperty("http.proxyHost", "foo.com");
-        System.setProperty("http.proxyPort", "5555");
-        System.setProperty("http.nonProxyHosts", "bar.com");
-        System.setProperty("http.proxyUser", "user");
-
-        ProxyConfiguration config = ProxyConfiguration.builder()
-                                                      .nonProxyHosts(nonProxyHosts)
-                                                      .build();
-
-        assertThat(config.nonProxyHosts()).isEqualTo(nonProxyHosts);
-        assertThat(config.host()).isEqualTo("foo.com");
-        assertThat(config.username()).isEqualTo("user");
+        assertThat(config.host("http")).isEqualTo("localhost");
+        assertThat(config.port("http")).isEqualTo(1234);
+        assertThat(config.scheme("http")).isEqualTo("http");
+        assertThat(config.username("http")).isEqualTo("testuser");
+        assertThat(config.password("http")).isEqualTo("testpass");
     }
 
     @Test
     void testProxyConfigurationWithoutNonProxyHosts_toBuilder_shouldNotThrowNPE() {
-        ProxyConfiguration proxyConfiguration =
-            ProxyConfiguration.builder()
-                              .endpoint(URI.create("http://localhost:4321"))
-                              .username("username")
-                              .password("password")
-                              .build();
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder()
+                                                                  .endpoint(URI.create("http://localhost:4321"))
+                                                                  .username("username")
+                                                                  .password("password")
+                                                                  .build();
 
         assertThat(proxyConfiguration.toBuilder()).isNotNull();
+    }
+
+    @Test
+    void testExplicitEndpointOverridesEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@localhost:25565/"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "https://user:pass@localhost:25566/"
+        );
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder()
+                                                                  .endpoint(URI.create("http://example.com:4321"))
+                                                                  .username("mycooluser")
+                                                                  .password("mycoolpass")
+                                                                  .build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.host("https")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(4321);
+        assertThat(proxyConfiguration.port("https")).isEqualTo(4321);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.username("https")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("mycoolpass");
+        assertThat(proxyConfiguration.password("https")).isEqualTo("mycoolpass");
+    }
+
+    @Test
+    void testExplicitPropertiesOverridesEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@localhost:25565/"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "https://user:pass@localhost:25566/"
+        );
+        System.setProperty("http.proxyHost", "example.com");
+        System.setProperty("http.proxyPort", "4321");
+        System.setProperty("http.proxyUser", "mycooluser");
+        System.setProperty("http.proxyPassword", "mycoolpass");
+        System.setProperty("https.proxyHost", "example.com");
+        System.setProperty("https.proxyPort", "4321");
+        System.setProperty("https.proxyUser", "mycooluser");
+        System.setProperty("https.proxyPassword", "mycoolpass");
+
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder().build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.host("https")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(4321);
+        assertThat(proxyConfiguration.port("https")).isEqualTo(4321);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.username("https")).isEqualTo("mycooluser");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("mycoolpass");
+        assertThat(proxyConfiguration.password("https")).isEqualTo("mycoolpass");
+    }
+
+    @Test
+    void testCanParseEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "http://user:pass@localhost:25565/"
+        );
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder().build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("localhost");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(25565);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("user");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("pass");
+    }
+
+    @Test
+    void testEnvWorksWhenExplicitNotConfigured() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "http://user:pass@localhost:25565/"
+        );
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder()
+                                                                  .endpoint(URI.create("https://example.com:8080"))
+                                                                  .username("insecure")
+                                                                  .password("insecure")
+                                                                  .proxyOverHttps(false)
+                                                                  .build();
+
+        assertThat(proxyConfiguration.host("http")).isEqualTo("example.com");
+        assertThat(proxyConfiguration.port("http")).isEqualTo(8080);
+        assertThat(proxyConfiguration.scheme("http")).isEqualTo("https");
+        assertThat(proxyConfiguration.username("http")).isEqualTo("insecure");
+        assertThat(proxyConfiguration.password("http")).isEqualTo("insecure");
+
+        assertThat(proxyConfiguration.host("https")).isEqualTo("localhost");
+        assertThat(proxyConfiguration.port("https")).isEqualTo(25565);
+        assertThat(proxyConfiguration.scheme("https")).isEqualTo("http");
+        assertThat(proxyConfiguration.username("https")).isEqualTo("user");
+        assertThat(proxyConfiguration.password("https")).isEqualTo("pass");
+    }
+
+    @Test
+    void testCanInferSchemeBasedOnEnvironmentVariables() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@localhost:25565/"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "http://user:pass@localhost:25566/"
+        );
+
+        ProxyConfiguration config = ProxyConfiguration.builder().build();
+        assertThat(config.scheme("http")).isEqualTo("https");
+        assertThat(config.scheme("https")).isEqualTo("http");
+    }
+
+    @Test
+    void testEnvironmentVariableNoProxy() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "no_proxy",
+            "169.254.169.254,test-two.example.com,*.example.com"
+        );
+        // This shouldn't be taken as it isn't being used.
+        System.setProperty("http.nonProxyHosts", "");
+        ProxyConfiguration config = ProxyConfiguration.builder().build();
+
+        assertThat(config.nonProxyHosts()).contains(
+            "test-two.example.com", ".*?.example.com", "169.254.169.254");
+    }
+
+    @Test
+    void testIgnoresEnvironmentWhenToldTo() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "http://user:pass@localhost:25565/index.html"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "https_proxy",
+            "https://user:pass@localhost:25566/index.html"
+        );
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "no_proxy",
+            "localhost,test-two.example.com,*.example.com"
+        );
+        ProxyConfiguration config = ProxyConfiguration.builder().useEnvironmentVariables(false).build();
+
+        assertThat(config.host("http")).isNull();
+        assertThat(config.host("https")).isNull();
+        assertThat(config.port("http")).isEqualTo(0);
+        assertThat(config.port("https")).isEqualTo(0);
+        assertThat(config.username("http")).isNull();
+        assertThat(config.username("https")).isNull();
+        assertThat(config.password("http")).isNull();
+        assertThat(config.password("https")).isNull();
+        assertThat(config.nonProxyHosts()).isEmpty();
+        assertThat(config.scheme("http")).isNull();
+    }
+
+    private static void clearProxyProperties() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("http.nonProxyHosts");
+        System.clearProperty("http.proxyUser");
+        System.clearProperty("http.proxyPassword");
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtProxyConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtProxyConfiguration.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.crtcore.CrtProxyConfiguration;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.utils.ProxySystemSetting;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -86,6 +87,25 @@ public final class S3CrtProxyConfiguration extends CrtProxyConfiguration
 
         @Override
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
+
+        /**
+         * Option whether to use environment variable values from {@link ProxySystemSetting} if any of the config options are
+         * missing.
+         * This value is set to "true" by default which means SDK will automatically use environment variable values
+         * for options that are not provided during building the {@link CrtProxyConfiguration} object. To disable this behavior,
+         * set this value to "false".
+         */
+        Builder useEnvironmentVariables(Boolean useEnvironmentVariables);
+
+        /**
+         * Configure whether to attempt to use this proxy for HTTP requests.
+         */
+        Builder proxyOverHttp(Boolean overHttp);
+
+        /**
+         * Configure whether to attempt to use this proxy for HTTPS requests.
+         */
+        Builder proxyOverHttps(Boolean overHttps);
 
         @Override
         S3CrtProxyConfiguration build();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -84,7 +84,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         if (s3NativeClientConfiguration.standardRetryOptions() != null) {
             this.s3ClientOptions.withStandardRetryOptions(s3NativeClientConfiguration.standardRetryOptions());
         }
-        Optional.ofNullable(s3NativeClientConfiguration.proxyOptions()).ifPresent(s3ClientOptions::withProxyOptions);
+        Optional.ofNullable(s3NativeClientConfiguration.httpsProxyOptions()).ifPresent(s3ClientOptions::withProxyOptions);
         Optional.ofNullable(s3NativeClientConfiguration.connectionTimeout())
                 .map(Duration::toMillis)
                 .map(NumericUtils::saturatedCast)

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -58,7 +58,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final Long readBufferSizeInBytes;
 
     private final TlsContext tlsContext;
-    private final HttpProxyOptions proxyOptions;
+    private final HttpProxyOptions httpProxyOptions;
+    private final HttpProxyOptions httpsProxyOptions;
     private final Duration connectionTimeout;
     private final HttpMonitoringOptions httpMonitoringOptions;
 
@@ -99,12 +100,15 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
                                      partSizeInBytes * 10 : builder.readBufferSizeInBytes;
 
         if (builder.httpConfiguration != null) {
-            this.proxyOptions = resolveProxy(builder.httpConfiguration.proxyConfiguration(), tlsContext).orElse(null);
+            this.httpProxyOptions = resolveProxy(builder.httpConfiguration.proxyConfiguration(), tlsContext, "http").orElse(null);
+            this.httpsProxyOptions =
+                resolveProxy(builder.httpConfiguration.proxyConfiguration(), tlsContext, "https").orElse(null);
             this.connectionTimeout = builder.httpConfiguration.connectionTimeout();
             this.httpMonitoringOptions =
                 resolveHttpMonitoringOptions(builder.httpConfiguration.healthConfiguration()).orElse(null);
         } else {
-            this.proxyOptions = null;
+            this.httpProxyOptions = null;
+            this.httpsProxyOptions = null;
             this.connectionTimeout = null;
             this.httpMonitoringOptions = null;
         }
@@ -115,8 +119,12 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         return httpMonitoringOptions;
     }
 
-    public HttpProxyOptions proxyOptions() {
-        return proxyOptions;
+    public HttpProxyOptions httpProxyOptions() {
+        return httpProxyOptions;
+    }
+
+    public HttpProxyOptions httpsProxyOptions() {
+        return httpsProxyOptions;
     }
 
     public Duration connectionTimeout() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfigurationTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfigurationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.crt.http.HttpProxyOptions;
+import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
+import software.amazon.awssdk.services.s3.crt.S3CrtProxyConfiguration;
+import software.amazon.awssdk.utils.internal.SystemSettingUtilsTestBackdoor;
+
+class S3NativeClientConfigurationTest {
+    @BeforeEach
+    public void preCleanup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
+    }
+
+    @BeforeEach
+    public void postCleanup() {
+        SystemSettingUtilsTestBackdoor.clearEnvironmentVariableOverrides();
+    }
+
+    @Test
+    public void testAllowsSeparatingProxies() {
+        SystemSettingUtilsTestBackdoor.addEnvironmentVariableOverride(
+            "http_proxy",
+            "https://user:pass@example.com:1234"
+        );
+        S3NativeClientConfiguration configuration = S3NativeClientConfiguration.builder().httpConfiguration(
+            S3CrtHttpConfiguration.builder()
+                                  .proxyConfiguration(
+                                      S3CrtProxyConfiguration.builder()
+                                                             .host("localhost")
+                                                             .port(4321)
+                                                             .scheme("http")
+                                                             .username("other")
+                                                             .password("other-pass")
+                                                             .proxyOverHttps(false)
+                                                             .build()
+                                  )
+                                  .build()
+        ).build();
+
+        HttpProxyOptions httpProxy = configuration.httpProxyOptions();
+        assertThat(httpProxy.getHost()).isEqualTo("localhost");
+        assertThat(httpProxy.getPort()).isEqualTo(4321);
+        assertThat(httpProxy.getAuthorizationUsername()).isEqualTo("other");
+        assertThat(httpProxy.getAuthorizationPassword()).isEqualTo("other-pass");
+
+        HttpProxyOptions httpsProxy = configuration.httpsProxyOptions();
+        assertThat(httpsProxy.getHost()).isEqualTo("example.com");
+        assertThat(httpsProxy.getPort()).isEqualTo(1234);
+        assertThat(httpsProxy.getAuthorizationUsername()).isEqualTo("user");
+        assertThat(httpsProxy.getAuthorizationPassword()).isEqualTo("pass");
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/ProxyEnvironmentSetting.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ProxyEnvironmentSetting.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import static software.amazon.awssdk.utils.internal.SystemSettingUtils.resolveEnvironmentVariable;
+
+import java.util.Locale;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * Environment variables used to set a proxy
+ */
+@SdkProtectedApi
+public enum ProxyEnvironmentSetting implements SystemSetting {
+
+    HTTP_PROXY("http_proxy"),
+    HTTPS_PROXY("https_proxy"),
+    NO_PROXY("no_proxy")
+    ;
+
+    private final String environmentVariable;
+
+    ProxyEnvironmentSetting(String environmentVariable) {
+        this.environmentVariable = environmentVariable;
+    }
+
+    @Override
+    public Optional<String> getStringValue() {
+        Optional<String> envVarLowercase = resolveEnvironmentVariable(environmentVariable);
+        if (envVarLowercase.isPresent() && !envVarLowercase.get().trim().isEmpty()) {
+            return envVarLowercase.map(String::trim);
+        }
+
+        Optional<String> envVarUppercase = resolveEnvironmentVariable(environmentVariable.toUpperCase(Locale.getDefault()));
+        if (envVarUppercase.isPresent() && !envVarUppercase.get().trim().isEmpty()) {
+            return envVarUppercase.map(String::trim);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String property() {
+        return null;
+    }
+
+    @Override
+    public String environmentVariable() {
+        return environmentVariable;
+    }
+
+    @Override
+    public String defaultValue() {
+        return null;
+    }
+
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/ProxyEnvironmentSettingTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/ProxyEnvironmentSettingTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+public class ProxyEnvironmentSettingTest {
+    private final Map<String, String> savedEnvironmentVariableValues = new HashMap<>();
+
+    private static final List<String> SAVED_ENVIRONMENT_VARIABLES = Arrays.asList("http_proxy",
+                                                                                  "https_proxy",
+                                                                                  "no_proxy",
+                                                                                  "HTTP_PROXY",
+                                                                                  "HTTPS_PROXY",
+                                                                                  "NO_PROXY",
+                                                                                  "nO_pRoXy");
+
+    private EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    /**
+     * Save the current state of the environment variables we're messing around with in these tests so that we can restore them
+     * when we are done.
+     */
+    @BeforeEach
+    public void saveEnvironment() throws Exception {
+        for (String variable : SAVED_ENVIRONMENT_VARIABLES) {
+            savedEnvironmentVariableValues.put(variable, System.getenv(variable));
+        }
+    }
+
+    /**
+     * Reset the environment variables after each test.
+     */
+    @AfterEach
+    public void restoreEnvironment() throws Exception {
+        for (String variable : SAVED_ENVIRONMENT_VARIABLES) {
+            String savedValue = savedEnvironmentVariableValues.get(variable);
+
+            if (savedValue == null) {
+                ENVIRONMENT_VARIABLE_HELPER.remove(variable);
+            } else {
+                ENVIRONMENT_VARIABLE_HELPER.set(variable, savedValue);
+            }
+        }
+    }
+
+    @Test
+    public void settingsReturnSomeForLowercaseAndUppercaseOnly() throws Exception {
+        ENVIRONMENT_VARIABLE_HELPER.set("HTTP_PROXY", "http://localhost:25565");
+        ENVIRONMENT_VARIABLE_HELPER.set("https_proxy", "https://localhost:25566");
+        ENVIRONMENT_VARIABLE_HELPER.set("nO_pRoXy", "    ");
+
+        assertThat(ProxyEnvironmentSetting.HTTP_PROXY.getStringValue()).isEqualTo(Optional.of("http://localhost:25565"));
+        assertThat(ProxyEnvironmentSetting.HTTPS_PROXY.getStringValue()).isEqualTo(Optional.of("https://localhost:25566"));
+        assertThat(ProxyEnvironmentSetting.NO_PROXY.getStringValue()).isEmpty();
+
+        ENVIRONMENT_VARIABLE_HELPER.remove("HTTP_PROXY");
+        ENVIRONMENT_VARIABLE_HELPER.remove("https_proxy");
+        ENVIRONMENT_VARIABLE_HELPER.remove("nO_pRoXy");
+    }
+
+    @Test
+    public void settingsReturnEmptyForJustSpacesLowercase() throws Exception {
+        ENVIRONMENT_VARIABLE_HELPER.set("http_proxy", "    ");
+        ENVIRONMENT_VARIABLE_HELPER.set("https_proxy", "    ");
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", "    ");
+
+        assertThat(ProxyEnvironmentSetting.HTTP_PROXY.getStringValue()).isEmpty();
+        assertThat(ProxyEnvironmentSetting.HTTPS_PROXY.getStringValue()).isEmpty();
+        assertThat(ProxyEnvironmentSetting.NO_PROXY.getStringValue()).isEmpty();
+
+        ENVIRONMENT_VARIABLE_HELPER.remove("http_proxy");
+        ENVIRONMENT_VARIABLE_HELPER.remove("https_proxy");
+        ENVIRONMENT_VARIABLE_HELPER.remove("no_proxy");
+    }
+
+    @Test
+    public void settingsReturnEmptyForJustSpacesUppercase() throws Exception {
+        ENVIRONMENT_VARIABLE_HELPER.set("HTTP_PROXY", "    ");
+        ENVIRONMENT_VARIABLE_HELPER.set("HTTPS_PROXY", "    ");
+        ENVIRONMENT_VARIABLE_HELPER.set("NO_PROXY", "    ");
+
+        assertThat(ProxyEnvironmentSetting.HTTP_PROXY.getStringValue()).isEmpty();
+        assertThat(ProxyEnvironmentSetting.HTTPS_PROXY.getStringValue()).isEmpty();
+        assertThat(ProxyEnvironmentSetting.NO_PROXY.getStringValue()).isEmpty();
+
+        ENVIRONMENT_VARIABLE_HELPER.remove("HTTP_PROXY");
+        ENVIRONMENT_VARIABLE_HELPER.remove("HTTPS_PROXY");
+        ENVIRONMENT_VARIABLE_HELPER.remove("NO_PROXY");
+    }
+
+}


### PR DESCRIPTION
## Motivation and Context

***note: I'm opening this early because as far as I can tell it requires changing the public API, but I'm opening to see if others have ideas, or how we can handle this.***

fixes #2958 

The goal of this is to allow like many other SDKs (including aws-sdk-java v1) support for specifying proxies through environment variables. Using `http_proxy` & `https_proxy` for environment variables. `http_proxy` will be used for connections to HTTP sites, and `https_proxy` for HTTPS sites.

While making this change, I also noticed a bug in how we were selecting the `http.proxyHost` & `https.proxyHost` System Properties. I've gotten them to follow: https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html correctly now. Before we weren't passing the scheme in and only selecting based on explicit configuration (which you can still do, and doesn't break)!

I've changed all the HTTP clients that are in the source tree.

## Modifications

- Every single builder now has support for allowing reading from environment variables (by default this is true like system properties), and is not overriding of anything that exists (not breaking, and also like other SDKs).
  - There is now a way to set whether you want an explicitly configured process to handle HTTP or not HTTPS. By default explicit overrides everything like always. This allows it to play with system properties and environment variables too.
- Every proxy configuration type now takes in the _scheme_ it's connecting too, to change between `http` & `https` proxies without manual configuration, or multiple clients at all.

## Testing

- [x] I've been running tests locally to confirm unit tests continue to pass.
- [ ] When I take this out of WIP I will run integration tests through a proxy to confirm it doesn't break anything.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This is also a breaking change -- i cannot see a way to avoid it

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
