### PR TITLE
Remove Signer related codegen logic in Clients

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
@@ -93,10 +93,6 @@ public class Metadata {
 
     private String signingName;
 
-    private boolean requiresIamSigners;
-
-    private boolean requiresApiKey;
-
     private String uid;
 
     private AuthType authType;
@@ -605,23 +601,6 @@ public class Metadata {
 
     public String getContentType() {
         return contentType;
-    }
-
-    public boolean isRequiresIamSigners() {
-        return requiresIamSigners;
-    }
-
-    public void setRequiresIamSigners(boolean requiresIamSigners) {
-        this.requiresIamSigners = requiresIamSigners;
-    }
-
-    public boolean isRequiresApiKey() {
-        return requiresApiKey;
-    }
-
-    public Metadata withRequiresApiKey(boolean requiresApiKey) {
-        this.requiresApiKey = requiresApiKey;
-        return this;
     }
 
     public String getUid() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -37,29 +37,24 @@ import java.util.Optional;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
-import software.amazon.awssdk.codegen.model.service.AuthType;
 import software.amazon.awssdk.codegen.model.service.ClientContextParam;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.auth.scheme.AuthSchemeSpecUtils;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
 import software.amazon.awssdk.codegen.utils.AuthUtils;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.endpointdiscovery.providers.DefaultEndpointDiscoveryProviderChain;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
@@ -119,7 +114,6 @@ public class BaseClientBuilderClass implements ClassSpec {
         mergeInternalDefaultsMethod().ifPresent(builder::addMethod);
 
         builder.addMethod(finalizeServiceConfigurationMethod());
-        defaultAwsAuthSignerMethod().ifPresent(builder::addMethod);
         builder.addMethod(signingNameMethod());
         builder.addMethod(defaultEndpointProviderMethod());
 
@@ -139,7 +133,6 @@ public class BaseClientBuilderClass implements ClassSpec {
 
         if (AuthUtils.usesBearerAuth(model)) {
             builder.addMethod(defaultBearerTokenProviderMethod());
-            builder.addMethod(defaultTokenAuthSignerMethod());
         }
         builder.addMethod(defaultAuthSchemesMethod());
 
@@ -164,15 +157,6 @@ public class BaseClientBuilderClass implements ClassSpec {
                          .returns(String.class)
                          .addCode("return $S;", model.getMetadata().getSigningName())
                          .build();
-    }
-
-    private Optional<MethodSpec> defaultAwsAuthSignerMethod() {
-        return awsAuthSignerDefinitionMethodBody().map(body -> MethodSpec.methodBuilder("defaultSigner")
-                                                                         .returns(Signer.class)
-                                                                         .addModifiers(PRIVATE)
-                                                                         .addCode(body)
-                                                                         .build());
-
     }
 
     private MethodSpec serviceEndpointPrefixMethod() {
@@ -207,9 +191,6 @@ public class BaseClientBuilderClass implements ClassSpec {
         builder.addCode(".option($T.AUTH_SCHEME_PROVIDER, defaultAuthSchemeProvider())", SdkClientOption.class);
         builder.addCode(".option($T.AUTH_SCHEMES, defaultAuthSchemes())", SdkClientOption.class);
 
-        if (defaultAwsAuthSignerMethod().isPresent()) {
-            builder.addCode(".option($T.SIGNER, defaultSigner())\n", SdkAdvancedClientOption.class);
-        }
         builder.addCode(".option($T.CRC32_FROM_COMPRESSED_DATA_ENABLED, $L)\n",
                         SdkClientOption.class, crc32FromCompressedDataEnabled);
 
@@ -221,7 +202,6 @@ public class BaseClientBuilderClass implements ClassSpec {
 
         if (AuthUtils.usesBearerAuth(model)) {
             builder.addCode(".option($T.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider())\n", AwsClientOption.class);
-            builder.addCode(".option($T.TOKEN_SIGNER, defaultTokenSigner())", SdkAdvancedClientOption.class);
         }
 
         builder.addCode(");");
@@ -579,31 +559,6 @@ public class BaseClientBuilderClass implements ClassSpec {
         return builder.build();
     }
 
-    private Optional<CodeBlock> awsAuthSignerDefinitionMethodBody() {
-        AuthType authType = model.getMetadata().getAuthType();
-        switch (authType) {
-            case V4:
-                return Optional.of(v4SignerDefinitionMethodBody());
-            case S3:
-            case S3V4:
-                return Optional.of(s3SignerDefinitionMethodBody());
-            case BEARER:
-                return Optional.empty();
-            default:
-                throw new UnsupportedOperationException("Unsupported signer type: " + authType);
-        }
-    }
-
-    private CodeBlock v4SignerDefinitionMethodBody() {
-        return CodeBlock.of("return $T.create();", Aws4Signer.class);
-    }
-
-
-    private CodeBlock s3SignerDefinitionMethodBody() {
-        return CodeBlock.of("return $T.create();\n",
-                            ClassName.get("software.amazon.awssdk.auth.signer", "AwsS3V4Signer"));
-    }
-
     private MethodSpec defaultEndpointProviderMethod() {
         return MethodSpec.methodBuilder("defaultEndpointProvider")
                          .addModifiers(PRIVATE)
@@ -655,14 +610,6 @@ public class BaseClientBuilderClass implements ClassSpec {
                          .build();
     }
 
-    private MethodSpec defaultTokenAuthSignerMethod() {
-        return MethodSpec.methodBuilder("defaultTokenSigner")
-                         .returns(Signer.class)
-                         .addModifiers(PRIVATE)
-                         .addStatement("return $T.create()", BearerTokenSigner.class)
-                         .build();
-    }
-
     private MethodSpec defaultAuthSchemesMethod() {
         TypeName returns = ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class),
                                                      ParameterizedTypeName.get(ClassName.get(AuthScheme.class),
@@ -704,19 +651,7 @@ public class BaseClientBuilderClass implements ClassSpec {
                                                .addParameter(SdkClientConfiguration.class, "c")
                                                .returns(void.class);
 
-        if (AuthUtils.usesAwsAuth(model)) {
-            builder.addStatement("$T.notNull(c.option($T.SIGNER), $S)",
-                                 Validate.class,
-                                 SdkAdvancedClientOption.class,
-                                 "The 'overrideConfiguration.advancedOption[SIGNER]' must be configured in the client builder.");
-        }
-
         if (AuthUtils.usesBearerAuth(model)) {
-            builder.addStatement("$T.notNull(c.option($T.TOKEN_SIGNER), $S)",
-                                 Validate.class,
-                                 SdkAdvancedClientOption.class,
-                                 "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' "
-                                 + "must be configured in the client builder.");
             builder.addStatement("$T.notNull(c.option($T.TOKEN_IDENTITY_PROVIDER), $S)",
                                  Validate.class,
                                  AwsClientOption.class,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/NoneAuthTypeRequestTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/NoneAuthTypeRequestTrait.java
@@ -26,6 +26,9 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
  * Trait which defines if a given request needs to be authenticated.
  * A request is not authenticated only if it has "auththpe" trait  explicitly marked as "none"
  */
+// TODO(sra-identity-and-auth): I think this class can be deleted. Old clients will still have the writer for this generated
+//  and we have to leave the reader of this attribute around for them (in AwsExecutionContextBuilder), but the writer in new
+//  clients can be deleted.
 @SdkInternalApi
 public class NoneAuthTypeRequestTrait {
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -8,15 +8,12 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.auth.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
@@ -53,8 +50,7 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                 .option(SdkClientOption.AUTH_SCHEME_PROVIDER, defaultAuthSchemeProvider())
                 .option(SdkClientOption.AUTH_SCHEMES, defaultAuthSchemes())
                 .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
-                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider())
-                .option(SdkAdvancedClientOption.TOKEN_SIGNER, defaultTokenSigner()));
+                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider()));
     }
 
     @Override
@@ -104,10 +100,6 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         return DefaultAwsTokenProvider.create();
     }
 
-    private Signer defaultTokenSigner() {
-        return BearerTokenSigner.create();
-    }
-
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
         Map<String, AuthScheme<?>> schemes = new HashMap<>(1);
         BearerAuthScheme bearerAuthScheme = BearerAuthScheme.create();
@@ -116,8 +108,6 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {
-        Validate.notNull(c.option(SdkAdvancedClientOption.TOKEN_SIGNER),
-                "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' must be configured in the client builder.");
         Validate.notNull(c.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER),
                 "The 'tokenProvider' must be configured in the client builder.");
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -9,17 +9,13 @@ import software.amazon.MyServiceHttpConfig;
 import software.amazon.MyServiceRetryPolicy;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.auth.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
@@ -58,11 +54,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         return config.merge(c -> c.option(SdkClientOption.ENDPOINT_PROVIDER, defaultEndpointProvider())
                 .option(SdkClientOption.AUTH_SCHEME_PROVIDER, defaultAuthSchemeProvider())
                 .option(SdkClientOption.AUTH_SCHEMES, defaultAuthSchemes())
-                .option(SdkAdvancedClientOption.SIGNER, defaultSigner())
                 .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
                 .option(SdkClientOption.SERVICE_CONFIGURATION, ServiceConfiguration.builder().build())
-                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider())
-                .option(SdkAdvancedClientOption.TOKEN_SIGNER, defaultTokenSigner()));
+                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider()));
     }
 
     @Override
@@ -149,10 +143,6 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         return builder.build();
     }
 
-    private Signer defaultSigner() {
-        return Aws4Signer.create();
-    }
-
     @Override
     protected final String signingName() {
         return "json-service";
@@ -184,10 +174,6 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         return DefaultAwsTokenProvider.create();
     }
 
-    private Signer defaultTokenSigner() {
-        return BearerTokenSigner.create();
-    }
-
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
         Map<String, AuthScheme<?>> schemes = new HashMap<>(2);
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
@@ -204,10 +190,6 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {
-        Validate.notNull(c.option(SdkAdvancedClientOption.SIGNER),
-                "The 'overrideConfiguration.advancedOption[SIGNER]' must be configured in the client builder.");
-        Validate.notNull(c.option(SdkAdvancedClientOption.TOKEN_SIGNER),
-                "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' must be configured in the client builder.");
         Validate.notNull(c.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER),
                 "The 'tokenProvider' must be configured in the client builder.");
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -7,17 +7,13 @@ import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.auth.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
@@ -57,10 +53,8 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         return config.merge(c -> c.option(SdkClientOption.ENDPOINT_PROVIDER, defaultEndpointProvider())
                 .option(SdkClientOption.AUTH_SCHEME_PROVIDER, defaultAuthSchemeProvider())
                 .option(SdkClientOption.AUTH_SCHEMES, defaultAuthSchemes())
-                .option(SdkAdvancedClientOption.SIGNER, defaultSigner())
                 .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
-                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider())
-                .option(SdkAdvancedClientOption.TOKEN_SIGNER, defaultTokenSigner()));
+                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider()));
     }
 
     @Override
@@ -89,10 +83,6 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors).option(SdkClientOption.CLIENT_CONTEXT_PARAMS,
                 clientContextParams.build());
         return builder.build();
-    }
-
-    private Signer defaultSigner() {
-        return Aws4Signer.create();
     }
 
     @Override
@@ -127,10 +117,6 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         return DefaultAwsTokenProvider.create();
     }
 
-    private Signer defaultTokenSigner() {
-        return BearerTokenSigner.create();
-    }
-
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
         Map<String, AuthScheme<?>> schemes = new HashMap<>(3);
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
@@ -143,10 +129,6 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {
-        Validate.notNull(c.option(SdkAdvancedClientOption.SIGNER),
-                "The 'overrideConfiguration.advancedOption[SIGNER]' must be configured in the client builder.");
-        Validate.notNull(c.option(SdkAdvancedClientOption.TOKEN_SIGNER),
-                "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' must be configured in the client builder.");
         Validate.notNull(c.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER),
                 "The 'tokenProvider' must be configured in the client builder.");
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -7,15 +7,12 @@ import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
@@ -25,7 +22,6 @@ import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointAuthS
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.awssdk.utils.Validate;
 
 /**
  * Internal base class for {@link DefaultJsonClientBuilder} and {@link DefaultJsonAsyncClientBuilder}.
@@ -48,7 +44,6 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         return config.merge(c -> c.option(SdkClientOption.ENDPOINT_PROVIDER, defaultEndpointProvider())
                 .option(SdkClientOption.AUTH_SCHEME_PROVIDER, defaultAuthSchemeProvider())
                 .option(SdkClientOption.AUTH_SCHEMES, defaultAuthSchemes())
-                .option(SdkAdvancedClientOption.SIGNER, defaultSigner())
                 .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false));
     }
 
@@ -79,10 +74,6 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         return builder.build();
     }
 
-    private Signer defaultSigner() {
-        return Aws4Signer.create();
-    }
-
     @Override
     protected final String signingName() {
         return "json-service";
@@ -109,7 +100,5 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {
-        Validate.notNull(c.option(SdkAdvancedClientOption.SIGNER),
-                "The 'overrideConfiguration.advancedOption[SIGNER]' must be configured in the client builder.");
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -7,17 +7,13 @@ import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.auth.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
@@ -56,10 +52,8 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         return config.merge(c -> c.option(SdkClientOption.ENDPOINT_PROVIDER, defaultEndpointProvider())
                 .option(SdkClientOption.AUTH_SCHEME_PROVIDER, defaultAuthSchemeProvider())
                 .option(SdkClientOption.AUTH_SCHEMES, defaultAuthSchemes())
-                .option(SdkAdvancedClientOption.SIGNER, defaultSigner())
                 .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
-                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider())
-                .option(SdkAdvancedClientOption.TOKEN_SIGNER, defaultTokenSigner()));
+                .option(AwsClientOption.TOKEN_IDENTITY_PROVIDER, defaultTokenProvider()));
     }
 
     @Override
@@ -88,10 +82,6 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors).option(SdkClientOption.CLIENT_CONTEXT_PARAMS,
                 clientContextParams.build());
         return builder.build();
-    }
-
-    private Signer defaultSigner() {
-        return Aws4Signer.create();
     }
 
     @Override
@@ -126,10 +116,6 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         return DefaultAwsTokenProvider.create();
     }
 
-    private Signer defaultTokenSigner() {
-        return BearerTokenSigner.create();
-    }
-
     private Map<String, AuthScheme<?>> defaultAuthSchemes() {
         Map<String, AuthScheme<?>> schemes = new HashMap<>(2);
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
@@ -140,10 +126,6 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
     }
 
     protected static void validateClientOptions(SdkClientConfiguration c) {
-        Validate.notNull(c.option(SdkAdvancedClientOption.SIGNER),
-                "The 'overrideConfiguration.advancedOption[SIGNER]' must be configured in the client builder.");
-        Validate.notNull(c.option(SdkAdvancedClientOption.TOKEN_SIGNER),
-                "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' must be configured in the client builder.");
         Validate.notNull(c.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER),
                 "The 'tokenProvider' must be configured in the client builder.");
     }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/bearerauth/ClientBuilderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/bearerauth/ClientBuilderTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
@@ -42,8 +41,6 @@ public class ClientBuilderTest {
 
         assertThat(config.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER))
             .isInstanceOf(DefaultAwsTokenProvider.class);
-        assertThat(config.option(SdkAdvancedClientOption.TOKEN_SIGNER))
-            .isInstanceOf(BearerTokenSigner.class);
     }
 
     @Test
@@ -90,8 +87,6 @@ public class ClientBuilderTest {
 
         assertThat(config.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER))
             .isInstanceOf(DefaultAwsTokenProvider.class);
-        assertThat(config.option(SdkAdvancedClientOption.TOKEN_SIGNER))
-            .isInstanceOf(BearerTokenSigner.class);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Currently, Clients are setup with a default `Signer`. With SRA, the new signer interface HttpSigner is used and these signers are configured via AuthSchemes, which is already added to generated clients. So removing codegen to setup default `Signer.

Related: In #4280 setting up Signer overrides was already removed.

Note, customer can still provide old `Signer` at the client/request level, which will result in SIGNER_OVERRIDDEN=true, and that will continue to be supported at that's a public interface (but will be marked deprecated).

This PR deletes codegen logic to _write_ the default signer into clients. Logic to _read_ the default signer is in aws-core (AwsExecutionContextBuilder, AuthorizationStrategy, SigningStage, etc.) which needs to remain to support old clients as well as customer provided overrides.

I thought more tests would fail, especially related to flexible checksums since it is dependent on AuthorizationStrategy returning the `Signer` which `resolveSigningMethodUsed` uses. But those tests aren't failing because of some endpoints 2.0 related logic, which I have another task for. EndpointAuthSchemeInterceptor is still setting authScheme and thus `Signer` which is causing SigningStage to use pre-SRA path. It may also be related that the tests in codegen-generated-classes-test only test the SigningMethod.UNSIGNED_PAYLOAD case. 

## Modifications
<!--- Describe your changes in detail -->
Delete more code!

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually integ tested:
* acm - vanilla sigv4 case still works with updated generated client
* codecatalyst - vanilla bearer token still works with updated generated client

Waiting to see if CI passes.