### PR TITLE
Allow null in SelectedAuthScheme

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SelectedAuthScheme.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SelectedAuthScheme.java
@@ -37,8 +37,8 @@ public final class SelectedAuthScheme<T extends Identity> {
     public SelectedAuthScheme(IdentityProvider<T> identityProvider,
                               HttpSigner<T> signer,
                               AuthSchemeOption authSchemeOption) {
-        this.identityProvider = Validate.paramNotNull(identityProvider, "identityProvider");
-        this.signer = Validate.paramNotNull(signer, "signer");
+        this.identityProvider = identityProvider;
+        this.signer = signer;
         this.authSchemeOption = Validate.paramNotNull(authSchemeOption, "authSchemeOption");
     }
 

--- a/services/acm/src/main/java/software/amazon/awssdk/services/acm/auth/scheme/internal/AcmAuthSchemeInterceptor.java
+++ b/services/acm/src/main/java/software/amazon/awssdk/services/acm/auth/scheme/internal/AcmAuthSchemeInterceptor.java
@@ -83,7 +83,7 @@ public final class AcmAuthSchemeInterceptor implements ExecutionInterceptor {
         for (AuthSchemeOption authOption : authOptions) {
             // If we're using no-auth, don't consider which options are enabled.
             if (authOption.schemeId().equals("smithy.auth#noAuth")) {
-                return new SelectedAuthScheme(null, null, authOption);
+                return new SelectedAuthScheme<>(null, null, authOption);
             }
 
             AuthScheme<?> authScheme = authSchemes.get(authOption.schemeId());

--- a/services/codecatalyst/src/main/java/software/amazon/awssdk/services/codecatalyst/auth/scheme/internal/CodeCatalystAuthSchemeInterceptor.java
+++ b/services/codecatalyst/src/main/java/software/amazon/awssdk/services/codecatalyst/auth/scheme/internal/CodeCatalystAuthSchemeInterceptor.java
@@ -83,7 +83,7 @@ public final class CodeCatalystAuthSchemeInterceptor implements ExecutionInterce
         for (AuthSchemeOption authOption : authOptions) {
             // If we're using no-auth, don't consider which options are enabled.
             if (authOption.schemeId().equals("smithy.auth#noAuth")) {
-                return new SelectedAuthScheme(null, null, authOption);
+                return new SelectedAuthScheme<>(null, null, authOption);
             }
 
             AuthScheme<?> authScheme = authSchemes.get(authOption.schemeId());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The auth scheme interceptors have a use case for `null` IdentityProvider and Signer when schemeId is `smithy.api#noAuth`.

## Modifications
<!--- Describe your changes in detail -->
Remove non-null validation for these.
Also fixed `Raw use of parameterized class 'SelectedAuthScheme'` warning with `<>`.