### PR TITLE
Add new exclude/include to augment the created service pom

### DIFF
--- a/release-scripts/src/main/java/software/amazon/awssdk/release/Cli.java
+++ b/release-scripts/src/main/java/software/amazon/awssdk/release/Cli.java
@@ -63,5 +63,13 @@ public abstract class Cli {
         return new Option(null, longCommand, true, description);
     }
 
+    protected static Option optionalMultiValueOption(String longCommand, String description) {
+        return Option.builder()
+            .longOpt(longCommand)
+            .desc(description)
+            .hasArgs()
+            .build();
+    }
+
     protected abstract void run(CommandLine commandLine) throws Exception;
 }

--- a/release-scripts/src/main/java/software/amazon/awssdk/release/CreateNewServiceModuleMain.java
+++ b/release-scripts/src/main/java/software/amazon/awssdk/release/CreateNewServiceModuleMain.java
@@ -53,6 +53,21 @@ import software.amazon.awssdk.utils.internal.CodegenNamingUtils;
  *                  --service-module-name service-module-name
  *                  --service-protocol json"
  * </pre>
+ *
+ * <p>By default the service new pom will include a dependency to the http-auth-aws module, this is only needed if the service
+ * has one or more operations signed by any of the aws algorithms, e.g., sigv4 or sigv4a, but not needed if the service uses,
+ * say, bearer auth (e.g., codecatalyst at the moment). Excluding this can be done by adding the
+ * {@code --exclude-internal-dependency http-auth-aws} switch. For example
+ * <pre>
+ * mvn exec:java -pl :release-scripts \
+ *     -Dexec.mainClass="software.amazon.awssdk.release.CreateNewServiceModuleMain" \
+ *     -Dexec.args="--maven-project-root /path/to/root
+ *                  --maven-project-version 2.1.4-SNAPSHOT
+ *                  --service-id 'Service Id'
+ *                  --service-module-name service-module-name
+ *                  --service-protocol json
+ *                  --exclude-internal-dependency http-auth-aws"
+ * </pre>
  */
 public class CreateNewServiceModuleMain extends Cli {
 

--- a/release-scripts/src/main/java/software/amazon/awssdk/release/NewServiceMain.java
+++ b/release-scripts/src/main/java/software/amazon/awssdk/release/NewServiceMain.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.release;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static software.amazon.awssdk.release.CreateNewServiceModuleMain.computeInternalDependencies;
+import static software.amazon.awssdk.release.CreateNewServiceModuleMain.toList;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -24,6 +26,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.cli.CommandLine;
@@ -49,16 +54,27 @@ import software.amazon.awssdk.utils.internal.CodegenNamingUtils;
  * </pre>
  */
 public class NewServiceMain extends Cli {
+
+    private static final Set<String> DEFAULT_INTERNAL_DEPENDENCIES = defaultInternalDependencies();
+
     private NewServiceMain() {
         super(requiredOption("service-module-name", "The name of the service module to be created."),
               requiredOption("service-id", "The service ID of the service module to be created."),
               requiredOption("service-protocol", "The protocol of the service module to be created."),
               requiredOption("maven-project-root", "The root directory for the maven project."),
-              requiredOption("maven-project-version", "The maven version of the service module to be created."));
+              requiredOption("maven-project-version", "The maven version of the service module to be created."),
+              optionalMultiValueOption("include-internal-dependency", "Includes an internal dependency from new service pom."),
+              optionalMultiValueOption("exclude-internal-dependency", "Excludes an internal dependency from new service pom."));
     }
 
     public static void main(String[] args) {
         new NewServiceMain().run(args);
+    }
+
+    private static Set<String> defaultInternalDependencies() {
+        Set<String> defaultInternalDependencies = new LinkedHashSet<>();
+        defaultInternalDependencies.add("http-auth-aws");
+        return Collections.unmodifiableSet(defaultInternalDependencies);
     }
 
     @Override
@@ -72,6 +88,7 @@ public class NewServiceMain extends Cli {
         private final String serviceModuleName;
         private final String serviceId;
         private final String serviceProtocol;
+        private final Set<String> internalDependencies;
 
         private NewServiceCreator(CommandLine commandLine) {
             this.mavenProjectRoot = Paths.get(commandLine.getOptionValue("maven-project-root").trim());
@@ -79,7 +96,10 @@ public class NewServiceMain extends Cli {
             this.serviceModuleName = commandLine.getOptionValue("service-module-name").trim();
             this.serviceId = commandLine.getOptionValue("service-id").trim();
             this.serviceProtocol = transformSpecialProtocols(commandLine.getOptionValue("service-protocol").trim());
-
+            this.internalDependencies = computeInternalDependencies(toList(commandLine
+                                                                               .getOptionValues("include-internal-dependency")),
+                                                                    toList(commandLine
+                                                                               .getOptionValues("exclude-internal-dependency")));
             Validate.isTrue(Files.exists(mavenProjectRoot), "Project root does not exist: " + mavenProjectRoot);
         }
 
@@ -100,6 +120,7 @@ public class NewServiceMain extends Cli {
             createNewModuleFromTemplate(templateModulePath, newServiceModulePath);
             replaceTemplatePlaceholders(newServiceModulePath);
 
+
             Path servicesPomPath = mavenProjectRoot.resolve("services").resolve("pom.xml");
             Path aggregatePomPath = mavenProjectRoot.resolve("aws-sdk-java").resolve("pom.xml");
             Path bomPomPath = mavenProjectRoot.resolve("bom").resolve("pom.xml");
@@ -107,6 +128,9 @@ public class NewServiceMain extends Cli {
             new AddSubmoduleTransformer().transform(servicesPomPath);
             new AddDependencyTransformer().transform(aggregatePomPath);
             new AddDependencyManagementDependencyTransformer().transform(bomPomPath);
+
+            Path newServicePom = newServiceModulePath.resolve("pom.xml");
+            new CreateNewServiceModuleMain.AddInternalDependenciesTransformer(internalDependencies).transform(newServicePom);
         }
 
         private void createNewModuleFromTemplate(Path templateModulePath, Path newServiceModule) throws IOException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

After adding the new `http-auth-aws` dependency this is needed by almost all but one service, codecatalyst which uses an bearer auth scheme and thus does not need to depend on this package. To bootstrap new services that might also need to opt-out of pulling this dependency this change adds to the commands

* `software.amazon.awssdk.release.CreateNewServiceModuleMain`
* `software.amazon.awssdk.release.NewServiceMain`

New, multivalued switches that can be used to either remove default dependencies or to add unlisted ones.

* `include-internal-dependency`
* `exclude-internal-dependency`

#### Behavior 

By default the default internal dependencies will be added:

```
 ./mvnw exec:java -pl :release-scripts -Dexec.mainClass="software.amazon.awssdk.release.CreateNewServiceModuleMain" \
     -Dexec.args="--maven-project-root '.' \
                  --maven-project-version 2.20.125-SNAPSHOT
                  --service-id 'FooBar' \
                  --service-module-name foobar
                  --service-protocol json"
```

Yields the following `services/foobar/pom.xml` (notice **http-auth-aws** is added by default)

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    ⋯ <!-- skipped for brevity -->
    <dependencies>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>protocol-core</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>aws-json-protocol</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>http-auth-aws</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
    </dependencies>
</project>
```

Default internal dependencies can be excluded:

```
 ./mvnw exec:java -pl :release-scripts -Dexec.mainClass="software.amazon.awssdk.release.CreateNewServiceModuleMain" \
     -Dexec.args="--maven-project-root '.' \
                  --maven-project-version 2.20.125-SNAPSHOT
                  --service-id 'FooBar' \
                  --service-module-name foobar
                  --service-protocol json
                  --exclude-internal-dependency http-auth-aws"
```

Yields the following `services/foobar/pom.xml` (notice **http-auth-aws** is **not** added)

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    ⋯ <!-- skipped for brevity -->
    <dependencies>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>protocol-core</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>aws-json-protocol</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
    </dependencies>
</project>

```

Other internal dependencies can be included:

```
 ./mvnw exec:java -pl :release-scripts -Dexec.mainClass="software.amazon.awssdk.release.CreateNewServiceModuleMain" \
     -Dexec.args="--maven-project-root '.' \
                  --maven-project-version 2.20.125-SNAPSHOT
                  --service-id 'FooBar' \
                  --service-module-name foobar
                  --service-protocol json
                  --include-internal-dependency http-auth-aws-crt"
```

Yields the following `services/foobar/pom.xml` (notice **http-auth-aws** is added and so is **http-auth-aws-crt**)

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    ⋯ <!-- skipped for brevity -->
    <dependencies>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>protocol-core</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>aws-json-protocol</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>http-auth-aws</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>http-auth-aws-crt</artifactId>
            <version>${awsjavasdk.version}</version>
        </dependency>
    </dependencies>
</project>

```


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
