### PR TITLE
Expose thresholdSizeInBytes in AWS CRT-based S3 client

### DIFF
--- a/.changes/next-release/feature-AmazonS3-318ca43.json
+++ b/.changes/next-release/feature-AmazonS3-318ca43.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Allow users to configure upload threshold size for AWS CRT-based S3 client via `S3CrtAsyncClientBuilder#thresholdInBytes`."
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientPutObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientPutObjectIntegrationTest.java
@@ -47,7 +47,7 @@ import software.amazon.awssdk.testutils.service.AwsTestBase;
 public class S3CrtClientPutObjectIntegrationTest extends S3IntegrationTestBase {
     private static final String TEST_BUCKET = temporaryBucketName(S3CrtClientPutObjectIntegrationTest.class);
     private static final String TEST_KEY = "8mib_file.dat";
-    private static final int OBJ_SIZE = 8 * 1024 * 1024;
+    private static final int OBJ_SIZE = 10 * 1024 * 1024;
 
     private static RandomTempFile testFile;
     private static S3AsyncClient s3Crt;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
@@ -234,6 +234,26 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      */
     S3CrtAsyncClientBuilder crossRegionAccessEnabled(Boolean crossRegionAccessEnabled);
 
+    /**
+     * Configure the size threshold, in bytes, for when to use multipart upload. Uploads/copies over this size will automatically
+     * use a multipart upload strategy, while uploads/copies smaller than this threshold will use a single connection to
+     * upload/copy the whole object.
+     *
+     * <p>
+     * Multipart uploads are easier to recover from and also potentially faster than single part uploads, especially when the
+     * upload parts can be uploaded in parallel. Because there are additional network API calls, small objects are still
+     * recommended to use a single connection for the upload. See
+     * <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html">Uploading and copying objects using
+     * multipart upload</a>.
+     *
+     * <p>
+     * By default, it is the same as {@link #minimumPartSizeInBytes(Long)}.
+     *
+     * @param thresholdInBytes the value of the threshold to set.
+     * @return an instance of this builder.
+     */
+    S3CrtAsyncClientBuilder thresholdInBytes(Long thresholdInBytes);
+
     @Override
     S3AsyncClient build();
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -70,9 +70,10 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         super(initializeS3AsyncClient(builder));
         long partSizeInBytes = builder.minimalPartSizeInBytes == null ? DEFAULT_PART_SIZE_IN_BYTES :
                                builder.minimalPartSizeInBytes;
+        long thresholdInBytes = builder.thresholdInBytes == null ? partSizeInBytes : builder.thresholdInBytes;
         this.copyObjectHelper = new CopyObjectHelper((S3AsyncClient) delegate(),
                                                      partSizeInBytes,
-                                                     partSizeInBytes);
+                                                     thresholdInBytes);
     }
 
     @Override
@@ -117,6 +118,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         Validate.isPositiveOrNull(builder.maxConcurrency, "maxConcurrency");
         Validate.isPositiveOrNull(builder.targetThroughputInGbps, "targetThroughputInGbps");
         Validate.isPositiveOrNull(builder.minimalPartSizeInBytes, "minimalPartSizeInBytes");
+        Validate.isPositiveOrNull(builder.thresholdInBytes, "thresholdInBytes");
 
         S3NativeClientConfiguration.Builder nativeClientBuilder =
             S3NativeClientConfiguration.builder()
@@ -128,7 +130,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                        .endpointOverride(builder.endpointOverride)
                                        .credentialsProvider(builder.credentialsProvider)
                                        .readBufferSizeInBytes(builder.readBufferSizeInBytes)
-                                       .httpConfiguration(builder.httpConfiguration);
+                                       .httpConfiguration(builder.httpConfiguration)
+                                       .thresholdInBytes(builder.thresholdInBytes);
 
         if (builder.retryConfiguration != null) {
             nativeClientBuilder.standardRetryOptions(
@@ -156,6 +159,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         private List<ExecutionInterceptor> executionInterceptors;
         private S3CrtRetryConfiguration retryConfiguration;
         private boolean crossRegionAccessEnabled;
+        private Long thresholdInBytes;
 
         public AwsCredentialsProvider credentialsProvider() {
             return credentialsProvider;
@@ -273,6 +277,12 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         @Override
         public S3CrtAsyncClientBuilder crossRegionAccessEnabled(Boolean crossRegionAccessEnabled) {
             this.crossRegionAccessEnabled = crossRegionAccessEnabled;
+            return this;
+        }
+
+        @Override
+        public S3CrtAsyncClientBuilder thresholdInBytes(Long thresholdInBytes) {
+            this.thresholdInBytes = thresholdInBytes;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -75,6 +75,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
                                  .withCredentialsProvider(s3NativeClientConfiguration.credentialsProvider())
                                  .withClientBootstrap(s3NativeClientConfiguration.clientBootstrap())
                                  .withPartSize(s3NativeClientConfiguration.partSizeBytes())
+                                 .withMultipartUploadThreshold(s3NativeClientConfiguration.thresholdInBytes())
                                  .withComputeContentMd5(false)
                                  .withMaxConnections(s3NativeClientConfiguration.maxConcurrency())
                                  .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps())

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -51,6 +51,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final CrtCredentialsProviderAdapter credentialProviderAdapter;
     private final CredentialsProvider credentialsProvider;
     private final long partSizeInBytes;
+    private final long thresholdInBytes;
     private final double targetThroughputInGbps;
     private final int maxConcurrency;
     private final URI endpointOverride;
@@ -86,6 +87,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         this.partSizeInBytes = builder.partSizeInBytes == null ? DEFAULT_PART_SIZE_IN_BYTES :
                                builder.partSizeInBytes;
+        this.thresholdInBytes = builder.thresholdInBytes == null ? this.partSizeInBytes :
+                                builder.thresholdInBytes;
         this.targetThroughputInGbps = builder.targetThroughputInGbps == null ?
                                       DEFAULT_TARGET_THROUGHPUT_IN_GBPS : builder.targetThroughputInGbps;
 
@@ -144,6 +147,10 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         return partSizeInBytes;
     }
 
+    public long thresholdInBytes() {
+        return thresholdInBytes;
+    }
+
     public double targetThroughputInGbps() {
         return targetThroughputInGbps;
     }
@@ -187,6 +194,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         private S3CrtHttpConfiguration httpConfiguration;
         private StandardRetryOptions standardRetryOptions;
+        private Long thresholdInBytes;
 
         private Builder() {
         }
@@ -245,6 +253,11 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         public Builder standardRetryOptions(StandardRetryOptions standardRetryOptions) {
             this.standardRetryOptions = standardRetryOptions;
+            return this;
+        }
+
+        public Builder thresholdInBytes(Long thresholdInBytes) {
+            this.thresholdInBytes = thresholdInBytes;
             return this;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Allow users to configure upload threshold size for AWS CRT-based S3 client via `S3CrtAsyncClientBuilder#thresholdInBytes`

## Modifications
Expose thresholdSizeInBytes in AWS CRT-based S3 client builder

## Testing
Added tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
