### PR TITLE
Remove dependency on http-auth-aws from codecatalyst.

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -108,7 +108,7 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         b.addMethod(setStaticContextParamsMethod());
         addStaticContextParamMethods(b);
 
-        b.addMethod(copyEndpointSignerPropertiesToAuthMethod());
+        b.addMethod(authSchemeWithEndpointSignerPropertiesMethod());
         b.addMethod(copySignerPropertiesToAttributesMethod());
 
         if (hasClientContextParams()) {
@@ -165,7 +165,7 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         b.addStatement("$T<?> selectedAuthScheme = executionAttributes.getAttribute($T.SELECTED_AUTH_SCHEME)",
                        SelectedAuthScheme.class, SdkInternalExecutionAttribute.class);
         b.beginControlFlow("if (endpointAuthSchemes != null && selectedAuthScheme != null)");
-        b.addStatement("selectedAuthScheme = copyEndpointSignerPropertiesToAuth(endpointAuthSchemes, selectedAuthScheme)");
+        b.addStatement("selectedAuthScheme = authSchemeWithEndpointSignerProperties(endpointAuthSchemes, selectedAuthScheme)");
 
         b.addStatement("executionAttributes.putAttribute($T.SELECTED_AUTH_SCHEME, selectedAuthScheme)",
                        SdkInternalExecutionAttribute.class);
@@ -529,14 +529,14 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         return endpointTrait.getHostPrefix();
     }
 
-    private MethodSpec copyEndpointSignerPropertiesToAuthMethod() {
+    private MethodSpec authSchemeWithEndpointSignerPropertiesMethod() {
         TypeVariableName tExtendsIdentity = TypeVariableName.get("T", Identity.class);
         TypeName selectedAuthSchemeOfT = ParameterizedTypeName.get(ClassName.get(SelectedAuthScheme.class),
                                                                    TypeVariableName.get("T"));
         TypeName listOfEndpointAuthScheme = ParameterizedTypeName.get(List.class, EndpointAuthScheme.class);
 
         MethodSpec.Builder method =
-            MethodSpec.methodBuilder("copyEndpointSignerPropertiesToAuth")
+            MethodSpec.methodBuilder("authSchemeWithEndpointSignerProperties")
                       .addModifiers(Modifier.PRIVATE)
                       .addTypeVariable(tExtendsIdentity)
                       .returns(selectedAuthSchemeOfT)
@@ -628,7 +628,6 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
                       .addParameter(AuthSchemeOption.class, "authOption")
                       .addParameter(ExecutionAttributes.class, "executionAttributes");
 
-        // TODO(sra-identity-and-auth): What about bearer auth properties?
         if (dependsOnHttpAuthAws) {
             method.addCode(copyV4SignerPropertiesToAttributes());
             method.addCode(copyV4aSignerPropertiesToAttributes());

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AuthSchemeUtils.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AuthSchemeUtils.java.resource
@@ -2,22 +2,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
-import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
-import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.aws.AwsV4aAuthScheme;
-import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
-import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.RegionScope;
 import software.amazon.awssdk.utils.Logger;
 
 @SdkProtectedApi
@@ -111,43 +101,5 @@ public final class AuthSchemeUtils {
             }
         }
         return authSchemes;
-    }
-
-    public static void setSigningParams(ExecutionAttributes executionAttributes, AuthSchemeOption authOption) {
-        if (authOption.schemeId().equals(AwsV4AuthScheme.SCHEME_ID)) {
-            setSigV4SigningParams(executionAttributes, authOption);
-        } else if (authOption.schemeId().equals(AwsV4aAuthScheme.SCHEME_ID)) {
-            setSigV4aAuthSigningParams(executionAttributes, authOption);
-        }
-    }
-
-    private static void setSigV4SigningParams(ExecutionAttributes executionAttributes, AuthSchemeOption authOption) {
-        if (authOption.signerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE) != null) {
-            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE,
-                                             authOption.signerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE));
-        }
-        if (authOption.signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME) != null) {
-            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME,
-                                             authOption.signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME));
-        }
-        if (authOption.signerProperty(AwsV4HttpSigner.REGION_NAME) != null) {
-            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION,
-                                             Region.of(authOption.signerProperty(AwsV4HttpSigner.REGION_NAME)));
-        }
-    }
-
-    private static void setSigV4aAuthSigningParams(ExecutionAttributes executionAttributes, AuthSchemeOption authOption) {
-        if (authOption.signerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE) != null) {
-            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE,
-                                             authOption.signerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE));
-        }
-        if (authOption.signerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME) != null) {
-            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME,
-                                             authOption.signerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME));
-        }
-        if (authOption.signerProperty(AwsV4aHttpSigner.REGION_NAME) != null) {
-            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE,
-                                             RegionScope.create(authOption.signerProperty(AwsV4aHttpSigner.REGION_NAME)));
-        }
     }
 }

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
@@ -6,20 +6,12 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
-import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
-import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
-import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
-import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
-import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
-import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.HostnameValidator;
 import software.amazon.awssdk.utils.Logger;
@@ -181,60 +173,6 @@ public final class AwsEndpointProviderUtils {
         String requestPathWithClientPathRemoved = StringUtils.replaceOnce(requestPath, clientEndpointPath, "");
         String finalPath = SdkHttpUtils.appendUri(resolvedUriPath, requestPathWithClientPathRemoved);
         return finalPath;
-    }
-
-    /**
-     * Merge the resolved endpoint auth scheme settings into the selected auth scheme. Endpoint auth schemes settings
-     * take priority over settings already set in the selected auth scheme.
-     */
-    public static <T extends Identity> SelectedAuthScheme<T> mergeIntoResolvedAuthScheme(
-            List<EndpointAuthScheme> endpointAuthSchemes, SelectedAuthScheme<T> selectedAuthScheme) {
-        for (EndpointAuthScheme endpointAuthScheme : endpointAuthSchemes) {
-            if (!endpointAuthScheme.schemeId().equals(selectedAuthScheme.authSchemeOption().schemeId())) {
-                // Don't include signer properties for auth options that don't match our selected auth scheme
-                continue;
-            }
-
-            if (endpointAuthScheme instanceof SigV4AuthScheme) {
-                SigV4AuthScheme v4AuthScheme = (SigV4AuthScheme) endpointAuthScheme;
-                AuthSchemeOption authSchemeOption = selectedAuthScheme.authSchemeOption().toBuilder()
-                        .applyMutation(o -> overrideV4SignerProperties(o, v4AuthScheme)).build();
-                return new SelectedAuthScheme<>(selectedAuthScheme.identity(), selectedAuthScheme.signer(), authSchemeOption);
-            }
-
-            if (endpointAuthScheme instanceof SigV4aAuthScheme) {
-                SigV4aAuthScheme v4aAuthScheme = (SigV4aAuthScheme) endpointAuthScheme;
-                AuthSchemeOption authSchemeOption = selectedAuthScheme.authSchemeOption().toBuilder()
-                        .applyMutation(o -> overrideV4aSignerProperties(o, v4aAuthScheme)).build();
-                return new SelectedAuthScheme<>(selectedAuthScheme.identity(), selectedAuthScheme.signer(), authSchemeOption);
-            }
-        }
-
-        return selectedAuthScheme;
-    }
-
-    private static void overrideV4SignerProperties(AuthSchemeOption.Builder option, SigV4AuthScheme endpointAuthScheme) {
-        if (endpointAuthScheme.isDisableDoubleEncodingSet()) {
-            option.putSignerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, !endpointAuthScheme.disableDoubleEncoding());
-        }
-        if (endpointAuthScheme.signingRegion() != null) {
-            option.putSignerProperty(AwsV4HttpSigner.REGION_NAME, endpointAuthScheme.signingRegion());
-        }
-        if (endpointAuthScheme.signingName() != null) {
-            option.putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, endpointAuthScheme.signingName());
-        }
-    }
-
-    private static void overrideV4aSignerProperties(AuthSchemeOption.Builder option, SigV4aAuthScheme endpointAuthScheme) {
-        if (endpointAuthScheme.isDisableDoubleEncodingSet()) {
-            option.putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, !endpointAuthScheme.disableDoubleEncoding());
-        }
-        if (endpointAuthScheme.signingRegionSet() != null) {
-            option.putSignerProperty(AwsV4aHttpSigner.REGION_NAME, String.join(",", endpointAuthScheme.signingRegionSet()));
-        }
-        if (endpointAuthScheme.signingName() != null) {
-            option.putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, endpointAuthScheme.signingName());
-        }
     }
 
     private static void addKnownProperties(Endpoint.Builder builder, Map<String, Value> properties) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -5,9 +5,12 @@ import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
 import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -18,6 +21,14 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.aws.AwsV4aAuthScheme;
+import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.RegionScope;
 import software.amazon.awssdk.services.query.endpoints.QueryClientContextParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
@@ -44,15 +55,15 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
                     endpoint = AwsEndpointProviderUtils.addHostPrefix(endpoint, hostPrefix.get());
                 }
             }
-            List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+            List<EndpointAuthScheme> endpointAuthSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
             SelectedAuthScheme<?> selectedAuthScheme = executionAttributes
                 .getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
-            if (authSchemes != null && selectedAuthScheme != null) {
-                selectedAuthScheme = AwsEndpointProviderUtils.mergeIntoResolvedAuthScheme(authSchemes, selectedAuthScheme);
+            if (endpointAuthSchemes != null && selectedAuthScheme != null) {
+                selectedAuthScheme = copyEndpointSignerPropertiesToAuth(endpointAuthSchemes, selectedAuthScheme);
                 executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme);
             }
             if (selectedAuthScheme != null) {
-                AuthSchemeUtils.setSigningParams(executionAttributes, selectedAuthScheme.authSchemeOption());
+                copySignerPropertiesToAttributes(selectedAuthScheme.authSchemeOption(), executionAttributes);
             }
             executionAttributes.putAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT, endpoint);
             return result;
@@ -116,6 +127,78 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
 
     private static void operationWithStaticContextParamsStaticContextParams(QueryEndpointParams.Builder params) {
         params.staticStringParam("hello");
+    }
+
+    private <T extends Identity> SelectedAuthScheme<T> copyEndpointSignerPropertiesToAuth(
+        List<EndpointAuthScheme> endpointAuthSchemes, SelectedAuthScheme<T> selectedAuthScheme) {
+        for (EndpointAuthScheme endpointAuthScheme : endpointAuthSchemes) {
+            if (!endpointAuthScheme.schemeId().equals(selectedAuthScheme.authSchemeOption().schemeId())) {
+                continue;
+            }
+            AuthSchemeOption.Builder option = selectedAuthScheme.authSchemeOption().toBuilder();
+            if (endpointAuthScheme instanceof SigV4AuthScheme) {
+                SigV4AuthScheme v4AuthScheme = (SigV4AuthScheme) endpointAuthScheme;
+                if (v4AuthScheme.isDisableDoubleEncodingSet()) {
+                    option.putSignerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, !v4AuthScheme.disableDoubleEncoding());
+                }
+                if (v4AuthScheme.signingRegion() != null) {
+                    option.putSignerProperty(AwsV4HttpSigner.REGION_NAME, v4AuthScheme.signingRegion());
+                }
+                if (v4AuthScheme.signingName() != null) {
+                    option.putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, v4AuthScheme.signingName());
+                }
+                return new SelectedAuthScheme<>(selectedAuthScheme.identity(), selectedAuthScheme.signer(), option.build());
+            }
+            if (endpointAuthScheme instanceof SigV4aAuthScheme) {
+                SigV4aAuthScheme v4aAuthScheme = (SigV4aAuthScheme) endpointAuthScheme;
+                if (v4aAuthScheme.isDisableDoubleEncodingSet()) {
+                    option.putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, !v4aAuthScheme.disableDoubleEncoding());
+                }
+                if (v4aAuthScheme.signingRegionSet() != null) {
+                    option.putSignerProperty(AwsV4aHttpSigner.REGION_NAME, String.join(",", v4aAuthScheme.signingRegionSet()));
+                }
+                if (v4aAuthScheme.signingName() != null) {
+                    option.putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, v4aAuthScheme.signingName());
+                }
+                return new SelectedAuthScheme<>(selectedAuthScheme.identity(), selectedAuthScheme.signer(), option.build());
+            }
+            throw new IllegalArgumentException("Endpoint auth scheme '" + endpointAuthScheme.name()
+                                               + "' cannot be mapped to the SDK auth scheme. Was it declared in the service's model?");
+        }
+        return selectedAuthScheme;
+    }
+
+    private void copySignerPropertiesToAttributes(AuthSchemeOption authOption, ExecutionAttributes executionAttributes) {
+        if (authOption.schemeId().equals(AwsV4AuthScheme.SCHEME_ID)) {
+            if (authOption.signerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE) != null) {
+                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE,
+                                                 authOption.signerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE));
+            }
+            if (authOption.signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME) != null) {
+                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME,
+                                                 authOption.signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME));
+            }
+            if (authOption.signerProperty(AwsV4HttpSigner.REGION_NAME) != null) {
+                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION,
+                                                 Region.of(authOption.signerProperty(AwsV4HttpSigner.REGION_NAME)));
+            }
+            return;
+        }
+        if (authOption.schemeId().equals(AwsV4aAuthScheme.SCHEME_ID)) {
+            if (authOption.signerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE) != null) {
+                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE,
+                                                 authOption.signerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE));
+            }
+            if (authOption.signerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME) != null) {
+                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME,
+                                                 authOption.signerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME));
+            }
+            if (authOption.signerProperty(AwsV4aHttpSigner.REGION_NAME) != null) {
+                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE,
+                                                 RegionScope.create(authOption.signerProperty(AwsV4aHttpSigner.REGION_NAME)));
+            }
+            return;
+        }
     }
 
     private static void setClientContextParams(QueryEndpointParams.Builder params, ExecutionAttributes executionAttributes) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -59,7 +59,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
             SelectedAuthScheme<?> selectedAuthScheme = executionAttributes
                 .getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
             if (endpointAuthSchemes != null && selectedAuthScheme != null) {
-                selectedAuthScheme = copyEndpointSignerPropertiesToAuth(endpointAuthSchemes, selectedAuthScheme);
+                selectedAuthScheme = authSchemeWithEndpointSignerProperties(endpointAuthSchemes, selectedAuthScheme);
                 executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme);
             }
             if (selectedAuthScheme != null) {
@@ -129,7 +129,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
         params.staticStringParam("hello");
     }
 
-    private <T extends Identity> SelectedAuthScheme<T> copyEndpointSignerPropertiesToAuth(
+    private <T extends Identity> SelectedAuthScheme<T> authSchemeWithEndpointSignerProperties(
         List<EndpointAuthScheme> endpointAuthSchemes, SelectedAuthScheme<T> selectedAuthScheme) {
         for (EndpointAuthScheme endpointAuthScheme : endpointAuthSchemes) {
             if (!endpointAuthScheme.schemeId().equals(selectedAuthScheme.authSchemeOption().schemeId())) {

--- a/services/codecatalyst/pom.xml
+++ b/services/codecatalyst/pom.xml
@@ -61,12 +61,6 @@
             <artifactId>http-auth</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
-        <!-- TODO(sra-identity-and-auth): CodeCatalyst shouldn't depend on http-auth-aws, because it doesn't use it -->
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>http-auth-aws</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssooidc</artifactId>

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AuthSchemeUtilsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AuthSchemeUtilsTest.java
@@ -23,19 +23,10 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
-import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
-import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.aws.AwsV4aAuthScheme;
-import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
-import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.RegionScope;
 import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.internal.AuthSchemeUtils;
 
 public class AuthSchemeUtilsTest {
@@ -65,77 +56,5 @@ public class AuthSchemeUtilsTest {
         EndpointAuthScheme sigv4a = SigV4aAuthScheme.builder().build();
 
         assertThat(AuthSchemeUtils.chooseAuthScheme(Arrays.asList(sigv4, sigv4a))).isEqualTo(sigv4);
-    }
-
-    @Test
-    public void setSigningParams_sigv4_setsParamsCorrectly() {
-        AuthSchemeOption sigv4 = AuthSchemeOption.builder()
-                                                 .schemeId(AwsV4AuthScheme.SCHEME_ID)
-                                                 .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "myservice")
-                                                 .putSignerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, false)
-                                                 .putSignerProperty(AwsV4HttpSigner.REGION_NAME, "us-west-2")
-                                                 .build();
-
-        ExecutionAttributes attrs = new ExecutionAttributes();
-
-        AuthSchemeUtils.setSigningParams(attrs, sigv4);
-
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME)).isEqualTo("myservice");
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION)).isEqualTo(Region.of("us-west-2"));
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE)).isEqualTo(false);
-    }
-
-    @Test
-    public void setSigningParams_sigv4_paramsAreNull_doesNotOverrideAttrs() {
-        AuthSchemeOption sigv4 = AuthSchemeOption.builder()
-                                                 .schemeId(AwsV4AuthScheme.SCHEME_ID)
-                                                 .build();
-
-        ExecutionAttributes attrs = new ExecutionAttributes();
-        attrs.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, "myservice");
-        attrs.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, Region.of("us-west-2"));
-        attrs.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE, true);
-
-        AuthSchemeUtils.setSigningParams(attrs, sigv4);
-
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME)).isEqualTo("myservice");
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION)).isEqualTo(Region.of("us-west-2"));
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE)).isEqualTo(true);
-    }
-
-    @Test
-    public void setSigningParams_sigv4a_setsParamsCorrectly() {
-        AuthSchemeOption sigv4a = AuthSchemeOption.builder()
-                                                  .schemeId(AwsV4aAuthScheme.SCHEME_ID)
-                                                  .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "myservice")
-                                                  .putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, false)
-                                                  .putSignerProperty(AwsV4aHttpSigner.REGION_NAME, "*")
-                                                  .build();
-
-        ExecutionAttributes attrs = new ExecutionAttributes();
-
-        AuthSchemeUtils.setSigningParams(attrs, sigv4a);
-
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME)).isEqualTo("myservice");
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE)).isEqualTo(RegionScope.GLOBAL);
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE)).isEqualTo(false);
-    }
-
-    @Test
-    public void setSigningParams_sigv4a_signingNameNull_doesNotOverrideAttrs() {
-        AuthSchemeOption sigv4a = AuthSchemeOption.builder()
-                                                  .schemeId(AwsV4aAuthScheme.SCHEME_ID)
-                                                  .putSignerProperty(AwsV4aHttpSigner.REGION_NAME, "*")
-                                                  .build();
-
-        ExecutionAttributes attrs = new ExecutionAttributes();
-        attrs.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, "myservice");
-        attrs.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE, true);
-
-        AuthSchemeUtils.setSigningParams(attrs, sigv4a);
-
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME)).isEqualTo("myservice");
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE)).isEqualTo(RegionScope.GLOBAL);
-        assertThat(attrs.getAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE)).isEqualTo(true);
     }
 }


### PR DESCRIPTION
Previously (#4311), AwsEndpointProviderUtils and AuthSchemeUtils, which are copied into every client, depend on classes from http-auth-aws. As a result, every client needed a dependency on http-auth-aws. With this change, we move the methods from those classes that depend on http-auth-aws to be code generated within only the clients that need them.