### PR TITLE
Copy SSE-C parameters when performing multipart copy

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-d9c09d4.json
+++ b/.changes/next-release/bugfix-S3TransferManager-d9c09d4.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Fix a bug where the SSE-C parameters are not copied to the CompleteMultipartUpload request when transforming to a multipart copy."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelper.java
@@ -189,6 +189,9 @@ public final class CopyObjectHelper {
                                           .multipartUpload(CompletedMultipartUpload.builder()
                                                                                    .parts(parts)
                                                                                    .build())
+                                          .sseCustomerAlgorithm(copyObjectRequest.sseCustomerAlgorithm())
+                                          .sseCustomerKey(copyObjectRequest.sseCustomerKey())
+                                          .sseCustomerKeyMD5(copyObjectRequest.sseCustomerKeyMD5())
                                           .build();
 
         return s3AsyncClient.completeMultipartUpload(completeMultipartUploadRequest);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,9 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
+import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Md5Utils;
 
 class CopyObjectHelperTest {
 
@@ -56,13 +59,15 @@ class CopyObjectHelperTest {
     private static final String DESTINATION_BUCKET = "destination";
     private static final String DESTINATION_KEY = "destinationKey";
     private static final String MULTIPART_ID = "multipartId";
+
+    private static final Long PART_SIZE_BYTES = 1024L;
     private S3AsyncClient s3AsyncClient;
     private CopyObjectHelper copyHelper;
 
     @BeforeEach
     public void setUp() {
         s3AsyncClient = Mockito.mock(S3AsyncClient.class);
-        copyHelper = new CopyObjectHelper(s3AsyncClient, 1024L);
+        copyHelper = new CopyObjectHelper(s3AsyncClient, PART_SIZE_BYTES);
     }
 
     @Test
@@ -254,6 +259,35 @@ class CopyObjectHelperTest {
             assertThat(actualUploadPartCopyRequests.get(i).copySourceRange()).isEqualTo(
                 String.format("bytes=%d-%d", rangeStart, rangeEnd));
         }
+    }
+
+    @Test
+    public void multiPartCopy_sseCHeadersSetInOriginalRequest_includedInCompleteMultipart() {
+        String customerAlgorithm = "algorithm";
+        String customerKey = "key";
+        String customerKeyMd5 = "keyMd5";
+
+        CopyObjectRequest copyRequest = copyObjectRequest().copy(r -> r.sseCustomerAlgorithm(customerAlgorithm)
+                                                                       .sseCustomerKey(customerKey)
+                                                                       .sseCustomerKeyMD5(customerKeyMd5));
+
+        stubSuccessfulHeadObjectCall(2 * PART_SIZE_BYTES);
+        stubSuccessfulCreateMulipartCall();
+        stubSuccessfulUploadPartCopyCalls();
+        stubSuccessfulCompleteMultipartCall();
+
+        copyHelper.copyObject(copyRequest).join();
+
+        ArgumentCaptor<CompleteMultipartUploadRequest> completeMultipartCaptor =
+            ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+
+        verify(s3AsyncClient).completeMultipartUpload(completeMultipartCaptor.capture());
+
+        CompleteMultipartUploadRequest completeRequest = completeMultipartCaptor.getValue();
+
+        assertThat(completeRequest.sseCustomerAlgorithm()).isEqualTo(customerAlgorithm);
+        assertThat(completeRequest.sseCustomerKey()).isEqualTo(customerKey);
+        assertThat(completeRequest.sseCustomerKeyMD5()).isEqualTo(customerKeyMd5);
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
This commit fixes a bug where the SSE-C parameters are not copied to the CompleteMultipartUpload request when transforming to a multipart copy.

## Modifications
<!--- Describe your changes in detail -->

## Testing
Added new unit test.
One off testing with S3.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
