### PR TITLE
Create a configuration class for SdkPublisher#split

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBodySplitConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBodySplitConfiguration.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import java.util.Objects;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * Configuration options for {@link AsyncRequestBody#split} to configure how the SDK
+ * should split an {@link SdkPublisher}.
+ */
+@SdkPublicApi
+public final class AsyncRequestBodySplitConfiguration implements ToCopyableBuilder<AsyncRequestBodySplitConfiguration.Builder,
+    AsyncRequestBodySplitConfiguration> {
+    private final Long chunkSizeInBytes;
+    private final Long bufferSizeInBytes;
+
+    private AsyncRequestBodySplitConfiguration(DefaultBuilder builder) {
+        this.chunkSizeInBytes = Validate.isPositiveOrNull(builder.chunkSizeInBytes, "chunkSizeInBytes");
+        this.bufferSizeInBytes = Validate.isPositiveOrNull(builder.bufferSizeInBytes, "bufferSizeInBytes");
+    }
+
+    /**
+     * The configured chunk size for each divided {@link AsyncRequestBody}.
+     */
+    public Long chunkSizeInBytes() {
+        return chunkSizeInBytes;
+    }
+
+    /**
+     * The configured maximum buffer size the SDK will use to buffer the content from the source {@link SdkPublisher}.
+     */
+    public Long bufferSizeInBytes() {
+        return bufferSizeInBytes;
+    }
+
+    /**
+     * Create a {@link Builder}, used to create a {@link AsyncRequestBodySplitConfiguration}.
+     */
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AsyncRequestBodySplitConfiguration that = (AsyncRequestBodySplitConfiguration) o;
+
+        if (!Objects.equals(chunkSizeInBytes, that.chunkSizeInBytes)) {
+            return false;
+        }
+        return Objects.equals(bufferSizeInBytes, that.bufferSizeInBytes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = chunkSizeInBytes != null ? chunkSizeInBytes.hashCode() : 0;
+        result = 31 * result + (bufferSizeInBytes != null ? bufferSizeInBytes.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public AsyncRequestBodySplitConfiguration.Builder toBuilder() {
+        return new DefaultBuilder(this);
+    }
+
+    public interface Builder extends CopyableBuilder<AsyncRequestBodySplitConfiguration.Builder,
+        AsyncRequestBodySplitConfiguration>  {
+
+        /**
+         * Configures the size for each divided chunk. The last chunk may be smaller than the configured size. The default value
+         * is 2MB.
+         *
+         * @param chunkSizeInBytes the chunk size in bytes
+         * @return This object for method chaining.
+         */
+        Builder chunkSizeInBytes(Long chunkSizeInBytes);
+
+        /**
+         * The maximum buffer size the SDK will use to buffer the content from the source {@link SdkPublisher}. The default value
+         * is 8MB.
+         *
+         * @param bufferSizeInBytes the buffer size in bytes
+         * @return This object for method chaining.
+         */
+        Builder bufferSizeInBytes(Long bufferSizeInBytes);
+    }
+
+    private static final class DefaultBuilder implements Builder {
+        private Long chunkSizeInBytes;
+        private Long bufferSizeInBytes;
+
+        private DefaultBuilder(AsyncRequestBodySplitConfiguration asyncRequestBodySplitConfiguration) {
+            this.chunkSizeInBytes = asyncRequestBodySplitConfiguration.chunkSizeInBytes;
+            this.bufferSizeInBytes = asyncRequestBodySplitConfiguration.bufferSizeInBytes;
+        }
+
+        private DefaultBuilder() {
+
+        }
+
+        @Override
+        public Builder chunkSizeInBytes(Long chunkSizeInBytes) {
+            this.chunkSizeInBytes = chunkSizeInBytes;
+            return this;
+        }
+
+        @Override
+        public Builder bufferSizeInBytes(Long bufferSizeInBytes) {
+            this.bufferSizeInBytes = bufferSizeInBytes;
+            return this;
+        }
+
+        @Override
+        public AsyncRequestBodySplitConfiguration build() {
+            return new AsyncRequestBodySplitConfiguration(this);
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyConfigurationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class AsyncRequestBodyConfigurationTest {
+
+    @Test
+    void equalsHashCode() {
+        EqualsVerifier.forClass(AsyncRequestBodySplitConfiguration.class)
+                      .verify();
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void nonPositiveValue_shouldThrowException(long size) {
+        assertThatThrownBy(() ->
+                               AsyncRequestBodySplitConfiguration.builder()
+                                                                 .chunkSizeInBytes(size)
+                                                                 .build())
+            .hasMessageContaining("must be positive");
+        assertThatThrownBy(() ->
+                               AsyncRequestBodySplitConfiguration.builder()
+                                                                 .bufferSizeInBytes(size)
+                                                                 .build())
+            .hasMessageContaining("must be positive");
+    }
+
+    @Test
+    void toBuilder_shouldCopyAllFields() {
+        AsyncRequestBodySplitConfiguration config = AsyncRequestBodySplitConfiguration.builder()
+                                                                                     .bufferSizeInBytes(1L)
+                                                                                     .chunkSizeInBytes(2L)
+                                                                                     .build();
+
+        assertThat(config.toBuilder().build()).isEqualTo(config);
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyTest.java
@@ -356,25 +356,4 @@ public class AsyncRequestBodyTest {
         AsyncRequestBody requestBody = AsyncRequestBody.fromPublisher(bodyPublisher);
         assertEquals(Mimetype.MIMETYPE_OCTET_STREAM, requestBody.contentType());
     }
-
-    @Test
-    public void split_nonPositiveInput_shouldThrowException() {
-        AsyncRequestBody body = AsyncRequestBody.fromString("test");
-        assertThatThrownBy(() -> body.split(0, 4)).hasMessageContaining("must be positive");
-        assertThatThrownBy(() -> body.split(-1, 4)).hasMessageContaining("must be positive");
-        assertThatThrownBy(() -> body.split(5, 0)).hasMessageContaining("must be positive");
-        assertThatThrownBy(() -> body.split(5, -1)).hasMessageContaining("must be positive");
-    }
-
-    @Test
-    public void split_contentUnknownMaxMemorySmallerThanChunkSize_shouldThrowException() {
-        AsyncRequestBody body = AsyncRequestBody.fromPublisher(new Publisher<ByteBuffer>() {
-            @Override
-            public void subscribe(Subscriber<? super ByteBuffer> s) {
-
-            }
-        });
-        assertThatThrownBy(() -> body.split(10, 4))
-            .hasMessageContaining("must be larger than or equal");
-    }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
@@ -119,7 +119,8 @@ public final class UploadWithKnownContentLengthHelper {
         MpuRequestContext mpuRequestContext = new MpuRequestContext(request, contentLength, optimalPartSize, uploadId);
 
         request.right()
-               .split(mpuRequestContext.partSize, maxMemoryUsageInBytes)
+               .split(b -> b.chunkSizeInBytes(mpuRequestContext.partSize)
+                            .bufferSizeInBytes(maxMemoryUsageInBytes))
                .subscribe(new KnownContentLengthAsyncRequestBodySubscriber(mpuRequestContext,
                                                                            returnFuture));
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelper.java
@@ -74,8 +74,8 @@ public final class UploadWithUnknownContentLengthHelper {
         CompletableFuture<PutObjectResponse> returnFuture = new CompletableFuture<>();
 
         SdkPublisher<AsyncRequestBody> splitAsyncRequestBodyResponse =
-            asyncRequestBody.split(partSizeInBytes,
-                                   maxMemoryUsageInBytes);
+            asyncRequestBody.split(b -> b.chunkSizeInBytes(partSizeInBytes)
+                                         .bufferSizeInBytes(maxMemoryUsageInBytes));
 
         splitAsyncRequestBodyResponse.subscribe(new UnknownContentLengthAsyncRequestBodySubscriber(partSizeInBytes,
                                                                                                    putObjectRequest,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In the API surface area review meeting, we decided to create a wrapper class for split settings since it's more flexible to add more settings in the future.

## Modifications
Create a configuration class for `SdkPublisher#split`

