### PR TITLE
Remove SignerOverride related codegen logic

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -37,7 +37,6 @@ import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.model.rules.endpoints.EndpointTestSuiteModel;
-import software.amazon.awssdk.codegen.model.service.AuthType;
 import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
 import software.amazon.awssdk.codegen.model.service.Operation;
 import software.amazon.awssdk.codegen.model.service.Paginators;
@@ -162,7 +161,6 @@ public class IntermediateModelBuilder {
 
         linkMembersToShapes(trimmedModel);
         linkOperationsToInputOutputShapes(trimmedModel);
-        linkCustomAuthorizationToRequestShapes(trimmedModel);
 
         setSimpleMethods(trimmedModel);
 
@@ -201,44 +199,6 @@ public class IntermediateModelBuilder {
                     model.getShapeByNameAndC2jName(entry.getValue().getReturnType().getReturnType(), outputShapeName);
                 entry.getValue().setOutputShape(outputShape);
             }
-        }
-    }
-
-    private void linkCustomAuthorizationToRequestShapes(IntermediateModel model) {
-        model.getOperations().values().stream()
-             .filter(OperationModel::isAuthenticated)
-             .forEach(operation -> {
-                 Operation c2jOperation = service.getOperation(operation.getOperationName());
-
-                 ShapeModel shape = operation.getInputShape();
-                 if (shape == null) {
-                     throw new RuntimeException(String.format("Operation %s has unknown input shape",
-                                                              operation.getOperationName()));
-                 }
-
-                 linkAuthorizationToRequestShapeForAwsProtocol(c2jOperation.getAuthtype(), shape);
-             });
-    }
-
-    private void linkAuthorizationToRequestShapeForAwsProtocol(AuthType authType, ShapeModel shape) {
-        if (authType == null) {
-            return;
-        }
-
-        switch (authType) {
-            case V4:
-                shape.setRequestSignerClassFqcn("software.amazon.awssdk.auth.signer.Aws4Signer");
-                break;
-            case V4_UNSIGNED_BODY:
-                shape.setRequestSignerClassFqcn("software.amazon.awssdk.auth.signer.Aws4UnsignedPayloadSigner");
-                break;
-            case BEARER:
-                shape.setRequestSignerClassFqcn("software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner");
-                break;
-            case NONE:
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported authtype for AWS Request: " + authType);
         }
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
@@ -280,14 +280,4 @@ public final class IntermediateModel {
     public boolean hasWaiters() {
         return waiters.size() > 0;
     }
-
-    public boolean containsRequestSigners() {
-        return getShapes().values().stream()
-                          .anyMatch(ShapeModel::isRequestSignerAware);
-    }
-
-    public boolean containsRequestEventStreams() {
-        return getOperations().values().stream()
-                              .anyMatch(OperationModel::hasEventStreamInput);
-    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
@@ -48,7 +48,6 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
     private boolean hasRequiresLengthMember;
     private boolean wrapper;
     private boolean simpleMethod;
-    private String requestSignerClassFqcn;
     private EndpointDiscovery endpointDiscovery;
 
     private List<MemberModel> members;
@@ -562,18 +561,6 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
 
     public void setHttpStatusCode(Integer httpStatusCode) {
         this.httpStatusCode = httpStatusCode;
-    }
-
-    public boolean isRequestSignerAware() {
-        return requestSignerClassFqcn != null;
-    }
-
-    public String getRequestSignerClassFqcn() {
-        return requestSignerClassFqcn;
-    }
-
-    public void setRequestSignerClassFqcn(String authorizerClass) {
-        this.requestSignerClassFqcn = authorizerClass;
     }
 
     public EndpointDiscovery getEndpointDiscovery() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -25,7 +25,6 @@ import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.internal.Constant.EVENT_PUBLISHER_PARAM_NAME;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.addS3ArnableFieldCode;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applyPaginatorUserAgentMethod;
-import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applySignerOverrideMethod;
 import static software.amazon.awssdk.codegen.poet.client.SyncClientClass.getProtocolSpecs;
 
 import com.squareup.javapoet.ClassName;
@@ -51,7 +50,6 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.AsyncAws4Signer;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
@@ -63,7 +61,6 @@ import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
-import software.amazon.awssdk.codegen.model.service.AuthType;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.StaticImport;
@@ -159,11 +156,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
 
         if (model.hasPaginators()) {
             type.addMethod(applyPaginatorUserAgentMethod(poetExtensions, model));
-        }
-
-        if (model.containsRequestSigners() || model.containsRequestEventStreams() || hasStreamingV4AuthOperations()) {
-            type.addMethod(applySignerOverrideMethod(poetExtensions, model));
-            type.addMethod(isSignerOverriddenOnClientMethod());
         }
 
         protocolSpec.createErrorResponseHandler().ifPresent(type::addMethod);
@@ -334,12 +326,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
                                  Void.class,
                                  "endOfStreamFuture",
                                  "pair");
-        }
-        
-        if (shouldUseAsyncWithBodySigner(opModel)) {
-            builder.addCode(applyAsyncWithBodyV4SignerOverride(opModel));
-        } else {
-            builder.addCode(ClientClassUtils.callApplySignerOverrideMethod(opModel));
         }
 
         builder.addCode(protocolSpec.responseHandler(model, opModel));
@@ -546,43 +532,4 @@ public final class AsyncClientClass extends AsyncClientInterface {
         return methodBuilder.build();
     }
 
-    private boolean shouldUseAsyncWithBodySigner(OperationModel opModel) {
-        if (opModel.getInputShape().getRequestSignerClassFqcn() != null) {
-            return false;
-        }
-
-        AuthType authTypeForOperation = opModel.getAuthType();
-
-        if (authTypeForOperation == null) {
-            authTypeForOperation = model.getMetadata().getAuthType();
-        }
-
-        return authTypeForOperation == AuthType.V4 && opModel.hasStreamingInput();
-    }
-
-    private CodeBlock applyAsyncWithBodyV4SignerOverride(OperationModel opModel) {
-        return CodeBlock.builder()
-                .beginControlFlow("if (!isSignerOverridden($N))", "clientConfiguration")
-                .addStatement("$1L = applySignerOverride($1L, $2T.create())",
-                        opModel.getInput().getVariableName(), AsyncAws4Signer.class)
-                .endControlFlow()
-                .build();
-    }
-
-    private MethodSpec isSignerOverriddenOnClientMethod() {
-        String clientConfigurationName = "clientConfiguration";
-
-        return MethodSpec.methodBuilder("isSignerOverridden")
-                .returns(boolean.class)
-                .addModifiers(PRIVATE, STATIC)
-                .addParameter(SdkClientConfiguration.class, clientConfigurationName)
-                .addStatement("return $T.TRUE.equals($N.option($T.$N))", Boolean.class, clientConfigurationName,
-                        SdkClientOption.class, "SIGNER_OVERRIDDEN")
-                .build();
-    }
-
-    private boolean hasStreamingV4AuthOperations() {
-        return model.getOperations().values().stream()
-                .anyMatch(this::shouldUseAsyncWithBodySigner);
-    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -30,18 +30,14 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.arns.Arn;
-import software.amazon.awssdk.auth.signer.EventStreamAws4Signer;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.codegen.model.config.customization.S3ArnableFieldConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
-import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.model.service.HostPrefixProcessor;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
-import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.core.ApiName;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.utils.HostnameValidator;
 import software.amazon.awssdk.utils.StringUtils;
@@ -117,60 +113,6 @@ final class ClientClassUtils {
                          .addCode(codeBlock)
                          .returns(typeVariableName)
                          .build();
-    }
-
-    static MethodSpec applySignerOverrideMethod(PoetExtension poetExtensions, IntermediateModel model) {
-        String signerOverrideVariable = "signerOverride";
-
-        TypeVariableName typeVariableName =
-            TypeVariableName.get("T", poetExtensions.getModelClass(model.getSdkRequestBaseClassName()));
-
-        ParameterizedTypeName parameterizedTypeName = ParameterizedTypeName
-            .get(ClassName.get(Consumer.class), ClassName.get(AwsRequestOverrideConfiguration.Builder.class));
-
-        CodeBlock codeBlock = CodeBlock.builder()
-                                       .beginControlFlow("if (request.overrideConfiguration().flatMap(c -> c.signer())"
-                                                         + ".isPresent())")
-                                       .addStatement("return request")
-                                       .endControlFlow()
-                                       .addStatement("$T $L = b -> b.signer(signer).build()",
-                                                     parameterizedTypeName,
-                                                     signerOverrideVariable)
-                                       .addStatement("$1T overrideConfiguration =\n"
-                                                     + "            request.overrideConfiguration().map(c -> c.toBuilder()"
-                                                     + ".applyMutation($2L).build())\n"
-                                                     + "            .orElse((AwsRequestOverrideConfiguration.builder()"
-                                                     + ".applyMutation($2L).build()))",
-                                                     AwsRequestOverrideConfiguration.class,
-                                                     signerOverrideVariable)
-                                       .addStatement("return (T) request.toBuilder().overrideConfiguration"
-                                                     + "(overrideConfiguration).build()")
-                                       .build();
-
-        return MethodSpec.methodBuilder("applySignerOverride")
-                         .addModifiers(Modifier.PRIVATE)
-                         .addParameter(typeVariableName, "request")
-                         .addParameter(Signer.class, "signer")
-                         .addTypeVariable(typeVariableName)
-                         .addCode(codeBlock)
-                         .returns(typeVariableName)
-                         .build();
-    }
-
-    static CodeBlock callApplySignerOverrideMethod(OperationModel opModel) {
-        CodeBlock.Builder code = CodeBlock.builder();
-        ShapeModel inputShape = opModel.getInputShape();
-
-        if (inputShape.getRequestSignerClassFqcn() != null) {
-            code.addStatement("$1L = applySignerOverride($1L, $2T.create())",
-                              opModel.getInput().getVariableName(),
-                              PoetUtils.classNameFromFqcn(inputShape.getRequestSignerClassFqcn()));
-        } else if (opModel.hasEventStreamInput()) {
-            code.addStatement("$1L = applySignerOverride($1L, $2T.create())",
-                              opModel.getInput().getVariableName(), EventStreamAws4Signer.class);
-        }
-
-        return code.build();
     }
 
     static CodeBlock addEndpointTraitCode(OperationModel opModel) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -22,7 +22,6 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.addS3ArnableFieldCode;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applyPaginatorUserAgentMethod;
-import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applySignerOverrideMethod;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
@@ -120,10 +119,6 @@ public class SyncClientClass extends SyncClientInterface {
 
         if (model.hasPaginators()) {
             type.addMethod(applyPaginatorUserAgentMethod(poetExtensions, model));
-        }
-
-        if (model.containsRequestSigners()) {
-            type.addMethod(applySignerOverrideMethod(poetExtensions, model));
         }
 
         model.getEndpointOperation().ifPresent(
@@ -224,7 +219,6 @@ public class SyncClientClass extends SyncClientInterface {
 
         MethodSpec.Builder method = SyncClientInterface.operationMethodSignature(model, opModel)
                                                        .addAnnotation(Override.class)
-                                                       .addCode(ClientClassUtils.callApplySignerOverrideMethod(opModel))
                                                        .addCode(protocolSpec.responseHandler(model, opModel));
 
         protocolSpec.errorResponseHandler(opModel).ifPresent(method::addCode);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -13,9 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.AsyncAws4Signer;
-import software.amazon.awssdk.auth.signer.Aws4UnsignedPayloadSigner;
-import software.amazon.awssdk.auth.signer.EventStreamAws4Signer;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
 import software.amazon.awssdk.awscore.client.handler.AwsClientHandlerUtils;
@@ -43,7 +40,6 @@ import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
@@ -298,7 +294,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         try {
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "EventStreamOperation");
-            eventStreamOperationRequest = applySignerOverride(eventStreamOperationRequest, EventStreamAws4Signer.create());
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
                                                                            .isPayloadJson(true).build();
 
@@ -389,8 +384,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         try {
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "EventStreamOperationWithOnlyInput");
-            eventStreamOperationWithOnlyInputRequest = applySignerOverride(eventStreamOperationWithOnlyInputRequest,
-                                                                           EventStreamAws4Signer.create());
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
                                                                            .isPayloadJson(true).build();
 
@@ -984,9 +977,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         try {
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "StreamingInputOperation");
-            if (!isSignerOverridden(clientConfiguration)) {
-                streamingInputOperationRequest = applySignerOverride(streamingInputOperationRequest, AsyncAws4Signer.create());
-            }
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
                                                                            .isPayloadJson(true).build();
 
@@ -1060,8 +1050,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                 .wrapWithEndOfStreamFuture(asyncResponseTransformer);
             asyncResponseTransformer = pair.left();
             CompletableFuture<Void> endOfStreamFuture = pair.right();
-            streamingInputOutputOperationRequest = applySignerOverride(streamingInputOutputOperationRequest,
-                                                                       Aws4UnsignedPayloadSigner.create());
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(true)
                                                                            .isPayloadJson(false).build();
 
@@ -1226,21 +1214,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                                                                        .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
                                                                        .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
         return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
-    }
-
-    private <T extends JsonRequest> T applySignerOverride(T request, Signer signer) {
-        if (request.overrideConfiguration().flatMap(c -> c.signer()).isPresent()) {
-            return request;
-        }
-        Consumer<AwsRequestOverrideConfiguration.Builder> signerOverride = b -> b.signer(signer).build();
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(signerOverride).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
-    }
-
-    private static boolean isSignerOverridden(SdkClientConfiguration clientConfiguration) {
-        return Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.SIGNER_OVERRIDDEN));
     }
 
     private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -6,14 +6,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.AsyncAws4Signer;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.CredentialType;
@@ -31,7 +27,6 @@ import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -57,7 +52,6 @@ import software.amazon.awssdk.services.query.model.OperationWithStaticContextPar
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.query.model.QueryException;
-import software.amazon.awssdk.services.query.model.QueryRequest;
 import software.amazon.awssdk.services.query.model.StreamingInputOperationRequest;
 import software.amazon.awssdk.services.query.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.query.model.StreamingOutputOperationRequest;
@@ -249,7 +243,6 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
         try {
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Query Service");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "BearerAuthOperation");
-            bearerAuthOperationRequest = applySignerOverride(bearerAuthOperationRequest, BearerTokenSigner.create());
 
             HttpResponseHandler<BearerAuthOperationResponse> responseHandler = protocolFactory
                 .createResponseHandler(BearerAuthOperationResponse::builder);
@@ -599,9 +592,6 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
                 .wrapWithEndOfStreamFuture(asyncResponseTransformer);
             asyncResponseTransformer = pair.left();
             CompletableFuture<Void> endOfStreamFuture = pair.right();
-            if (!isSignerOverridden(clientConfiguration)) {
-                putOperationWithChecksumRequest = applySignerOverride(putOperationWithChecksumRequest, AsyncAws4Signer.create());
-            }
 
             HttpResponseHandler<PutOperationWithChecksumResponse> responseHandler = protocolFactory
                 .createResponseHandler(PutOperationWithChecksumResponse::builder);
@@ -680,9 +670,6 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
         try {
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Query Service");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "StreamingInputOperation");
-            if (!isSignerOverridden(clientConfiguration)) {
-                streamingInputOperationRequest = applySignerOverride(streamingInputOperationRequest, AsyncAws4Signer.create());
-            }
 
             HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory
                 .createResponseHandler(StreamingInputOperationResponse::builder);
@@ -819,21 +806,6 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
             publishers = Collections.emptyList();
         }
         return publishers;
-    }
-
-    private <T extends QueryRequest> T applySignerOverride(T request, Signer signer) {
-        if (request.overrideConfiguration().flatMap(c -> c.signer()).isPresent()) {
-            return request;
-        }
-        Consumer<AwsRequestOverrideConfiguration.Builder> signerOverride = b -> b.signer(signer).build();
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(signerOverride).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
-    }
-
-    private static boolean isSignerOverridden(SdkClientConfiguration clientConfiguration) {
-        return Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.SIGNER_OVERRIDDEN));
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -2,11 +2,8 @@ package software.amazon.awssdk.services.query;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.CredentialType;
@@ -22,7 +19,6 @@ import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -50,7 +46,6 @@ import software.amazon.awssdk.services.query.model.OperationWithStaticContextPar
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.query.model.QueryException;
-import software.amazon.awssdk.services.query.model.QueryRequest;
 import software.amazon.awssdk.services.query.model.StreamingInputOperationRequest;
 import software.amazon.awssdk.services.query.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.query.model.StreamingOutputOperationRequest;
@@ -210,7 +205,6 @@ final class DefaultQueryClient implements QueryClient {
     @Override
     public BearerAuthOperationResponse bearerAuthOperation(BearerAuthOperationRequest bearerAuthOperationRequest)
         throws AwsServiceException, SdkClientException, QueryException {
-        bearerAuthOperationRequest = applySignerOverride(bearerAuthOperationRequest, BearerTokenSigner.create());
 
         HttpResponseHandler<BearerAuthOperationResponse> responseHandler = protocolFactory
             .createResponseHandler(BearerAuthOperationResponse::builder);
@@ -670,17 +664,6 @@ final class DefaultQueryClient implements QueryClient {
     @Override
     public QueryWaiter waiter() {
         return QueryWaiter.builder().client(this).build();
-    }
-
-    private <T extends QueryRequest> T applySignerOverride(T request, Signer signer) {
-        if (request.overrideConfiguration().flatMap(c -> c.signer()).isPresent()) {
-            return request;
-        }
-        Consumer<AwsRequestOverrideConfiguration.Builder> signerOverride = b -> b.signer(signer).build();
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(signerOverride).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -2,11 +2,8 @@ package software.amazon.awssdk.services.xml;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.CredentialType;
@@ -23,7 +20,6 @@ import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -52,7 +48,6 @@ import software.amazon.awssdk.services.xml.model.StreamingInputOperationResponse
 import software.amazon.awssdk.services.xml.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.xml.model.StreamingOutputOperationResponse;
 import software.amazon.awssdk.services.xml.model.XmlException;
-import software.amazon.awssdk.services.xml.model.XmlRequest;
 import software.amazon.awssdk.services.xml.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.BearerAuthOperationRequestMarshaller;
@@ -200,8 +195,6 @@ final class DefaultXmlClient implements XmlClient {
     @Override
     public BearerAuthOperationResponse bearerAuthOperation(BearerAuthOperationRequest bearerAuthOperationRequest)
         throws AwsServiceException, SdkClientException, XmlException {
-        bearerAuthOperationRequest = applySignerOverride(bearerAuthOperationRequest, BearerTokenSigner.create());
-
         HttpResponseHandler<Response<BearerAuthOperationResponse>> responseHandler = protocolFactory
             .createCombinedResponseHandler(BearerAuthOperationResponse::builder,
                                            new XmlOperationMetadata().withHasStreamingSuccessResponse(false));
@@ -550,17 +543,6 @@ final class DefaultXmlClient implements XmlClient {
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
-    }
-
-    private <T extends XmlRequest> T applySignerOverride(T request, Signer signer) {
-        if (request.overrideConfiguration().flatMap(c -> c.signer()).isPresent()) {
-            return request;
-        }
-        Consumer<AwsRequestOverrideConfiguration.Builder> signerOverride = b -> b.signer(signer).build();
-        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(signerOverride).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
-        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently, `Client`s are setup with a default signer, which is overridden for certain operations:
* unsigned payload
* event streaming
* async v4 streaming 
* have different authType than service.

With SRA, we do not have separate signers, the AwsV4HttpSigner interface supports all the sigv4 use cases, so this type of signer override is not needed in generated clients. And different authType than service (e.g., bearerToken, as opposed to sigv4) is supported by AuthSchemeProvider logic which is operation aware.

Note, customer can still override the default `Signer` at the client/request level, which will result in SIGNER_OVERRIDDEN=true, and that will continue to be supported at that's a public interface (but will be marked deprecated) and old clients may still use it. This PR just takes out the concept of automatic signer overrides within the client.

Note, old `Signer` itself isn't needed to be configured on the client as the default signer too, as with SRA, signers are configured via AuthSchemes, which is already added to generated clients. But will remove those in a separate PR.

## Modifications
<!--- Describe your changes in detail -->
Delete a bunch of unneeded code! IMO, that code was also complex and icky - if an operation needed signer different from client, it was setup by abusing RequestOverrideConfiguration. It's a good outcome to delete that code!

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually integ tested:
* acm - vanilla sigv4 case (no signer override), still works with updated generated client
* glacier.uploadArchive - sigv4 case with signer override for async streaming (AsyncAws4Signer)
Haven't tested unsigned payload/event streaming explicitly, but they fall under similar case as glacier.