### PR TITLE
Fixed the issue where the position of the ByteBuffer from the request…

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-6afb88b.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-6afb88b.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO HTTP Client",
+    "contributor": "",
+    "description": "Fixed the issue where the position of the ByteBuffer from the request is not honored in NettyNioAsyncHttpClient."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -445,7 +445,7 @@ public final class NettyRequestExecutor {
 
                     try {
                         int newLimit = clampedBufferLimit(contentBytes.remaining());
-                        contentBytes.limit(newLimit);
+                        contentBytes.limit(contentBytes.position() + newLimit);
                         ByteBuf contentByteBuf = Unpooled.wrappedBuffer(contentBytes);
                         HttpContent content = new DefaultHttpContent(contentByteBuf);
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.http.nio.netty;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -572,13 +573,14 @@ public class NettyNioAsyncHttpClientWireMockTest {
         String expected = new String(content, 95, 5);
 
         URI uri = URI.create("http://localhost:" + mockServer.port());
-        stubFor(any(urlPathEqualTo("/"))
+        stubFor(post(urlPathEqualTo("/"))
                     .withRequestBody(equalTo(expected)).willReturn(aResponse().withBody(body)));
         SdkHttpRequest request = createRequest(uri, "/", expected, SdkHttpMethod.POST, emptyMap());
         RecordingResponseHandler recorder = new RecordingResponseHandler();
 
         client.execute(AsyncExecuteRequest.builder().request(request).requestContentPublisher(new SimpleHttpContentPublisher(requestContent)).responseHandler(recorder).build());
         recorder.completeFuture.get(5, TimeUnit.SECONDS);
+        verify(postRequestedFor(urlPathEqualTo("/")).withRequestBody(equalTo(expected)));
     }
 
     // Needs to be a non-anon class in order to spy


### PR DESCRIPTION
… is not honored in NettyNioAsyncHttpClient.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Currently, the position of the ByteBuffer from the request is not honored in NettyNioAsyncHttpClient. If the position is not zero, the HTTP client would fail to send data to the server and eventually return error.

## Modifications
Set the ByteBuffer limit to `position + limit` instead of just limit.

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
