### PR TITLE
Enable request-level token provider override

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-bc8f1f1.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-bc8f1f1.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "chenying-wang", 
+    "type": "feature", 
+    "description": "Enable request-level token provider override"
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsRequestOverrideConfiguration.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsRequestOverrideConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.utils.builder.SdkBuilder;
 
@@ -28,10 +29,12 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
 @SdkPublicApi
 public final class AwsRequestOverrideConfiguration extends RequestOverrideConfiguration {
     private final AwsCredentialsProvider credentialsProvider;
+    private final SdkTokenProvider tokenProvider;
 
     private AwsRequestOverrideConfiguration(Builder builder) {
         super(builder);
         this.credentialsProvider = builder.credentialsProvider();
+        this.tokenProvider = builder.tokenProvider();
     }
 
     /**
@@ -62,6 +65,16 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
         return Optional.ofNullable(credentialsProvider);
     }
 
+    /**
+     * The optional {@link SdkTokenProvider} that will provide a token to be used to authorize this request. This will
+     * be used only if the requested operation uses bearer token authorization.
+     *
+     * @return The optional {@link SdkTokenProvider}.
+     */
+    public Optional<SdkTokenProvider> tokenProvider() {
+        return Optional.ofNullable(tokenProvider);
+    }
+
     @Override
     public Builder toBuilder() {
         return new BuilderImpl(this);
@@ -84,7 +97,8 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
             return false;
         }
         AwsRequestOverrideConfiguration that = (AwsRequestOverrideConfiguration) o;
-        return Objects.equals(credentialsProvider, that.credentialsProvider);
+        return Objects.equals(credentialsProvider, that.credentialsProvider)
+               && Objects.equals(tokenProvider, that.tokenProvider);
     }
 
     @Override
@@ -92,6 +106,7 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
         int hashCode = 1;
         hashCode = 31 * hashCode + super.hashCode();
         hashCode = 31 * hashCode + Objects.hashCode(credentialsProvider);
+        hashCode = 31 * hashCode + Objects.hashCode(tokenProvider);
         return hashCode;
     }
 
@@ -113,6 +128,23 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
          */
         AwsCredentialsProvider credentialsProvider();
 
+        /**
+         * Set the optional {@link SdkTokenProvider} that will provide a token to be used to authorize this request.
+         * This will be used only if the requested operation uses bearer token authorization.
+         *
+         * @param tokenProvider The {@link SdkTokenProvider}.
+         * @return This object for chaining.
+         */
+        Builder tokenProvider(SdkTokenProvider tokenProvider);
+
+        /**
+         * Return the optional {@link SdkTokenProvider} that will provide a token to be used to authorize this request.
+         * This will be used only if the requested operation uses bearer token authorization.
+         *
+         * @return The optional {@link AwsCredentialsProvider}.
+         */
+        SdkTokenProvider tokenProvider();
+
         @Override
         AwsRequestOverrideConfiguration build();
     }
@@ -120,7 +152,7 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
     private static final class BuilderImpl extends RequestOverrideConfiguration.BuilderImpl<Builder> implements Builder {
 
         private AwsCredentialsProvider awsCredentialsProvider;
-
+        private SdkTokenProvider sdkTokenProvider;
 
         private BuilderImpl() {
         }
@@ -132,6 +164,7 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
         private BuilderImpl(AwsRequestOverrideConfiguration awsRequestOverrideConfig) {
             super(awsRequestOverrideConfig);
             this.awsCredentialsProvider = awsRequestOverrideConfig.credentialsProvider;
+            this.sdkTokenProvider = awsRequestOverrideConfig.tokenProvider;
         }
 
         @Override
@@ -143,6 +176,17 @@ public final class AwsRequestOverrideConfiguration extends RequestOverrideConfig
         @Override
         public AwsCredentialsProvider credentialsProvider() {
             return awsCredentialsProvider;
+        }
+
+        @Override
+        public Builder tokenProvider(SdkTokenProvider tokenProvider) {
+            this.sdkTokenProvider = tokenProvider;
+            return this;
+        }
+
+        @Override
+        public SdkTokenProvider tokenProvider() {
+            return sdkTokenProvider;
         }
 
         @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Currently, AWS SDK for Java 2.0 clients don't support override `SdkTokenProvider` in the request level for the bearer token authorization operations. If using different `SdkTokenProvider`s, it will be required to create one instances of the client per `SdkTokenProvider`, which will undermine the runtime performance.

## Modifications
<!--- Describe your changes in detail -->

This change enables request-level `SdkTokenProvider` override.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The Unit test is added to cover the change.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
