### PR TITLE
Add ToCopyableBuilder to AuthSchemeOption

### DIFF
--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
@@ -18,7 +18,8 @@ package software.amazon.awssdk.http.auth.spi;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.http.auth.spi.internal.DefaultAuthSchemeOption;
 import software.amazon.awssdk.identity.spi.IdentityProperty;
-import software.amazon.awssdk.utils.builder.SdkBuilder;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * An authentication scheme option, composed of the scheme ID and properties for use when resolving the identity and signing
@@ -30,13 +31,13 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
  * @see AuthScheme
  */
 @SdkProtectedApi
-public interface AuthSchemeOption {
+public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Builder, AuthSchemeOption> {
 
     /**
      * Get a new builder for creating a {@link AuthSchemeOption}.
      */
     static Builder builder() {
-        return new DefaultAuthSchemeOption.BuilderImpl();
+        return DefaultAuthSchemeOption.builder();
     }
 
     /**
@@ -80,7 +81,7 @@ public interface AuthSchemeOption {
         <T> void accept(SignerProperty<T> propertyKey, T propertyValue);
     }
 
-    interface Builder extends SdkBuilder<Builder, AuthSchemeOption> {
+    interface Builder extends CopyableBuilder<Builder, AuthSchemeOption> {
         Builder schemeId(String schemeId);
 
         <T> Builder putIdentityProperty(IdentityProperty<T> key, T value);

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultAuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultAuthSchemeOption.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.http.auth.spi.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
 import software.amazon.awssdk.http.auth.spi.SignerProperty;
@@ -25,6 +26,7 @@ import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
+@Immutable
 public final class DefaultAuthSchemeOption implements AuthSchemeOption {
 
     private final String schemeId;
@@ -35,6 +37,10 @@ public final class DefaultAuthSchemeOption implements AuthSchemeOption {
         this.schemeId = Validate.paramNotBlank(builder.schemeId, "schemeId");
         this.identityProperties = new HashMap<>(builder.identityProperties);
         this.signerProperties = new HashMap<>(builder.signerProperties);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
     }
 
     @Override
@@ -68,9 +74,16 @@ public final class DefaultAuthSchemeOption implements AuthSchemeOption {
         }
     }
 
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
     @Override
     public String toString() {
         return ToString.builder("AuthSchemeOption")
+                       .add("schemeId", schemeId)
                        .add("identityProperties", identityProperties)
                        .add("signerProperties", signerProperties)
                        .build();
@@ -81,6 +94,15 @@ public final class DefaultAuthSchemeOption implements AuthSchemeOption {
         private String schemeId;
         private final Map<IdentityProperty<?>, Object> identityProperties = new HashMap<>();
         private final Map<SignerProperty<?>, Object> signerProperties = new HashMap<>();
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(DefaultAuthSchemeOption authSchemeOption) {
+            this.schemeId = authSchemeOption.schemeId;
+            this.identityProperties.putAll(authSchemeOption.identityProperties);
+            this.signerProperties.putAll(authSchemeOption.signerProperties);
+        }
 
         @Override
         public Builder schemeId(String schemeId) {

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOptionTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOptionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.identity.spi.IdentityProperty;
+
+class AuthSchemeOptionTest {
+
+    @Test
+    public void emptyBuilder_isNotSuccessful() {
+        assertThrows(NullPointerException.class, () -> AuthSchemeOption.builder().build());
+    }
+
+    @Test
+    public void build_withSchemeId_isSuccessful() {
+        AuthSchemeOption authSchemeOption = AuthSchemeOption.builder().schemeId("my.api#myAuth").build();
+        assertEquals("my.api#myAuth", authSchemeOption.schemeId());
+    }
+
+    @Test
+    public void putProperty_sameProperty_isReplaced() {
+        IdentityProperty<String> identityProperty = IdentityProperty.create(String.class, "identityKey1");
+        SignerProperty<String> signerProperty = SignerProperty.create(String.class, "signingKey1");
+
+        AuthSchemeOption authSchemeOption = AuthSchemeOption.builder()
+                                                            .schemeId("my.api#myAuth")
+                                                            .putIdentityProperty(identityProperty, "identity-value1")
+                                                            .putIdentityProperty(identityProperty, "identity-value2")
+                                                            .putSignerProperty(signerProperty, "signing-value1")
+                                                            .putSignerProperty(signerProperty, "signing-value2")
+                                                            .build();
+
+        assertEquals("identity-value2", authSchemeOption.identityProperty(identityProperty));
+        assertEquals("signing-value2", authSchemeOption.signerProperty(signerProperty));
+    }
+
+    @Test
+    public void copyBuilder_addProperty_retains() {
+        IdentityProperty<String> identityProperty = IdentityProperty.create(String.class, "identityKey");
+        SignerProperty<String> signerProperty = SignerProperty.create(String.class, "signingKey");
+        AuthSchemeOption authSchemeOption = AuthSchemeOption.builder()
+                                                            .schemeId("my.api#myAuth")
+                                                            .putIdentityProperty(identityProperty, "identity-value1")
+                                                            .putSignerProperty(signerProperty, "signing-value1")
+                                                            .build();
+
+        IdentityProperty<String> identityProperty2 = IdentityProperty.create(String.class, "identityKey2");
+        SignerProperty<String> signerProperty2 = SignerProperty.create(String.class, "signingKey2");
+
+        authSchemeOption =
+            authSchemeOption.copy(builder -> builder.putIdentityProperty(identityProperty2, "identity2-value1")
+                                                    .putSignerProperty(signerProperty2, "signing2-value1"));
+
+        assertEquals("identity-value1", authSchemeOption.identityProperty(identityProperty));
+        assertEquals("identity2-value1", authSchemeOption.identityProperty(identityProperty2));
+        assertEquals("signing-value1", authSchemeOption.signerProperty(signerProperty));
+        assertEquals("signing2-value1", authSchemeOption.signerProperty(signerProperty2));
+    }
+
+    @Test
+    public void copyBuilder_updateProperty_updates() {
+        IdentityProperty<String> identityProperty = IdentityProperty.create(String.class, "identityKey");
+        SignerProperty<String> signerProperty = SignerProperty.create(String.class, "signingKey");
+        AuthSchemeOption authSchemeOption = AuthSchemeOption.builder()
+                                                            .schemeId("my.api#myAuth")
+                                                            .putIdentityProperty(identityProperty, "identity-value1")
+                                                            .putSignerProperty(signerProperty, "signing-value1")
+                                                            .build();
+
+        authSchemeOption =
+            authSchemeOption.copy(builder -> builder.putIdentityProperty(identityProperty, "identity-value2")
+                                                    .putSignerProperty(signerProperty, "signing-value2"));
+
+        assertEquals("identity-value2", authSchemeOption.identityProperty(identityProperty));
+        assertEquals("signing-value2", authSchemeOption.signerProperty(signerProperty));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
If someone wants to provide their own AuthSchemeProvider that decorates the default one, they may need to mutate the properties of an AuthSchemeOption.

## Modifications
<!--- Describe your changes in detail -->
This change adds a ToCopyableBuilder to AuthSchemeOption to allow creating modified copy.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests
