### PR TITLE
Request compression: non-streaming operations

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-e418083.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-e418083.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Adding support for \"requestCompression\" trait to GZIP compress payloads for non-streaming operations."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -165,6 +165,7 @@ final class AddOperations {
             operationModel.setEndpointTrait(op.getEndpoint());
             operationModel.setHttpChecksumRequired(op.isHttpChecksumRequired());
             operationModel.setHttpChecksum(op.getHttpChecksum());
+            operationModel.setRequestCompression(op.getRequestCompression());
             operationModel.setStaticContextParams(op.getStaticContextParams());
 
             Input input = op.getInput();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/compression/RequestCompression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/compression/RequestCompression.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.compression;
+
+import java.util.List;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Class to map the RequestCompression trait of an operation.
+ */
+@SdkInternalApi
+public class RequestCompression {
+
+    private List<String> encodings;
+
+    public List<String> getEncodings() {
+        return encodings;
+    }
+
+    public void setEncodings(List<String> encodings) {
+        this.encodings = encodings;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.codegen.checksum.HttpChecksum;
+import software.amazon.awssdk.codegen.compression.RequestCompression;
 import software.amazon.awssdk.codegen.docs.ClientType;
 import software.amazon.awssdk.codegen.docs.DocConfiguration;
 import software.amazon.awssdk.codegen.docs.OperationDocs;
@@ -70,6 +71,8 @@ public class OperationModel extends DocumentationModel {
     private boolean httpChecksumRequired;
 
     private HttpChecksum httpChecksum;
+
+    private RequestCompression requestCompression;
 
     @JsonIgnore
     private Map<String, StaticContextParam> staticContextParams;
@@ -307,6 +310,14 @@ public class OperationModel extends DocumentationModel {
 
     public void setHttpChecksum(HttpChecksum httpChecksum) {
         this.httpChecksum = httpChecksum;
+    }
+
+    public RequestCompression getRequestCompression() {
+        return requestCompression;
+    }
+
+    public void setRequestCompression(RequestCompression requestCompression) {
+        this.requestCompression = requestCompression;
     }
 
     public Map<String, StaticContextParam> getStaticContextParams() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Operation.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Operation.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.codegen.model.service;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.codegen.checksum.HttpChecksum;
+import software.amazon.awssdk.codegen.compression.RequestCompression;
 import software.amazon.awssdk.codegen.model.intermediate.EndpointDiscovery;
 
 public class Operation {
@@ -51,6 +52,8 @@ public class Operation {
     private boolean httpChecksumRequired;
 
     private HttpChecksum httpChecksum;
+
+    private RequestCompression requestCompression;
 
     private Map<String, StaticContextParam> staticContextParams;
 
@@ -187,6 +190,14 @@ public class Operation {
 
     public void setHttpChecksum(HttpChecksum httpChecksum) {
         this.httpChecksum = httpChecksum;
+    }
+
+    public RequestCompression getRequestCompression() {
+        return requestCompression;
+    }
+
+    public void setRequestCompression(RequestCompression requestCompression) {
+        this.requestCompression = requestCompression;
     }
 
     public Map<String, StaticContextParam> getStaticContextParams() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumRequiredTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.NoneAuthTypeRequestTrait;
+import software.amazon.awssdk.codegen.poet.client.traits.RequestCompressionTrait;
 import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.codegen.poet.model.EventStreamSpecHelper;
 import software.amazon.awssdk.core.SdkPojoBuilder;
@@ -187,7 +188,8 @@ public class JsonProtocolSpec implements ProtocolSpec {
                      .add(".withMetricCollector(apiCallMetricCollector)")
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                      .add(HttpChecksumTrait.create(opModel))
-                     .add(NoneAuthTypeRequestTrait.create(opModel));
+                     .add(NoneAuthTypeRequestTrait.create(opModel))
+                     .add(RequestCompressionTrait.create(opModel));
 
         if (opModel.hasStreamingInput()) {
             codeBlock.add(".withRequestBody(requestBody)")
@@ -257,6 +259,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                .add(HttpChecksumTrait.create(opModel))
                .add(NoneAuthTypeRequestTrait.create(opModel))
+               .add(RequestCompressionTrait.create(opModel))
                .add(".withInput($L)$L);",
                     opModel.getInput().getVariableName(), asyncResponseTransformerVariable(isStreaming, isRestJson, opModel));
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -189,7 +189,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                      .add(HttpChecksumTrait.create(opModel))
                      .add(NoneAuthTypeRequestTrait.create(opModel))
-                     .add(RequestCompressionTrait.create(opModel));
+                     .add(RequestCompressionTrait.create(opModel, model));
 
         if (opModel.hasStreamingInput()) {
             codeBlock.add(".withRequestBody(requestBody)")
@@ -259,7 +259,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                .add(HttpChecksumTrait.create(opModel))
                .add(NoneAuthTypeRequestTrait.create(opModel))
-               .add(RequestCompressionTrait.create(opModel))
+               .add(RequestCompressionTrait.create(opModel, model))
                .add(".withInput($L)$L);",
                     opModel.getInput().getVariableName(), asyncResponseTransformerVariable(isStreaming, isRestJson, opModel));
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumRequiredTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.NoneAuthTypeRequestTrait;
+import software.amazon.awssdk.codegen.poet.client.traits.RequestCompressionTrait;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
@@ -116,7 +117,8 @@ public class QueryProtocolSpec implements ProtocolSpec {
                      .add(".withMetricCollector(apiCallMetricCollector)")
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                      .add(HttpChecksumTrait.create(opModel))
-                     .add(NoneAuthTypeRequestTrait.create(opModel));
+                     .add(NoneAuthTypeRequestTrait.create(opModel))
+                     .add(RequestCompressionTrait.create(opModel));
 
 
         if (opModel.hasStreamingInput()) {
@@ -151,7 +153,8 @@ public class QueryProtocolSpec implements ProtocolSpec {
                      .add(".withMetricCollector(apiCallMetricCollector)\n")
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                      .add(HttpChecksumTrait.create(opModel))
-                     .add(NoneAuthTypeRequestTrait.create(opModel));
+                     .add(NoneAuthTypeRequestTrait.create(opModel))
+                     .add(RequestCompressionTrait.create(opModel));
 
 
         builder.add(hostPrefixExpression(opModel) + asyncRequestBody + ".withInput($L)$L);",

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
@@ -118,7 +118,7 @@ public class QueryProtocolSpec implements ProtocolSpec {
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                      .add(HttpChecksumTrait.create(opModel))
                      .add(NoneAuthTypeRequestTrait.create(opModel))
-                     .add(RequestCompressionTrait.create(opModel));
+                     .add(RequestCompressionTrait.create(opModel, intermediateModel));
 
 
         if (opModel.hasStreamingInput()) {
@@ -154,7 +154,7 @@ public class QueryProtocolSpec implements ProtocolSpec {
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                      .add(HttpChecksumTrait.create(opModel))
                      .add(NoneAuthTypeRequestTrait.create(opModel))
-                     .add(RequestCompressionTrait.create(opModel));
+                     .add(RequestCompressionTrait.create(opModel, intermediateModel));
 
 
         builder.add(hostPrefixExpression(opModel) + asyncRequestBody + ".withInput($L)$L);",

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumRequiredTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.NoneAuthTypeRequestTrait;
+import software.amazon.awssdk.codegen.poet.client.traits.RequestCompressionTrait;
 import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.codegen.poet.model.EventStreamSpecHelper;
 import software.amazon.awssdk.core.SdkPojoBuilder;
@@ -135,7 +136,8 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
                                                .add(".withInput($L)", opModel.getInput().getVariableName())
                                                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                                                .add(HttpChecksumTrait.create(opModel))
-                                               .add(NoneAuthTypeRequestTrait.create(opModel));
+                                               .add(NoneAuthTypeRequestTrait.create(opModel))
+                                               .add(RequestCompressionTrait.create(opModel));
 
 
         s3ArnableFields(opModel, model).ifPresent(codeBlock::add);
@@ -213,7 +215,8 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
                .add(asyncRequestBody(opModel))
                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                .add(HttpChecksumTrait.create(opModel))
-               .add(NoneAuthTypeRequestTrait.create(opModel));
+               .add(NoneAuthTypeRequestTrait.create(opModel))
+               .add(RequestCompressionTrait.create(opModel));
 
         s3ArnableFields(opModel, model).ifPresent(builder::add);
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
@@ -137,7 +137,7 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
                                                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                                                .add(HttpChecksumTrait.create(opModel))
                                                .add(NoneAuthTypeRequestTrait.create(opModel))
-                                               .add(RequestCompressionTrait.create(opModel));
+                                               .add(RequestCompressionTrait.create(opModel, model));
 
 
         s3ArnableFields(opModel, model).ifPresent(codeBlock::add);
@@ -216,7 +216,7 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                .add(HttpChecksumTrait.create(opModel))
                .add(NoneAuthTypeRequestTrait.create(opModel))
-               .add(RequestCompressionTrait.create(opModel));
+               .add(RequestCompressionTrait.create(opModel, model));
 
         s3ArnableFields(opModel, model).ifPresent(builder::add);
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.client.traits;
+
+import com.squareup.javapoet.CodeBlock;
+import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+
+/**
+ * The logic for handling the "requestCompression" trait within the code generator.
+ */
+public class RequestCompressionTrait {
+
+    private RequestCompressionTrait() {
+    }
+
+    /**
+     * Generate a ".putExecutionAttribute(...)" code-block for the provided operation model. This should be used within the
+     * context of initializing {@link ClientExecutionParams}. If request compression is not required by the operation, this will
+     * return an empty code-block.
+     */
+    public static CodeBlock create(OperationModel operationModel) {
+        if (operationModel.getRequestCompression() == null) {
+            return CodeBlock.of("");
+        }
+
+        List<String> encodings = operationModel.getRequestCompression().getEncodings();
+
+        return CodeBlock.builder()
+                        .add(CodeBlock.of(".putExecutionAttribute($T.REQUEST_COMPRESSION, "
+                                          + "$T.builder().encodings($L).isStreaming($L).build())",
+                                          SdkInternalExecutionAttribute.class, RequestCompression.class,
+                                          encodings.stream().collect(Collectors.joining("\", \"", "\"", "\"")),
+                                          operationModel.hasStreamingInput()))
+                        .add(CodeBlock.of(".putExecutionAttribute($T.REQUEST_COMPRESSION_CONFIGURATION,"
+                                          + "clientConfiguration.option($T.REQUEST_COMPRESSION_CONFIGURATION))",
+                                          SdkExecutionAttribute.class, SdkClientOption.class))
+                        .build();
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
@@ -20,9 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
-import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 
@@ -63,9 +61,6 @@ public class RequestCompressionTrait {
                                           SdkInternalExecutionAttribute.class, RequestCompression.class,
                                           encodings.stream().collect(Collectors.joining("\", \"", "\"", "\"")),
                                           operationModel.hasStreamingInput()))
-                        .add(CodeBlock.of(".putExecutionAttribute($T.REQUEST_COMPRESSION_CONFIGURATION,"
-                                          + "clientConfiguration.option($T.REQUEST_COMPRESSION_CONFIGURATION))",
-                                          SdkExecutionAttribute.class, SdkClientOption.class))
                         .build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 
 /**
  * The logic for handling the "requestCompression" trait within the code generator.

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.codegen.poet.client.traits;
 import com.squareup.javapoet.CodeBlock;
 import java.util.List;
 import java.util.stream.Collectors;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
@@ -38,7 +39,7 @@ public class RequestCompressionTrait {
      * context of initializing {@link ClientExecutionParams}. If request compression is not required by the operation, this will
      * return an empty code-block.
      */
-    public static CodeBlock create(OperationModel operationModel) {
+    public static CodeBlock create(OperationModel operationModel, IntermediateModel model) {
         if (operationModel.getRequestCompression() == null) {
             return CodeBlock.of("");
         }
@@ -47,6 +48,11 @@ public class RequestCompressionTrait {
         if (operationModel.isStreaming()) {
             throw new IllegalStateException("Request compression for streaming operations is not yet supported in the AWS SDK "
                                             + "for Java.");
+        }
+
+        // TODO : remove once S3 checksum interceptors are moved to occur after CompressRequestStage
+        if (model.getMetadata().getServiceName().equals("S3")) {
+            throw new IllegalStateException("Request compression for S3 is not yet supported in the AWS SDK for Java.");
         }
 
         List<String> encodings = operationModel.getRequestCompression().getEncodings();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/RequestCompressionTrait.java
@@ -43,6 +43,12 @@ public class RequestCompressionTrait {
             return CodeBlock.of("");
         }
 
+        // TODO : remove once request compression for streaming operations is supported
+        if (operationModel.isStreaming()) {
+            throw new IllegalStateException("Request compression for streaming operations is not yet supported in the AWS SDK "
+                                            + "for Java.");
+        }
+
         List<String> encodings = operationModel.getRequestCompression().getEncodings();
 
         return CodeBlock.builder()

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
@@ -30,6 +30,16 @@
       },
       "authtype": "none"
     },
+    "OperationWithRequestCompression": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "requestCompression": {
+        "encodings": ["gzip"]
+      }
+    },
     "APostOperation": {
       "name": "APostOperation",
       "http": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
@@ -59,6 +59,16 @@
       },
       "authtype": "none"
     },
+    "OperationWithRequestCompression": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "requestCompression": {
+        "encodings": ["gzip"]
+      }
+    },
     "APostOperation": {
       "name": "APostOperation",
       "http": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/service-2.json
@@ -22,6 +22,16 @@
       },
       "httpChecksumRequired": true
     },
+    "OperationWithRequestCompression": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "requestCompression": {
+        "encodings": ["gzip"]
+      }
+    },
     "APostOperation": {
       "name": "APostOperation",
       "http": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/xml/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/xml/service-2.json
@@ -29,6 +29,16 @@
       },
       "authtype": "none"
     },
+    "OperationWithRequestCompression": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "requestCompression": {
+        "encodings": ["gzip"]
+      }
+    },
     "APostOperation": {
       "name": "APostOperation",
       "http": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
@@ -29,6 +29,8 @@ import software.amazon.awssdk.services.json.model.InputEventStreamTwo;
 import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -303,6 +305,32 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     public CompletableFuture<OperationWithChecksumRequiredResponse> operationWithChecksumRequired(
         OperationWithChecksumRequiredRequest operationWithChecksumRequiredRequest) {
         return invokeOperation(operationWithChecksumRequiredRequest, request -> delegate.operationWithChecksumRequired(request));
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation asynchronously.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return A Java Future containing the result of the OperationWithRequestCompression operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) {
+        return delegate.operationWithRequestCompression(operationWithRequestCompressionRequest);
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
@@ -330,7 +330,8 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
         OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) {
-        return delegate.operationWithRequestCompression(operationWithRequestCompressionRequest);
+        return invokeOperation(operationWithRequestCompressionRequest,
+                               request -> delegate.operationWithRequestCompression(request));
     }
 
     /**
@@ -496,7 +497,7 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
         StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, AsyncRequestBody requestBody,
         AsyncResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> asyncResponseTransformer) {
         return invokeOperation(streamingInputOutputOperationRequest,
-                        request -> delegate.streamingInputOutputOperation(request, requestBody, asyncResponseTransformer));
+                               request -> delegate.streamingInputOutputOperation(request, requestBody, asyncResponseTransformer));
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
@@ -1,9 +1,11 @@
 package software.amazon.awssdk.services.json;
 
-import java.util.function.Function;
+import java.nio.file.Path;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -20,9 +22,10 @@ import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersReque
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InvalidInputException;
 import software.amazon.awssdk.services.json.model.JsonException;
-import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -35,6 +38,8 @@ import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationR
 import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable;
 import software.amazon.awssdk.utils.Validate;
 
 @Generated("software.amazon.awssdk:codegen")
@@ -66,11 +71,14 @@ public abstract class DelegatingJsonClient implements JsonClient {
      * @sample JsonClient.APostOperation
      * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
      *      API Documentation</a>
+     *
+     * @deprecated This API is deprecated, use something else
      */
     @Override
+    @Deprecated
     public APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
                                                                                                      AwsServiceException, SdkClientException, JsonException {
-        return invokeOperation(aPostOperationRequest, request -> delegate.aPostOperation(request));
+        return delegate.aPostOperation(aPostOperationRequest);
     }
 
     /**
@@ -97,7 +105,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public APostOperationWithOutputResponse aPostOperationWithOutput(
         APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
                                                                                 SdkClientException, JsonException {
-        return invokeOperation(aPostOperationWithOutputRequest, request -> delegate.aPostOperationWithOutput(request));
+        return delegate.aPostOperationWithOutput(aPostOperationWithOutputRequest);
     }
 
     /**
@@ -119,7 +127,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     @Override
     public BearerAuthOperationResponse bearerAuthOperation(BearerAuthOperationRequest bearerAuthOperationRequest)
         throws AwsServiceException, SdkClientException, JsonException {
-        return invokeOperation(bearerAuthOperationRequest, request -> delegate.bearerAuthOperation(request));
+        return delegate.bearerAuthOperation(bearerAuthOperationRequest);
     }
 
     /**
@@ -142,7 +150,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public GetOperationWithChecksumResponse getOperationWithChecksum(
         GetOperationWithChecksumRequest getOperationWithChecksumRequest) throws AwsServiceException, SdkClientException,
                                                                                 JsonException {
-        return invokeOperation(getOperationWithChecksumRequest, request -> delegate.getOperationWithChecksum(request));
+        return delegate.getOperationWithChecksum(getOperationWithChecksumRequest);
     }
 
     /**
@@ -169,7 +177,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
         GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
                                                                                   SdkClientException, JsonException {
-        return invokeOperation(getWithoutRequiredMembersRequest, request -> delegate.getWithoutRequiredMembers(request));
+        return delegate.getWithoutRequiredMembers(getWithoutRequiredMembersRequest);
     }
 
     /**
@@ -192,7 +200,52 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public OperationWithChecksumRequiredResponse operationWithChecksumRequired(
         OperationWithChecksumRequiredRequest operationWithChecksumRequiredRequest) throws AwsServiceException,
                                                                                           SdkClientException, JsonException {
-        return invokeOperation(operationWithChecksumRequiredRequest, request -> delegate.operationWithChecksumRequired(request));
+        return delegate.operationWithChecksumRequired(operationWithChecksumRequiredRequest);
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return Result of the OperationWithRequestCompression operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public OperationWithRequestCompressionResponse operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) throws AwsServiceException,
+                                                                                              SdkClientException, JsonException {
+        return delegate.operationWithRequestCompression(operationWithRequestCompressionRequest);
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see #paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey() throws AwsServiceException,
+                                                                                            SdkClientException, JsonException {
+        return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder().build());
     }
 
     /**
@@ -215,8 +268,162 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
-        return invokeOperation(paginatedOperationWithResultKeyRequest,
-                               request -> delegate.paginatedOperationWithResultKey(request));
+        return delegate.paginatedOperationWithResultKey(paginatedOperationWithResultKeyRequest);
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client
+     *             .paginatedOperationWithResultKeyPaginator(request);
+     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
+     * paginator. It only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see #paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator() throws AwsServiceException,
+                                                                                                     SdkClientException, JsonException {
+        return paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest.builder().build());
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client
+     *             .paginatedOperationWithResultKeyPaginator(request);
+     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
+     * paginator. It only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
+                                                                                              SdkClientException, JsonException {
+        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
     }
 
     /**
@@ -239,8 +446,85 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
-        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
-                               request -> delegate.paginatedOperationWithoutResultKey(request));
+        return delegate.paginatedOperationWithoutResultKey(paginatedOperationWithoutResultKeyRequest);
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client
+     *             .paginatedOperationWithoutResultKeyPaginator(request);
+     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
+     * paginator. It only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithoutResultKey
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
+                                                                                                    SdkClientException, JsonException {
+        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
     }
 
     /**
@@ -289,8 +573,50 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public <ReturnT> ReturnT putOperationWithChecksum(PutOperationWithChecksumRequest putOperationWithChecksumRequest,
                                                       RequestBody requestBody, ResponseTransformer<PutOperationWithChecksumResponse, ReturnT> responseTransformer)
         throws AwsServiceException, SdkClientException, JsonException {
-        return invokeOperation(putOperationWithChecksumRequest,
-                               request -> delegate.putOperationWithChecksum(request, requestBody, responseTransformer));
+        return delegate.putOperationWithChecksum(putOperationWithChecksumRequest, requestBody, responseTransformer);
+    }
+
+    /**
+     * Invokes the PutOperationWithChecksum operation.
+     *
+     * @param putOperationWithChecksumRequest
+     * @param sourcePath
+     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
+     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
+     *        access to read it then an exception will be thrown. The service documentation for the request content is
+     *        as follows '
+     *        <p>
+     *        Object data.
+     *        </p>
+     *        '
+     * @param destinationPath
+     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
+     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
+     *        The service documentation for the response content is as follows '
+     *        <p>
+     *        Object data.
+     *        </p>
+     *        '.
+     * @return The transformed result of the ResponseTransformer.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PutOperationWithChecksum
+     * @see #putOperationWithChecksum(PutOperationWithChecksumRequest, RequestBody)
+     * @see #putOperationWithChecksum(PutOperationWithChecksumRequest, ResponseTransformer)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PutOperationWithChecksum"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PutOperationWithChecksumResponse putOperationWithChecksum(
+        PutOperationWithChecksumRequest putOperationWithChecksumRequest, Path sourcePath, Path destinationPath)
+        throws AwsServiceException, SdkClientException, JsonException {
+        return putOperationWithChecksum(putOperationWithChecksumRequest, RequestBody.fromFile(sourcePath),
+                                        ResponseTransformer.toFile(destinationPath));
     }
 
     /**
@@ -323,7 +649,35 @@ public abstract class DelegatingJsonClient implements JsonClient {
     @Override
     public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
                                                                    RequestBody requestBody) throws AwsServiceException, SdkClientException, JsonException {
-        return invokeOperation(streamingInputOperationRequest, request -> delegate.streamingInputOperation(request, requestBody));
+        return delegate.streamingInputOperation(streamingInputOperationRequest, requestBody);
+    }
+
+    /**
+     * Some operation with a streaming input
+     *
+     * @param streamingInputOperationRequest
+     * @param sourcePath
+     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
+     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
+     *        access to read it then an exception will be thrown. The service documentation for the request content is
+     *        as follows 'This be a stream'
+     * @return Result of the StreamingInputOperation operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.StreamingInputOperation
+     * @see #streamingInputOperation(StreamingInputOperationRequest, RequestBody)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
+                                                                   Path sourcePath) throws AwsServiceException, SdkClientException, JsonException {
+        return streamingInputOperation(streamingInputOperationRequest, RequestBody.fromFile(sourcePath));
     }
 
     /**
@@ -365,8 +719,42 @@ public abstract class DelegatingJsonClient implements JsonClient {
         StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, RequestBody requestBody,
         ResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                         SdkClientException, JsonException {
-        return invokeOperation(streamingInputOutputOperationRequest,
-                               request -> delegate.streamingInputOutputOperation(request, requestBody, responseTransformer));
+        return delegate.streamingInputOutputOperation(streamingInputOutputOperationRequest, requestBody, responseTransformer);
+    }
+
+    /**
+     * Some operation with streaming input and streaming output
+     *
+     * @param streamingInputOutputOperationRequest
+     * @param sourcePath
+     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
+     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
+     *        access to read it then an exception will be thrown. The service documentation for the request content is
+     *        as follows 'This be a stream'
+     * @param destinationPath
+     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
+     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
+     *        The service documentation for the response content is as follows 'This be a stream'.
+     * @return The transformed result of the ResponseTransformer.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.StreamingInputOutputOperation
+     * @see #streamingInputOutputOperation(StreamingInputOutputOperationRequest, RequestBody)
+     * @see #streamingInputOutputOperation(StreamingInputOutputOperationRequest, ResponseTransformer)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public StreamingInputOutputOperationResponse streamingInputOutputOperation(
+        StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, Path sourcePath, Path destinationPath)
+        throws AwsServiceException, SdkClientException, JsonException {
+        return streamingInputOutputOperation(streamingInputOutputOperationRequest, RequestBody.fromFile(sourcePath),
+                                             ResponseTransformer.toFile(destinationPath));
     }
 
     /**
@@ -396,10 +784,92 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
                                                       ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                                                                  SdkClientException, JsonException {
-        return invokeOperation(streamingOutputOperationRequest,
-                               request -> delegate.streamingOutputOperation(request, responseTransformer));
+        return delegate.streamingOutputOperation(streamingOutputOperationRequest, responseTransformer);
     }
 
+    /**
+     * Some operation with a streaming output
+     *
+     * @param streamingOutputOperationRequest
+     * @param destinationPath
+     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
+     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
+     *        The service documentation for the response content is as follows 'This be a stream'.
+     * @return The transformed result of the ResponseTransformer.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.StreamingOutputOperation
+     * @see #streamingOutputOperation(StreamingOutputOperationRequest, ResponseTransformer)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public StreamingOutputOperationResponse streamingOutputOperation(
+        StreamingOutputOperationRequest streamingOutputOperationRequest, Path destinationPath) throws AwsServiceException,
+                                                                                                      SdkClientException, JsonException {
+        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toFile(destinationPath));
+    }
+
+    /**
+     * Some operation with a streaming output
+     *
+     * @param streamingOutputOperationRequest
+     * @return A {@link ResponseInputStream} containing data streamed from service. Note that this is an unmanaged
+     *         reference to the underlying HTTP connection so great care must be taken to ensure all data if fully read
+     *         from the input stream and that it is properly closed. Failure to do so may result in sub-optimal behavior
+     *         and exhausting connections in the connection pool. The unmarshalled response object can be obtained via
+     *         {@link ResponseInputStream#response()}. The service documentation for the response content is as follows
+     *         'This be a stream'.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.StreamingOutputOperation
+     * @see #getObject(streamingOutputOperation, ResponseTransformer)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
+        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
+                                                                                JsonException {
+        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toInputStream());
+    }
+
+    /**
+     * Some operation with a streaming output
+     *
+     * @param streamingOutputOperationRequest
+     * @return A {@link ResponseBytes} that loads the data streamed from the service into memory and exposes it in
+     *         convenient in-memory representations like a byte buffer or string. The unmarshalled response object can
+     *         be obtained via {@link ResponseBytes#response()}. The service documentation for the response content is
+     *         as follows 'This be a stream'.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.StreamingOutputOperation
+     * @see #getObject(streamingOutputOperation, ResponseTransformer)
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationAsBytes(
+        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
+                                                                                JsonException {
+        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toBytes());
+    }
 
     /**
      * Creates an instance of {@link JsonUtilities} object with the configuration set on this client.
@@ -416,10 +886,6 @@ public abstract class DelegatingJsonClient implements JsonClient {
 
     public SdkClient delegate() {
         return this.delegate;
-    }
-
-    protected <T extends JsonRequest, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
-        return operation.apply(request);
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-sync-client-class.java
@@ -1,11 +1,9 @@
 package software.amazon.awssdk.services.json;
 
-import java.nio.file.Path;
+import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.ResponseBytes;
-import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -22,6 +20,7 @@ import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersReque
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InvalidInputException;
 import software.amazon.awssdk.services.json.model.JsonException;
+import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
 import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
@@ -38,8 +37,6 @@ import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationR
 import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable;
-import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable;
 import software.amazon.awssdk.utils.Validate;
 
 @Generated("software.amazon.awssdk:codegen")
@@ -71,14 +68,11 @@ public abstract class DelegatingJsonClient implements JsonClient {
      * @sample JsonClient.APostOperation
      * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
      *      API Documentation</a>
-     *
-     * @deprecated This API is deprecated, use something else
      */
     @Override
-    @Deprecated
     public APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
                                                                                                      AwsServiceException, SdkClientException, JsonException {
-        return delegate.aPostOperation(aPostOperationRequest);
+        return invokeOperation(aPostOperationRequest, request -> delegate.aPostOperation(request));
     }
 
     /**
@@ -105,7 +99,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public APostOperationWithOutputResponse aPostOperationWithOutput(
         APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
                                                                                 SdkClientException, JsonException {
-        return delegate.aPostOperationWithOutput(aPostOperationWithOutputRequest);
+        return invokeOperation(aPostOperationWithOutputRequest, request -> delegate.aPostOperationWithOutput(request));
     }
 
     /**
@@ -127,7 +121,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     @Override
     public BearerAuthOperationResponse bearerAuthOperation(BearerAuthOperationRequest bearerAuthOperationRequest)
         throws AwsServiceException, SdkClientException, JsonException {
-        return delegate.bearerAuthOperation(bearerAuthOperationRequest);
+        return invokeOperation(bearerAuthOperationRequest, request -> delegate.bearerAuthOperation(request));
     }
 
     /**
@@ -150,7 +144,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public GetOperationWithChecksumResponse getOperationWithChecksum(
         GetOperationWithChecksumRequest getOperationWithChecksumRequest) throws AwsServiceException, SdkClientException,
                                                                                 JsonException {
-        return delegate.getOperationWithChecksum(getOperationWithChecksumRequest);
+        return invokeOperation(getOperationWithChecksumRequest, request -> delegate.getOperationWithChecksum(request));
     }
 
     /**
@@ -177,7 +171,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
         GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
                                                                                   SdkClientException, JsonException {
-        return delegate.getWithoutRequiredMembers(getWithoutRequiredMembersRequest);
+        return invokeOperation(getWithoutRequiredMembersRequest, request -> delegate.getWithoutRequiredMembers(request));
     }
 
     /**
@@ -200,7 +194,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public OperationWithChecksumRequiredResponse operationWithChecksumRequired(
         OperationWithChecksumRequiredRequest operationWithChecksumRequiredRequest) throws AwsServiceException,
                                                                                           SdkClientException, JsonException {
-        return delegate.operationWithChecksumRequired(operationWithChecksumRequiredRequest);
+        return invokeOperation(operationWithChecksumRequiredRequest, request -> delegate.operationWithChecksumRequired(request));
     }
 
     /**
@@ -223,29 +217,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public OperationWithRequestCompressionResponse operationWithRequestCompression(
         OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
-        return delegate.operationWithRequestCompression(operationWithRequestCompressionRequest);
-    }
-
-    /**
-     * Some paginated operation with result_key in paginators.json file
-     *
-     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see #paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey() throws AwsServiceException,
-                                                                                            SdkClientException, JsonException {
-        return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder().build());
+        return invokeOperation(operationWithRequestCompressionRequest,
+                               request -> delegate.operationWithRequestCompression(request));
     }
 
     /**
@@ -268,162 +241,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
         PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
-        return delegate.paginatedOperationWithResultKey(paginatedOperationWithResultKeyRequest);
-    }
-
-    /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client
-     *             .paginatedOperationWithResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see #paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator() throws AwsServiceException,
-                                                                                                     SdkClientException, JsonException {
-        return paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest.builder().build());
-    }
-
-    /**
-     * Some paginated operation with result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client
-     *             .paginatedOperationWithResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyIterable responses = client.paginatedOperationWithResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithResultKeyRequest
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
-                                                                                              SdkClientException, JsonException {
-        return delegate.paginatedOperationWithResultKeyPaginator(paginatedOperationWithResultKeyRequest);
+        return invokeOperation(paginatedOperationWithResultKeyRequest,
+                               request -> delegate.paginatedOperationWithResultKey(request));
     }
 
     /**
@@ -446,85 +265,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
         PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
-        return delegate.paginatedOperationWithoutResultKey(paginatedOperationWithoutResultKeyRequest);
-    }
-
-    /**
-     * Some paginated operation without result_key in paginators.json file<br/>
-     * <p>
-     * This is a variant of
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
-     * internally handle making service calls for you.
-     * </p>
-     * <p>
-     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
-     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
-     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
-     * request, you will see the failures only after you start iterating through the iterable.
-     * </p>
-     *
-     * <p>
-     * The following are few ways to iterate through the response pages:
-     * </p>
-     * 1) Using a Stream
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * responses.stream().forEach(....);
-     * }
-     * </pre>
-     *
-     * 2) Using For loop
-     *
-     * <pre>
-     * {
-     *     &#064;code
-     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client
-     *             .paginatedOperationWithoutResultKeyPaginator(request);
-     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response : responses) {
-     *         // do something;
-     *     }
-     * }
-     * </pre>
-     *
-     * 3) Use iterator directly
-     *
-     * <pre>
-     * {@code
-     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyIterable responses = client.paginatedOperationWithoutResultKeyPaginator(request);
-     * responses.iterator().forEachRemaining(....);
-     * }
-     * </pre>
-     * <p>
-     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
-     * paginator. It only limits the number of results in each page.</b>
-     * </p>
-     * <p>
-     * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
-     * operation.</b>
-     * </p>
-     *
-     * @param paginatedOperationWithoutResultKeyRequest
-     * @return A custom iterable that can be used to iterate through all the response pages.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PaginatedOperationWithoutResultKey
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
-                                                                                                    SdkClientException, JsonException {
-        return delegate.paginatedOperationWithoutResultKeyPaginator(paginatedOperationWithoutResultKeyRequest);
+        return invokeOperation(paginatedOperationWithoutResultKeyRequest,
+                               request -> delegate.paginatedOperationWithoutResultKey(request));
     }
 
     /**
@@ -573,50 +315,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public <ReturnT> ReturnT putOperationWithChecksum(PutOperationWithChecksumRequest putOperationWithChecksumRequest,
                                                       RequestBody requestBody, ResponseTransformer<PutOperationWithChecksumResponse, ReturnT> responseTransformer)
         throws AwsServiceException, SdkClientException, JsonException {
-        return delegate.putOperationWithChecksum(putOperationWithChecksumRequest, requestBody, responseTransformer);
-    }
-
-    /**
-     * Invokes the PutOperationWithChecksum operation.
-     *
-     * @param putOperationWithChecksumRequest
-     * @param sourcePath
-     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
-     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
-     *        access to read it then an exception will be thrown. The service documentation for the request content is
-     *        as follows '
-     *        <p>
-     *        Object data.
-     *        </p>
-     *        '
-     * @param destinationPath
-     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
-     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
-     *        The service documentation for the response content is as follows '
-     *        <p>
-     *        Object data.
-     *        </p>
-     *        '.
-     * @return The transformed result of the ResponseTransformer.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.PutOperationWithChecksum
-     * @see #putOperationWithChecksum(PutOperationWithChecksumRequest, RequestBody)
-     * @see #putOperationWithChecksum(PutOperationWithChecksumRequest, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PutOperationWithChecksum"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public PutOperationWithChecksumResponse putOperationWithChecksum(
-        PutOperationWithChecksumRequest putOperationWithChecksumRequest, Path sourcePath, Path destinationPath)
-        throws AwsServiceException, SdkClientException, JsonException {
-        return putOperationWithChecksum(putOperationWithChecksumRequest, RequestBody.fromFile(sourcePath),
-                                        ResponseTransformer.toFile(destinationPath));
+        return invokeOperation(putOperationWithChecksumRequest,
+                               request -> delegate.putOperationWithChecksum(request, requestBody, responseTransformer));
     }
 
     /**
@@ -649,35 +349,7 @@ public abstract class DelegatingJsonClient implements JsonClient {
     @Override
     public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
                                                                    RequestBody requestBody) throws AwsServiceException, SdkClientException, JsonException {
-        return delegate.streamingInputOperation(streamingInputOperationRequest, requestBody);
-    }
-
-    /**
-     * Some operation with a streaming input
-     *
-     * @param streamingInputOperationRequest
-     * @param sourcePath
-     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
-     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
-     *        access to read it then an exception will be thrown. The service documentation for the request content is
-     *        as follows 'This be a stream'
-     * @return Result of the StreamingInputOperation operation returned by the service.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingInputOperation
-     * @see #streamingInputOperation(StreamingInputOperationRequest, RequestBody)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
-                                                                   Path sourcePath) throws AwsServiceException, SdkClientException, JsonException {
-        return streamingInputOperation(streamingInputOperationRequest, RequestBody.fromFile(sourcePath));
+        return invokeOperation(streamingInputOperationRequest, request -> delegate.streamingInputOperation(request, requestBody));
     }
 
     /**
@@ -719,42 +391,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
         StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, RequestBody requestBody,
         ResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                         SdkClientException, JsonException {
-        return delegate.streamingInputOutputOperation(streamingInputOutputOperationRequest, requestBody, responseTransformer);
-    }
-
-    /**
-     * Some operation with streaming input and streaming output
-     *
-     * @param streamingInputOutputOperationRequest
-     * @param sourcePath
-     *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
-     *        multiple times in the event of a retry. If the file does not exist or the current user does not have
-     *        access to read it then an exception will be thrown. The service documentation for the request content is
-     *        as follows 'This be a stream'
-     * @param destinationPath
-     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
-     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
-     *        The service documentation for the response content is as follows 'This be a stream'.
-     * @return The transformed result of the ResponseTransformer.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingInputOutputOperation
-     * @see #streamingInputOutputOperation(StreamingInputOutputOperationRequest, RequestBody)
-     * @see #streamingInputOutputOperation(StreamingInputOutputOperationRequest, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public StreamingInputOutputOperationResponse streamingInputOutputOperation(
-        StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, Path sourcePath, Path destinationPath)
-        throws AwsServiceException, SdkClientException, JsonException {
-        return streamingInputOutputOperation(streamingInputOutputOperationRequest, RequestBody.fromFile(sourcePath),
-                                             ResponseTransformer.toFile(destinationPath));
+        return invokeOperation(streamingInputOutputOperationRequest,
+                               request -> delegate.streamingInputOutputOperation(request, requestBody, responseTransformer));
     }
 
     /**
@@ -784,91 +422,8 @@ public abstract class DelegatingJsonClient implements JsonClient {
     public <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
                                                       ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                                                                  SdkClientException, JsonException {
-        return delegate.streamingOutputOperation(streamingOutputOperationRequest, responseTransformer);
-    }
-
-    /**
-     * Some operation with a streaming output
-     *
-     * @param streamingOutputOperationRequest
-     * @param destinationPath
-     *        {@link Path} to file that response contents will be written to. The file must not exist or this method
-     *        will throw an exception. If the file is not writable by the current user then an exception will be thrown.
-     *        The service documentation for the response content is as follows 'This be a stream'.
-     * @return The transformed result of the ResponseTransformer.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingOutputOperation
-     * @see #streamingOutputOperation(StreamingOutputOperationRequest, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public StreamingOutputOperationResponse streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest, Path destinationPath) throws AwsServiceException,
-                                                                                                      SdkClientException, JsonException {
-        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toFile(destinationPath));
-    }
-
-    /**
-     * Some operation with a streaming output
-     *
-     * @param streamingOutputOperationRequest
-     * @return A {@link ResponseInputStream} containing data streamed from service. Note that this is an unmanaged
-     *         reference to the underlying HTTP connection so great care must be taken to ensure all data if fully read
-     *         from the input stream and that it is properly closed. Failure to do so may result in sub-optimal behavior
-     *         and exhausting connections in the connection pool. The unmarshalled response object can be obtained via
-     *         {@link ResponseInputStream#response()}. The service documentation for the response content is as follows
-     *         'This be a stream'.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingOutputOperation
-     * @see #getObject(streamingOutputOperation, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
-                                                                                JsonException {
-        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toInputStream());
-    }
-
-    /**
-     * Some operation with a streaming output
-     *
-     * @param streamingOutputOperationRequest
-     * @return A {@link ResponseBytes} that loads the data streamed from the service into memory and exposes it in
-     *         convenient in-memory representations like a byte buffer or string. The unmarshalled response object can
-     *         be obtained via {@link ResponseBytes#response()}. The service documentation for the response content is
-     *         as follows 'This be a stream'.
-     * @throws SdkException
-     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
-     *         catch all scenarios.
-     * @throws SdkClientException
-     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
-     * @throws JsonException
-     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample JsonClient.StreamingOutputOperation
-     * @see #getObject(streamingOutputOperation, ResponseTransformer)
-     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
-     *      target="_top">AWS API Documentation</a>
-     */
-    @Override
-    public ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationAsBytes(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
-                                                                                JsonException {
-        return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toBytes());
+        return invokeOperation(streamingOutputOperationRequest,
+                               request -> delegate.streamingOutputOperation(request, responseTransformer));
     }
 
     /**
@@ -886,6 +441,10 @@ public abstract class DelegatingJsonClient implements JsonClient {
 
     public SdkClient delegate() {
         return this.delegate;
+    }
+
+    protected <T extends JsonRequest, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation) {
+        return operation.apply(request);
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -37,8 +37,10 @@ import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
@@ -75,6 +77,8 @@ import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredR
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
 import software.amazon.awssdk.services.json.model.OperationWithNoneAuthTypeRequest;
 import software.amazon.awssdk.services.json.model.OperationWithNoneAuthTypeResponse;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -99,6 +103,7 @@ import software.amazon.awssdk.services.json.transform.InputEventMarshaller;
 import software.amazon.awssdk.services.json.transform.InputEventTwoMarshaller;
 import software.amazon.awssdk.services.json.transform.OperationWithChecksumRequiredRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.OperationWithNoneAuthTypeRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.OperationWithRequestCompressionRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingInputOperationRequestMarshaller;
@@ -669,6 +674,68 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
                              .withInput(operationWithNoneAuthTypeRequest));
             CompletableFuture<OperationWithNoneAuthTypeResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation asynchronously.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return A Java Future containing the result of the OperationWithRequestCompression operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                                                                         operationWithRequestCompressionRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithRequestCompression");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                                                                           .isPayloadJson(true).build();
+
+            HttpResponseHandler<OperationWithRequestCompressionResponse> responseHandler = protocolFactory.createResponseHandler(
+                operationMetadata, OperationWithRequestCompressionResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                                                                                                       operationMetadata);
+
+            CompletableFuture<OperationWithRequestCompressionResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<OperationWithRequestCompressionRequest, OperationWithRequestCompressionResponse>()
+                             .withOperationName("OperationWithRequestCompression")
+                             .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler)
+                             .withErrorResponseHandler(errorResponseHandler)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                    RequestCompression.builder().encodings("gzip").isStreaming(false).build())
+                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
+                             .withInput(operationWithRequestCompressionRequest));
+            CompletableFuture<OperationWithRequestCompressionResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -37,7 +37,6 @@ import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
 import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
@@ -732,8 +731,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                              .withMetricCollector(apiCallMetricCollector)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
                                                     RequestCompression.builder().encodings("gzip").isStreaming(false).build())
-                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
                              .withInput(operationWithRequestCompressionRequest));
             CompletableFuture<OperationWithRequestCompressionResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -40,7 +40,6 @@ import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
@@ -810,8 +809,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                              .withMetricCollector(apiCallMetricCollector)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
                                                     RequestCompression.builder().encodings("gzip").isStreaming(false).build())
-                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
                              .withInput(operationWithRequestCompressionRequest));
             CompletableFuture<OperationWithRequestCompressionResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -40,9 +40,11 @@ import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
@@ -81,6 +83,8 @@ import software.amazon.awssdk.services.json.model.JsonException;
 import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -107,6 +111,7 @@ import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersR
 import software.amazon.awssdk.services.json.transform.InputEventMarshaller;
 import software.amazon.awssdk.services.json.transform.InputEventTwoMarshaller;
 import software.amazon.awssdk.services.json.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.OperationWithRequestCompressionRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PutOperationWithChecksumRequestMarshaller;
@@ -747,6 +752,68 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
                                                     HttpChecksumRequired.create()).withInput(operationWithChecksumRequiredRequest));
             CompletableFuture<OperationWithChecksumRequiredResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation asynchronously.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return A Java Future containing the result of the OperationWithRequestCompression operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                                                                         operationWithRequestCompressionRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithRequestCompression");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                                                                           .isPayloadJson(true).build();
+
+            HttpResponseHandler<OperationWithRequestCompressionResponse> responseHandler = protocolFactory.createResponseHandler(
+                operationMetadata, OperationWithRequestCompressionResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                                                                                                       operationMetadata);
+
+            CompletableFuture<OperationWithRequestCompressionResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<OperationWithRequestCompressionRequest, OperationWithRequestCompressionResponse>()
+                             .withOperationName("OperationWithRequestCompression")
+                             .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler)
+                             .withErrorResponseHandler(errorResponseHandler)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                    RequestCompression.builder().encodings("gzip").isStreaming(false).build())
+                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
+                             .withInput(operationWithRequestCompressionRequest));
+            CompletableFuture<OperationWithRequestCompressionResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -34,6 +34,8 @@ import software.amazon.awssdk.services.json.model.InputEventStream;
 import software.amazon.awssdk.services.json.model.InputEventStreamTwo;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -607,6 +609,63 @@ public interface JsonAsyncClient extends AwsClient {
         Consumer<OperationWithChecksumRequiredRequest.Builder> operationWithChecksumRequiredRequest) {
         return operationWithChecksumRequired(OperationWithChecksumRequiredRequest.builder()
                                                                                  .applyMutation(operationWithChecksumRequiredRequest).build());
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation asynchronously.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return A Java Future containing the result of the OperationWithRequestCompression operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation asynchronously.<br/>
+     * <p>
+     * This is a convenience which creates an instance of the {@link OperationWithRequestCompressionRequest.Builder}
+     * avoiding the need to create one manually via {@link OperationWithRequestCompressionRequest#builder()}
+     * </p>
+     *
+     * @param operationWithRequestCompressionRequest
+     *        A {@link Consumer} that will call methods on {@link OperationWithRequestCompressionRequest.Builder} to
+     *        create a request.
+     * @return A Java Future containing the result of the OperationWithRequestCompression operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
+        Consumer<OperationWithRequestCompressionRequest.Builder> operationWithRequestCompressionRequest) {
+        return operationWithRequestCompression(OperationWithRequestCompressionRequest.builder()
+                                                                                     .applyMutation(operationWithRequestCompressionRequest).build());
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -18,9 +18,11 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
@@ -49,6 +51,8 @@ import software.amazon.awssdk.services.json.model.JsonException;
 import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -67,6 +71,7 @@ import software.amazon.awssdk.services.json.transform.BearerAuthOperationRequest
 import software.amazon.awssdk.services.json.transform.GetOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.OperationWithRequestCompressionRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PutOperationWithChecksumRequestMarshaller;
@@ -403,6 +408,59 @@ final class DefaultJsonClient implements JsonClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
                                                     HttpChecksumRequired.create())
                              .withMarshaller(new OperationWithChecksumRequiredRequestMarshaller(protocolFactory)));
+        } finally {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+        }
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return Result of the OperationWithRequestCompression operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public OperationWithRequestCompressionResponse operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) throws AwsServiceException,
+                                                                                              SdkClientException, JsonException {
+        JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                                                                       .isPayloadJson(true).build();
+
+        HttpResponseHandler<OperationWithRequestCompressionResponse> responseHandler = protocolFactory.createResponseHandler(
+            operationMetadata, OperationWithRequestCompressionResponse::builder);
+
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                                                                                                   operationMetadata);
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                                                                         operationWithRequestCompressionRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithRequestCompression");
+
+            return clientHandler
+                .execute(new ClientExecutionParams<OperationWithRequestCompressionRequest, OperationWithRequestCompressionResponse>()
+                             .withOperationName("OperationWithRequestCompression")
+                             .withResponseHandler(responseHandler)
+                             .withErrorResponseHandler(errorResponseHandler)
+                             .withInput(operationWithRequestCompressionRequest)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                    RequestCompression.builder().encodings("gzip").isStreaming(false).build())
+                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
+                             .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
@@ -458,8 +457,6 @@ final class DefaultJsonClient implements JsonClient {
                              .withMetricCollector(apiCallMetricCollector)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
                                                     RequestCompression.builder().encodings("gzip").isStreaming(false).build())
-                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
                              .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -27,6 +27,8 @@ import software.amazon.awssdk.services.json.model.InvalidInputException;
 import software.amazon.awssdk.services.json.model.JsonException;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.json.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -389,6 +391,57 @@ public interface JsonClient extends AwsClient {
         throws AwsServiceException, SdkClientException, JsonException {
         return operationWithChecksumRequired(OperationWithChecksumRequiredRequest.builder()
                                                                                  .applyMutation(operationWithChecksumRequiredRequest).build());
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return Result of the OperationWithRequestCompression operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default OperationWithRequestCompressionResponse operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) throws AwsServiceException,
+                                                                                              SdkClientException, JsonException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation.<br/>
+     * <p>
+     * This is a convenience which creates an instance of the {@link OperationWithRequestCompressionRequest.Builder}
+     * avoiding the need to create one manually via {@link OperationWithRequestCompressionRequest#builder()}
+     * </p>
+     *
+     * @param operationWithRequestCompressionRequest
+     *        A {@link Consumer} that will call methods on {@link OperationWithRequestCompressionRequest.Builder} to
+     *        create a request.
+     * @return Result of the OperationWithRequestCompression operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default OperationWithRequestCompressionResponse operationWithRequestCompression(
+        Consumer<OperationWithRequestCompressionRequest.Builder> operationWithRequestCompressionRequest)
+        throws AwsServiceException, SdkClientException, JsonException {
+        return operationWithRequestCompression(OperationWithRequestCompressionRequest.builder()
+                                                                                     .applyMutation(operationWithRequestCompressionRequest).build());
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -26,9 +26,11 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
@@ -52,6 +54,8 @@ import software.amazon.awssdk.services.query.model.OperationWithContextParamRequ
 import software.amazon.awssdk.services.query.model.OperationWithContextParamResponse;
 import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeRequest;
 import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeResponse;
+import software.amazon.awssdk.services.query.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.query.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.query.model.OperationWithStaticContextParamsRequest;
 import software.amazon.awssdk.services.query.model.OperationWithStaticContextParamsResponse;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumRequest;
@@ -69,6 +73,7 @@ import software.amazon.awssdk.services.query.transform.GetOperationWithChecksumR
 import software.amazon.awssdk.services.query.transform.OperationWithChecksumRequiredRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithContextParamRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithNoneAuthTypeRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.OperationWithRequestCompressionRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithStaticContextParamsRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.StreamingInputOperationRequestMarshaller;
@@ -484,6 +489,65 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
                              .withInput(operationWithNoneAuthTypeRequest));
             CompletableFuture<OperationWithNoneAuthTypeResponse> whenCompleteFuture = null;
+            whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            return CompletableFutureUtils.forwardExceptionTo(whenCompleteFuture, executeFuture);
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation asynchronously.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return A Java Future containing the result of the OperationWithRequestCompression operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>QueryException Base class for all service exceptions. Unknown exceptions will be thrown as an
+     *         instance of this type.</li>
+     *         </ul>
+     * @sample QueryAsyncClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                                                                         operationWithRequestCompressionRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Query Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithRequestCompression");
+
+            HttpResponseHandler<OperationWithRequestCompressionResponse> responseHandler = protocolFactory
+                .createResponseHandler(OperationWithRequestCompressionResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+            CompletableFuture<OperationWithRequestCompressionResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<OperationWithRequestCompressionRequest, OperationWithRequestCompressionResponse>()
+                             .withOperationName("OperationWithRequestCompression")
+                             .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler)
+                             .withErrorResponseHandler(errorResponseHandler)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                    RequestCompression.builder().encodings("gzip").isStreaming(false).build())
+                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
+                             .withInput(operationWithRequestCompressionRequest));
+            CompletableFuture<OperationWithRequestCompressionResponse> whenCompleteFuture = null;
             whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -26,7 +26,6 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
@@ -544,8 +543,6 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
                              .withMetricCollector(apiCallMetricCollector)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
                                                     RequestCompression.builder().encodings("gzip").isStreaming(false).build())
-                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
                              .withInput(operationWithRequestCompressionRequest));
             CompletableFuture<OperationWithRequestCompressionResponse> whenCompleteFuture = null;
             whenCompleteFuture = executeFuture.whenComplete((r, e) -> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -17,9 +17,11 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
@@ -45,6 +47,8 @@ import software.amazon.awssdk.services.query.model.OperationWithContextParamRequ
 import software.amazon.awssdk.services.query.model.OperationWithContextParamResponse;
 import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeRequest;
 import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeResponse;
+import software.amazon.awssdk.services.query.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.query.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.query.model.OperationWithStaticContextParamsRequest;
 import software.amazon.awssdk.services.query.model.OperationWithStaticContextParamsResponse;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumRequest;
@@ -62,6 +66,7 @@ import software.amazon.awssdk.services.query.transform.GetOperationWithChecksumR
 import software.amazon.awssdk.services.query.transform.OperationWithChecksumRequiredRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithContextParamRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithNoneAuthTypeRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.OperationWithRequestCompressionRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithStaticContextParamsRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.StreamingInputOperationRequestMarshaller;
@@ -417,6 +422,56 @@ final class DefaultQueryClient implements QueryClient {
                              .withMetricCollector(apiCallMetricCollector)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
                              .withMarshaller(new OperationWithNoneAuthTypeRequestMarshaller(protocolFactory)));
+        } finally {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+        }
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return Result of the OperationWithRequestCompression operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws QueryException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample QueryClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public OperationWithRequestCompressionResponse operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) throws AwsServiceException,
+                                                                                              SdkClientException, QueryException {
+
+        HttpResponseHandler<OperationWithRequestCompressionResponse> responseHandler = protocolFactory
+            .createResponseHandler(OperationWithRequestCompressionResponse::builder);
+
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                                                                         operationWithRequestCompressionRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Query Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithRequestCompression");
+
+            return clientHandler
+                .execute(new ClientExecutionParams<OperationWithRequestCompressionRequest, OperationWithRequestCompressionResponse>()
+                             .withOperationName("OperationWithRequestCompression")
+                             .withResponseHandler(responseHandler)
+                             .withErrorResponseHandler(errorResponseHandler)
+                             .withInput(operationWithRequestCompressionRequest)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                    RequestCompression.builder().encodings("gzip").isStreaming(false).build())
+                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
+                             .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -17,7 +17,6 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
@@ -469,8 +468,6 @@ final class DefaultQueryClient implements QueryClient {
                              .withMetricCollector(apiCallMetricCollector)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
                                                     RequestCompression.builder().encodings("gzip").isStreaming(false).build())
-                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
                              .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -32,9 +32,11 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
@@ -61,6 +63,8 @@ import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredRe
 import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredResponse;
 import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeRequest;
 import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeResponse;
+import software.amazon.awssdk.services.xml.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.xml.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.xml.model.StreamingInputOperationRequest;
@@ -76,6 +80,7 @@ import software.amazon.awssdk.services.xml.transform.EventStreamOperationRequest
 import software.amazon.awssdk.services.xml.transform.GetOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.OperationWithChecksumRequiredRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.OperationWithNoneAuthTypeRequestMarshaller;
+import software.amazon.awssdk.services.xml.transform.OperationWithRequestCompressionRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingOutputOperationRequestMarshaller;
@@ -508,6 +513,64 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
                              .withInput(operationWithNoneAuthTypeRequest));
             CompletableFuture<OperationWithNoneAuthTypeResponse> whenCompleteFuture = null;
+            whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            CompletableFutureUtils.forwardExceptionTo(whenCompleteFuture, executeFuture);
+            return whenCompleteFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation asynchronously.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return A Java Future containing the result of the OperationWithRequestCompression operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>XmlException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample XmlAsyncClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/xml-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithRequestCompressionResponse> operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                                                                         operationWithRequestCompressionRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Xml Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithRequestCompression");
+
+            HttpResponseHandler<Response<OperationWithRequestCompressionResponse>> responseHandler = protocolFactory
+                .createCombinedResponseHandler(OperationWithRequestCompressionResponse::builder,
+                                               new XmlOperationMetadata().withHasStreamingSuccessResponse(false));
+
+            CompletableFuture<OperationWithRequestCompressionResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<OperationWithRequestCompressionRequest, OperationWithRequestCompressionResponse>()
+                             .withOperationName("OperationWithRequestCompression")
+                             .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory))
+                             .withCombinedResponseHandler(responseHandler)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                    RequestCompression.builder().encodings("gzip").isStreaming(false).build())
+                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
+                             .withInput(operationWithRequestCompressionRequest));
+            CompletableFuture<OperationWithRequestCompressionResponse> whenCompleteFuture = null;
             whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -32,7 +32,6 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
@@ -567,8 +566,6 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
                              .withMetricCollector(apiCallMetricCollector)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
                                                     RequestCompression.builder().encodings("gzip").isStreaming(false).build())
-                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
                              .withInput(operationWithRequestCompressionRequest));
             CompletableFuture<OperationWithRequestCompressionResponse> whenCompleteFuture = null;
             whenCompleteFuture = executeFuture.whenComplete((r, e) -> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -36,7 +36,7 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -18,9 +18,11 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
@@ -45,6 +47,8 @@ import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredRe
 import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredResponse;
 import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeRequest;
 import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeResponse;
+import software.amazon.awssdk.services.xml.model.OperationWithRequestCompressionRequest;
+import software.amazon.awssdk.services.xml.model.OperationWithRequestCompressionResponse;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.xml.model.StreamingInputOperationRequest;
@@ -59,6 +63,7 @@ import software.amazon.awssdk.services.xml.transform.BearerAuthOperationRequestM
 import software.amazon.awssdk.services.xml.transform.GetOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.OperationWithChecksumRequiredRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.OperationWithNoneAuthTypeRequestMarshaller;
+import software.amazon.awssdk.services.xml.transform.OperationWithRequestCompressionRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingOutputOperationRequestMarshaller;
@@ -356,6 +361,54 @@ final class DefaultXmlClient implements XmlClient {
                              .withMetricCollector(apiCallMetricCollector).withInput(operationWithNoneAuthTypeRequest)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
                              .withMarshaller(new OperationWithNoneAuthTypeRequestMarshaller(protocolFactory)));
+        } finally {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+        }
+    }
+
+    /**
+     * Invokes the OperationWithRequestCompression operation.
+     *
+     * @param operationWithRequestCompressionRequest
+     * @return Result of the OperationWithRequestCompression operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws XmlException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample XmlClient.OperationWithRequestCompression
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/xml-service-2010-05-08/OperationWithRequestCompression"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public OperationWithRequestCompressionResponse operationWithRequestCompression(
+        OperationWithRequestCompressionRequest operationWithRequestCompressionRequest) throws AwsServiceException,
+                                                                                              SdkClientException, XmlException {
+
+        HttpResponseHandler<Response<OperationWithRequestCompressionResponse>> responseHandler = protocolFactory
+            .createCombinedResponseHandler(OperationWithRequestCompressionResponse::builder,
+                                           new XmlOperationMetadata().withHasStreamingSuccessResponse(false));
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                                                                         operationWithRequestCompressionRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Xml Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithRequestCompression");
+
+            return clientHandler
+                .execute(new ClientExecutionParams<OperationWithRequestCompressionRequest, OperationWithRequestCompressionResponse>()
+                             .withOperationName("OperationWithRequestCompression")
+                             .withCombinedResponseHandler(responseHandler)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .withInput(operationWithRequestCompressionRequest)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                    RequestCompression.builder().encodings("gzip").isStreaming(false).build())
+                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
+                             .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
@@ -406,8 +405,6 @@ final class DefaultXmlClient implements XmlClient {
                              .withInput(operationWithRequestCompressionRequest)
                              .putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
                                                     RequestCompression.builder().encodings("gzip").isStreaming(false).build())
-                             .putExecutionAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                    clientConfiguration.option(SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION))
                              .withMarshaller(new OperationWithRequestCompressionRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -141,6 +141,18 @@ public final class ProfileProperty {
 
     public static final String EC2_METADATA_SERVICE_ENDPOINT = "ec2_metadata_service_endpoint";
 
+    /**
+     * Whether request compression is disabled for operations marked with the RequestCompression trait. The default value is
+     * false, i.e., request compression is enabled.
+     */
+    public static final String DISABLE_REQUEST_COMPRESSION = "disable_request_compression";
+
+    /**
+     * The minimum compression size in bytes, inclusive, for a request to be compressed. The default value is 10_240.
+     * The value must be non-negative and no greater than 10_485_760.
+     */
+    public static final String REQUEST_MIN_COMPRESSION_SIZE_BYTES = "request_min_compression_size_bytes";
+
     private ProfileProperty() {
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestCompressionConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestCompressionConfiguration.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core;
+
+import java.util.Objects;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * Configuration options for operations with the RequestCompression trait to disable request configuration and set the minimum
+ * compression threshold in bytes.
+ */
+@SdkPublicApi
+public final class RequestCompressionConfiguration implements ToCopyableBuilder<RequestCompressionConfiguration.Builder,
+    RequestCompressionConfiguration> {
+
+    private final Boolean requestCompressionEnabled;
+    private final Integer minimumCompressionThresholdInBytes;
+
+    private RequestCompressionConfiguration(DefaultBuilder builder) {
+        this.requestCompressionEnabled = builder.requestCompressionEnabled;
+        this.minimumCompressionThresholdInBytes = builder.minimumCompressionThresholdInBytes;
+    }
+
+    /**
+     * If set, returns true if request compression is enabled, else false if request compression is disabled.
+     */
+    public Boolean requestCompressionEnabled() {
+        return requestCompressionEnabled;
+    }
+
+    /**
+     * If set, returns the minimum compression threshold in bytes, inclusive, in order to trigger request compression.
+     */
+    public Integer minimumCompressionThresholdInBytes() {
+        return minimumCompressionThresholdInBytes;
+    }
+
+    /**
+     * Create a {@link RequestCompressionConfiguration.Builder}, used to create a {@link RequestCompressionConfiguration}.
+     */
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new DefaultBuilder(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RequestCompressionConfiguration that = (RequestCompressionConfiguration) o;
+
+        if (!requestCompressionEnabled.equals(that.requestCompressionEnabled)) {
+            return false;
+        }
+        return Objects.equals(minimumCompressionThresholdInBytes, that.minimumCompressionThresholdInBytes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = requestCompressionEnabled != null ? requestCompressionEnabled.hashCode() : 0;
+        result = 31 * result + (minimumCompressionThresholdInBytes != null ? minimumCompressionThresholdInBytes.hashCode() : 0);
+        return result;
+    }
+
+
+    public interface Builder extends CopyableBuilder<Builder, RequestCompressionConfiguration> {
+
+        /**
+         * Configures whether request compression is enabled or not. The default value is true.
+         *
+         * @param requestCompressionEnabled
+         * @return This object for method chaining.
+         */
+        Builder requestCompressionEnabled(Boolean requestCompressionEnabled);
+
+        /**
+         * Configures the minimum compression threshold, inclusive, in bytes. The default value is 10_240. The value must be
+         * non-negative and no greater than 10_485_760.
+         *
+         * @param minimumCompressionThresholdInBytes
+         * @return This object for method chaining.
+         */
+        Builder minimumCompressionThresholdInBytes(Integer minimumCompressionThresholdInBytes);
+    }
+
+    private static final class DefaultBuilder implements Builder {
+        private Boolean requestCompressionEnabled;
+        private Integer minimumCompressionThresholdInBytes;
+
+        private DefaultBuilder() {
+        }
+
+        private DefaultBuilder(RequestCompressionConfiguration requestCompressionConfiguration) {
+            this.requestCompressionEnabled = requestCompressionConfiguration.requestCompressionEnabled;
+            this.minimumCompressionThresholdInBytes = requestCompressionConfiguration.minimumCompressionThresholdInBytes;
+        }
+
+        @Override
+        public Builder requestCompressionEnabled(Boolean requestCompressionEnabled) {
+            this.requestCompressionEnabled = requestCompressionEnabled;
+            return this;
+        }
+
+        @Override
+        public Builder minimumCompressionThresholdInBytes(Integer minimumCompressionThresholdInBytes) {
+            this.minimumCompressionThresholdInBytes = minimumCompressionThresholdInBytes;
+            return this;
+        }
+
+        @Override
+        public RequestCompressionConfiguration build() {
+            return new RequestCompressionConfiguration(this);
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestCompressionConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestCompressionConfiguration.java
@@ -90,7 +90,8 @@ public final class RequestCompressionConfiguration implements ToCopyableBuilder<
     public interface Builder extends CopyableBuilder<Builder, RequestCompressionConfiguration> {
 
         /**
-         * Configures whether request compression is enabled or not. The default value is true.
+         * Configures whether request compression is enabled or not, for operations that have the "requestCompression" C2J trait.
+         * The default value is true.
          *
          * @param requestCompressionEnabled
          * @return This object for method chaining.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestCompressionConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestCompressionConfiguration.java
@@ -98,7 +98,8 @@ public final class RequestCompressionConfiguration implements ToCopyableBuilder<
         Builder requestCompressionEnabled(Boolean requestCompressionEnabled);
 
         /**
-         * Configures the minimum compression threshold, inclusive, in bytes. The default value is 10_240. The value must be
+         * Configures the minimum compression threshold, inclusive, in bytes. A request whose size is less than the threshold
+         * will not be compressed, even if the compression trait is present. The default value is 10_240. The value must be
          * non-negative and no greater than 10_485_760.
          *
          * @param minimumCompressionThresholdInBytes

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
@@ -51,8 +51,8 @@ public abstract class RequestOverrideConfiguration {
     private final Signer signer;
     private final List<MetricPublisher> metricPublishers;
     private final ExecutionAttributes executionAttributes;
-
     private final EndpointProvider endpointProvider;
+    private final RequestCompressionConfiguration requestCompressionConfiguration;
 
     protected RequestOverrideConfiguration(Builder<?> builder) {
         this.headers = CollectionUtils.deepUnmodifiableMap(builder.headers(), () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
@@ -64,6 +64,7 @@ public abstract class RequestOverrideConfiguration {
         this.metricPublishers = Collections.unmodifiableList(new ArrayList<>(builder.metricPublishers()));
         this.executionAttributes = ExecutionAttributes.unmodifiableExecutionAttributes(builder.executionAttributes());
         this.endpointProvider = builder.endpointProvider();
+        this.requestCompressionConfiguration = builder.requestCompressionConfiguration();
     }
 
     /**
@@ -165,6 +166,15 @@ public abstract class RequestOverrideConfiguration {
         return Optional.ofNullable(endpointProvider);
     }
 
+    /**
+     * Returns the request compression configuration object, if present, which includes options to enable/disable request
+     * compression and set the minimum compression threshold. This request compression config object supersedes the request
+     * compression config object set on the client.
+     */
+    public Optional<RequestCompressionConfiguration> requestCompressionConfiguration() {
+        return Optional.ofNullable(requestCompressionConfiguration);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -182,7 +192,8 @@ public abstract class RequestOverrideConfiguration {
                Objects.equals(signer, that.signer) &&
                Objects.equals(metricPublishers, that.metricPublishers) &&
                Objects.equals(executionAttributes, that.executionAttributes) &&
-               Objects.equals(endpointProvider, that.endpointProvider);
+               Objects.equals(endpointProvider, that.endpointProvider) &&
+               Objects.equals(requestCompressionConfiguration, that.requestCompressionConfiguration);
     }
 
     @Override
@@ -197,6 +208,7 @@ public abstract class RequestOverrideConfiguration {
         hashCode = 31 * hashCode + Objects.hashCode(metricPublishers);
         hashCode = 31 * hashCode + Objects.hashCode(executionAttributes);
         hashCode = 31 * hashCode + Objects.hashCode(endpointProvider);
+        hashCode = 31 * hashCode + Objects.hashCode(requestCompressionConfiguration);
         return hashCode;
     }
 
@@ -439,6 +451,28 @@ public abstract class RequestOverrideConfiguration {
         EndpointProvider endpointProvider();
 
         /**
+         * Sets the {@link RequestCompressionConfiguration} for this request. The order of precedence, from highest to lowest,
+         * for this setting is: 1) Per request configuration 2) Client configuration 3) Environment variables 4) Profile setting.
+         *
+         * @param requestCompressionConfiguration Request compression configuration object for this request.
+         */
+        B requestCompressionConfiguration(RequestCompressionConfiguration requestCompressionConfiguration);
+
+        /**
+         * Sets the {@link RequestCompressionConfiguration} for this request. The order of precedence, from highest to lowest,
+         * for this setting is: 1) Per request configuration 2) Client configuration 3) Environment variables 4) Profile setting.
+         *
+         * @param requestCompressionConfigurationConsumer A {@link Consumer} that accepts a
+         *        {@link RequestCompressionConfiguration.Builder}
+         *
+         * @return This object for method chaining
+         */
+        B requestCompressionConfiguration(Consumer<RequestCompressionConfiguration.Builder>
+                                              requestCompressionConfigurationConsumer);
+
+        RequestCompressionConfiguration requestCompressionConfiguration();
+
+        /**
          * Create a new {@code SdkRequestOverrideConfiguration} with the properties set on this builder.
          *
          * @return The new {@code SdkRequestOverrideConfiguration}.
@@ -455,9 +489,8 @@ public abstract class RequestOverrideConfiguration {
         private Signer signer;
         private List<MetricPublisher> metricPublishers = new ArrayList<>();
         private ExecutionAttributes.Builder executionAttributesBuilder = ExecutionAttributes.builder();
-
         private EndpointProvider endpointProvider;
-
+        private RequestCompressionConfiguration requestCompressionConfiguration;
 
         protected BuilderImpl() {
         }
@@ -472,6 +505,7 @@ public abstract class RequestOverrideConfiguration {
             metricPublishers(sdkRequestOverrideConfig.metricPublishers());
             executionAttributes(sdkRequestOverrideConfig.executionAttributes());
             endpointProvider(sdkRequestOverrideConfig.endpointProvider);
+            requestCompressionConfiguration(sdkRequestOverrideConfig.requestCompressionConfiguration);
         }
 
         @Override
@@ -626,7 +660,6 @@ public abstract class RequestOverrideConfiguration {
             executionAttributes(executionAttributes);
         }
 
-
         @Override
         public B endpointProvider(EndpointProvider endpointProvider) {
             this.endpointProvider = endpointProvider;
@@ -640,6 +673,26 @@ public abstract class RequestOverrideConfiguration {
         @Override
         public EndpointProvider endpointProvider() {
             return endpointProvider;
+        }
+
+        @Override
+        public B requestCompressionConfiguration(RequestCompressionConfiguration requestCompressionConfiguration) {
+            this.requestCompressionConfiguration = requestCompressionConfiguration;
+            return (B) this;
+        }
+
+        @Override
+        public B requestCompressionConfiguration(Consumer<RequestCompressionConfiguration.Builder>
+                                              requestCompressionConfigurationConsumer) {
+            RequestCompressionConfiguration.Builder b = RequestCompressionConfiguration.builder();
+            requestCompressionConfigurationConsumer.accept(b);
+            requestCompressionConfiguration(b.build());
+            return (B) this;
+        }
+
+        @Override
+        public RequestCompressionConfiguration requestCompressionConfiguration() {
+            return requestCompressionConfiguration;
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -184,6 +184,18 @@ public enum SdkSystemSetting implements SystemSetting {
      */
     AWS_USE_FIPS_ENDPOINT("aws.useFipsEndpoint", null),
 
+    /**
+     * Whether request compression is disabled for operations marked with the RequestCompression trait. The default value is
+     * false, i.e., request compression is enabled.
+     */
+    AWS_DISABLE_REQUEST_COMPRESSION("aws.disableRequestCompression", null),
+
+    /**
+     * Defines the minimum compression size in bytes, inclusive, for a request to be compressed. The default value is 10_240.
+     * The value must be non-negative and no greater than 10_485_760.
+     */
+    AWS_REQUEST_MIN_COMPRESSION_SIZE_BYTES("aws.requestMinCompressionSizeBytes", null),
+
     ;
 
     private final String systemProperty;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -329,12 +329,15 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
         Integer minCompressionThreshold = null;
 
         // Client level
-        RequestCompressionConfiguration clientConfig =
-            clientOverrideConfiguration.requestCompressionConfiguration().orElse(null);
-        if (clientConfig != null) {
-            requestCompressionEnabled = clientConfig.requestCompressionEnabled();
-            minCompressionThreshold = clientConfig.minimumCompressionThresholdInBytes();
+        if (clientOverrideConfiguration != null) {
+            RequestCompressionConfiguration clientConfig =
+                clientOverrideConfiguration.requestCompressionConfiguration().orElse(null);
+            if (clientConfig != null) {
+                requestCompressionEnabled = clientConfig.requestCompressionEnabled();
+                minCompressionThreshold = clientConfig.minimumCompressionThresholdInBytes();
+            }
         }
+
 
         // Env level
         if (requestCompressionEnabled == null) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -38,6 +38,7 @@ import static software.amazon.awssdk.core.client.config.SdkClientOption.METRIC_P
 import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_FILE;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_FILE_SUPPLIER;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_NAME;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.REQUEST_COMPRESSION_CONFIGURATION;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.RETRY_POLICY;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.SCHEDULED_EXECUTOR_SERVICE;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.SIGNER_OVERRIDDEN;
@@ -237,6 +238,8 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
         builder.option(METRIC_PUBLISHERS, clientOverrideConfiguration.metricPublishers());
         builder.option(EXECUTION_ATTRIBUTES, clientOverrideConfiguration.executionAttributes());
         builder.option(TOKEN_SIGNER, clientOverrideConfiguration.advancedOption(TOKEN_SIGNER).orElse(null));
+        builder.option(REQUEST_COMPRESSION_CONFIGURATION,
+                       clientOverrideConfiguration.requestCompressionConfiguration().orElse(null));
 
         clientOverrideConfiguration.advancedOption(ENDPOINT_OVERRIDDEN_OVERRIDE).ifPresent(value -> {
             builder.option(ENDPOINT_OVERRIDDEN, value);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ToBuilderIgnoreField;
+import software.amazon.awssdk.core.RequestCompressionConfiguration;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -64,6 +65,7 @@ public final class ClientOverrideConfiguration
     private final List<MetricPublisher> metricPublishers;
     private final ExecutionAttributes executionAttributes;
     private final ScheduledExecutorService scheduledExecutorService;
+    private final RequestCompressionConfiguration requestCompressionConfiguration;
 
     /**
      * Initialize this configuration. Private to require use of {@link #builder()}.
@@ -80,6 +82,7 @@ public final class ClientOverrideConfiguration
         this.metricPublishers = Collections.unmodifiableList(new ArrayList<>(builder.metricPublishers()));
         this.executionAttributes = ExecutionAttributes.unmodifiableExecutionAttributes(builder.executionAttributes());
         this.scheduledExecutorService = builder.scheduledExecutorService();
+        this.requestCompressionConfiguration = builder.requestCompressionConfiguration();
     }
 
     @Override
@@ -96,7 +99,8 @@ public final class ClientOverrideConfiguration
             .defaultProfileName(defaultProfileName)
             .executionAttributes(executionAttributes)
             .metricPublishers(metricPublishers)
-            .scheduledExecutorService(scheduledExecutorService);
+            .scheduledExecutorService(scheduledExecutorService)
+            .requestCompressionConfiguration(requestCompressionConfiguration);
     }
 
     /**
@@ -230,19 +234,30 @@ public final class ClientOverrideConfiguration
         return executionAttributes;
     }
 
+    /**
+     * The request compression configuration object, which includes options to enable/disable request compression and set the
+     * minimum compression threshold.
+     *
+     * @see Builder#requestCompressionConfiguration(RequestCompressionConfiguration)
+     */
+    public Optional<RequestCompressionConfiguration> requestCompressionConfiguration() {
+        return Optional.ofNullable(requestCompressionConfiguration);
+    }
+
     @Override
     public String toString() {
         return ToString.builder("ClientOverrideConfiguration")
-                .add("headers", headers)
-                .add("retryPolicy", retryPolicy)
-                .add("apiCallTimeout", apiCallTimeout)
-                .add("apiCallAttemptTimeout", apiCallAttemptTimeout)
-                .add("executionInterceptors", executionInterceptors)
-                .add("advancedOptions", advancedOptions)
-                .add("profileFile", defaultProfileFile)
-                .add("profileName", defaultProfileName)
-                .add("scheduledExecutorService", scheduledExecutorService)
-                .build();
+                       .add("headers", headers)
+                       .add("retryPolicy", retryPolicy)
+                       .add("apiCallTimeout", apiCallTimeout)
+                       .add("apiCallAttemptTimeout", apiCallAttemptTimeout)
+                       .add("executionInterceptors", executionInterceptors)
+                       .add("advancedOptions", advancedOptions)
+                       .add("profileFile", defaultProfileFile)
+                       .add("profileName", defaultProfileName)
+                       .add("scheduledExecutorService", scheduledExecutorService)
+                       .add("requestCompressionConfiguration", requestCompressionConfiguration)
+                       .build();
     }
 
     /**
@@ -513,6 +528,23 @@ public final class ClientOverrideConfiguration
         <T> Builder putExecutionAttribute(ExecutionAttribute<T> attribute, T value);
 
         ExecutionAttributes executionAttributes();
+
+        /**
+         * Sets the {@link RequestCompressionConfiguration} for this client.
+         */
+        Builder requestCompressionConfiguration(RequestCompressionConfiguration requestCompressionConfiguration);
+
+        /**
+         * Sets the {@link RequestCompressionConfiguration} for this client.
+         */
+        default Builder requestCompressionConfiguration(Consumer<RequestCompressionConfiguration.Builder>
+                                                            requestCompressionConfiguration) {
+            return requestCompressionConfiguration(RequestCompressionConfiguration.builder()
+                                                                                  .applyMutation(requestCompressionConfiguration)
+                                                                                  .build());
+        }
+
+        RequestCompressionConfiguration requestCompressionConfiguration();
     }
 
     /**
@@ -530,6 +562,7 @@ public final class ClientOverrideConfiguration
         private List<MetricPublisher> metricPublishers = new ArrayList<>();
         private ExecutionAttributes.Builder executionAttributes = ExecutionAttributes.builder();
         private ScheduledExecutorService scheduledExecutorService;
+        private RequestCompressionConfiguration requestCompressionConfiguration;
 
         @Override
         public Builder headers(Map<String, List<String>> headers) {
@@ -722,6 +755,21 @@ public final class ClientOverrideConfiguration
         @Override
         public ExecutionAttributes executionAttributes() {
             return executionAttributes.build();
+        }
+
+        @Override
+        public Builder requestCompressionConfiguration(RequestCompressionConfiguration requestCompressionConfiguration) {
+            this.requestCompressionConfiguration = requestCompressionConfiguration;
+            return this;
+        }
+
+        public void setRequestCompressionEnabled(RequestCompressionConfiguration requestCompressionConfiguration) {
+            requestCompressionConfiguration(requestCompressionConfiguration);
+        }
+
+        @Override
+        public RequestCompressionConfiguration requestCompressionConfiguration() {
+            return requestCompressionConfiguration;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.RequestCompressionConfiguration;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -189,6 +190,12 @@ public final class SdkClientOption<T> extends ClientOption<T> {
      */
     public static final SdkClientOption<AttributeMap> CLIENT_CONTEXT_PARAMS =
         new SdkClientOption<>(AttributeMap.class);
+
+    /**
+     * Option to specify the request compression configuration settings.
+     */
+    public static final SdkClientOption<RequestCompressionConfiguration> REQUEST_COMPRESSION_CONFIGURATION =
+        new SdkClientOption<>(RequestCompressionConfiguration.class);
 
     private SdkClientOption(Class<T> valueClass) {
         super(valueClass);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/Compressor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.compression;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.CompressRequestStage;
+
+/**
+ * Interface for compressors used by {@link CompressRequestStage} to compress requests.
+ */
+@SdkInternalApi
+public interface Compressor {
+
+    /**
+     * The compression algorithm type.
+     *
+     * @return The {@link String} compression algorithm type.
+     */
+    String compressorType();
+
+    /**
+     * Compress a {@link SdkBytes} payload.
+     *
+     * @param content
+     * @return The compressed {@link SdkBytes}.
+     */
+    SdkBytes compress(SdkBytes content);
+
+    /**
+     * Compress a byte[] payload.
+     *
+     * @param content
+     * @return The compressed byte array.
+     */
+    default byte[] compress(byte[] content) {
+        return compress(SdkBytes.fromByteArray(content)).asByteArray();
+    }
+
+    /**
+     * Compress an {@link InputStream} payload.
+     *
+     * @param content
+     * @return The compressed {@link InputStream}.
+     */
+    default InputStream compress(InputStream content) {
+        return compress(SdkBytes.fromInputStream(content)).asInputStream();
+    }
+
+    /**
+     * Compress an {@link ByteBuffer} payload.
+     *
+     * @param content
+     * @return The compressed {@link ByteBuffer}.
+     */
+    default ByteBuffer compress(ByteBuffer content) {
+        return compress(SdkBytes.fromByteBuffer(content)).asByteBuffer();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/CompressorType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/compression/CompressorType.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.compression;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.internal.compression.GzipCompressor;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * The supported compression algorithms for operations with the requestCompression trait. Each supported algorithm will have an
+ * {@link Compressor} implementation.
+ */
+@SdkInternalApi
+public final class CompressorType {
+
+    public static final CompressorType GZIP = CompressorType.of("gzip");
+
+    private static Map<String, Compressor> compressorMap = new HashMap<String, Compressor>() {{
+            put("gzip", new GzipCompressor());
+        }};
+
+    private final String id;
+
+    private CompressorType(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Creates a new {@link CompressorType} of the given value.
+     */
+    public static CompressorType of(String value) {
+        Validate.paramNotBlank(value, "compressionType");
+        return CompressorTypeCache.put(value);
+    }
+
+    /**
+     * Returns the {@link Set} of {@link String}s of compressor types supported by the SDK.
+     */
+    public static Set<String> compressorTypes() {
+        return compressorMap.keySet();
+    }
+
+    /**
+     * Whether or not the compressor type is supported by the SDK.
+     */
+    public static boolean isSupported(String compressionType) {
+        return compressorTypes().contains(compressionType);
+    }
+
+    /**
+     * Maps the {@link CompressorType} to its corresponding {@link Compressor}.
+     */
+    public Compressor newCompressor() {
+        Compressor compressor = compressorMap.getOrDefault(this.id, null);
+        if (compressor == null) {
+            throw new UnsupportedOperationException("The compression type " + id + " does not have an implementation of "
+                                                    + "Compressor");
+        }
+        return compressor;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CompressorType that = (CompressorType) o;
+        return Objects.equals(id, that.id)
+               && Objects.equals(compressorMap, that.compressorMap);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (compressorMap != null ? compressorMap.hashCode() : 0);
+        return result;
+    }
+
+    private static class CompressorTypeCache {
+        private static final ConcurrentHashMap<String, CompressorType> VALUES = new ConcurrentHashMap<>();
+
+        private CompressorTypeCache() {
+        }
+
+        private static CompressorType put(String value) {
+            return VALUES.computeIfAbsent(value, v -> new CompressorType(value));
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.RequestCompressionConfiguration;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.core.checksums.Algorithm;
 import software.amazon.awssdk.core.checksums.ChecksumSpecs;
@@ -109,6 +110,12 @@ public class SdkExecutionAttribute {
     public static final ExecutionAttribute<ChecksumValidation> HTTP_RESPONSE_CHECKSUM_VALIDATION = new ExecutionAttribute<>(
         "HttpResponseChecksumValidation");
 
+    /**
+     * The {@link RequestCompressionConfiguration}, which includes options to enable/disable request compression and set the
+     * minimum compression threshold.
+     */
+    public static final ExecutionAttribute<RequestCompressionConfiguration> REQUEST_COMPRESSION_CONFIGURATION =
+        new ExecutionAttribute<>("RequestCompressionConfiguration");
 
     protected SdkExecutionAttribute() {
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.ClientType;
-import software.amazon.awssdk.core.RequestCompressionConfiguration;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.core.checksums.Algorithm;
 import software.amazon.awssdk.core.checksums.ChecksumSpecs;
@@ -109,13 +108,6 @@ public class SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<ChecksumValidation> HTTP_RESPONSE_CHECKSUM_VALIDATION = new ExecutionAttribute<>(
         "HttpResponseChecksumValidation");
-
-    /**
-     * The {@link RequestCompressionConfiguration}, which includes options to enable/disable request compression and set the
-     * minimum compression threshold.
-     */
-    public static final ExecutionAttribute<RequestCompressionConfiguration> REQUEST_COMPRESSION_CONFIGURATION =
-        new ExecutionAttribute<>("RequestCompressionConfiguration");
 
     protected SdkExecutionAttribute() {
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.interceptor;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
@@ -91,6 +92,12 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<Boolean> IS_DISCOVERED_ENDPOINT =
         new ExecutionAttribute<>("IsDiscoveredEndpoint");
+
+    /**
+     * The supported compression algorithms for an operation, and whether the operation is streaming or not.
+     */
+    public static final ExecutionAttribute<RequestCompression> REQUEST_COMPRESSION =
+        new ExecutionAttribute<>("RequestCompression");
 
     private SdkInternalExecutionAttribute() {
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -18,7 +18,7 @@ package software.amazon.awssdk.core.interceptor;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/trait/RequestCompression.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/trait/RequestCompression.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.interceptor.trait;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public final class RequestCompression {
+
+    private List<String> encodings;
+    private boolean isStreaming;
+
+    private RequestCompression(Builder builder) {
+        this.encodings = builder.encodings;
+        this.isStreaming = builder.isStreaming;
+    }
+
+    public List<String> getEncodings() {
+        return encodings;
+    }
+
+    public boolean isStreaming() {
+        return isStreaming;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private List<String> encodings;
+        private boolean isStreaming;
+
+        public Builder encodings(List<String> encodings) {
+            this.encodings = encodings;
+            return this;
+        }
+
+        public Builder encodings(String... encodings) {
+            if (encodings != null) {
+                this.encodings = Arrays.asList(encodings);
+            }
+            return this;
+        }
+
+        public Builder isStreaming(boolean isStreaming) {
+            this.isStreaming = isStreaming;
+            return this;
+        }
+
+        public RequestCompression build() {
+            return new RequestCompression(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RequestCompression that = (RequestCompression) o;
+        return isStreaming == that.isStreaming()
+               && Objects.equals(encodings, that.getEncodings());
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + (isStreaming ? 1 : 0);
+        hashCode = 31 * hashCode + Objects.hashCode(encodings);
+        return hashCode;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/Compressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/Compressor.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.compression;
+package software.amazon.awssdk.core.internal.compression;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/CompressorType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/CompressorType.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.compression;
+package software.amazon.awssdk.core.internal.compression;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.internal.compression.GzipCompressor;
 import software.amazon.awssdk.utils.Validate;
 
 /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.compression;
+
+import static software.amazon.awssdk.utils.IoUtils.closeQuietly;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.zip.GZIPOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.compression.Compressor;
+
+@SdkInternalApi
+public final class GzipCompressor implements Compressor {
+
+    private static final String COMPRESSOR_TYPE = "gzip";
+    private static final Logger log = LoggerFactory.getLogger(GzipCompressor.class);
+
+    @Override
+    public String compressorType() {
+        return COMPRESSOR_TYPE;
+    }
+
+    @Override
+    public SdkBytes compress(SdkBytes content) {
+        GZIPOutputStream gzipOutputStream = null;
+        try {
+            ByteArrayOutputStream compressedOutputStream = new ByteArrayOutputStream();
+            gzipOutputStream = new GZIPOutputStream(compressedOutputStream);
+            gzipOutputStream.write(content.asByteArray());
+            gzipOutputStream.close();
+            return SdkBytes.fromByteArray(compressedOutputStream.toByteArray());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            closeQuietly(gzipOutputStream, log);
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/compression/GzipCompressor.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.core.compression.Compressor;
 
 @SdkInternalApi
 public final class GzipCompressor implements Compressor {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncBeforeTran
 import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncExecutionFailureExceptionReportingStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncSigningStage;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.CompressRequestStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.HttpChecksumStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.MakeAsyncHttpRequestStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.MakeRequestImmutableStage;
@@ -171,6 +172,7 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
                                 .then(ApplyUserAgentStage::new)
                                 .then(MergeCustomHeadersStage::new)
                                 .then(MergeCustomQueryParamsStage::new)
+                                .then(CompressRequestStage::new)
                                 .then(() -> new HttpChecksumStage(ClientType.ASYNC))
                                 .then(MakeRequestImmutableStage::new)
                                 .then(RequestPipelineBuilder

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
@@ -172,7 +172,7 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
                                 .then(ApplyUserAgentStage::new)
                                 .then(MergeCustomHeadersStage::new)
                                 .then(MergeCustomQueryParamsStage::new)
-                                .then(CompressRequestStage::new)
+                                .then(() -> new CompressRequestStage(httpClientDependencies))
                                 .then(() -> new HttpChecksumStage(ClientType.ASYNC))
                                 .then(MakeRequestImmutableStage::new)
                                 .then(RequestPipelineBuilder

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
@@ -173,7 +173,7 @@ public final class AmazonSyncHttpClient implements SdkAutoCloseable {
                                .then(ApplyUserAgentStage::new)
                                .then(MergeCustomHeadersStage::new)
                                .then(MergeCustomQueryParamsStage::new)
-                               .then(CompressRequestStage::new)
+                               .then(() -> new CompressRequestStage(httpClientDependencies))
                                .then(() -> new HttpChecksumStage(ClientType.SYNC))
                                .then(MakeRequestImmutableStage::new)
                                // End of mutating request

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.core.internal.http.pipeline.stages.ApplyTransactio
 import software.amazon.awssdk.core.internal.http.pipeline.stages.ApplyUserAgentStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.BeforeTransmissionExecutionInterceptorsStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.BeforeUnmarshallingExecutionInterceptorsStage;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.CompressRequestStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.HttpChecksumStage;
@@ -172,6 +173,7 @@ public final class AmazonSyncHttpClient implements SdkAutoCloseable {
                                .then(ApplyUserAgentStage::new)
                                .then(MergeCustomHeadersStage::new)
                                .then(MergeCustomQueryParamsStage::new)
+                               .then(CompressRequestStage::new)
                                .then(() -> new HttpChecksumStage(ClientType.SYNC))
                                .then(MakeRequestImmutableStage::new)
                                // End of mutating request

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/CompressRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/CompressRequestStage.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.compression.Compressor;
+import software.amazon.awssdk.core.compression.CompressorType;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.pipeline.MutableRequestToRequestPipeline;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Compress requests whose operations are marked with the "requestCompression" C2J trait.
+ */
+@SdkInternalApi
+public class CompressRequestStage implements MutableRequestToRequestPipeline {
+    private static final int DEFAULT_MIN_COMPRESSION_SIZE = 10_240;
+    private static final int MIN_COMPRESSION_SIZE_LIMIT = 10_485_760;
+    private static final Supplier<ProfileFile> PROFILE_FILE = ProfileFile::defaultProfileFile;
+    private static final String PROFILE_NAME = ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow();
+
+    @Override
+    public SdkHttpFullRequest.Builder execute(SdkHttpFullRequest.Builder input, RequestExecutionContext context)
+            throws Exception {
+
+        if (!shouldCompress(input, context)) {
+            return input;
+        }
+
+        Compressor compressor = resolveCompressorType(context.executionAttributes());
+
+        // non-streaming
+        if (!isStreaming(context)) {
+            compressEntirePayload(input, compressor);
+            updateContentEncodingHeader(input, compressor);
+            updateContentLengthHeader(input);
+        }
+
+        // TODO : streaming - sync & async
+
+        return input;
+    }
+
+    private static boolean shouldCompress(SdkHttpFullRequest.Builder input, RequestExecutionContext context) {
+        if (context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION) == null) {
+            return false;
+        }
+        if (resolveCompressorType(context.executionAttributes()) == null) {
+            return false;
+        }
+        if (!resolveRequestCompressionEnabled(context)) {
+            return false;
+        }
+        if (isStreaming(context)) {
+            return true;
+        }
+        if (input.contentStreamProvider() == null) {
+            return false;
+        }
+        return isRequestSizeWithinThreshold(input, context);
+    }
+
+    private static boolean isStreaming(RequestExecutionContext context) {
+        return context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION).isStreaming();
+    }
+
+    private void compressEntirePayload(SdkHttpFullRequest.Builder input, Compressor compressor) {
+        ContentStreamProvider wrappedProvider = input.contentStreamProvider();
+        ContentStreamProvider compressedStreamProvider = () -> compressor.compress(wrappedProvider.newStream());
+        input.contentStreamProvider(compressedStreamProvider);
+    }
+
+    private static void updateContentEncodingHeader(SdkHttpFullRequest.Builder input,
+                                                                          Compressor compressor) {
+        if (input.firstMatchingHeader("Content-encoding").isPresent()) {
+            input.appendHeader("Content-encoding", compressor.compressorType());
+        } else {
+            input.putHeader("Content-encoding", compressor.compressorType());
+        }
+    }
+
+    private static void updateContentLengthHeader(SdkHttpFullRequest.Builder input) {
+        InputStream inputStream = input.contentStreamProvider().newStream();
+        try {
+            byte[] bytes = IoUtils.toByteArray(inputStream);
+            String length = String.valueOf(bytes.length);
+            input.putHeader("Content-Length", length);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Compressor resolveCompressorType(ExecutionAttributes executionAttributes) {
+        List<String> encodings =
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION).getEncodings();
+
+        for (String encoding: encodings) {
+            encoding = encoding.toLowerCase(Locale.ROOT);
+            if (CompressorType.isSupported(encoding)) {
+                return CompressorType.of(encoding).newCompressor();
+            }
+        }
+        return null;
+    }
+
+    private static boolean resolveRequestCompressionEnabled(RequestExecutionContext context) {
+
+        if (context.originalRequest().overrideConfiguration().isPresent()
+            && context.originalRequest().overrideConfiguration().get().requestCompressionConfiguration().isPresent()) {
+            Boolean requestCompressionEnabled = context.originalRequest().overrideConfiguration().get()
+                                                       .requestCompressionConfiguration().get()
+                                                       .requestCompressionEnabled();
+            if (requestCompressionEnabled != null) {
+                return requestCompressionEnabled;
+            }
+        }
+
+        if (context.executionAttributes().getAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION) != null) {
+            Boolean requestCompressionEnabled = context.executionAttributes().getAttribute(
+                SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION).requestCompressionEnabled();
+            if (requestCompressionEnabled != null) {
+                return requestCompressionEnabled;
+            }
+        }
+
+        if (SdkSystemSetting.AWS_DISABLE_REQUEST_COMPRESSION.getBooleanValue().isPresent()) {
+            return !SdkSystemSetting.AWS_DISABLE_REQUEST_COMPRESSION.getBooleanValue().get();
+        }
+
+        Optional<Boolean> profileSetting =
+            PROFILE_FILE.get()
+                        .profile(PROFILE_NAME)
+                        .flatMap(p -> p.booleanProperty(ProfileProperty.DISABLE_REQUEST_COMPRESSION));
+        if (profileSetting.isPresent()) {
+            return !profileSetting.get();
+        }
+
+        return true;
+    }
+
+    private static boolean isRequestSizeWithinThreshold(SdkHttpFullRequest.Builder input, RequestExecutionContext context) {
+        int minimumCompressionThreshold = resolveMinCompressionSize(context);
+        validateMinCompressionSizeInput(minimumCompressionThreshold);
+        int requestSize = SdkBytes.fromInputStream(input.contentStreamProvider().newStream()).asByteArray().length;
+        return requestSize >= minimumCompressionThreshold;
+    }
+
+    private static int resolveMinCompressionSize(RequestExecutionContext context) {
+
+        if (context.originalRequest().overrideConfiguration().isPresent()
+            && context.originalRequest().overrideConfiguration().get().requestCompressionConfiguration().isPresent()) {
+            Integer minCompressionSize = context.originalRequest().overrideConfiguration().get()
+                                                .requestCompressionConfiguration().get()
+                                                .minimumCompressionThresholdInBytes();
+            if (minCompressionSize != null) {
+                return minCompressionSize;
+            }
+        }
+
+        if (context.executionAttributes().getAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION) != null) {
+            Integer minCompressionSize = context.executionAttributes()
+                                                .getAttribute(SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION)
+                                                .minimumCompressionThresholdInBytes();
+            if (minCompressionSize != null) {
+                return minCompressionSize;
+            }
+        }
+
+        if (SdkSystemSetting.AWS_REQUEST_MIN_COMPRESSION_SIZE_BYTES.getIntegerValue().isPresent()) {
+            return SdkSystemSetting.AWS_REQUEST_MIN_COMPRESSION_SIZE_BYTES.getIntegerValue().get();
+        }
+
+        Optional<String> profileSetting =
+            PROFILE_FILE.get()
+                        .profile(PROFILE_NAME)
+                        .flatMap(p -> p.property(ProfileProperty.REQUEST_MIN_COMPRESSION_SIZE_BYTES));
+        if (profileSetting.isPresent()) {
+            return Integer.parseInt(profileSetting.get());
+        }
+
+        return DEFAULT_MIN_COMPRESSION_SIZE;
+    }
+
+    private static void validateMinCompressionSizeInput(int minCompressionSize) {
+        if (!(minCompressionSize >= 0 && minCompressionSize <= MIN_COMPRESSION_SIZE_LIMIT)) {
+            throw SdkClientException.create("The minimum compression size must be non-negative with a maximum value of "
+                                            + "10485760.", new IllegalArgumentException());
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/trait/RequestCompression.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/trait/RequestCompression.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.interceptor.trait;
+package software.amazon.awssdk.core.internal.interceptor.trait;
 
 import java.util.Arrays;
 import java.util.List;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/RequestCompressionConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/RequestCompressionConfigurationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class RequestCompressionConfigurationTest {
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(RequestCompressionConfiguration.class)
+                      .withNonnullFields("requestCompressionEnabled", "minimumCompressionThresholdInBytes")
+                      .verify();
+    }
+
+    @Test
+    public void toBuilder() {
+        RequestCompressionConfiguration configuration =
+            RequestCompressionConfiguration.builder()
+                                           .requestCompressionEnabled(true)
+                                           .minimumCompressionThresholdInBytes(99999)
+                                           .build();
+
+        RequestCompressionConfiguration another = configuration.toBuilder().build();
+        assertThat(configuration).isEqualTo(another);
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/compression/CompressorTypeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/compression/CompressorTypeTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.internal.compression.CompressorType;
 
 public class CompressorTypeTest {
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/compression/CompressorTypeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/compression/CompressorTypeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.compression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class CompressorTypeTest {
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(CompressorType.class)
+                      .withNonnullFields("id")
+                      .verify();
+    }
+
+    @Test
+    public void compressorType_gzip() {
+        CompressorType gzip = CompressorType.GZIP;
+        CompressorType gzipFromString = CompressorType.of("gzip");
+        assertThat(gzip).isSameAs(gzipFromString);
+        assertThat(gzip).isEqualTo(gzipFromString);
+    }
+
+    @Test
+    public void compressorType_usesSameInstance_when_sameCompressorTypeOfSameValue() {
+        CompressorType brotliFromString = CompressorType.of("brotli");
+        CompressorType brotliFromStringDuplicate = CompressorType.of("brotli");
+        assertThat(brotliFromString).isSameAs(brotliFromStringDuplicate);
+        assertThat(brotliFromString).isEqualTo(brotliFromStringDuplicate);
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/compression/GzipCompressorTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/compression/GzipCompressorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.compression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.core.Is.is;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+import org.junit.Test;
+import software.amazon.awssdk.core.compression.Compressor;
+
+public class GzipCompressorTest {
+    private static final Compressor gzipCompressor = new GzipCompressor();
+    private static final String COMPRESSABLE_STRING =
+        "RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest";
+
+    @Test
+    public void compressedData_decompressesCorrectly() throws IOException {
+        byte[] originalData = COMPRESSABLE_STRING.getBytes(StandardCharsets.UTF_8);
+        byte[] compressedData = gzipCompressor.compress(originalData);
+
+        int uncompressedSize = originalData.length;
+        int compressedSize = compressedData.length;
+        assertThat(compressedSize, lessThan(uncompressedSize));
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(compressedData);
+        GZIPInputStream gzipInputStream = new GZIPInputStream(bais);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int bytesRead;
+        while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
+            baos.write(buffer, 0, bytesRead);
+        }
+        gzipInputStream.close();
+        byte[] decompressedData = baos.toByteArray();
+
+        assertThat(decompressedData, is(originalData));
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/compression/GzipCompressorTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/compression/GzipCompressorTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 import org.junit.Test;
-import software.amazon.awssdk.core.compression.Compressor;
 
 public class GzipCompressorTest {
     private static final Compressor gzipCompressor = new GzipCompressor();

--- a/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
+++ b/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.core.SdkGlobalTime;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
-import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
+import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
 import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest;

--- a/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
+++ b/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
@@ -189,10 +189,7 @@ public class CloudWatchIntegrationTest extends AwsIntegrationTestBase {
                             .credentialsProvider(getCredentialsProvider())
                             .region(Region.US_WEST_2)
                             .overrideConfiguration(c -> c.putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
-                                                                                requestCompressionTrait)
-                                                         .putExecutionAttribute(
-                                                             SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
-                                                             compressionConfiguration))
+                                                                                requestCompressionTrait))
                             .build();
 
         String measureName = this.getClass().getName() + System.currentTimeMillis();
@@ -203,7 +200,10 @@ public class CloudWatchIntegrationTest extends AwsIntegrationTestBase {
                                        .unit("Count").value(42.0).build();
 
         requestCompressionClient.putMetricData(PutMetricDataRequest.builder()
-                                                                   .namespace("AWS.EC2").metricData(datum).build());
+                                                                   .namespace("AWS.EC2")
+                                                                   .metricData(datum)
+                                                                   .overrideConfiguration(c -> c.requestCompressionConfiguration(compressionConfiguration))
+                                                                   .build());
 
         GetMetricStatisticsResponse result =
             Waiter.run(() -> requestCompressionClient

--- a/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
+++ b/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
@@ -39,8 +39,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.RequestCompressionConfiguration;
 import software.amazon.awssdk.core.SdkGlobalTime;
 import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
 import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest;
@@ -108,7 +112,6 @@ public class CloudWatchIntegrationTest extends AwsIntegrationTestBase {
     /**
      * Tests putting metrics and then getting them back.
      */
-
     @Test
     public void put_get_metricdata_list_metric_returns_success() throws
                                                                  InterruptedException {
@@ -148,6 +151,87 @@ public class CloudWatchIntegrationTest extends AwsIntegrationTestBase {
         }
 
         ListMetricsResponse listResult = cloudwatch.listMetrics(ListMetricsRequest.builder().build());
+
+        boolean seenDimensions = false;
+        assertTrue(listResult.metrics().size() > 0);
+        for (Metric metric : listResult.metrics()) {
+            assertNotNull(metric.metricName());
+            assertNotNull(metric.namespace());
+
+            for (Dimension dimension : metric.dimensions()) {
+                seenDimensions = true;
+                assertNotNull(dimension.name());
+                assertNotNull(dimension.value());
+            }
+        }
+        assertTrue(seenDimensions);
+    }
+
+    /**
+     * Tests putting metrics with request compression and then getting them back.
+     * TODO: We can remove this test once CloudWatch adds "RequestCompression" trait to PutMetricData
+     */
+    @Test
+    public void put_get_metricdata_list_metric_withRequestCompression_returns_success() {
+
+        RequestCompression requestCompressionTrait = RequestCompression.builder()
+                                                                       .encodings("gzip")
+                                                                       .isStreaming(false)
+                                                                       .build();
+        RequestCompressionConfiguration compressionConfiguration =
+            RequestCompressionConfiguration.builder()
+                                           // uncompressed payload is 404 bytes
+                                           .minimumCompressionThresholdInBytes(100)
+                                           .build();
+
+        CloudWatchClient requestCompressionClient =
+            CloudWatchClient.builder()
+                            .credentialsProvider(getCredentialsProvider())
+                            .region(Region.US_WEST_2)
+                            .overrideConfiguration(c -> c.putExecutionAttribute(SdkInternalExecutionAttribute.REQUEST_COMPRESSION,
+                                                                                requestCompressionTrait)
+                                                         .putExecutionAttribute(
+                                                             SdkExecutionAttribute.REQUEST_COMPRESSION_CONFIGURATION,
+                                                             compressionConfiguration))
+                            .build();
+
+        String measureName = this.getClass().getName() + System.currentTimeMillis();
+
+        MetricDatum datum = MetricDatum.builder().dimensions(
+                                           Dimension.builder().name("InstanceType").value("m1.small").build())
+                                       .metricName(measureName).timestamp(Instant.now())
+                                       .unit("Count").value(42.0).build();
+
+        requestCompressionClient.putMetricData(PutMetricDataRequest.builder()
+                                                                   .namespace("AWS.EC2").metricData(datum).build());
+
+        GetMetricStatisticsResponse result =
+            Waiter.run(() -> requestCompressionClient
+                      .getMetricStatistics(r -> r.startTime(Instant.now().minus(Duration.ofDays(7)))
+                                                 .namespace("AWS.EC2")
+                                                 .period(60 * 60)
+                                                 .dimensions(Dimension.builder().name("InstanceType")
+                                                                      .value("m1.small").build())
+                                                 .metricName(measureName)
+                                                 .statisticsWithStrings("Average", "Maximum", "Minimum", "Sum")
+                                                 .endTime(Instant.now())))
+                  .until(r -> r.datapoints().size() == 1)
+                  .orFailAfter(Duration.ofMinutes(2));
+
+        assertNotNull(result.label());
+        assertEquals(measureName, result.label());
+
+        assertEquals(1, result.datapoints().size());
+        for (Datapoint datapoint : result.datapoints()) {
+            assertEquals(datum.value(), datapoint.average());
+            assertEquals(datum.value(), datapoint.maximum());
+            assertEquals(datum.value(), datapoint.minimum());
+            assertEquals(datum.value(), datapoint.sum());
+            assertNotNull(datapoint.timestamp());
+            assertEquals(datum.unit(), datapoint.unit());
+        }
+
+        ListMetricsResponse listResult = requestCompressionClient.listMetrics(ListMetricsRequest.builder().build());
 
         boolean seenDimensions = false;
         assertTrue(listResult.metrics().size() > 0);

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
@@ -277,6 +277,18 @@
         "requestAlgorithmMember": "ChecksumAlgorithm"
       }
     },
+    "PutOperationWithRequestCompression":{
+      "name":"PutOperationWithRequestCompression",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/"
+      },
+      "input":{"shape":"RequestCompressionStructure"},
+      "output":{"shape":"RequestCompressionStructure"},
+      "requestCompression": {
+        "encodings": ["gzip"]
+      }
+    },
     "GetOperationWithChecksum":{
       "name":"GetOperationWithChecksum",
       "http":{
@@ -1007,6 +1019,17 @@
         }
       },
       "payload":"NestedQueryParameterOperation"
+    },
+    "RequestCompressionStructure":{
+      "type":"structure",
+      "members":{
+        "Body":{
+          "shape":"Body",
+          "documentation":"<p>Object data.</p>",
+          "streaming":false
+        }
+      },
+      "payload":"Body"
     }
   }
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/RequestCompressionTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/RequestCompressionTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.core.compression.Compressor;
+import software.amazon.awssdk.core.internal.compression.Compressor;
 import software.amazon.awssdk.core.internal.compression.GzipCompressor;
 import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpFullRequest;

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/RequestCompressionTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/RequestCompressionTest.java
@@ -41,11 +41,11 @@ public class RequestCompressionTest {
         "RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest";
     private String compressedBody;
     private int compressedLen;
-    MockSyncHttpClient mockHttpClient;
-    MockAsyncHttpClient mockAsyncHttpClient;
-    ProtocolRestJsonClient syncClient;
-    ProtocolRestJsonAsyncClient asyncClient;
-    Compressor compressor;
+    private MockSyncHttpClient mockHttpClient;
+    private MockAsyncHttpClient mockAsyncHttpClient;
+    private ProtocolRestJsonClient syncClient;
+    private ProtocolRestJsonAsyncClient asyncClient;
+    private Compressor compressor;
 
     @BeforeEach
     public void setUp() {
@@ -143,7 +143,7 @@ public class RequestCompressionTest {
 
     @Test
     public void async_nonStreaming_compression_withRetry_compressesCorrectly() {
-        mockHttpClient.stubNextResponse(mockErrorResponse(), Duration.ofMillis(500));
+        mockAsyncHttpClient.stubNextResponse(mockErrorResponse(), Duration.ofMillis(500));
         mockAsyncHttpClient.stubNextResponse(mockResponse(), Duration.ofMillis(500));
 
         PutOperationWithRequestCompressionRequest request =

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/RequestCompressionTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/RequestCompressionTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.compression.Compressor;
+import software.amazon.awssdk.core.internal.compression.GzipCompressor;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.model.PutOperationWithRequestCompressionRequest;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+
+public class RequestCompressionTest {
+    private static final String UNCOMPRESSED_BODY =
+        "RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest";
+    private String compressedBody;
+    private int compressedLen;
+    MockSyncHttpClient mockHttpClient;
+    MockAsyncHttpClient mockAsyncHttpClient;
+    ProtocolRestJsonClient syncClient;
+    ProtocolRestJsonAsyncClient asyncClient;
+    Compressor compressor;
+
+    @BeforeEach
+    public void setUp() {
+        mockHttpClient = new MockSyncHttpClient();
+        mockAsyncHttpClient = new MockAsyncHttpClient();
+        syncClient = ProtocolRestJsonClient.builder()
+                                           .credentialsProvider(AnonymousCredentialsProvider.create())
+                                           .region(Region.US_EAST_1)
+                                           .httpClient(mockHttpClient)
+                                           .build();
+        asyncClient = ProtocolRestJsonAsyncClient.builder()
+                                                 .credentialsProvider(AnonymousCredentialsProvider.create())
+                                                 .region(Region.US_EAST_1)
+                                                 .httpClient(mockAsyncHttpClient)
+                                                 .build();
+        compressor = new GzipCompressor();
+        byte[] compressedBodyBytes = compressor.compress(SdkBytes.fromUtf8String(UNCOMPRESSED_BODY)).asByteArray();
+        compressedLen = compressedBodyBytes.length;
+        compressedBody = new String(compressedBodyBytes);
+    }
+
+    @AfterEach
+    public void reset() {
+        mockHttpClient.reset();
+        mockAsyncHttpClient.reset();
+    }
+
+    @Test
+    public void sync_nonStreaming_compression_compressesCorrectly() {
+        mockHttpClient.stubNextResponse(mockResponse(), Duration.ofMillis(500));
+
+        PutOperationWithRequestCompressionRequest request =
+            PutOperationWithRequestCompressionRequest.builder()
+                                                     .body(SdkBytes.fromUtf8String(UNCOMPRESSED_BODY))
+                                                     .overrideConfiguration(o -> o.requestCompressionConfiguration(
+                                                         c -> c.minimumCompressionThresholdInBytes(1)))
+                                                     .build();
+        syncClient.putOperationWithRequestCompression(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockHttpClient.getLastRequest();
+        InputStream loggedStream = loggedRequest.contentStreamProvider().get().newStream();
+        String loggedBody = new String(SdkBytes.fromInputStream(loggedStream).asByteArray());
+        int loggedSize = Integer.valueOf(loggedRequest.firstMatchingHeader("Content-Length").get());
+
+        assertThat(loggedBody).isEqualTo(compressedBody);
+        assertThat(loggedSize).isEqualTo(compressedLen);
+        assertThat(loggedRequest.firstMatchingHeader("Content-encoding").get()).isEqualTo("gzip");
+    }
+
+    @Test
+    public void async_nonStreaming_compression_compressesCorrectly() {
+        mockAsyncHttpClient.stubNextResponse(mockResponse(), Duration.ofMillis(500));
+
+        PutOperationWithRequestCompressionRequest request =
+            PutOperationWithRequestCompressionRequest.builder()
+                                                     .body(SdkBytes.fromUtf8String(UNCOMPRESSED_BODY))
+                                                     .overrideConfiguration(o -> o.requestCompressionConfiguration(
+                                                         c -> c.minimumCompressionThresholdInBytes(1)))
+                                                     .build();
+
+        asyncClient.putOperationWithRequestCompression(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockAsyncHttpClient.getLastRequest();
+        InputStream loggedStream = loggedRequest.contentStreamProvider().get().newStream();
+        String loggedBody = new String(SdkBytes.fromInputStream(loggedStream).asByteArray());
+        int loggedSize = Integer.valueOf(loggedRequest.firstMatchingHeader("Content-Length").get());
+
+        assertThat(loggedBody).isEqualTo(compressedBody);
+        assertThat(loggedSize).isEqualTo(compressedLen);
+        assertThat(loggedRequest.firstMatchingHeader("Content-encoding").get()).isEqualTo("gzip");
+    }
+
+    @Test
+    public void sync_nonStreaming_compression_withRetry_compressesCorrectly() {
+        mockHttpClient.stubNextResponse(mockErrorResponse(), Duration.ofMillis(500));
+        mockHttpClient.stubNextResponse(mockResponse(), Duration.ofMillis(500));
+
+        PutOperationWithRequestCompressionRequest request =
+            PutOperationWithRequestCompressionRequest.builder()
+                                                     .body(SdkBytes.fromUtf8String(UNCOMPRESSED_BODY))
+                                                     .overrideConfiguration(o -> o.requestCompressionConfiguration(
+                                                         c -> c.minimumCompressionThresholdInBytes(1)))
+                                                     .build();
+        syncClient.putOperationWithRequestCompression(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockHttpClient.getLastRequest();
+        InputStream loggedStream = loggedRequest.contentStreamProvider().get().newStream();
+        String loggedBody = new String(SdkBytes.fromInputStream(loggedStream).asByteArray());
+        int loggedSize = Integer.valueOf(loggedRequest.firstMatchingHeader("Content-Length").get());
+
+        assertThat(loggedBody).isEqualTo(compressedBody);
+        assertThat(loggedSize).isEqualTo(compressedLen);
+        assertThat(loggedRequest.firstMatchingHeader("Content-encoding").get()).isEqualTo("gzip");
+    }
+
+    @Test
+    public void async_nonStreaming_compression_withRetry_compressesCorrectly() {
+        mockHttpClient.stubNextResponse(mockErrorResponse(), Duration.ofMillis(500));
+        mockAsyncHttpClient.stubNextResponse(mockResponse(), Duration.ofMillis(500));
+
+        PutOperationWithRequestCompressionRequest request =
+            PutOperationWithRequestCompressionRequest.builder()
+                                                     .body(SdkBytes.fromUtf8String(UNCOMPRESSED_BODY))
+                                                     .overrideConfiguration(o -> o.requestCompressionConfiguration(
+                                                         c -> c.minimumCompressionThresholdInBytes(1)))
+                                                     .build();
+
+        asyncClient.putOperationWithRequestCompression(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockAsyncHttpClient.getLastRequest();
+        InputStream loggedStream = loggedRequest.contentStreamProvider().get().newStream();
+        String loggedBody = new String(SdkBytes.fromInputStream(loggedStream).asByteArray());
+        int loggedSize = Integer.valueOf(loggedRequest.firstMatchingHeader("Content-Length").get());
+
+        assertThat(loggedBody).isEqualTo(compressedBody);
+        assertThat(loggedSize).isEqualTo(compressedLen);
+        assertThat(loggedRequest.firstMatchingHeader("Content-encoding").get()).isEqualTo("gzip");
+    }
+
+    private HttpExecuteResponse mockResponse() {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder().statusCode(200).build())
+                                  .build();
+    }
+
+    private HttpExecuteResponse mockErrorResponse() {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder().statusCode(500).build())
+                                  .build();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Adding request compression support for non-streaming operations (e.g., CloudWatch `putMetricData`), excluding S3 operations.
To add support for compression for streaming operations and S3 in future PRs.

## Modifications
<!--- Describe your changes in detail -->
Added codegen updates and configuration options.
`CompressRequestStage` handler in `AmazonSyncHttpClient` / `AmazonAsyncHttpClient` to resolve config settings and compress the request if necessary.
`Compressor` / `GzipCompressor` / `CompressorType` for compressing payload.


## Testing
<!--- Please describe in detail how you tested your changes -->
Added unit tests, codegen tests, and CloudWatch `putMetricData` integ tests
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
