### PR TITLE
chore: added workflow for handling stale discussions

### DIFF
--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -1,0 +1,18 @@
+name: HandleStaleDiscussions
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  discussion_comment:
+    types: [created]
+
+jobs:
+  handle-stale-discussions:
+    name: Handle stale discussions
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: write
+    steps:
+      - name: Stale discussions action
+        uses: aws-github-ops/handle-stale-discussions@v1
+        env:
+          GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This workflow will handle the discussions (posted in answerable category) and take appropriate action.

## Context

Whenever a discussion is replied with keyword `@github-actions proposed-answer`, is considered for action by this workflow and based on the responses/reactions received, appropriate action is taken. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
