### PR TITLE
S3 Async GetObject `toBytes`: 3x memory reduction, less array-copying

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
@@ -19,8 +19,10 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.FileTransformerConfiguration;
 import software.amazon.awssdk.core.ResponseBytes;
@@ -202,7 +204,11 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
      * @return AsyncResponseTransformer instance.
      */
     static <ResponseT> AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> toBytes() {
-        return new ByteArrayAsyncResponseTransformer<>();
+        return new ByteArrayAsyncResponseTransformer<>(Optional.empty());
+    }
+
+    static <ResponseT> AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> toBytes(Function<ResponseT, Integer> f) {
+        return new ByteArrayAsyncResponseTransformer<>(Optional.of(f));
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
@@ -15,11 +15,14 @@
 
 package software.amazon.awssdk.core.internal.async;
 
+import static software.amazon.awssdk.utils.BinaryUtils.copyBytes;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -41,13 +44,18 @@ import software.amazon.awssdk.utils.BinaryUtils;
 public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
         AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> {
 
+    private final Optional<Function<ResponseT, Integer>> knownSize;
     private volatile CompletableFuture<byte[]> cf;
     private volatile ResponseT response;
+
+    public ByteArrayAsyncResponseTransformer(Optional<Function<ResponseT, Integer>> knownSize) {
+        this.knownSize = knownSize;
+    }
 
     @Override
     public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
         cf = new CompletableFuture<>();
-        return cf.thenApply(arr -> ResponseBytes.fromByteArray(response, arr));
+        return cf.thenApply(arr -> ResponseBytes.fromByteArrayUnsafe(response, arr));
     }
 
     @Override
@@ -57,7 +65,9 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
 
     @Override
     public void onStream(SdkPublisher<ByteBuffer> publisher) {
-        publisher.subscribe(new BaosSubscriber(cf));
+        ByteStore byteStore =
+            knownSize.<ByteStore>map(f -> new KnownLengthStore(f.apply(response))).orElseGet(BaosStore::new);
+        publisher.subscribe(new ByteSubscriber(cf, byteStore));
     }
 
     @Override
@@ -65,15 +75,17 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
         cf.completeExceptionally(throwable);
     }
 
-    static class BaosSubscriber implements Subscriber<ByteBuffer> {
+
+    static class ByteSubscriber implements Subscriber<ByteBuffer> {
         private final CompletableFuture<byte[]> resultFuture;
 
-        private ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        private ByteStore byteStore;
 
         private Subscription subscription;
 
-        BaosSubscriber(CompletableFuture<byte[]> resultFuture) {
+        ByteSubscriber(CompletableFuture<byte[]> resultFuture, ByteStore byteStore) {
             this.resultFuture = resultFuture;
+            this.byteStore = byteStore;
         }
 
         @Override
@@ -88,19 +100,54 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
 
         @Override
         public void onNext(ByteBuffer byteBuffer) {
-            invokeSafely(() -> baos.write(BinaryUtils.copyBytesFrom(byteBuffer)));
+            byteStore.append(byteBuffer);
             subscription.request(1);
         }
 
         @Override
         public void onError(Throwable throwable) {
-            baos = null;
+            byteStore = null;
             resultFuture.completeExceptionally(throwable);
         }
 
         @Override
         public void onComplete() {
-            resultFuture.complete(baos.toByteArray());
+            resultFuture.complete(byteStore.toByteArray());
+        }
+    }
+
+    interface ByteStore {
+        void append(ByteBuffer byteBuffer);
+        
+        byte[] toByteArray();
+    }
+
+    static class BaosStore implements ByteStore {
+        private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        public void append(ByteBuffer byteBuffer) {
+            invokeSafely(() -> baos.write(BinaryUtils.copyBytesFrom(byteBuffer)));
+        }
+
+        public byte[] toByteArray() {
+            return baos.toByteArray();
+        }
+    }
+
+    static class KnownLengthStore implements ByteStore {
+        private final byte[] byteArray;
+        private int offset = 0;
+
+        KnownLengthStore(int contentSize) {
+            this.byteArray = new byte[contentSize];
+        }
+
+        public void append(ByteBuffer byteBuffer) {
+            offset += copyBytes(byteBuffer, byteArray, offset);
+        }
+
+        public byte[] toByteArray() {
+            return byteArray;
         }
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/AsyncS3ResponseTransformer.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/AsyncS3ResponseTransformer.java
@@ -1,0 +1,11 @@
+package software.amazon.awssdk.services.s3;
+
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+public class AsyncS3ResponseTransformer {
+    public static AsyncResponseTransformer<GetObjectResponse, ResponseBytes<GetObjectResponse>> toBytes() {
+        return AsyncResponseTransformer.toBytes(r -> r.contentLength().intValue());
+    }
+}

--- a/test/sdk-native-image-test/src/main/java/software/amazon/awssdk/nativeimagetest/S3TestRunner.java
+++ b/test/sdk-native-image-test/src/main/java/software/amazon/awssdk/nativeimagetest/S3TestRunner.java
@@ -19,8 +19,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.AsyncS3ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
@@ -54,7 +54,7 @@ public class S3TestRunner implements TestRunner {
                                          requestBody);
 
             s3NettyClient.getObject(b -> b.bucket(BUCKET_NAME).key(KEY),
-                               AsyncResponseTransformer.toBytes()).join();
+                               AsyncS3ResponseTransformer.toBytes()).join();
 
         } finally {
             if (bucketResponse != null) {

--- a/utils/src/main/java/software/amazon/awssdk/utils/BinaryUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/BinaryUtils.java
@@ -304,4 +304,22 @@ public final class BinaryUtils {
         return dst;
     }
 
+
+    /**
+     * This behaves identically to {@link software.amazon.awssdk.utils.BinaryUtils#copyBytesFrom(ByteBuffer)}, except
+     * that the bytes are copied to the supplied destination array, at the supplied destination offset.
+     */
+    public static int copyBytes(ByteBuffer bb, byte[] dest, int destOffset) {
+        if (bb == null) {
+            return 0;
+        }
+
+        int remaining = bb.remaining();
+        if (bb.hasArray()) {
+            System.arraycopy(bb.array(), bb.arrayOffset() + bb.position(), dest, destOffset, remaining);
+        } else {
+            bb.asReadOnlyBuffer().get(dest, destOffset, remaining);
+        }
+        return remaining;
+    }
 }


### PR DESCRIPTION
## Motivation and Context

This fixes https://github.com/aws/aws-sdk-java-v2/issues/4392 (duplicate of https://github.com/aws/aws-sdk-java-v2/issues/3193): loading an S3 object into memory using [`AsyncResponseTransformer.toBytes()`](https://github.com/aws/aws-sdk-java-v2/blob/69f7191252c26b351f7fb1c5f031948dac43e4c9/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java#L204-L206) has these problems:

* **Memory: Excessive peak requirements** - peak memory requirement is **4x the actual size of the S3 object** - loading a 258MB object into memory takes 1070MB of RAM.
* **CPU: Unnecessary `byte[]` allocations, copies & GC**

## Modifications

### Change A : Improve `byte[]` storage by using the known Content Length
When reading an S3 `GetObject` response, we have the S3 Content Length available to us, meaning we can create a `AsyncS3ResponseTransformer` which has these enhancements:

* **A1** Use the Content Length to initialise the `ByteArrayOutputStream` with **a byte array of the right size**.
  * Array copies removed : $`ceil(log_2 (N/32))`$ (eg a 40MB object takes 21 array copies - [graph](https://www.desmos.com/calculator/lnt4spptyz))
  * Memory: 2N → N
* **A2** Use a simple fixed-size byte array in preference to a `ByteArrayOutputStream`
  * Storing a chunk of X bytes (where X <= N - ie may equal N)
    * Array copies removed: 1 per chunk
    * Memory: X → 0
  * Retrieving the final N bytes
    * Array copies removed: 1
    * Memory: 2N → N

### Change B : Use `ResponseBytes.fromByteArrayUnsafe()`

* Avoid performing a byte array copy to create the `ResponseBytes` instance
  * Array copies removed: 1
  * Memory: 2N → N

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In https://github.com/rtyley/aws-sdk-async-response-bytes I've added [automated memory testing](https://github.com/rtyley/aws-sdk-async-response-bytes#automated-memory-consumption-tests) of the various enhancements above. These are the resulting memory requirements, in MB, for all possible permutations
of the fixes:

|           | Exclude A                                                                                                  | A1                                                                                                        | A1+A2                                                                                                     |
|-----------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
| Exclude B | [1070](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058076293#summary-16439864723) | [934](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058092753#summary-16439895976) | [644](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058095645#summary-16439901557) |
| Include B | [787](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058093770#summary-16439898197)  | [657](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058097434#summary-16439905403) | [357](https://github.com/rtyley/aws-sdk-async-response-bytes/actions/runs/6058098624#summary-16439907698) |

From the results, it's clear that we need all 3 changes (A1, A2, & B) in order to get the lowest memory usage.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes https://github.com/aws/aws-sdk-java-v2/issues/4392)
- [x] New feature (non-breaking change which introduces `AsyncS3ResponseTransformer`, optimised for handling `GetObjectResponse`)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
