### PR TITLE
Changes default behavior for DynamoDb Enhanced atomic counter extension

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2DynamoDbEnhanced-05cdcee.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2DynamoDbEnhanced-05cdcee.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 - DynamoDb Enhanced",
+    "contributor": "",
+    "description": "Changes the default behavior of the DynamoDb Enhanced atomic counter extension to automatically filter out any counter attributes in the item to be updated. This allows users to read and update items without DynamoDb collision errors."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/AtomicCounterExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/AtomicCounterExtension.java
@@ -19,8 +19,10 @@ import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUt
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.valueRef;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.update.UpdateExpressionUtils.ifNotExists;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -37,10 +39,11 @@ import software.amazon.awssdk.enhanced.dynamodb.update.SetAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.Logger;
 
 /**
- * This extension enables atomic counter attributes to be written to the database.
- * The extension is loaded by default when you instantiate a
+ * This extension enables atomic counter attributes to be changed in DynamoDb by creating instructions for modifying
+ * an existing value or setting a start value. The extension is loaded by default when you instantiate a
  * {@link DynamoDbEnhancedClient} and only needs to be added to the client if you
  * are adding custom extensions to the client.
  * <p>
@@ -56,8 +59,7 @@ import software.amazon.awssdk.utils.CollectionUtils;
  * <p>
  * Every time a new update of the record is successfully written to the database, the counter will be updated automatically.
  * By default, the counter starts at 0 and increments by 1 for each update. The tags provide the capability of adjusting
- * the counter start and increment/decrement values such as described in
- * {@link DynamoDbAtomicCounter}.
+ * the counter start and increment/decrement values such as described in {@link DynamoDbAtomicCounter}.
  * <p>
  * Example 1: Using a bean based table schema
  * <pre>
@@ -86,10 +88,17 @@ import software.amazon.awssdk.utils.CollectionUtils;
  * }
  * </pre>
  * <p>
- * <b>NOTE: </b>When using putItem, the counter will be reset to its start value.
+ * <b>NOTES: </b>
+ * <ul>
+ *     <li>When using putItem, the counter will be reset to its start value.</li>
+ *     <li>The extension will remove any existing occurrences of the atomic counter attributes.</li>
+ * </ul>
  */
 @SdkPublicApi
 public final class AtomicCounterExtension implements DynamoDbEnhancedClientExtension {
+
+    private static final Logger log = Logger.loggerFor(AtomicCounterExtension.class);
+
     private AtomicCounterExtension() {
     }
 
@@ -118,6 +127,7 @@ public final class AtomicCounterExtension implements DynamoDbEnhancedClientExten
                 break;
             case UPDATE_ITEM:
                 modificationBuilder.updateExpression(createUpdateExpression(counters));
+                modificationBuilder.transformedItem(filterFromItem(counters, context.items()));
                 break;
             default: break;
         }
@@ -133,6 +143,22 @@ public final class AtomicCounterExtension implements DynamoDbEnhancedClientExten
     private Map<String, AttributeValue> addToItem(Map<String, AtomicCounter> counters, Map<String, AttributeValue> items) {
         Map<String, AttributeValue> itemToTransform = new HashMap<>(items);
         counters.forEach((attribute, counter) -> itemToTransform.put(attribute, attributeValue(counter.startValue().value())));
+        return Collections.unmodifiableMap(itemToTransform);
+    }
+
+    private Map<String, AttributeValue> filterFromItem(Map<String, AtomicCounter> counters, Map<String, AttributeValue> items) {
+        Map<String, AttributeValue> itemToTransform = new HashMap<>(items);
+        List<String> removedAttributes = new ArrayList<>();
+        for (String attributeName : counters.keySet()) {
+            if (itemToTransform.containsKey(attributeName)) {
+                itemToTransform.remove(attributeName);
+                removedAttributes.add(attributeName);
+            }
+        }
+        if (!removedAttributes.isEmpty()) {
+            log.debug(() -> String.format("Filtered atomic counter attributes from existing update item to avoid collisions: %s",
+                                          String.join(",", removedAttributes)));
+        }
         return Collections.unmodifiableMap(itemToTransform);
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/AtomicCounterExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/AtomicCounterExtension.java
@@ -44,8 +44,7 @@ import software.amazon.awssdk.utils.Logger;
 /**
  * This extension enables atomic counter attributes to be changed in DynamoDb by creating instructions for modifying
  * an existing value or setting a start value. The extension is loaded by default when you instantiate a
- * {@link DynamoDbEnhancedClient} and only needs to be added to the client if you
- * are adding custom extensions to the client.
+ * {@link DynamoDbEnhancedClient} and only needs to be added to the client if you are adding custom extensions to the client.
  * <p>
  * To utilize atomic counters, first create a field in your model that will be used to store the counter.
  * This class field should of type {@link Long} and you need to tag it as an atomic counter:
@@ -91,7 +90,8 @@ import software.amazon.awssdk.utils.Logger;
  * <b>NOTES: </b>
  * <ul>
  *     <li>When using putItem, the counter will be reset to its start value.</li>
- *     <li>The extension will remove any existing occurrences of the atomic counter attributes.</li>
+ *     <li>The extension will remove any existing occurrences of the atomic counter attributes from the record during an
+ *     <i>updateItem</i> operation. Manually editing attributes marked as atomic counters will have <b>NO EFFECT</b>.</li>
  * </ul>
  */
 @SdkPublicApi

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AtomicCounterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AtomicCounterTest.java
@@ -136,7 +136,11 @@ public class AtomicCounterTest extends LocalDynamoDbSyncTestBase {
         AtomicCounterRecord retrievedRecord = mappedTable.getItem(record);
         retrievedRecord.setAttribute1("ChangingThisAttribute");
 
-        assertThat(mappedTable.updateItem(retrievedRecord)).isNotNull();
+        retrievedRecord = mappedTable.updateItem(retrievedRecord);
+        assertThat(retrievedRecord).isNotNull();
+        assertThat(retrievedRecord.getDefaultCounter()).isEqualTo(1L);
+        assertThat(retrievedRecord.getCustomCounter()).isEqualTo(15L);
+        assertThat(retrievedRecord.getDecreasingCounter()).isEqualTo(-21L);
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AtomicCounterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AtomicCounterTest.java
@@ -112,15 +112,31 @@ public class AtomicCounterTest extends LocalDynamoDbSyncTestBase {
     }
 
     @Test
-    public void createViaUpdate_settingCounterInPojo_throwsException() {
+    public void createViaUpdate_settingCounterInPojo_hasNoEffect() {
         AtomicCounterRecord record = new AtomicCounterRecord();
         record.setId(RECORD_ID);
         record.setDefaultCounter(10L);
         record.setAttribute1(STRING_VALUE);
 
-        assertThatThrownBy(() -> mappedTable.updateItem(record))
-            .isInstanceOf(DynamoDbException.class)
-            .hasMessageContaining("Two document paths");
+        mappedTable.updateItem(record);
+        AtomicCounterRecord persistedRecord = mappedTable.getItem(record);
+        assertThat(persistedRecord.getAttribute1()).isEqualTo(STRING_VALUE);
+        assertThat(persistedRecord.getDefaultCounter()).isEqualTo(0L);
+        assertThat(persistedRecord.getCustomCounter()).isEqualTo(10L);
+        assertThat(persistedRecord.getDecreasingCounter()).isEqualTo(-20L);
+    }
+
+    @Test
+    public void updateItem_retrievedFromDb_shouldNotThrowException() {
+        AtomicCounterRecord record = new AtomicCounterRecord();
+        record.setId(RECORD_ID);
+        record.setAttribute1(STRING_VALUE);
+        mappedTable.updateItem(record);
+
+        AtomicCounterRecord retrievedRecord = mappedTable.getItem(record);
+        retrievedRecord.setAttribute1("ChangingThisAttribute");
+
+        assertThat(mappedTable.updateItem(retrievedRecord)).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
The initial implementation of the atomic counter extension made the assumption that it was not necessary to modify the item itself while adding an update expression, because users should not include attributes that were tagged as an atomic counter in the item to be updated and if they did, they would get an error back. 

For instance, if attribute `accessCounter` of the class `Balance` was marked with the `AtomicCounter` attribute, this would result in an error:
~~~
Balance balanceToUpdate = new Balance();
balanceToUpdate.accessCounter(4);
table.updateItem(balanceToUpdate);
~~~
Which makes sense since `accessCounter` will be updated anyway in the `AtomicCounterExtension`, and the assumption was that an error is better than silently changing the item when `updateItem` was called. This assumption did not take into account that a very common, and natural, behavior for users is read-modify-update:
~~~
Balance balanceToUpdate = table.getItem(key);
balanceToUpdate.anImportantAttribute(newValue);
table.updateItem(balanceToUpdate);
~~~
Here, the user will actually get the same error as above, because while they did not explicitly set `accessCounter`, the instance returned from DDB will have it set, and it's included when the user calls `updateItem`. 

Therefore, we should change this behavior to filter out any counter attributes in the item map if they're present when we add an update expression for the atomic counter. From a backwards compatibility perspective, this change should have little effect on existing user code. 

## Modifications
AtomicCounterExpression filters any attributes from the item that are marked as atomic counters. If it finds any, it also logs a debug level warning to provide context to users.  

## Testing
Unit and functional testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
