### PR TITLE
Fix incorrect documentation, add missing @Override annotation

### DIFF
--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullRequest.java
@@ -214,7 +214,7 @@ public interface SdkHttpFullRequest
         Builder method(SdkHttpMethod httpMethod);
 
         /**
-         * The query parameters, exactly as they were configured with {@link #headers(Map)},
+         * The headers, exactly as they were configured with {@link #headers(Map)},
          * {@link #putHeader(String, String)} and {@link #putHeader(String, List)}.
          */
         @Override

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullResponse.java
@@ -86,7 +86,7 @@ public interface SdkHttpFullResponse
         Builder statusCode(int statusCode);
 
         /**
-         * The query parameters, exactly as they were configured with {@link #headers(Map)},
+         * The headers, exactly as they were configured with {@link #headers(Map)},
          * {@link #putHeader(String, String)} and {@link #putHeader(String, List)}.
          */
         @Override

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpRequest.java
@@ -323,9 +323,10 @@ public interface SdkHttpRequest extends SdkHttpHeaders, ToCopyableBuilder<SdkHtt
         Builder method(SdkHttpMethod httpMethod);
 
         /**
-         * The query parameters, exactly as they were configured with {@link #headers(Map)},
+         * The headers, exactly as they were configured with {@link #headers(Map)},
          * {@link #putHeader(String, String)} and {@link #putHeader(String, List)}.
          */
+        @Override
         Map<String, List<String>> headers();
 
         /**


### PR DESCRIPTION
## Motivation and Context
I came across some incorrect documentation earlier today, so I decided to fix it.

## Modifications
A few methods claim in their documentation that they return the query parameters of an HTTP request, but the methods actually return the headers of the request. I updated the documentation to reflect the correct behavior, and added a missing `@Override` annotation onto one of the affected methods.

## Testing
This change doesn't require any testing, but I ran `./mvnw clean install` anyway, which succeeded.

## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

I'm encountering a weird issue on my Windows environment that's preventing me from creating a new changelog entry. If this is necessary, I can clone my fork on a different environment and generate it.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
