### PR TITLE
Set PAYLOAD_SIGNING_ENABLED for the S3 auth type

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadata.java
@@ -65,6 +65,26 @@ public final class AuthSchemeCodegenMetadata {
                                                      .fieldName("NORMALIZE_PATH")
                                                      .valueEmitter((spec, utils) -> spec.addCode("$L", "false"))
                                                      .build())
+             .addProperty(SignerPropertyValueProvider.builder()
+                                                     .containingClass(AwsV4HttpSigner.class)
+                                                     .fieldName(
+                                                         "PAYLOAD_SIGNING_ENABLED")
+                                                     .valueEmitter((spec, utils) -> spec.addCode("$L", false))
+                                                     .build())
+             .build();
+
+    static final AuthSchemeCodegenMetadata S3V4 =
+        SIGV4.toBuilder()
+             .addProperty(SignerPropertyValueProvider.builder()
+                                                     .containingClass(AwsV4HttpSigner.class)
+                                                     .fieldName("DOUBLE_URL_ENCODE")
+                                                     .valueEmitter((spec, utils) -> spec.addCode("$L", "false"))
+                                                     .build())
+             .addProperty(SignerPropertyValueProvider.builder()
+                                                     .containingClass(AwsV4HttpSigner.class)
+                                                     .fieldName("NORMALIZE_PATH")
+                                                     .valueEmitter((spec, utils) -> spec.addCode("$L", "false"))
+                                                     .build())
              .build();
 
     static final AuthSchemeCodegenMetadata BEARER = builder()
@@ -123,8 +143,9 @@ public final class AuthSchemeCodegenMetadata {
             case V4_UNSIGNED_BODY:
                 return SIGV4_UNSIGNED_BODY;
             case S3:
-            case S3V4:
                 return S3;
+            case S3V4:
+                return S3V4;
             default:
                 throw new IllegalArgumentException("Unknown auth type: " + type);
         }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadata.java
@@ -47,8 +47,7 @@ public final class AuthSchemeCodegenMetadata {
         SIGV4.toBuilder()
              .addProperty(SignerPropertyValueProvider.builder()
                                                      .containingClass(AwsV4HttpSigner.class)
-                                                     .fieldName(
-                                                         "PAYLOAD_SIGNING_ENABLED")
+                                                     .fieldName("PAYLOAD_SIGNING_ENABLED")
                                                      .valueEmitter((spec, utils) -> spec.addCode("$L", false))
                                                      .build())
              .build();
@@ -67,8 +66,7 @@ public final class AuthSchemeCodegenMetadata {
                                                      .build())
              .addProperty(SignerPropertyValueProvider.builder()
                                                      .containingClass(AwsV4HttpSigner.class)
-                                                     .fieldName(
-                                                         "PAYLOAD_SIGNING_ENABLED")
+                                                     .fieldName("PAYLOAD_SIGNING_ENABLED")
                                                      .valueEmitter((spec, utils) -> spec.addCode("$L", false))
                                                      .build())
              .build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/mini-s3-auth-scheme-default-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/mini-s3-auth-scheme-default-provider.java
@@ -43,7 +43,8 @@ public final class DefaultMiniS3AuthSchemeProvider implements MiniS3AuthSchemePr
                 .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "mini-s3-service")
                 .putSignerProperty(AwsV4HttpSigner.REGION_NAME, params.region().id())
                 .putSignerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, false)
-                .putSignerProperty(AwsV4HttpSigner.NORMALIZE_PATH, false).build());
+                .putSignerProperty(AwsV4HttpSigner.NORMALIZE_PATH, false)
+                .putSignerProperty(AwsV4HttpSigner.PAYLOAD_SIGNING_ENABLED, false).build());
         return Collections.unmodifiableList(options);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This change is a follow up to #4285, in which the defaults for auth type "s3" and "s3v4" are now split and for s3 in particular `PAYLOAD_SIGNING_ENABLED` is set to `false` to mirror the previous behavior in [AwsS3V4SignerParams](https://github.com/aws/aws-sdk-java-v2/blob/4ea3cc28a0825fa101547fd82cfb2b5767b040d9/core/auth/src/main/java/software/amazon/awssdk/auth/signer/params/AwsS3V4SignerParams.java#L70C12-L73C53). Since `WriteGetObjectResponse` is using a different authtype it will not be using the other S3 signer settings, we might need to special case this in a follow up PR if this is required.

For S3 the `ModeledS3AuthSchemeProvider#resolveAuthScheme` looks like this after this change:

```java

    @Override
    public List<AuthSchemeOption> resolveAuthScheme(S3AuthSchemeParams params) {
        List<AuthSchemeOption> options = new ArrayList<>();
        switch (params.operation()) {
        case "WriteGetObjectResponse":
            options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4")
                    .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "s3")
                    .putSignerProperty(AwsV4HttpSigner.REGION_NAME, params.region().id())
                    .putSignerProperty(AwsV4HttpSigner.PAYLOAD_SIGNING_ENABLED, false).build());
            break;
        default:
            options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4")
                    .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "s3")
                    .putSignerProperty(AwsV4HttpSigner.REGION_NAME, params.region().id())
                    .putSignerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, false)
                    .putSignerProperty(AwsV4HttpSigner.NORMALIZE_PATH, false)
                    .putSignerProperty(AwsV4HttpSigner.PAYLOAD_SIGNING_ENABLED, false).build());
            break;
        }
        return Collections.unmodifiableList(options);
    }
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Added unit tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
