### PR TITLE
Handle sign/signAsync in AsyncSigningStage

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
@@ -147,6 +147,9 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
 
     private SdkHttpFullRequest.Builder toSdkHttpFullRequestBuilder(SignedRequest<?> signedRequest) {
         SdkHttpRequest request = signedRequest.request();
+        if (request instanceof SdkHttpFullRequest) {
+            return ((SdkHttpFullRequest) request).toBuilder();
+        }
         return SdkHttpFullRequest.builder()
                                  .protocol(request.protocol())
                                  .method(request.method())

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -110,6 +110,9 @@ public class SigningStage implements RequestToRequestPipeline {
 
     private SdkHttpFullRequest toSdkHttpFullRequest(SyncSignedRequest signedRequest) {
         SdkHttpRequest request = signedRequest.request();
+        if (request instanceof SdkHttpFullRequest) {
+            return (SdkHttpFullRequest) request;
+        }
         return SdkHttpFullRequest.builder()
                                  .contentStreamProvider(signedRequest.payload().orElse(null))
                                  .protocol(request.protocol())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Add SRA signing logic to AsyncSigningStage. SigingStage logic was added in [#4111](https://github.com/aws/aws-sdk-java-v2/pull/4111/files#diff-d42322e3fc21746722508844b8868872976da81f4db212d0f60212d36c37b395)

## Modifications
<!--- Describe your changes in detail -->
* Call sign v/s signAsync appropriately

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing:
* Used Glacier's uploadArchive as example API that has a streaming API. So the AsyncClient would use AsyncRequestBody to test signAsync. Similar to https://github.com/aws/aws-sdk-java-v2/pull/4111, hand edited the code generated Glacier files and added a GlacierAuthSchemeInterceptor. Wrote an integ test based on https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/javav2/example_code/glacier/src/main/java/com/example/glacier/UploadArchive.java and verified via debugger that it uses SRA logic and call succeeds.
* Another test case would be event streaming, but will test that later once event streaming signer is done.