### PR TITLE
Fix javadocs links - consumer request objects

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.codegen.docs;
 import static software.amazon.awssdk.codegen.internal.DocumentationUtils.createLinkToServiceDocumentation;
 import static software.amazon.awssdk.codegen.internal.DocumentationUtils.stripHtmlTags;
 
+import com.squareup.javapoet.ClassName;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -171,10 +172,13 @@ abstract class OperationDocProvider {
     final void emitRequestParm(DocumentationBuilder docBuilder) {
         String parameterDocs = stripHtmlTags(opModel.getInput().getDocumentation());
 
+        String shapeName = opModel.getInputShape().getShapeName();
+        ClassName fcqn = ClassName.get(model.getMetadata().getFullModelPackageName(), shapeName);
+
         if (config.isConsumerBuilder()) {
             docBuilder.param(opModel.getInput().getVariableName(),
                              "A {@link Consumer} that will call methods on {@link %s.Builder} to create a request. %s",
-                             opModel.getInputShape().getShapeName(),
+                             fcqn.toString(),
                              parameterDocs);
         } else {
             docBuilder.param(opModel.getInput().getVariableName(), parameterDocs);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
@@ -172,15 +172,9 @@ abstract class OperationDocProvider {
         String parameterDocs = stripHtmlTags(opModel.getInput().getDocumentation());
 
         if (config.isConsumerBuilder()) {
-
-            String inputShapeName = opModel.getInputShape().getC2jName();
-            if (inputShapeName.endsWith("Input")) {
-                inputShapeName = inputShapeName.replaceAll("Input$", "Request");
-            }
-
             docBuilder.param(opModel.getInput().getVariableName(),
                              "A {@link Consumer} that will call methods on {@link %s.Builder} to create a request. %s",
-                             inputShapeName,
+                             opModel.getInputShape().getShapeName(),
                              parameterDocs);
         } else {
             docBuilder.param(opModel.getInput().getVariableName(), parameterDocs);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
@@ -172,9 +172,15 @@ abstract class OperationDocProvider {
         String parameterDocs = stripHtmlTags(opModel.getInput().getDocumentation());
 
         if (config.isConsumerBuilder()) {
+
+            String inputShapeName = opModel.getInputShape().getC2jName();
+            if (inputShapeName.endsWith("Input")) {
+                inputShapeName = inputShapeName.replaceAll("Input$", "Request");
+            }
+
             docBuilder.param(opModel.getInput().getVariableName(),
                              "A {@link Consumer} that will call methods on {@link %s.Builder} to create a request. %s",
-                             opModel.getInputShape().getC2jName(),
+                             inputShapeName,
                              parameterDocs);
         } else {
             docBuilder.param(opModel.getInput().getVariableName(), parameterDocs);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -115,7 +115,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param aPostOperationRequest
-     *        A {@link Consumer} that will call methods on {@link APostOperationRequest.Builder} to create a request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.APostOperationRequest.Builder} to create a request.
      * @return A Java Future containing the result of the APostOperation operation returned by the service.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
      *         exceptions.
@@ -179,7 +180,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param aPostOperationWithOutputRequest
-     *        A {@link Consumer} that will call methods on {@link APostOperationWithOutputRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest.Builder} to create a
      *        request.
      * @return A Java Future containing the result of the APostOperationWithOutput operation returned by the service.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
@@ -236,8 +238,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param bearerAuthOperationRequest
-     *        A {@link Consumer} that will call methods on {@link BearerAuthOperationRequest.Builder} to create a
-     *        request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.BearerAuthOperationRequest.Builder} to create a request.
      * @return A Java Future containing the result of the BearerAuthOperation operation returned by the service.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
      *         exceptions.
@@ -290,7 +292,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param eventStreamOperationRequest
-     *        A {@link Consumer} that will call methods on {@link EventStreamOperationRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.EventStreamOperationRequest.Builder} to create a
      *        request.
      * @return A Java Future containing the result of the EventStreamOperation operation returned by the service.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
@@ -348,7 +351,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param eventStreamOperationWithOnlyInputRequest
-     *        A {@link Consumer} that will call methods on {@link EventStreamOperationWithOnlyInputRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyInputRequest.Builder} to
      *        create a request.
      * @return A Java Future containing the result of the EventStreamOperationWithOnlyInput operation returned by the
      *         service.<br/>
@@ -408,7 +412,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param eventStreamOperationWithOnlyOutputRequest
-     *        A {@link Consumer} that will call methods on {@link EventStreamOperationWithOnlyOutputRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputRequest.Builder} to
      *        create a request.
      * @return A Java Future containing the result of the EventStreamOperationWithOnlyOutput operation returned by the
      *         service.<br/>
@@ -466,7 +471,9 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param getOperationWithChecksumRequest
-     *        A {@link Consumer} that will call methods on {@link ChecksumStructure.Builder} to create a request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.GetOperationWithChecksumRequest.Builder} to create a
+     *        request.
      * @return A Java Future containing the result of the GetOperationWithChecksum operation returned by the service.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
      *         exceptions.
@@ -527,7 +534,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param getWithoutRequiredMembersRequest
-     *        A {@link Consumer} that will call methods on {@link GetWithoutRequiredMembersRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest.Builder} to create a
      *        request.
      * @return A Java Future containing the result of the GetWithoutRequiredMembers operation returned by the service.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
@@ -585,8 +593,9 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param operationWithChecksumRequiredRequest
-     *        A {@link Consumer} that will call methods on {@link OperationWithChecksumRequiredRequest.Builder} to
-     *        create a request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest.Builder} to create
+     *        a request.
      * @return A Java Future containing the result of the OperationWithChecksumRequired operation returned by the
      *         service.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
@@ -642,7 +651,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest.Builder} to
      *        create a request.
      * @return A Java Future containing the result of the PaginatedOperationWithResultKey operation returned by the
      *         service.<br/>
@@ -902,7 +912,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest.Builder} to
      *        create a request.
      * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
@@ -958,7 +969,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithoutResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithoutResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest.Builder} to
      *        create a request.
      * @return A Java Future containing the result of the PaginatedOperationWithoutResultKey operation returned by the
      *         service.<br/>
@@ -1120,7 +1132,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithoutResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithoutResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest.Builder} to
      *        create a request.
      * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
      *         The CompletableFuture returned by this method can be completed exceptionally with the following
@@ -1194,7 +1207,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param putOperationWithChecksumRequest
-     *        A {@link Consumer} that will call methods on {@link ChecksumStructureWithStreaming.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PutOperationWithChecksumRequest.Builder} to create a
      *        request.
      * @param requestBody
      *        Functional interface that can be implemented to produce the request content in a non-blocking manner. The
@@ -1286,7 +1300,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param putOperationWithChecksumRequest
-     *        A {@link Consumer} that will call methods on {@link ChecksumStructureWithStreaming.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PutOperationWithChecksumRequest.Builder} to create a
      *        request.
      * @param sourcePath
      *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
@@ -1364,7 +1379,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOperationRequest.Builder} to create a
      *        request.
      * @param requestBody
      *        Functional interface that can be implemented to produce the request content in a non-blocking manner. The
@@ -1429,7 +1445,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOperationRequest.Builder} to create a
      *        request.
      * @param sourcePath
      *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
@@ -1500,8 +1517,9 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
-     *        request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOutputOperationRequest.Builder} to create
+     *        a request.
      * @param requestBody
      *        Functional interface that can be implemented to produce the request content in a non-blocking manner. The
      *        size of the content is expected to be known up front. See {@link AsyncRequestBody} for specific details on
@@ -1578,8 +1596,9 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
-     *        request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOutputOperationRequest.Builder} to create
+     *        a request.
      * @param sourcePath
      *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
      *        multiple times in the event of a retry. If the file does not exist or the current user does not have
@@ -1650,7 +1669,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param streamingOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StreamingOutputOperationRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest.Builder} to create a
      *        request.
      * @param asyncResponseTransformer
      *        The response transformer for processing the streaming response in a non-blocking manner. See
@@ -1715,7 +1735,8 @@ public interface JsonAsyncClient extends AwsClient {
      * </p>
      *
      * @param streamingOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StreamingOutputOperationRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest.Builder} to create a
      *        request.
      * @param destinationPath
      *        {@link Path} to file that response contents will be written to. The file must not exist or this method

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -98,7 +98,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param aPostOperationRequest
-     *        A {@link Consumer} that will call methods on {@link APostOperationRequest.Builder} to create a request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.APostOperationRequest.Builder} to create a request.
      * @return Result of the APostOperation operation returned by the service.
      * @throws InvalidInputException
      *         The request was rejected because an invalid or out-of-range value was supplied for an input parameter.
@@ -158,7 +159,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param aPostOperationWithOutputRequest
-     *        A {@link Consumer} that will call methods on {@link APostOperationWithOutputRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest.Builder} to create a
      *        request.
      * @return Result of the APostOperationWithOutput operation returned by the service.
      * @throws InvalidInputException
@@ -210,8 +212,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param bearerAuthOperationRequest
-     *        A {@link Consumer} that will call methods on {@link BearerAuthOperationRequest.Builder} to create a
-     *        request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.BearerAuthOperationRequest.Builder} to create a request.
      * @return Result of the BearerAuthOperation operation returned by the service.
      * @throws SdkException
      *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
@@ -260,7 +262,9 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param getOperationWithChecksumRequest
-     *        A {@link Consumer} that will call methods on {@link ChecksumStructure.Builder} to create a request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.GetOperationWithChecksumRequest.Builder} to create a
+     *        request.
      * @return Result of the GetOperationWithChecksum operation returned by the service.
      * @throws SdkException
      *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
@@ -317,7 +321,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param getWithoutRequiredMembersRequest
-     *        A {@link Consumer} that will call methods on {@link GetWithoutRequiredMembersRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest.Builder} to create a
      *        request.
      * @return Result of the GetWithoutRequiredMembers operation returned by the service.
      * @throws InvalidInputException
@@ -370,8 +375,9 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param operationWithChecksumRequiredRequest
-     *        A {@link Consumer} that will call methods on {@link OperationWithChecksumRequiredRequest.Builder} to
-     *        create a request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest.Builder} to create
+     *        a request.
      * @return Result of the OperationWithChecksumRequired operation returned by the service.
      * @throws SdkException
      *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
@@ -421,7 +427,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest.Builder} to
      *        create a request.
      * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
      * @throws SdkException
@@ -679,7 +686,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest.Builder} to
      *        create a request.
      * @return A custom iterable that can be used to iterate through all the response pages.
      * @throws SdkException
@@ -730,7 +738,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithoutResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithoutResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest.Builder} to
      *        create a request.
      * @return Result of the PaginatedOperationWithoutResultKey operation returned by the service.
      * @throws SdkException
@@ -891,7 +900,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param paginatedOperationWithoutResultKeyRequest
-     *        A {@link Consumer} that will call methods on {@link PaginatedOperationWithoutResultKeyRequest.Builder} to
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest.Builder} to
      *        create a request.
      * @return A custom iterable that can be used to iterate through all the response pages.
      * @throws SdkException
@@ -968,7 +978,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param putOperationWithChecksumRequest
-     *        A {@link Consumer} that will call methods on {@link ChecksumStructureWithStreaming.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PutOperationWithChecksumRequest.Builder} to create a
      *        request.
      * @param requestBody
      *        The content to send to the service. A {@link RequestBody} can be created using one of several factory
@@ -1066,7 +1077,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param putOperationWithChecksumRequest
-     *        A {@link Consumer} that will call methods on {@link ChecksumStructureWithStreaming.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.PutOperationWithChecksumRequest.Builder} to create a
      *        request.
      * @param sourcePath
      *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
@@ -1147,7 +1159,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOperationRequest.Builder} to create a
      *        request.
      * @param requestBody
      *        The content to send to the service. A {@link RequestBody} can be created using one of several factory
@@ -1215,7 +1228,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOperationRequest.Builder} to create a
      *        request.
      * @param sourcePath
      *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
@@ -1291,8 +1305,9 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
-     *        request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOutputOperationRequest.Builder} to create
+     *        a request.
      * @param requestBody
      *        The content to send to the service. A {@link RequestBody} can be created using one of several factory
      *        methods for various sources of data. For example, to create a request body from a file you can do the
@@ -1374,8 +1389,9 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingInputOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StructureWithStreamingMember.Builder} to create a
-     *        request.
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingInputOutputOperationRequest.Builder} to create
+     *        a request.
      * @param sourcePath
      *        {@link Path} to file containing data to send to the service. File will be read entirely and may be read
      *        multiple times in the event of a retry. If the file does not exist or the current user does not have
@@ -1444,7 +1460,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StreamingOutputOperationRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest.Builder} to create a
      *        request.
      * @param responseTransformer
      *        Functional interface for processing the streamed response content. The unmarshalled
@@ -1508,7 +1525,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StreamingOutputOperationRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest.Builder} to create a
      *        request.
      * @param destinationPath
      *        {@link Path} to file that response contents will be written to. The file must not exist or this method
@@ -1570,7 +1588,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StreamingOutputOperationRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest.Builder} to create a
      *        request.
      * @return A {@link ResponseInputStream} containing data streamed from service. Note that this is an unmanaged
      *         reference to the underlying HTTP connection so great care must be taken to ensure all data if fully read
@@ -1631,7 +1650,8 @@ public interface JsonClient extends AwsClient {
      * </p>
      *
      * @param streamingOutputOperationRequest
-     *        A {@link Consumer} that will call methods on {@link StreamingOutputOperationRequest.Builder} to create a
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest.Builder} to create a
      *        request.
      * @return A {@link ResponseBytes} that loads the data streamed from the service into memory and exposes it in
      *         convenient in-memory representations like a byte buffer or string. The unmarshalled response object can


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Javadoc links are broken for Consumer operations `@param` when the model input shape has the suffix `Input`
Example: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cloudwatch/CloudWatchClient.html#putMetricData(software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest)

All request objects in the SDK have the `Request` suffix. If it is `Input` in the model, it is overridden [here
](https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java#L229)
## Modifications
<!--- Describe your changes in detail -->
Update codedgen to replace `getC2jName` with `getShapeName` when generating javadocs

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
