### PR TITLE
Fix immutableCopyOf bug

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-5ae7899.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-5ae7899.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fixed bug where limit was not copied over when cloning ByteBuffer using immutableCopyOf()"
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/BinaryUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/BinaryUtils.java
@@ -133,12 +133,12 @@ public final class BinaryUtils {
         if (bb == null) {
             return null;
         }
-        int sourceBufferPosition = bb.position();
         ByteBuffer readOnlyCopy = bb.asReadOnlyBuffer();
         readOnlyCopy.rewind();
         ByteBuffer cloned = ByteBuffer.allocate(readOnlyCopy.capacity())
                                       .put(readOnlyCopy);
-        cloned.position(sourceBufferPosition);
+        cloned.position(bb.position());
+        cloned.limit(bb.limit());
         return cloned.asReadOnlyBuffer();
     }
 

--- a/utils/src/test/java/software/amazon/awssdk/utils/BinaryUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/BinaryUtilsTest.java
@@ -227,6 +227,17 @@ public class BinaryUtilsTest {
     }
 
     @Test
+    public void immutableCopyOf_retainsOriginalLimit() {
+        ByteBuffer sourceBuffer = ByteBuffer.allocate(10);
+        byte[] bytes = {1, 2, 3, 4};
+        sourceBuffer.put(bytes);
+        sourceBuffer.rewind();
+        sourceBuffer.limit(bytes.length);
+        ByteBuffer copy = BinaryUtils.immutableCopyOf(sourceBuffer);
+        assertThat(copy.limit()).isEqualTo(sourceBuffer.limit());
+    }
+
+    @Test
     public void testImmutableCopyOfByteBuffer_nullBuffer() {
         assertNull(BinaryUtils.immutableCopyOf(null));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Limit is not copied over when cloning ByteBuffer using `BinaryUtils.immutableCopyOf()`
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws/aws-sdk-java-v2/issues/4166

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
