### PR TITLE
Add sigv4a for services that have enabled endpoint based auth params

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
@@ -182,19 +182,6 @@ public final class AuthSchemeSpecUtils {
         return Collections.singletonList(intermediateModel.getMetadata().getAuthType());
     }
 
-    public List<AuthType> allServiceAuthTypes() {
-        Set<AuthType> result =
-            intermediateModel.getOperations()
-                             .values()
-                             .stream()
-                             .map(OperationModel::getAuth)
-                             .flatMap(List::stream)
-                             .collect(Collectors.toSet());
-        List<AuthType> modeled = intermediateModel.getMetadata().getAuth();
-        result.addAll(modeled);
-        return result.stream().sorted().collect(Collectors.toList());
-    }
-
     public Set<Class<?>> allServiceConcreteAuthSchemeClasses() {
         Set<Class<?>> result =
             Stream.concat(intermediateModel.getOperations()
@@ -209,7 +196,7 @@ public final class AuthSchemeSpecUtils {
                   .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(Class::getSimpleName))));
 
         if (generateEndpointBasedParams()) {
-            // sigv4a is modeled but needed for the endpoints based auth-scheme cases.
+            // sigv4a is not modeled but needed for the endpoints based auth-scheme cases.
             result.add(AwsV4aAuthScheme.class);
         }
         return result;

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
@@ -195,7 +195,7 @@ public final class AuthSchemeSpecUtils {
                   .filter(Objects::nonNull)
                   .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(Class::getSimpleName))));
 
-        if (generateEndpointBasedParams()) {
+        if (useEndpointBasedAuthProvider()) {
             // sigv4a is not modeled but needed for the endpoints based auth-scheme cases.
             result.add(AwsV4aAuthScheme.class);
         }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
@@ -25,13 +25,17 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.service.AuthType;
 import software.amazon.awssdk.codegen.utils.AuthUtils;
+import software.amazon.awssdk.http.auth.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
 
 public final class AuthSchemeSpecUtils {
@@ -189,6 +193,26 @@ public final class AuthSchemeSpecUtils {
         List<AuthType> modeled = intermediateModel.getMetadata().getAuth();
         result.addAll(modeled);
         return result.stream().sorted().collect(Collectors.toList());
+    }
+
+    public Set<Class<?>> allServiceConcreteAuthSchemeClasses() {
+        Set<Class<?>> result =
+            Stream.concat(intermediateModel.getOperations()
+                                           .values()
+                                           .stream()
+                                           .map(OperationModel::getAuth)
+                                           .flatMap(List::stream),
+                          intermediateModel.getMetadata().getAuth().stream())
+                  .map(AuthSchemeCodegenMetadata::fromAuthType)
+                  .map(AuthSchemeCodegenMetadata::authSchemeClass)
+                  .filter(Objects::nonNull)
+                  .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(Class::getSimpleName))));
+
+        if (generateEndpointBasedParams()) {
+            // sigv4a is modeled but needed for the endpoints based auth-scheme cases.
+            result.add(AwsV4aAuthScheme.class);
+        }
+        return result;
     }
 
     private static Set<String> setOf(String v1, String v2) {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
@@ -60,7 +60,7 @@ public class BuilderClassTest {
 
     @Test
     public void baseClientBuilderClassWithEndpointsAuthParams() {
-        assertThat(new BaseClientBuilderClass(ClientTestModels.serviceMiniS3()), generatesTo("test-client-builder-endpoints-auth-params.java"));
+        assertThat(new BaseClientBuilderClass(ClientTestModels.queryServiceModelsEndpointAuthParamsWithAllowList()), generatesTo("test-client-builder-endpoints-auth-params.java"));
     }
 
     @Test

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
@@ -59,6 +59,11 @@ public class BuilderClassTest {
     }
 
     @Test
+    public void baseClientBuilderClassWithEndpointsAuthParams() {
+        assertThat(new BaseClientBuilderClass(ClientTestModels.serviceMiniS3()), generatesTo("test-client-builder-endpoints-auth-params.java"));
+    }
+
+    @Test
     public void syncClientBuilderInterface() throws Exception {
         validateGeneration(SyncClientBuilderInterface::new, "test-sync-client-builder-interface.java");
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -1,6 +1,8 @@
 package software.amazon.awssdk.services.json;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
@@ -27,7 +29,6 @@ import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointAuthS
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.awssdk.utils.MapUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -108,8 +109,10 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     }
 
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
+        Map<String, AuthScheme<?>> schemes = new HashMap<>(1);
         BearerAuthScheme bearerAuthScheme = BearerAuthScheme.create();
-        return MapUtils.of(bearerAuthScheme.schemeId(), bearerAuthScheme);
+        schemes.put(bearerAuthScheme.schemeId(), bearerAuthScheme);
+        return Collections.unmodifiableMap(schemes);
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -1,6 +1,8 @@
 package software.amazon.awssdk.services.json;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.MyServiceHttpConfig;
@@ -33,7 +35,6 @@ import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEnd
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.awssdk.utils.MapUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -188,9 +189,12 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     }
 
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
+        Map<String, AuthScheme<?>> schemes = new HashMap<>(2);
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
+        schemes.put(awsV4AuthScheme.schemeId(), awsV4AuthScheme);
         BearerAuthScheme bearerAuthScheme = BearerAuthScheme.create();
-        return MapUtils.of(awsV4AuthScheme.schemeId(), awsV4AuthScheme, bearerAuthScheme.schemeId(), bearerAuthScheme);
+        schemes.put(bearerAuthScheme.schemeId(), bearerAuthScheme);
+        return Collections.unmodifiableMap(schemes);
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.json;
+package software.amazon.awssdk.services.minis3;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -7,40 +7,39 @@ import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.auth.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
-import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
-import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
-import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
-import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointAuthSchemeInterceptor;
-import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
-import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
+import software.amazon.awssdk.services.minis3.auth.scheme.MiniS3AuthSchemeProvider;
+import software.amazon.awssdk.services.minis3.auth.scheme.internal.MiniS3AuthSchemeInterceptor;
+import software.amazon.awssdk.services.minis3.endpoints.MiniS3EndpointProvider;
+import software.amazon.awssdk.services.minis3.endpoints.internal.MiniS3EndpointAuthSchemeInterceptor;
+import software.amazon.awssdk.services.minis3.endpoints.internal.MiniS3RequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.minis3.endpoints.internal.MiniS3ResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * Internal base class for {@link DefaultJsonClientBuilder} and {@link DefaultJsonAsyncClientBuilder}.
+ * Internal base class for {@link DefaultMiniS3ClientBuilder} and {@link DefaultMiniS3AsyncClientBuilder}.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
-abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C>, C> extends AwsDefaultClientBuilder<B, C> {
+abstract class DefaultMiniS3BaseClientBuilder<B extends MiniS3BaseClientBuilder<B, C>, C> extends AwsDefaultClientBuilder<B, C> {
     @Override
     protected final String serviceEndpointPrefix() {
-        return "json-service-endpoint";
+        return "mini-s3-service-endpoint";
     }
 
     @Override
     protected final String serviceName() {
-        return "Json";
+        return "MiniS3";
     }
 
     @Override
@@ -53,23 +52,15 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     }
 
     @Override
-    protected final SdkClientConfiguration mergeInternalDefaults(SdkClientConfiguration config) {
-        return config.merge(c -> {
-            c.option(SdkClientOption.INTERNAL_USER_AGENT, "md/foobar");
-            c.option(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD);
-        });
-    }
-
-    @Override
     protected final SdkClientConfiguration finalizeServiceConfiguration(SdkClientConfiguration config) {
         List<ExecutionInterceptor> endpointInterceptors = new ArrayList<>();
-        endpointInterceptors.add(new JsonAuthSchemeInterceptor());
-        endpointInterceptors.add(new JsonResolveEndpointInterceptor());
-        endpointInterceptors.add(new JsonEndpointAuthSchemeInterceptor());
-        endpointInterceptors.add(new JsonRequestSetEndpointInterceptor());
+        endpointInterceptors.add(new MiniS3AuthSchemeInterceptor());
+        endpointInterceptors.add(new MiniS3ResolveEndpointInterceptor());
+        endpointInterceptors.add(new MiniS3EndpointAuthSchemeInterceptor());
+        endpointInterceptors.add(new MiniS3RequestSetEndpointInterceptor());
         ClasspathInterceptorChainFactory interceptorFactory = new ClasspathInterceptorChainFactory();
         List<ExecutionInterceptor> interceptors = interceptorFactory
-                .getInterceptors("software/amazon/awssdk/services/json/execution.interceptors");
+                .getInterceptors("software/amazon/awssdk/services/minis3/execution.interceptors");
         List<ExecutionInterceptor> additionalInterceptors = new ArrayList<>();
         interceptors = CollectionUtils.mergeLists(endpointInterceptors, interceptors);
         interceptors = CollectionUtils.mergeLists(interceptors, additionalInterceptors);
@@ -80,25 +71,25 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     }
 
     private Signer defaultSigner() {
-        return Aws4Signer.create();
+        return AwsS3V4Signer.create();
     }
 
     @Override
     protected final String signingName() {
-        return "json-service";
+        return "mini-s3-service";
     }
 
-    private JsonEndpointProvider defaultEndpointProvider() {
-        return JsonEndpointProvider.defaultProvider();
+    private MiniS3EndpointProvider defaultEndpointProvider() {
+        return MiniS3EndpointProvider.defaultProvider();
     }
 
-    public B authSchemeProvider(JsonAuthSchemeProvider authSchemeProvider) {
+    public B authSchemeProvider(MiniS3AuthSchemeProvider authSchemeProvider) {
         clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER, authSchemeProvider);
         return thisBuilder();
     }
 
-    private JsonAuthSchemeProvider defaultAuthSchemeProvider() {
-        return JsonAuthSchemeProvider.defaultProvider();
+    private MiniS3AuthSchemeProvider defaultAuthSchemeProvider() {
+        return MiniS3AuthSchemeProvider.defaultProvider();
     }
 
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.minis3;
+package software.amazon.awssdk.services.query;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -7,8 +7,11 @@ import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
+import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
@@ -16,30 +19,37 @@ import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.auth.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.AwsV4aAuthScheme;
+import software.amazon.awssdk.http.auth.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
-import software.amazon.awssdk.services.minis3.auth.scheme.MiniS3AuthSchemeProvider;
-import software.amazon.awssdk.services.minis3.auth.scheme.internal.MiniS3AuthSchemeInterceptor;
-import software.amazon.awssdk.services.minis3.endpoints.MiniS3EndpointProvider;
-import software.amazon.awssdk.services.minis3.endpoints.internal.MiniS3EndpointAuthSchemeInterceptor;
-import software.amazon.awssdk.services.minis3.endpoints.internal.MiniS3RequestSetEndpointInterceptor;
-import software.amazon.awssdk.services.minis3.endpoints.internal.MiniS3ResolveEndpointInterceptor;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.TokenIdentity;
+import software.amazon.awssdk.protocols.query.interceptor.QueryParametersToBodyInterceptor;
+import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
+import software.amazon.awssdk.services.query.auth.scheme.internal.QueryAuthSchemeInterceptor;
+import software.amazon.awssdk.services.query.endpoints.QueryClientContextParams;
+import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
+import software.amazon.awssdk.services.query.endpoints.internal.QueryEndpointAuthSchemeInterceptor;
+import software.amazon.awssdk.services.query.endpoints.internal.QueryRequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.query.endpoints.internal.QueryResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * Internal base class for {@link DefaultMiniS3ClientBuilder} and {@link DefaultMiniS3AsyncClientBuilder}.
+ * Internal base class for {@link DefaultQueryClientBuilder} and {@link DefaultQueryAsyncClientBuilder}.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
-abstract class DefaultMiniS3BaseClientBuilder<B extends MiniS3BaseClientBuilder<B, C>, C> extends AwsDefaultClientBuilder<B, C> {
+abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B, C>, C> extends AwsDefaultClientBuilder<B, C> {
     @Override
     protected final String serviceEndpointPrefix() {
-        return "mini-s3-service-endpoint";
+        return "query-service";
     }
 
     @Override
     protected final String serviceName() {
-        return "MiniS3";
+        return "Query";
     }
 
     @Override
@@ -48,59 +58,96 @@ abstract class DefaultMiniS3BaseClientBuilder<B extends MiniS3BaseClientBuilder<
                 .option(SdkClientOption.AUTH_SCHEME_PROVIDER, defaultAuthSchemeProvider())
                 .option(SdkClientOption.AUTH_SCHEMES, defaultAuthSchemes())
                 .option(SdkAdvancedClientOption.SIGNER, defaultSigner())
-                .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false));
+                .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
+                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider())
+                .option(SdkAdvancedClientOption.TOKEN_SIGNER, defaultTokenSigner()));
     }
 
     @Override
     protected final SdkClientConfiguration finalizeServiceConfiguration(SdkClientConfiguration config) {
         List<ExecutionInterceptor> endpointInterceptors = new ArrayList<>();
-        endpointInterceptors.add(new MiniS3AuthSchemeInterceptor());
-        endpointInterceptors.add(new MiniS3ResolveEndpointInterceptor());
-        endpointInterceptors.add(new MiniS3EndpointAuthSchemeInterceptor());
-        endpointInterceptors.add(new MiniS3RequestSetEndpointInterceptor());
+        endpointInterceptors.add(new QueryAuthSchemeInterceptor());
+        endpointInterceptors.add(new QueryResolveEndpointInterceptor());
+        endpointInterceptors.add(new QueryEndpointAuthSchemeInterceptor());
+        endpointInterceptors.add(new QueryRequestSetEndpointInterceptor());
         ClasspathInterceptorChainFactory interceptorFactory = new ClasspathInterceptorChainFactory();
         List<ExecutionInterceptor> interceptors = interceptorFactory
-                .getInterceptors("software/amazon/awssdk/services/minis3/execution.interceptors");
+                .getInterceptors("software/amazon/awssdk/services/query/execution.interceptors");
         List<ExecutionInterceptor> additionalInterceptors = new ArrayList<>();
         interceptors = CollectionUtils.mergeLists(endpointInterceptors, interceptors);
         interceptors = CollectionUtils.mergeLists(interceptors, additionalInterceptors);
         interceptors = CollectionUtils.mergeLists(interceptors, config.option(SdkClientOption.EXECUTION_INTERCEPTORS));
+        List<ExecutionInterceptor> protocolInterceptors = Collections.singletonList(new QueryParametersToBodyInterceptor());
+        interceptors = CollectionUtils.mergeLists(interceptors, protocolInterceptors);
         SdkClientConfiguration.Builder builder = config.toBuilder();
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        IdentityProvider<? extends TokenIdentity> identityProvider = config.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER);
+        if (identityProvider != null) {
+            IdentityProviderConfiguration identityProviderConfig = config.option(SdkClientOption.IDENTITY_PROVIDER_CONFIGURATION);
+            builder.option(SdkClientOption.IDENTITY_PROVIDER_CONFIGURATION, identityProviderConfig.toBuilder()
+                    .putIdentityProvider(identityProvider).build());
+        }
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors).option(SdkClientOption.CLIENT_CONTEXT_PARAMS,
+                clientContextParams.build());
         return builder.build();
     }
 
     private Signer defaultSigner() {
-        return AwsS3V4Signer.create();
+        return Aws4Signer.create();
     }
 
     @Override
     protected final String signingName() {
-        return "mini-s3-service";
+        return "query-service";
     }
 
-    private MiniS3EndpointProvider defaultEndpointProvider() {
-        return MiniS3EndpointProvider.defaultProvider();
+    private QueryEndpointProvider defaultEndpointProvider() {
+        return QueryEndpointProvider.defaultProvider();
     }
 
-    public B authSchemeProvider(MiniS3AuthSchemeProvider authSchemeProvider) {
+    public B authSchemeProvider(QueryAuthSchemeProvider authSchemeProvider) {
         clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER, authSchemeProvider);
         return thisBuilder();
     }
 
-    private MiniS3AuthSchemeProvider defaultAuthSchemeProvider() {
-        return MiniS3AuthSchemeProvider.defaultProvider();
+    private QueryAuthSchemeProvider defaultAuthSchemeProvider() {
+        return QueryAuthSchemeProvider.defaultProvider();
+    }
+
+    public B booleanContextParam(Boolean booleanContextParam) {
+        clientContextParams.put(QueryClientContextParams.BOOLEAN_CONTEXT_PARAM, booleanContextParam);
+        return thisBuilder();
+    }
+
+    public B stringContextParam(String stringContextParam) {
+        clientContextParams.put(QueryClientContextParams.STRING_CONTEXT_PARAM, stringContextParam);
+        return thisBuilder();
+    }
+
+    private IdentityProvider<? extends TokenIdentity> defaultTokenProvider() {
+        return DefaultAwsTokenProvider.create();
+    }
+
+    private Signer defaultTokenSigner() {
+        return BearerTokenSigner.create();
     }
 
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
-        Map<String, AuthScheme<?>> schemes = new HashMap<>(1);
+        Map<String, AuthScheme<?>> schemes = new HashMap<>(3);
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
         schemes.put(awsV4AuthScheme.schemeId(), awsV4AuthScheme);
+        AwsV4aAuthScheme awsV4aAuthScheme = AwsV4aAuthScheme.create();
+        schemes.put(awsV4aAuthScheme.schemeId(), awsV4aAuthScheme);
+        BearerAuthScheme bearerAuthScheme = BearerAuthScheme.create();
+        schemes.put(bearerAuthScheme.schemeId(), bearerAuthScheme);
         return Collections.unmodifiableMap(schemes);
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {
         Validate.notNull(c.option(SdkAdvancedClientOption.SIGNER),
                 "The 'overrideConfiguration.advancedOption[SIGNER]' must be configured in the client builder.");
+        Validate.notNull(c.option(SdkAdvancedClientOption.TOKEN_SIGNER),
+                "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' must be configured in the client builder.");
+        Validate.notNull(c.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER),
+                "The 'tokenProvider' must be configured in the client builder.");
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -2,6 +2,7 @@ package software.amazon.awssdk.services.query;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
@@ -32,7 +33,6 @@ import software.amazon.awssdk.services.query.endpoints.internal.QueryEndpointAut
 import software.amazon.awssdk.services.query.endpoints.internal.QueryRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.awssdk.utils.MapUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -131,9 +131,12 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
     }
 
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
+        Map<String, AuthScheme<?>> schemes = new HashMap<>(2);
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
+        schemes.put(awsV4AuthScheme.schemeId(), awsV4AuthScheme);
         BearerAuthScheme bearerAuthScheme = BearerAuthScheme.create();
-        return MapUtils.of(awsV4AuthScheme.schemeId(), awsV4AuthScheme, bearerAuthScheme.schemeId(), bearerAuthScheme);
+        schemes.put(bearerAuthScheme.schemeId(), bearerAuthScheme);
+        return Collections.unmodifiableMap(schemes);
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4aAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/AwsV4aAuthScheme.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.AuthScheme;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * The <a href="https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4a-trait">aws.auth#sigv4a</a>
+ * auth scheme, which uses a {@link AwsCredentialsIdentity} and AwsV4aHttpSigner.
+ */
+@SdkPublicApi
+public interface AwsV4aAuthScheme extends AuthScheme<AwsCredentialsIdentity> {
+
+    /**
+     * The scheme ID for this interface.
+     */
+    String SCHEME_ID = "aws.auth#sigv4a";
+
+    /**
+     * Get a default implementation of a {@link AwsV4aAuthScheme}
+     */
+    static AwsV4aAuthScheme create() {
+        return new AwsV4aAuthScheme() {
+        };
+    }
+
+    /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return SCHEME_ID;
+    }
+
+    /**
+     * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
+     */
+    @Override
+    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    /**
+     * TODO(sra-identity-and-auth): Not implemented yet.
+     */
+    @Override
+    default HttpSigner<AwsCredentialsIdentity> signer() {
+        throw new UnsupportedOperationException("todo");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

`Sigv4a` is a supported auth scheme for endpoints but not directly modeled. This change adds it if the auth params from endpoints param switch is enabled.

**Note** The scheme currently does not exist but in the CRT package, this change just adds the scheme and the changes to the base client builder, subsequent changes will implement the signer that will dynamically load the required classes as currently done as [`SignerLoader`](https://github.com/aws/aws-sdk-java-v2/blob/efb5655f19cd7dbbbf6f4b5b141c94aaf59abe19/core/auth/src/main/java/software/amazon/awssdk/auth/signer/SignerLoader.java#L30) currently does.

For S3 the generated code in the base client will look like:

```java
    private Map<String, AuthScheme<?>> defaultAuthSchemes() {
        AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
        AwsV4aAuthScheme awsV4aAuthScheme = AwsV4aAuthScheme.create();
        return MapUtils.of(awsV4AuthScheme.schemeId(), awsV4AuthScheme, awsV4aAuthScheme.schemeId(), awsV4aAuthScheme);
    }

```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Added unit tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
