### PR TITLE
Adds accountId support to process credentials provider

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-params-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-params-without-allowlist.java
@@ -32,6 +32,9 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
 
     private final Boolean useFIPSEndpoint;
 
+
+    private final String awsAccountId;
+
     private final String endpointId;
 
     private final Boolean defaultTrueParam;
@@ -51,6 +54,7 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
         this.region = builder.region;
         this.useDualStackEndpoint = builder.useDualStackEndpoint;
         this.useFIPSEndpoint = builder.useFIPSEndpoint;
+        this.awsAccountId = builder.awsAccountId;
         this.endpointId = builder.endpointId;
         this.defaultTrueParam = Validate.paramNotNull(builder.defaultTrueParam, "defaultTrueParam");
         this.defaultStringParam = Validate.paramNotNull(builder.defaultStringParam, "defaultStringParam");
@@ -82,6 +86,11 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
     @Override
     public Boolean useFipsEndpoint() {
         return useFIPSEndpoint;
+    }
+
+    @Override
+    public String awsAccountId() {
+        return awsAccountId;
     }
 
     @Override
@@ -134,6 +143,8 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
 
         private Boolean useFIPSEndpoint;
 
+        private String awsAccountId;
+
         private String endpointId;
 
         private Boolean defaultTrueParam = true;
@@ -156,6 +167,7 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
             this.region = params.region;
             this.useDualStackEndpoint = params.useDualStackEndpoint;
             this.useFIPSEndpoint = params.useFIPSEndpoint;
+            this.awsAccountId = params.awsAccountId;
             this.endpointId = params.endpointId;
             this.defaultTrueParam = params.defaultTrueParam;
             this.defaultStringParam = params.defaultStringParam;
@@ -186,6 +198,12 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
         @Override
         public Builder useFipsEndpoint(Boolean useFIPSEndpoint) {
             this.useFIPSEndpoint = useFIPSEndpoint;
+            return this;
+        }
+
+        @Override
+        public Builder awsAccountId(String awsAccountId) {
+            this.awsAccountId = awsAccountId;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
@@ -55,7 +55,7 @@ public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProv
     public List<AuthSchemeOption> resolveAuthScheme(QueryAuthSchemeParams params) {
         QueryEndpointParams endpointParameters = QueryEndpointParams.builder().region(params.region())
                 .useDualStackEndpoint(params.useDualStackEndpoint()).useFipsEndpoint(params.useFipsEndpoint())
-                .endpointId(params.endpointId()).defaultTrueParam(params.defaultTrueParam())
+                 .awsAccountId(params.awsAccountId()).endpointId(params.endpointId()).defaultTrueParam(params.defaultTrueParam())
                 .defaultStringParam(params.defaultStringParam()).deprecatedParam(params.deprecatedParam())
                 .booleanContextParam(params.booleanContextParam()).stringContextParam(params.stringContextParam())
                 .operationContextParam(params.operationContextParam()).build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-params-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-params-without-allowlist.java
@@ -49,6 +49,8 @@ public interface QueryAuthSchemeParams extends ToCopyableBuilder<QueryAuthScheme
 
     Boolean useFipsEndpoint();
 
+    String awsAccountId();
+
     String endpointId();
 
     /**
@@ -89,6 +91,8 @@ public interface QueryAuthSchemeParams extends ToCopyableBuilder<QueryAuthScheme
         Builder useDualStackEndpoint(Boolean useDualStackEndpoint);
 
         Builder useFipsEndpoint(Boolean useFIPSEndpoint);
+
+        Builder awsAccountId(String awsAccountId);
 
         Builder endpointId(String endpointId);
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
@@ -102,6 +102,7 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
         builder.region(endpointParams.region());
         builder.useDualStackEndpoint(endpointParams.useDualStackEndpoint());
         builder.useFipsEndpoint(endpointParams.useFipsEndpoint());
+        builder.awsAccountId(endpointParams.awsAccountId());
         builder.endpointId(endpointParams.endpointId());
         builder.defaultTrueParam(endpointParams.defaultTrueParam());
         builder.defaultStringParam(endpointParams.defaultStringParam());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -158,6 +158,7 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
             this.region = builder.region;
             this.useDualStackEndpoint = builder.useDualStackEndpoint;
             this.useFIPSEndpoint = builder.useFIPSEndpoint;
+            this.awsAccountId = builder.awsAccountId;
             this.endpointId = builder.endpointId;
             this.defaultTrueParam = builder.defaultTrueParam;
             this.defaultStringParam = builder.defaultStringParam;

--- a/core/auth/src/test/resources/resources/process/linux-credentials-script.sh
+++ b/core/auth/src/test/resources/resources/process/linux-credentials-script.sh
@@ -1,18 +1,36 @@
 #!/usr/bin/env bash
+
+parseAdditionalParams () {
+    local prefix=`echo $1 | cut -d= -f1`;
+    local param=`echo $1 | cut -d= -f2`;
+
+    case "$prefix" in
+    ("token"*)
+        if [[ "$param" = "RANDOM_TOKEN" ]]; then
+            echo "\"SessionToken\": \"$RANDOM\""
+        else
+            echo "\"SessionToken\": \"$param\""
+        fi;
+        ;;
+    ("exp"*)
+        echo "\"Expiration\": \"$param\"";
+        ;;
+    ("acctid"*)
+        echo "\"AccountId\": \"$param\"";
+        ;;
+    (*)
+        echo "\"$prefix\": \"$param\"";
+        ;;
+    esac
+}
+
 echo '{';
 echo '"Version": 1,';
 echo "\"AccessKeyId\": \"$1\",";
 echo "\"SecretAccessKey\": \"$2\"";
-if [[ $# -ge 3 ]]; then
+for args in "${@:3}"
+do
     echo ',';
-    if [[ "$3" = "RANDOM_TOKEN" ]]; then
-        echo "\"SessionToken\": \"$RANDOM\""
-    else
-        echo "\"SessionToken\": \"$3\""
-    fi;
-fi;
-if [[ $# -ge 4 ]]; then
-    echo ','
-    echo "\"Expiration\": \"$4\"";
-fi;
+    parseAdditionalParams $args;
+done;
 echo '}';

--- a/core/auth/src/test/resources/resources/process/windows-credentials-script.bat
+++ b/core/auth/src/test/resources/resources/process/windows-credentials-script.bat
@@ -1,19 +1,45 @@
 @ECHO OFF
-SET input=%1
 ECHO {
 ECHO "Version": 1,
 ECHO "AccessKeyId": "%1",
-ECHO "SecretAccessKey": "%2"
-IF NOT "%3"=="" (
+SHIFT
+ECHO "SecretAccessKey": "%1"
+SHIFT
+
+:LOOP
+    IF "%1"=="" (
+        GOTO :EXITLOOP
+    )
+    IF "%2"=="" (
+        echo "Expected value for param %1!"
+        exit /b 1
+    )
     ECHO ,
+    CALL :PARSE_ARGS %1 %2
+    SHIFT
+    SHIFT
+GOTO :LOOP
+
+:EXITLOOP
+
+ECHO }
+
+GOTO:EOF
+
+:PARSE_ARGS
+SET prefix=%1
+SET param=%2
+IF "%prefix%"=="token" (
     IF "%3"=="RANDOM_TOKEN" (
         ECHO "SessionToken": "%RANDOM%"
     ) ELSE (
-        ECHO "SessionToken": "%3"
+        ECHO "SessionToken": "%param%"
     )
+) ELSE IF "%prefix%"=="exp" (
+    ECHO "Expiration": "%param%"
+) ELSE IF "%prefix%"=="acctid" (
+    ECHO "AccountId": "%param%"
+) ELSE (
+    ECHO "%prefix%": "%param%"
 )
-IF NOT "%4"=="" (
-    ECHO ,
-    ECHO "Expiration": "%4"
-)
-echo }
+EXIT /B


### PR DESCRIPTION
## Motivation and Context
Adds accountId support to process credentials provider

## Modifications
- Process credentials provider attempts to read accountId from the JSON file and add to credentials
- Adds expiration time to the credentials as well since it's now supported
- Modifies the test scripts that produce different JSON files so they can handle an arbitrary number of optional arguments, with expiration, session token and accountId being named. 