### PR TITLE
Add endpoint based auth scheme customization for s3, eventbridge

### DIFF
--- a/services/eventbridge/src/main/resources/codegen-resources/customization.config
+++ b/services/eventbridge/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,6 @@
+{
+  "enableEndpointAuthSchemeParams": true,
+  "allowedEndpointAuthSchemeParams": [
+    "EndpointId"
+  ]
+}

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -248,5 +248,6 @@
     "software.amazon.awssdk.services.s3.internal.handlers.GetObjectInterceptor",
     "software.amazon.awssdk.services.s3.internal.handlers.CopySourceInterceptor"
   ],
-  "requiredTraitValidationEnabled": true
+  "requiredTraitValidationEnabled": true,
+  "enableEndpointAuthSchemeParams": true
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
S3 and EventBridge services are the only 2 services which will use endpoint based auth scheme resolution.

## Modifications
<!--- Describe your changes in detail -->
The codegen changes to support these cases are already in the feature branch. This PR adds the customization.config needed for s3 and eventbridge. For eventbridge - only EndpointId param is allowlisted. For s3 - no explicit allowlist enables all s3's params to be used for auth scheme resolution.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built the s3 and eventbridge modules and here is the generated AuthSchemeProvider for each.

<details> 
<summary>
S3
</summary>
<p>

```

@Generated("software.amazon.awssdk:codegen")
@SdkInternalApi
public final class DefaultS3AuthSchemeProvider implements S3AuthSchemeProvider {
    private static final DefaultS3AuthSchemeProvider DEFAULT = new DefaultS3AuthSchemeProvider();

    private static final S3AuthSchemeProvider MODELED_RESOLVER = ModeledS3AuthSchemeProvider.create();

    private static final S3EndpointProvider DELEGATE = S3EndpointProvider.defaultProvider();

    private DefaultS3AuthSchemeProvider() {
    }

    public static S3AuthSchemeProvider create() {
        return DEFAULT;
    }

    @Override
    public List<AuthSchemeOption> resolveAuthScheme(S3AuthSchemeParams params) {
        S3EndpointParams endpointParameters = S3EndpointParams.builder().bucket(params.bucket()).region(params.region())
                .useFips(params.useFips()).useDualStack(params.useDualStack()).endpoint(params.endpoint())
                .forcePathStyle(params.forcePathStyle()).accelerate(params.accelerate())
                .useGlobalEndpoint(params.useGlobalEndpoint()).useObjectLambdaEndpoint(params.useObjectLambdaEndpoint())
                .disableAccessPoints(params.disableAccessPoints())
                .disableMultiRegionAccessPoints(params.disableMultiRegionAccessPoints()).useArnRegion(params.useArnRegion())
                .build();
        Endpoint endpoint = DELEGATE.resolveEndpoint(endpointParameters).join();
        List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
        if (authSchemes == null) {
            return MODELED_RESOLVER.resolveAuthScheme(params);
        }
        List<AuthSchemeOption> options = new ArrayList<>();
        for (EndpointAuthScheme authScheme : authSchemes) {
            String name = authScheme.name();
            switch (name) {
            case "sigv4":
                SigV4AuthScheme sigv4AuthScheme = Validate.isInstanceOf(SigV4AuthScheme.class, authScheme,
                        "Expecting auth scheme of class SigV4AuthScheme, got instead object of class %s", authScheme.getClass()
                                .getName());
                options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4")
                        .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, sigv4AuthScheme.signingName())
                        .putSignerProperty(AwsV4HttpSigner.REGION_NAME, sigv4AuthScheme.signingRegion())
                        .putSignerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, !sigv4AuthScheme.disableDoubleEncoding()).build());
                break;
            case "sigv4a":
                throw new UnsupportedOperationException("SigV4a is not yet supported.");
            default:
                throw new IllegalArgumentException("Unknown auth scheme: " + name);
            }
        }
        return Collections.unmodifiableList(options);
    }
}
```

</p>
</details>

<details> 
<summary>
EventBridge
</summary>
<p>

```
@Generated("software.amazon.awssdk:codegen")
@SdkInternalApi
public final class DefaultEventBridgeAuthSchemeProvider implements EventBridgeAuthSchemeProvider {
    private static final DefaultEventBridgeAuthSchemeProvider DEFAULT = new DefaultEventBridgeAuthSchemeProvider();

    private static final EventBridgeAuthSchemeProvider MODELED_RESOLVER = ModeledEventBridgeAuthSchemeProvider.create();

    private static final EventBridgeEndpointProvider DELEGATE = EventBridgeEndpointProvider.defaultProvider();

    private DefaultEventBridgeAuthSchemeProvider() {
    }

    public static EventBridgeAuthSchemeProvider create() {
        return DEFAULT;
    }

    @Override
    public List<AuthSchemeOption> resolveAuthScheme(EventBridgeAuthSchemeParams params) {
        EventBridgeEndpointParams endpointParameters = EventBridgeEndpointParams.builder().region(params.region())
                .endpointId(params.endpointId()).build();
        Endpoint endpoint = DELEGATE.resolveEndpoint(endpointParameters).join();
        List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
        if (authSchemes == null) {
            return MODELED_RESOLVER.resolveAuthScheme(params);
        }
        List<AuthSchemeOption> options = new ArrayList<>();
        for (EndpointAuthScheme authScheme : authSchemes) {
            String name = authScheme.name();
            switch (name) {
            case "sigv4":
                SigV4AuthScheme sigv4AuthScheme = Validate.isInstanceOf(SigV4AuthScheme.class, authScheme,
                        "Expecting auth scheme of class SigV4AuthScheme, got instead object of class %s", authScheme.getClass()
                                .getName());
                options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4")
                        .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, sigv4AuthScheme.signingName())
                        .putSignerProperty(AwsV4HttpSigner.REGION_NAME, sigv4AuthScheme.signingRegion())
                        .putSignerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, !sigv4AuthScheme.disableDoubleEncoding()).build());
                break;
            case "sigv4a":
                throw new UnsupportedOperationException("SigV4a is not yet supported.");
            default:
                throw new IllegalArgumentException("Unknown auth scheme: " + name);
            }
        }
        return Collections.unmodifiableList(options);
    }
}
```

</p>
</details>