### PR TITLE
Use old SigningStage logic if Signer is overridden

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
@@ -51,6 +51,7 @@ public final class SignerOverrideUtils {
         return overrideSigner(request, signer.get());
     }
 
+    // Note, this is copied in SigningStage and AsyncSigningStage.
     public static boolean isSignerOverridden(SdkRequest request, ExecutionAttributes executionAttributes) {
         Optional<Boolean> isClientSignerOverridden = Optional.ofNullable(
             executionAttributes.getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
@@ -51,7 +51,9 @@ public final class SignerOverrideUtils {
         return overrideSigner(request, signer.get());
     }
 
-    // Note, this is copied in SigningStage and AsyncSigningStage.
+    /**
+     * Note, this is copied in {@link software.amazon.awssdk.core.internal.http.pipeline.stages.utils.SignerOverrideUtils}.
+     */
     public static boolean isSignerOverridden(SdkRequest request, ExecutionAttributes executionAttributes) {
         Optional<Boolean> isClientSignerOverridden = Optional.ofNullable(
             executionAttributes.getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.http.ExecutionContext;
@@ -31,6 +30,7 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.utils.SignerOverrideUtils;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.signer.AsyncRequestBodySigner;
 import software.amazon.awssdk.core.signer.AsyncSigner;
@@ -236,21 +236,8 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
      * Returns true if we should use SRA signing logic.
      */
     private boolean shouldDoSraSigning(RequestExecutionContext context) {
-        return !isSignerOverridden(context)
+        return !SignerOverrideUtils.isSignerOverridden(context)
                && context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME) != null;
-    }
-
-    // This is (mostly!) copied from SignerOverrideUtils.isSignerOverridden, but that is in aws-core, and this is in sdk-core.
-    // Just this method could be moved to sdk-core somewhere, but the other methods in SignerOverrideUtils depend on AwsRequest
-    // and AwsRequestOverrideConfiguration which are in aws-core. Just duplicating the logic here seemed ok.
-    private static boolean isSignerOverridden(RequestExecutionContext context) {
-        boolean isClientSignerOverridden =
-            Boolean.TRUE.equals(context.executionAttributes().getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
-
-        Optional<Signer> requestSigner = context.originalRequest()
-                                                .overrideConfiguration()
-                                                .flatMap(RequestOverrideConfiguration::signer);
-        return isClientSignerOverridden || requestSigner.isPresent();
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
@@ -240,16 +240,17 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
                && context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME) != null;
     }
 
-    // This is copied from SignerOverrideUtils.isSignerOverridden, but that is in aws-core, and this is in sdk-core.
+    // This is (mostly!) copied from SignerOverrideUtils.isSignerOverridden, but that is in aws-core, and this is in sdk-core.
     // Just this method could be moved to sdk-core somewhere, but the other methods in SignerOverrideUtils depend on AwsRequest
     // and AwsRequestOverrideConfiguration which are in aws-core. Just duplicating the logic here seemed ok.
     private static boolean isSignerOverridden(RequestExecutionContext context) {
-        Optional<Boolean> isClientSignerOverridden = Optional.ofNullable(
-            context.executionAttributes().getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
+        boolean isClientSignerOverridden =
+            Boolean.TRUE.equals(context.executionAttributes().getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
+
         Optional<Signer> requestSigner = context.originalRequest()
                                                 .overrideConfiguration()
                                                 .flatMap(RequestOverrideConfiguration::signer);
-        return isClientSignerOverridden.isPresent() || requestSigner.isPresent();
+        return isClientSignerOverridden || requestSigner.isPresent();
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -16,8 +16,10 @@
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.http.ExecutionContext;
@@ -62,7 +64,7 @@ public class SigningStage implements RequestToRequestPipeline {
     @Override
     public SdkHttpFullRequest execute(SdkHttpFullRequest request, RequestExecutionContext context) throws Exception {
         InterruptMonitor.checkInterrupted();
-        if (shouldUseSelectedAuthScheme(context)) {
+        if (shouldDoSraSigning(context)) {
             return sraSignRequest(request,
                                   context,
                                   context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME));
@@ -176,10 +178,23 @@ public class SigningStage implements RequestToRequestPipeline {
     }
 
     /**
-     * Returns true if we should use the selected out scheme attribute for signing.
+     * Returns true if we should use SRA signing logic.
      */
-    private boolean shouldUseSelectedAuthScheme(RequestExecutionContext context) {
-        return context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME) != null;
+    private boolean shouldDoSraSigning(RequestExecutionContext context) {
+        return !isSignerOverridden(context)
+               && context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME) != null;
+    }
+
+    // This is copied from SignerOverrideUtils.isSignerOverridden, but that is in aws-core, and this is in sdk-core.
+    // Just this method could be moved to sdk-core somewhere, but the other methods in SignerOverrideUtils depend on AwsRequest
+    // and AwsRequestOverrideConfiguration which are in aws-core. Just duplicating the logic here seemed ok.
+    private static boolean isSignerOverridden(RequestExecutionContext context) {
+        Optional<Boolean> isClientSignerOverridden = Optional.ofNullable(
+            context.executionAttributes().getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
+        Optional<Signer> requestSigner = context.originalRequest()
+                                                .overrideConfiguration()
+                                                .flatMap(RequestOverrideConfiguration::signer);
+        return isClientSignerOverridden.isPresent() || requestSigner.isPresent();
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -185,16 +185,17 @@ public class SigningStage implements RequestToRequestPipeline {
                && context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME) != null;
     }
 
-    // This is copied from SignerOverrideUtils.isSignerOverridden, but that is in aws-core, and this is in sdk-core.
+    // This is (mostly!) copied from SignerOverrideUtils.isSignerOverridden, but that is in aws-core, and this is in sdk-core.
     // Just this method could be moved to sdk-core somewhere, but the other methods in SignerOverrideUtils depend on AwsRequest
     // and AwsRequestOverrideConfiguration which are in aws-core. Just duplicating the logic here seemed ok.
     private static boolean isSignerOverridden(RequestExecutionContext context) {
-        Optional<Boolean> isClientSignerOverridden = Optional.ofNullable(
-            context.executionAttributes().getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
+        boolean isClientSignerOverridden =
+            Boolean.TRUE.equals(context.executionAttributes().getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
+
         Optional<Signer> requestSigner = context.originalRequest()
                                                 .overrideConfiguration()
                                                 .flatMap(RequestOverrideConfiguration::signer);
-        return isClientSignerOverridden.isPresent() || requestSigner.isPresent();
+        return isClientSignerOverridden || requestSigner.isPresent();
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/SignerOverrideUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/SignerOverrideUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages.utils;
+
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncSigningStage;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.SigningStage;
+import software.amazon.awssdk.core.signer.Signer;
+
+/**
+ * Utility to share across {@link SigningStage} and {@link AsyncSigningStage}.
+ */
+@SdkInternalApi
+public final class SignerOverrideUtils {
+
+    private SignerOverrideUtils() {
+    }
+
+    // This is (mostly) same as software.amazon.awssdk.awscore.util.SignerOverrideUtils.isSignerOverridden, but since that
+    // is in aws-core, and this is in sdk-core, copied here. It is "mostly" because it changes the SIGNER_OVERRIDDEN check to
+    // `true` instead of just isPresent().
+    public static boolean isSignerOverridden(RequestExecutionContext context) {
+        boolean isClientSignerOverridden =
+            Boolean.TRUE.equals(context.executionAttributes().getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
+
+        Optional<Signer> requestSigner = context.originalRequest()
+                                                .overrideConfiguration()
+                                                .flatMap(RequestOverrideConfiguration::signer);
+        return isClientSignerOverridden || requestSigner.isPresent();
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AsyncSignerOverrideTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AsyncSignerOverrideTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedClientOption.SIGNER;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -36,13 +37,12 @@ import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOper
  * Test to ensure that operations that use the {@link software.amazon.awssdk.auth.signer.AsyncAws4Signer} don't apply
  * the override when the signer is overridden by the customer.
  */
-//@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class AsyncSignerOverrideTest {
     @Mock
     public Signer mockSigner;
 
-    // TODO(sra-identity-and-auth): This test no longer works, we will fix this in the signing stage and re-enable when fixed.
-    //@Test
+    @Test
     public void test_signerOverriddenForStreamingInput_takesPrecedence() {
         ProtocolRestJsonAsyncClient asyncClient = ProtocolRestJsonAsyncClient.builder()
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
@@ -58,4 +58,10 @@ public class AsyncSignerOverrideTest {
 
         verify(mockSigner).sign(any(SdkHttpFullRequest.class), any(ExecutionAttributes.class));
     }
+
+    // TODO(sra-identity-and-auth): Does adding a test with SRA way of overriding signer here makes sense? Probably useful as a
+    //  general test of SRAs support of provider your own signer, though not specific to the overriding of of AsyncAws4Signer.
+    //  Maybe still makes sense, by asserting that signAsync is called for streaming input operation (may belong to a different
+    //  test class)?
+
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AsyncSignerOverrideTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AsyncSignerOverrideTest.java
@@ -59,9 +59,9 @@ public class AsyncSignerOverrideTest {
         verify(mockSigner).sign(any(SdkHttpFullRequest.class), any(ExecutionAttributes.class));
     }
 
-    // TODO(sra-identity-and-auth): Does adding a test with SRA way of overriding signer here makes sense? Probably useful as a
-    //  general test of SRAs support of provider your own signer, though not specific to the overriding of of AsyncAws4Signer.
-    //  Maybe still makes sense, by asserting that signAsync is called for streaming input operation (may belong to a different
-    //  test class)?
+    // TODO(sra-identity-and-auth): Add test for SRA way of overriding signer to assert that overridden signer is used.
+    //  To do this, need ability to inject AuthScheme which uses mock HttpSigner. This is pending https://i.amazon.com/SMITHY-1450
+    //  At that point, rename this class to SignerOverrideTest, not specific to AsyncSignerOverride (which was for operation
+    //  level codegen changes).
 
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/ProfileFileConfigurationTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/ProfileFileConfigurationTest.java
@@ -41,8 +41,7 @@ import software.amazon.awssdk.utils.StringInputStream;
 
 public class ProfileFileConfigurationTest {
 
-    // TODO(sra-identity-and-auth): This test no longer works, we will fix this in the signing stage and re-enable when fixed.
-    //@Test
+    @Test
     public void profileIsHonoredForCredentialsAndRegion() {
         EnvironmentVariableHelper.run(env -> {
             env.remove(SdkSystemSetting.AWS_REGION);
@@ -103,4 +102,8 @@ public class ProfileFileConfigurationTest {
                           .type(ProfileFile.Type.CONFIGURATION)
                           .build();
     }
+
+    // TODO(sra-identity-and-auth): Should add test for the same using SRA way, to assert the identity in SignRequest and
+    //  region SignerProperty are per profile.
+    //  To do this, need ability to inject AuthScheme which uses mock HttpSigner. This is pending https://i.amazon.com/SMITHY-1450
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
@@ -15,6 +15,11 @@
 
 package software.amazon.awssdk.services.protocolrestjson;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,12 +39,6 @@ import software.amazon.awssdk.services.protocolrestjson.model.EventStreamOperati
 import software.amazon.awssdk.services.protocolrestjson.model.EventStreamOperationResponseHandler;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
-
-import java.util.concurrent.CompletableFuture;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 /**
  * Test to ensure that cancelling the future returned for an async operation will cancel the future returned by the async HTTP client.
@@ -91,8 +90,10 @@ public class AsyncOperationCancelTest {
         assertThat(executeFuture.isCancelled()).isTrue();
     }
 
-    // TODO(sra-identity-and-auth): This test hangs after the changes to use the AuthSchemeProvider
-    // @Test
+    // TODO(sra-identity-and-auth): This test passes now (8/4/2023) because current client codegen uses signer override for
+    //  event stream operation. But with subsequent codegen changes for SRA, event stream won't have a signer override. And we may
+    //  need to check that this test still works.
+    @Test
     public void testEventStreamingOperation() {
         CompletableFuture<Void> responseFuture = client.eventStreamOperation(r -> {
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Pre SRA, customer can provide their own Signer. This will be deprecated with SRA, where customer can provide their own HttpSigner (new interface) via configuring AuthScheme. But for customers that are still using the old approach, it needs to continue to work and override the signer setup via new SRA code.

## Modifications
<!--- Describe your changes in detail -->
To support old signer override, leaving the previous signer logic in (Async)SigningStage as is and branching to it, if signer is overridden.
Currently, signer is considered overridden in 2 cases: 1. by customer specifiying signer explicitly, 2. but also via older codegen that used different signer for certain operations than the client's default signer for cases like event streaming , etc. In subsequent PRs, with SRA, these operations specific signer overrides will go away, so isSignerOverridden is represent only customer overridden signer.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This allows us to re-enable some tests that were disabled earlier in https://github.com/aws/aws-sdk-java-v2/pull/4220#discussion_r1272531389.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
