### PR TITLE
Add test to assert old properties are retained during copy

### DIFF
--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
@@ -55,6 +55,19 @@ public class ResolveIdentityRequestTest {
     }
 
     @Test
+    public void copyBuilder_addProperty_retains() {
+        IdentityProperty<String> property1 = IdentityProperty.create(String.class, "key1");
+        ResolveIdentityRequest request = ResolveIdentityRequest.builder()
+                                                               .putProperty(property1, "key1value1")
+                                                               .build();
+
+        IdentityProperty<String> property2 = IdentityProperty.create(String.class, "key2");
+        request = request.copy(builder -> builder.putProperty(property2, "key2value1"));
+        assertEquals("key1value1", request.property(property1));
+        assertEquals("key2value1", request.property(property2));
+    }
+
+    @Test
     public void copyBuilder_updateAddProperty_works() {
         IdentityProperty<String> property1 = IdentityProperty.create(String.class, "key1");
         ResolveIdentityRequest request = ResolveIdentityRequest.builder()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When adding tests for similar case in https://github.com/aws/aws-sdk-java-v2/pull/4208 realized I could add a similar test to existing ResolveIdentityRequestTest.

## Modifications
<!--- Describe your changes in detail -->
Added a unit test

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass