### PR TITLE
Enable UrlConnection http client chunked encoding

### DIFF
--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -154,6 +154,11 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
         HttpURLConnection connection = connectionFactory.createConnection(sdkHttpRequest.getUri());
         sdkHttpRequest.forEachHeader((key, values) -> values.forEach(value -> connection.setRequestProperty(key, value)));
 
+        // connection.setRequestProperty("Transfer-Encoding", "chunked") does not work, i.e., property does not get set
+        if (sdkHttpRequest.matchingHeaders("Transfer-Encoding").contains("chunked")) {
+            connection.setChunkedStreamingMode(-1);
+        }
+
         if (!sdkHttpRequest.firstMatchingHeader(ACCEPT).isPresent()) {
             // Override Accept header because the default one in JDK does not comply with RFC 7231
             // See: https://bugs.openjdk.org/browse/JDK-8163921

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
@@ -18,6 +18,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static software.amazon.awssdk.http.Header.ACCEPT;
+import static software.amazon.awssdk.http.Header.CHUNKED;
+import static software.amazon.awssdk.http.Header.TRANSFER_ENCODING;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
 
 import java.io.IOException;
@@ -90,6 +92,24 @@ public final class UrlConnectionHttpClientWireMockTest extends SdkHttpClientTest
                                         .call();
 
         mockServer.verify(postRequestedFor(urlPathEqualTo("/")).withHeader(ACCEPT, equalTo("text/html")));
+    }
+
+    @Test
+    public void hasTransferEncodingHeader_shouldBeSet() throws IOException {
+        SdkHttpClient client = createSdkHttpClient();
+
+        stubForMockRequest(200);
+
+        SdkHttpFullRequest req = mockSdkRequest("http://localhost:" + mockServer.port(), SdkHttpMethod.POST);
+        req = req.toBuilder().putHeader(TRANSFER_ENCODING, CHUNKED).build();
+        HttpExecuteResponse rsp = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                          .request(req)
+                                                                          .contentStreamProvider(req.contentStreamProvider()
+                                                                                                    .orElse(null))
+                                                                          .build())
+                                        .call();
+
+        mockServer.verify(postRequestedFor(urlPathEqualTo("/")).withHeader(TRANSFER_ENCODING, equalTo(CHUNKED)));
     }
 
 

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
@@ -110,6 +110,7 @@ public final class UrlConnectionHttpClientWireMockTest extends SdkHttpClientTest
                                         .call();
 
         mockServer.verify(postRequestedFor(urlPathEqualTo("/")).withHeader(TRANSFER_ENCODING, equalTo(CHUNKED)));
+        mockServer.verify(postRequestedFor(urlPathEqualTo("/")).withRequestBody(equalTo("Body")));
     }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Enable chunked encoding in URLConnection HTTP Client.
`setRequestProperty("Transfer-Encoding", "chunked")` does not have any effect

## Modifications
<!--- Describe your changes in detail -->
`setChunkedStreamingMode(-1)` when `Transfer-Encoding:chunked` is present, which will [prompt HttpURLConnection to use the default chunklen value](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html#setChunkedStreamingMode-int-) and enable chunked encoding
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To uncomment integ test from [Apache fix PR](https://github.com/aws/aws-sdk-java-v2/pull/4198/commits/9dec1a8d95ad13f087dcdfc5bdd24d2161316001#diff-decc1ffb0a2cfcfc59f6e9d52a961f670d2c442fb62ef8de718b5dfac66e293eR121) once merged

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
