### PR TITLE
Add default methods to AwsServiceClientConfiguration.Builder and SdkServiceClientConfiguration.Builder

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsServiceClientConfiguration.java
@@ -69,21 +69,31 @@ public abstract class AwsServiceClientConfiguration extends SdkServiceClientConf
         /**
          * Return the region
          */
-        Region region();
+        default Region region() {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Configure the region
          */
-        Builder region(Region region);
+        default Builder region(Region region) {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
-        Builder overrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration);
+        default Builder overrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration)  {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
-        Builder endpointOverride(URI endpointOverride);
+        default Builder endpointOverride(URI endpointOverride)  {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
-        Builder endpointProvider(EndpointProvider endpointProvider);
+        default Builder endpointProvider(EndpointProvider endpointProvider)  {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
         AwsServiceClientConfiguration build();

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkServiceClientConfiguration.java
@@ -97,27 +97,39 @@ public abstract class SdkServiceClientConfiguration {
         /**
          * Return the client override configuration
          */
-        ClientOverrideConfiguration overrideConfiguration();
+        default ClientOverrideConfiguration overrideConfiguration() {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Return the endpoint override
          */
-        URI endpointOverride();
+        default URI endpointOverride() {
+            throw new UnsupportedOperationException();
+        }
 
-        EndpointProvider endpointProvider();
+        default EndpointProvider endpointProvider() {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Configure the client override configuration
          */
-        Builder overrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration);
+        default Builder overrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Configure the endpoint override
          */
-        Builder endpointOverride(URI endpointOverride);
+        default Builder endpointOverride(URI endpointOverride) {
+            throw new UnsupportedOperationException();
+        }
 
 
-        Builder endpointProvider(EndpointProvider endpointProvider);
+        default Builder endpointProvider(EndpointProvider endpointProvider) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Build the service client configuration using the configuration on this builder


### PR DESCRIPTION
This allows older client versions to still compile with newer runtime versions.