### PR TITLE
Fix for Issue #4156 : Single quotes in toJson conversions for EnhancedDocuments are no longer being escaped.

### DIFF
--- a/.changes/next-release/bugfix-AWSDynamoDBEnhancedClient-8706d14.json
+++ b/.changes/next-release/bugfix-AWSDynamoDBEnhancedClient-8706d14.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Fix for Issue [#4156](https://github.com/aws/aws-sdk-java-v2/issues/4156) : Single quotes in toJson conversions for EnhancedDocuments are no longer being escaped."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/JsonStringFormatHelper.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/JsonStringFormatHelper.java
@@ -74,9 +74,6 @@ public final class JsonStringFormatHelper {
                 case '\"':
                     output.append("\\\""); // double-quote character
                     break;
-                case '\'':
-                    output.append("\\'"); // single-quote character
-                    break;
                 default:
                     output.append(ch);
                     break;


### PR DESCRIPTION
Fix for Issue [#4156](https://github.com/aws/aws-sdk-java-v2/issues/4156) : Single quotes in toJson conversions for EnhancedDocuments are no longer being escaped.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws/aws-sdk-java-v2/issues/4156


## Modifications
<!--- Describe your changes in detail -->
- The single quotes should not be escaped.
- Tested the behavior in V1 and confirmed single quotes not escaped

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits with ObjectMapper to test valid Jsons with escaped characters.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
