### PR TITLE
Adds account ID support for profile credentials provider sources

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
@@ -157,8 +157,11 @@ public final class ProfileCredentialsUtils {
     private AwsCredentialsProvider basicProfileCredentialsProvider() {
         requireProperties(ProfileProperty.AWS_ACCESS_KEY_ID,
                           ProfileProperty.AWS_SECRET_ACCESS_KEY);
-        AwsCredentials credentials = AwsBasicCredentials.create(properties.get(ProfileProperty.AWS_ACCESS_KEY_ID),
-                                                                     properties.get(ProfileProperty.AWS_SECRET_ACCESS_KEY));
+        AwsCredentials credentials = AwsBasicCredentials.builder()
+                                                        .accessKeyId(properties.get(ProfileProperty.AWS_ACCESS_KEY_ID))
+                                                        .secretAccessKey(properties.get(ProfileProperty.AWS_SECRET_ACCESS_KEY))
+                                                        .accountId(properties.get(ProfileProperty.AWS_ACCOUNT_ID))
+                                                        .build();
         return StaticCredentialsProvider.create(credentials);
     }
 
@@ -169,9 +172,12 @@ public final class ProfileCredentialsUtils {
         requireProperties(ProfileProperty.AWS_ACCESS_KEY_ID,
                           ProfileProperty.AWS_SECRET_ACCESS_KEY,
                           ProfileProperty.AWS_SESSION_TOKEN);
-        AwsCredentials credentials = AwsSessionCredentials.create(properties.get(ProfileProperty.AWS_ACCESS_KEY_ID),
-                                                                  properties.get(ProfileProperty.AWS_SECRET_ACCESS_KEY),
-                                                                  properties.get(ProfileProperty.AWS_SESSION_TOKEN));
+        AwsCredentials credentials = AwsSessionCredentials.builder()
+                                                          .accessKeyId(properties.get(ProfileProperty.AWS_ACCESS_KEY_ID))
+                                                          .secretAccessKey(properties.get(ProfileProperty.AWS_SECRET_ACCESS_KEY))
+                                                          .sessionToken(properties.get(ProfileProperty.AWS_SESSION_TOKEN))
+                                                          .accountId(properties.get(ProfileProperty.AWS_ACCOUNT_ID))
+                                                          .build();
         return StaticCredentialsProvider.create(credentials);
     }
 
@@ -180,6 +186,7 @@ public final class ProfileCredentialsUtils {
 
         return ProcessCredentialsProvider.builder()
                                          .command(properties.get(ProfileProperty.CREDENTIAL_PROCESS))
+                                         .staticAccountId(properties.get(ProfileProperty.AWS_ACCOUNT_ID))
                                          .build();
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -114,6 +115,24 @@ public class ProfileCredentialsProviderTest {
         assertThat(provider.resolveCredentials()).satisfies(credentials -> {
             assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
             assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+            assertThat(credentials.accountId()).isNotPresent();
+        });
+    }
+
+    @Test
+    void presentProfileWithAccountIdReturnsCredentialsWithAccountId() {
+        ProfileFile file = profileFile("[default]\n"
+                                       + "aws_access_key_id = defaultAccessKey\n"
+                                       + "aws_secret_access_key = defaultSecretAccessKey\n"
+                                       + "aws_account_id = defaultAccountId");
+
+        ProfileCredentialsProvider provider =
+            ProfileCredentialsProvider.builder().profileFile(file).profileName("default").build();
+
+        assertThat(provider.resolveCredentials()).satisfies(credentials -> {
+            assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
+            assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+            assertThat(credentials.accountId()).isPresent().isEqualTo(Optional.of("defaultAccountId"));
         });
     }
 
@@ -201,13 +220,15 @@ public class ProfileCredentialsProviderTest {
         assertThat(provider.resolveCredentials()).satisfies(credentials -> {
             assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
             assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+            assertThat(credentials.accountId()).isNotPresent();
         });
     }
 
     @Test
     void resolveCredentials_presentSupplierProfileFile_returnsCredentials() {
         Supplier<ProfileFile> supplier = () -> profileFile("[default]\naws_access_key_id = defaultAccessKey\n"
-                                                           + "aws_secret_access_key = defaultSecretAccessKey\n");
+                                                           + "aws_secret_access_key = defaultSecretAccessKey\n"
+                                                           + "aws_account_id = defaultAccountId");
 
         ProfileCredentialsProvider provider =
             ProfileCredentialsProvider.builder()
@@ -218,6 +239,7 @@ public class ProfileCredentialsProviderTest {
         assertThat(provider.resolveCredentials()).satisfies(credentials -> {
             assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
             assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+            assertThat(credentials.accountId()).isPresent();
         });
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
@@ -15,28 +15,52 @@
 
 package software.amazon.awssdk.auth.credentials;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StaticCredentialsProviderTest {
+
     @Test
-    public void getAwsCredentials_ReturnsSameCredentials() throws Exception {
-        final AwsCredentials credentials = AwsBasicCredentials.create("akid", "skid");
-        final AwsCredentials actualCredentials =
-                StaticCredentialsProvider.create(credentials).resolveCredentials();
-        assertEquals(credentials, actualCredentials);
+    void getAwsCredentials_ReturnsSameCredentials() {
+        AwsCredentials credentials = AwsBasicCredentials.create("akid", "skid");
+        AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
+        assertThat(actualCredentials).isEqualTo(credentials);
     }
 
     @Test
-    public void getSessionAwsCredentials_ReturnsSameCredentials() throws Exception {
-        final AwsSessionCredentials credentials = AwsSessionCredentials.create("akid", "skid", "token");
-        final AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
-        assertEquals(credentials, actualCredentials);
+    void getAwsCredentialsWithAccountId_ReturnsSameCredentials() {
+        AwsCredentials credentials = AwsBasicCredentials.builder()
+                                                        .accessKeyId("akid")
+                                                        .secretAccessKey("skid")
+                                                        .accountId("acctid")
+                                                        .build();
+        AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
+        assertThat(actualCredentials).isEqualTo(credentials);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void nullCredentials_ThrowsIllegalArgumentException() {
-        StaticCredentialsProvider.create(null);
+    @Test
+    void getSessionAwsCredentials_ReturnsSameCredentials() {
+        AwsSessionCredentials credentials = AwsSessionCredentials.create("akid", "skid", "token");
+        AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
+        assertThat(actualCredentials).isEqualTo(credentials);
+    }
+
+    @Test
+    void getSessionAwsCredentialsWithAccountId_ReturnsSameCredentials() {
+        AwsSessionCredentials credentials = AwsSessionCredentials.builder()
+                                                                 .accessKeyId("akid")
+                                                                 .secretAccessKey("skid")
+                                                                 .sessionToken("token")
+                                                                 .accountId("acctid")
+                                                                 .build();
+        AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
+        assertThat(actualCredentials).isEqualTo(credentials);
+    }
+
+    @Test
+    void nullCredentials_ThrowsException() {
+        assertThatThrownBy(() -> StaticCredentialsProvider.create(null)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -33,8 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.ProcessCredentialsProviderTest;
-import software.amazon.awssdk.core.checksums.Algorithm;
-import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileProperty;
 import software.amazon.awssdk.utils.StringInputStream;
@@ -58,7 +55,8 @@ public class ProfileCredentialsUtilsTest {
     public void roleProfileCanInheritFromAnotherFile() {
         String sourceProperties =
             "aws_access_key_id=defaultAccessKey\n" +
-            "aws_secret_access_key=defaultSecretAccessKey";
+            "aws_secret_access_key=defaultSecretAccessKey" +
+            "aws_account_id=defaultAccountId";
 
         String childProperties =
             "source_profile=source\n" +
@@ -117,13 +115,15 @@ public class ProfileCredentialsUtilsTest {
         ProfileFile profileFile = allTypesProfile();
         assertThat(profileFile.profile("default")).hasValueSatisfying(profile -> {
             assertThat(profile.name()).isEqualTo("default");
-            assertThat(profile.property(ProfileProperty.AWS_ACCESS_KEY_ID)).hasValue("defaultAccessKey");
             assertThat(profile.toString()).contains("default");
+            assertThat(profile.property(ProfileProperty.AWS_ACCESS_KEY_ID)).hasValue("defaultAccessKey");
+            assertThat(profile.property(ProfileProperty.AWS_ACCOUNT_ID)).hasValue("defaultAccountId");
             assertThat(profile.property(ProfileProperty.REGION)).isNotPresent();
             assertThat(new ProfileCredentialsUtils(profileFile, profile, profileFile::profile).credentialsProvider()).hasValueSatisfying(credentialsProvider -> {
                 assertThat(credentialsProvider.resolveCredentials()).satisfies(credentials -> {
                     assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
                     assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+                    assertThat(credentials.accountId()).isPresent().hasValue("defaultAccountId");
                 });
             });
         });
@@ -140,6 +140,7 @@ public class ProfileCredentialsUtilsTest {
                     assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
                     assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
                     assertThat(((AwsSessionCredentials) credentials).sessionToken()).isEqualTo("awsSessionToken");
+                    assertThat(credentials.accountId()).isPresent().hasValue("defaultAccountId");
                 });
             });
         });
@@ -155,6 +156,55 @@ public class ProfileCredentialsUtilsTest {
                     assertThat(credentials).isInstanceOf(AwsBasicCredentials.class);
                     assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
                     assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+                    assertThat(credentials.accountId()).isNotPresent();
+                });
+            });
+        });
+    }
+
+    @Test
+    public void profileFileWithProcessCredentialsAndAccountIdInFileFindsAccountId() {
+        ProfileFile profileFile = allTypesProfile();
+        assertThat(profileFile.profile("profile-credential-process-account-id")).hasValueSatisfying(profile -> {
+            assertThat(profile.property(ProfileProperty.REGION)).isNotPresent();
+            assertThat(new ProfileCredentialsUtils(profileFile, profile, profileFile::profile).credentialsProvider()).hasValueSatisfying(credentialsProvider -> {
+                assertThat(credentialsProvider.resolveCredentials()).satisfies(credentials -> {
+                    assertThat(credentials).isInstanceOf(AwsBasicCredentials.class);
+                    assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
+                    assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+                    assertThat(credentials.accountId()).isPresent().hasValue("123456789012");
+                });
+            });
+        });
+    }
+
+    @Test
+    public void profileFileWithProcessCredentialsAndAccountIdInFileAndProfilePicksFromFile() {
+        ProfileFile profileFile = allTypesProfile();
+        assertThat(profileFile.profile("profile-credential-process-account-id-override")).hasValueSatisfying(profile -> {
+            assertThat(profile.property(ProfileProperty.REGION)).isNotPresent();
+            assertThat(new ProfileCredentialsUtils(profileFile, profile, profileFile::profile).credentialsProvider()).hasValueSatisfying(credentialsProvider -> {
+                assertThat(credentialsProvider.resolveCredentials()).satisfies(credentials -> {
+                    assertThat(credentials).isInstanceOf(AwsBasicCredentials.class);
+                    assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
+                    assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+                    assertThat(credentials.accountId()).isPresent().hasValue("123456789012");
+                });
+            });
+        });
+    }
+
+    @Test
+    public void profileFileWithProcessCredentialsAndAccountIdInProfileFindsAccountId() {
+        ProfileFile profileFile = allTypesProfile();
+        assertThat(profileFile.profile("profile-credential-process-local-account-id")).hasValueSatisfying(profile -> {
+            assertThat(profile.property(ProfileProperty.REGION)).isNotPresent();
+            assertThat(new ProfileCredentialsUtils(profileFile, profile, profileFile::profile).credentialsProvider()).hasValueSatisfying(credentialsProvider -> {
+                assertThat(credentialsProvider.resolveCredentials()).satisfies(credentials -> {
+                    assertThat(credentials).isInstanceOf(AwsBasicCredentials.class);
+                    assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
+                    assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+                    assertThat(credentials.accountId()).isPresent().hasValue("defaultAccountId");
                 });
             });
         });
@@ -311,11 +361,13 @@ public class ProfileCredentialsUtilsTest {
         return configFile("[default]\n" +
                           "aws_access_key_id = defaultAccessKey\n" +
                           "aws_secret_access_key = defaultSecretAccessKey\n" +
+                          "aws_account_id = defaultAccountId\n" +
                           "\n" +
                           "[profile profile-with-session-token]\n" +
                           "aws_access_key_id = defaultAccessKey\n" +
                           "aws_secret_access_key = defaultSecretAccessKey\n" +
                           "aws_session_token = awsSessionToken\n" +
+                          "aws_account_id = defaultAccountId\n" +
                           "\n" +
                           "[profile profile-with-region]\n" +
                           "region = us-east-1\n" +
@@ -325,6 +377,17 @@ public class ProfileCredentialsUtilsTest {
                           "role_arn=arn:aws:iam::123456789012:role/testRole\n" +
                           "\n" +
                           "[profile profile-credential-process]\n" +
+                          "credential_process=" + scriptLocation +" defaultAccessKey defaultSecretAccessKey\n" +
+                          "\n" +
+                          "[profile profile-credential-process-account-id]\n" +
+                          "credential_process=" + scriptLocation +" defaultAccessKey defaultSecretAccessKey acctid=123456789012\n" +
+                          "\n" +
+                          "[profile profile-credential-process-account-id-override]\n" +
+                          "aws_account_id = defaultAccountId\n" +
+                          "credential_process=" + scriptLocation +" defaultAccessKey defaultSecretAccessKey acctid=123456789012\n" +
+                          "\n" +
+                          "[profile profile-credential-process-local-account-id]\n" +
+                          "aws_account_id = defaultAccountId\n" +
                           "credential_process=" + scriptLocation +" defaultAccessKey defaultSecretAccessKey\n" +
                           "\n" +
                           "[profile profile-with-container-credential-source]\n" +

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -40,6 +40,11 @@ public final class ProfileProperty {
     public static final String AWS_SESSION_TOKEN = "aws_session_token";
 
     /**
+     * Property name for specifying the Amazon AWS Account ID associated with credentials
+     */
+    public static final String AWS_ACCOUNT_ID = "aws_account_id";
+
+    /**
      * Property name for specifying the IAM role to assume
      */
     public static final String ROLE_ARN = "role_arn";

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
@@ -68,7 +68,7 @@ class ProfileFileSupplierTest {
 
     @Test
     void get_profileFileFixed_doesNotReloadProfileFile() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         ProfileFileSupplier supplier = builder()
             .fixedProfileFile(credentialsFilePath, ProfileFile.Type.CREDENTIALS)
@@ -76,7 +76,7 @@ class ProfileFileSupplierTest {
 
         ProfileFile file1 = supplier.get();
 
-        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey");
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
 
         ProfileFile file2 = supplier.get();
 
@@ -85,7 +85,7 @@ class ProfileFileSupplierTest {
 
     @Test
     void get_profileModifiedWithinJitterPeriod_doesNotReloadCredentials() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         AdjustableClock clock = new AdjustableClock();
         Duration durationWithinJitter = Duration.ofMillis(10);
@@ -95,7 +95,7 @@ class ProfileFileSupplierTest {
 
         ProfileFile file1 = supplier.get();
 
-        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey");
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plus(durationWithinJitter));
 
         clock.tickForward(durationWithinJitter);
@@ -106,7 +106,7 @@ class ProfileFileSupplierTest {
 
     @Test
     void get_profileModifiedOutsideJitterPeriod_reloadsCredentials() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         AdjustableClock clock = new AdjustableClock();
 
@@ -118,7 +118,7 @@ class ProfileFileSupplierTest {
 
         supplier.get();
 
-        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey");
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plus(durationOutsideJitter));
 
         clock.tickForward(durationOutsideJitter);
@@ -136,12 +136,17 @@ class ProfileFileSupplierTest {
             assertThat(awsSecretAccessKeyOptional).isPresent();
             String awsSecretAccessKey = awsSecretAccessKeyOptional.get();
             assertThat(awsSecretAccessKey).isEqualTo("modifiedSecretAccessKey");
+
+            Optional<String> awsAccountIdOptional = profile.property("aws_account_id");
+            assertThat(awsAccountIdOptional).isPresent();
+            String awsAccountId = awsAccountIdOptional.get();
+            assertThat(awsAccountId).isEqualTo("modifiedAccountId");
         });
     }
 
     @Test
     void get_profileModified_reloadsProfileFile() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         AdjustableClock clock = new AdjustableClock();
         ProfileFileSupplier supplier = builderWithClock(clock)
@@ -151,7 +156,7 @@ class ProfileFileSupplierTest {
         Duration duration = Duration.ofSeconds(10);
         ProfileFile file1 = supplier.get();
 
-        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey");
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plusMillis(1));
 
         clock.tickForward(duration);
@@ -162,7 +167,7 @@ class ProfileFileSupplierTest {
 
     @Test
     void get_profileModifiedOnceButRefreshedMultipleTimes_reloadsProfileFileOnce() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         AdjustableClock clock = new AdjustableClock();
         ProfileFileSupplier supplier = builderWithClock(clock)
@@ -173,7 +178,7 @@ class ProfileFileSupplierTest {
         clock.tickForward(Duration.ofSeconds(5));
         ProfileFile file2 = supplier.get();
 
-        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey");
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plusMillis(1));
 
         clock.tickForward(Duration.ofSeconds(5));
@@ -185,7 +190,7 @@ class ProfileFileSupplierTest {
 
     @Test
     void get_profileModifiedMultipleTimes_reloadsProfileFileOncePerChange() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         AdjustableClock clock = new AdjustableClock();
         ProfileFileSupplier supplier = builderWithClock(clock)
@@ -198,13 +203,13 @@ class ProfileFileSupplierTest {
         clock.tickForward(duration);
         ProfileFile file2 = supplier.get();
 
-        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey");
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plusMillis(1));
 
         clock.tickForward(duration);
         ProfileFile file3 = supplier.get();
 
-        generateTestCredentialsFile("updatedAccessKey", "updatedSecretAccessKey");
+        generateTestCredentialsFile("updatedAccessKey", "updatedSecretAccessKey", "updatedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plusMillis(1));
 
         clock.tickForward(duration);
@@ -221,7 +226,7 @@ class ProfileFileSupplierTest {
 
     @Test
     void get_supplierBuiltByReloadWhenModified_loadsProfileFile() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         ProfileFileSupplier supplier = ProfileFileSupplier.reloadWhenModified(credentialsFilePath, ProfileFile.Type.CREDENTIALS);
         ProfileFile file = supplier.get();
@@ -239,12 +244,17 @@ class ProfileFileSupplierTest {
             assertThat(awsSecretAccessKeyOptional).isPresent();
             String awsSecretAccessKey = awsSecretAccessKeyOptional.get();
             assertThat(awsSecretAccessKey).isEqualTo("defaultSecretAccessKey");
+
+            Optional<String> awsAccountIdOptional = profile.property("aws_account_id");
+            assertThat(awsAccountIdOptional).isPresent();
+            String awsAccountId = awsAccountIdOptional.get();
+            assertThat(awsAccountId).isEqualTo("defaultAccountId");
         });
     }
 
     @Test
     void get_supplierBuiltByFixedProfileFile_returnsProfileFile() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         ProfileFileSupplier supplier = ProfileFileSupplier.fixedProfileFile(ProfileFile.builder()
                                                                                        .content(credentialsFilePath)
@@ -265,12 +275,17 @@ class ProfileFileSupplierTest {
             assertThat(awsSecretAccessKeyOptional).isPresent();
             String awsSecretAccessKey = awsSecretAccessKeyOptional.get();
             assertThat(awsSecretAccessKey).isEqualTo("defaultSecretAccessKey");
+
+            Optional<String> awsAccountIdOptional = profile.property("aws_account_id");
+            assertThat(awsAccountIdOptional).isPresent();
+            String awsAccountId = awsAccountIdOptional.get();
+            assertThat(awsAccountId).isEqualTo("defaultAccountId");
         });
     }
 
     @Test
     void get_supplierBuiltByReloadWhenModifiedAggregate_reloadsCredentials() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
         Path configFilePath = generateTestConfigFile(Pair.of("region", "us-west-2"));
 
         ProfileFileSupplier credentialsProfileFileSupplier = ProfileFileSupplier.reloadWhenModified(credentialsFilePath,
@@ -302,7 +317,7 @@ class ProfileFileSupplierTest {
 
     @Test
     void get_supplierBuiltByFixedProfileFileAggregate_returnsAggregateProfileFileInstance() {
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
         Path configFilePath = generateTestConfigFile(Pair.of("region", "us-west-2"));
 
         ProfileFileSupplier credentialsProfileFileSupplier
@@ -332,6 +347,11 @@ class ProfileFileSupplierTest {
             String awsSecretAccessKey = awsSecretAccessKeyOptional.get();
             assertThat(awsSecretAccessKey).isEqualTo("defaultSecretAccessKey");
 
+            Optional<String> awsAccountIdOptional = profile.property("aws_account_id");
+            assertThat(awsAccountIdOptional).isPresent();
+            String awsAccountId = awsAccountIdOptional.get();
+            assertThat(awsAccountId).isEqualTo("defaultAccountId");
+
             Optional<String> regionOptional = profile.property("region");
             assertThat(regionOptional).isPresent();
             String region = regionOptional.get();
@@ -341,11 +361,13 @@ class ProfileFileSupplierTest {
 
     @Test
     void aggregate_supplierReturnsSameInstanceMultipleTimesAggregatingProfileFile_aggregatesOnlyDistinctInstances() {
-        ProfileFile credentialFile1 = credentialFile("test1", "key1", "secret1");
-        ProfileFile credentialFile2 = credentialFile("test2", "key2", "secret2");
-        ProfileFile credentialFile3 = credentialFile("test3", "key3", "secret3");
-        ProfileFile credentialFile4 = credentialFile("test4", "key4", "secret4");
-        ProfileFile configFile = configFile("profile test", Pair.of("region", "us-west-2"));
+        ProfileFile credentialFile1 = credentialProfileFile("test1", "key1", "secret1");
+        ProfileFile credentialFile2 = credentialProfileFile("test2", "key2", "secret2");
+        ProfileFile credentialFile3 = credentialProfileFile("test3", "key3", "secret3");
+        ProfileFile credentialFile4 = credentialProfileFile("test4", "key4", "secret4");
+        ProfileFile configFile = configProfileFile("profile test",
+                                                   Pair.of("region", "us-west-2"),
+                                                   Pair.of("aws_account_id", "012354678922"));
 
         List<ProfileFile> orderedCredentialsFiles
             = Arrays.asList(credentialFile1, credentialFile1, credentialFile2, credentialFile3, credentialFile3, credentialFile4,
@@ -370,13 +392,13 @@ class ProfileFileSupplierTest {
 
     @Test
     void aggregate_supplierReturnsSameInstanceMultipleTimesAggregatingProfileFileSupplier_aggregatesOnlyDistinctInstances() {
-        ProfileFile credentialFile1 = credentialFile("test1", "key1", "secret1");
-        ProfileFile credentialFile2 = credentialFile("test2", "key2", "secret2");
-        ProfileFile credentialFile3 = credentialFile("test3", "key3", "secret3");
-        ProfileFile credentialFile4 = credentialFile("test4", "key4", "secret4");
-        ProfileFile configFile1 = configFile("profile test", Pair.of("region", "us-west-1"));
-        ProfileFile configFile2 = configFile("profile test", Pair.of("region", "us-west-2"));
-        ProfileFile configFile3 = configFile("profile test", Pair.of("region", "us-west-3"));
+        ProfileFile credentialFile1 = credentialProfileFile("test1", "key1", "secret1");
+        ProfileFile credentialFile2 = credentialProfileFile("test2", "key2", "secret2");
+        ProfileFile credentialFile3 = credentialProfileFile("test3", "key3", "secret3");
+        ProfileFile credentialFile4 = credentialProfileFile("test4", "key4", "secret4");
+        ProfileFile configFile1 = configProfileFile("profile test", Pair.of("region", "us-west-1"));
+        ProfileFile configFile2 = configProfileFile("profile test", Pair.of("region", "us-west-2"));
+        ProfileFile configFile3 = configProfileFile("profile test", Pair.of("region", "us-west-3"));
 
         List<ProfileFile> orderedCredentialsFiles
             = Arrays.asList(credentialFile1, credentialFile1, credentialFile2, credentialFile2, credentialFile3,
@@ -412,8 +434,10 @@ class ProfileFileSupplierTest {
 
     @Test
     void aggregate_duplicateOptionsGivenFixedProfileFirst_preservesPrecedence() {
-        ProfileFile configFile1 = configFile("profile default", Pair.of("aws_access_key_id", "config-key"));
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        ProfileFile configFile1 = configProfileFile("profile default",
+                                                    Pair.of("aws_access_key_id", "config-key"),
+                                                    Pair.of("aws_account_id", "012354678922"));
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         ProfileFileSupplier supplier = ProfileFileSupplier.aggregate(
             ProfileFileSupplier.fixedProfileFile(configFile1),
@@ -421,15 +445,19 @@ class ProfileFileSupplierTest {
 
         ProfileFile profileFile = supplier.get();
         String accessKeyId = profileFile.profile("default").get().property("aws_access_key_id").get();
+        String accountId = profileFile.profile("default").get().property("aws_account_id").get();
 
         assertThat(accessKeyId).isEqualTo("config-key");
+        assertThat(accountId).isEqualTo("012354678922");
 
-        generateTestCredentialsFile("defaultAccessKey2", "defaultSecretAccessKey2");
+        generateTestCredentialsFile("defaultAccessKey2", "defaultSecretAccessKey2", "defaultAccountId2");
 
         profileFile = supplier.get();
         accessKeyId = profileFile.profile("default").get().property("aws_access_key_id").get();
+        accountId = profileFile.profile("default").get().property("aws_account_id").get();
 
         assertThat(accessKeyId).isEqualTo("config-key");
+        assertThat(accountId).isEqualTo("012354678922");
     }
 
     @Test
@@ -437,8 +465,8 @@ class ProfileFileSupplierTest {
         Instant startTime = Instant.now();
         AdjustableClock clock = new AdjustableClock(startTime);
 
-        ProfileFile configFile1 = configFile("profile default", Pair.of("aws_access_key_id", "config-key"));
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        ProfileFile configFile1 = configProfileFile("profile default", Pair.of("aws_access_key_id", "config-key"));
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         ProfileFileSupplier supplier = ProfileFileSupplier.aggregate(
             builderWithClock(clock)
@@ -451,7 +479,7 @@ class ProfileFileSupplierTest {
 
         assertThat(accessKeyId).isEqualTo("defaultAccessKey");
 
-        generateTestCredentialsFile("defaultAccessKey2", "defaultSecretAccessKey2");
+        generateTestCredentialsFile("defaultAccessKey2", "defaultSecretAccessKey2", "defaultAccountId2");
 
         Duration tick = Duration.ofMillis(1_000);
 
@@ -481,7 +509,7 @@ class ProfileFileSupplierTest {
         int actualProfilesCount = 3;
         AtomicInteger blockCount = new AtomicInteger();
 
-        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+        Path credentialsFilePath = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey", "defaultAccountId");
 
         AdjustableClock clock = new AdjustableClock();
         ProfileFileSupplier supplier = builderWithClock(clock)
@@ -495,13 +523,13 @@ class ProfileFileSupplierTest {
         clock.tickForward(duration);
         supplier.get();
 
-        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey");
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plusMillis(1));
 
         clock.tickForward(duration);
         supplier.get();
 
-        generateTestCredentialsFile("updatedAccessKey", "updatedSecretAccessKey");
+        generateTestCredentialsFile("updatedAccessKey", "updatedSecretAccessKey", "updatedAccountId");
         updateModificationTime(credentialsFilePath, clock.instant().plusMillis(1));
 
         clock.tickForward(duration);
@@ -522,9 +550,10 @@ class ProfileFileSupplierTest {
         }
     }
 
-    private Path generateTestCredentialsFile(String accessKeyId, String secretAccessKey) {
-        String contents = String.format("[default]\naws_access_key_id = %s\naws_secret_access_key = %s\n",
-                                        accessKeyId, secretAccessKey);
+    private Path generateTestCredentialsFile(String accessKeyId, String secretAccessKey, String accountId) {
+        String contents = String.format("[default]\naws_access_key_id = %s\naws_secret_access_key = %s\n"
+                                        + "aws_account_id = %s\n",
+                                        accessKeyId, secretAccessKey, accountId);
         return writeTestFile(contents, getTestCredentialsFilePath());
     }
 
@@ -549,33 +578,33 @@ class ProfileFileSupplierTest {
         }
     }
 
-    private ProfileFile credentialFile(String credentialFile) {
+    private ProfileFile credentialProfileFile(String credentialFile) {
         return ProfileFile.builder()
                           .content(new StringInputStream(credentialFile))
                           .type(ProfileFile.Type.CREDENTIALS)
                           .build();
     }
 
-    private ProfileFile credentialFile(String name, String accessKeyId, String secretAccessKey) {
+    private ProfileFile credentialProfileFile(String name, String accessKeyId, String secretAccessKey) {
         String contents = String.format("[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n",
                                         name, accessKeyId, secretAccessKey);
-        return credentialFile(contents);
+        return credentialProfileFile(contents);
     }
 
-    private ProfileFile configFile(String credentialFile) {
+    private ProfileFile configProfileFile(String credentialFile) {
         return ProfileFile.builder()
                           .content(new StringInputStream(credentialFile))
                           .type(ProfileFile.Type.CONFIGURATION)
                           .build();
     }
 
-    private ProfileFile configFile(String name, Pair<?, ?>... pairs) {
+    private ProfileFile configProfileFile(String name, Pair<?, ?>... pairs) {
         String values = Arrays.stream(pairs)
                               .map(pair -> String.format("%s=%s", pair.left(), pair.right()))
                               .collect(Collectors.joining(System.lineSeparator()));
         String contents = String.format("[%s]\n%s", name, values);
 
-        return configFile(contents);
+        return configProfileFile(contents);
     }
 
     private static <T> Predicate<T> uniqueInstances() {


### PR DESCRIPTION
## Motivation and Context
Adds support for account ID to profile credentials provider

## Modifications
- Adds a profile property for account ID
- Attempts to retrieve account ID from config and credential files if it exists
- Adds the capability to manually configure account ID to process credentials provider 

