### PR TITLE
Add support for "derived" execution attributes.

### DIFF
--- a/build-tools/src/main/resources/software/amazon/awssdk/spotbugs-suppressions.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/spotbugs-suppressions.xml
@@ -272,4 +272,13 @@
         <Method name="fromFile"/>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
     </Match>
+
+    <!-- Intentional for backwards-compatibility -->
+    <Match>
+        <Or>
+            <Class name="software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute"/>
+            <Class name="software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute"/>
+        </Or>
+        <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
+    </Match>
 </FindBugsFilter>

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeInterceptorSpec.java
@@ -108,8 +108,8 @@ public final class AuthSchemeInterceptorSpec implements ClassSpec {
                              listOf(AuthSchemeOption.class))
                .addStatement("$T selectedAuthScheme = selectAuthScheme(authOptions, executionAttributes)",
                              wildcardSelectedAuthScheme())
-               .addStatement("executionAttributes.putAttribute($T.SELECTED_AUTH_SCHEME, selectedAuthScheme)",
-                             SdkInternalExecutionAttribute.class);
+               .addStatement("$T.putSelectedAuthScheme(executionAttributes, selectedAuthScheme)",
+                             endpointRulesSpecUtils.rulesRuntimeClassName("AuthSchemeUtils"));
         return builder.build();
     }
 

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AuthSchemeUtils.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AuthSchemeUtils.java.resource
@@ -7,7 +7,12 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
+import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.utils.Logger;
 
 @SdkProtectedApi
@@ -50,56 +55,71 @@ public final class AuthSchemeUtils {
 
             String authSchemeName = scheme.get(Identifier.of("name")).expectString();
             switch (authSchemeName) {
-                case SIGV4A_NAME: {
-                    SigV4aAuthScheme.Builder schemeBuilder = SigV4aAuthScheme.builder();
+            case SIGV4A_NAME: {
+                SigV4aAuthScheme.Builder schemeBuilder = SigV4aAuthScheme.builder();
 
-                    Value signingName = scheme.get(Identifier.of("signingName"));
-                    if (signingName != null) {
-                        schemeBuilder.signingName(signingName.expectString());
-                    }
-
-                    Value signingRegionSet = scheme.get(Identifier.of("signingRegionSet"));
-                    if (signingRegionSet != null) {
-                        Value.Array signingRegionSetArray = signingRegionSet.expectArray();
-                        for (int j = 0; j < signingRegionSetArray.size(); ++j) {
-                            schemeBuilder.addSigningRegion(signingRegionSetArray.get(j).expectString());
-                        }
-                    }
-
-                    Value disableDoubleEncoding = scheme.get(Identifier.of("disableDoubleEncoding"));
-                    if (disableDoubleEncoding != null) {
-                        schemeBuilder.disableDoubleEncoding(disableDoubleEncoding.expectBool());
-                    }
-
-                    authSchemes.add(schemeBuilder.build());
+                Value signingName = scheme.get(Identifier.of("signingName"));
+                if (signingName != null) {
+                    schemeBuilder.signingName(signingName.expectString());
                 }
-                break;
-                case SIGV4_NAME: {
-                    SigV4AuthScheme.Builder schemeBuilder = SigV4AuthScheme.builder();
 
-                    Value signingName = scheme.get(Identifier.of("signingName"));
-                    if (signingName != null) {
-                        schemeBuilder.signingName(signingName.expectString());
+                Value signingRegionSet = scheme.get(Identifier.of("signingRegionSet"));
+                if (signingRegionSet != null) {
+                    Value.Array signingRegionSetArray = signingRegionSet.expectArray();
+                    for (int j = 0; j < signingRegionSetArray.size(); ++j) {
+                        schemeBuilder.addSigningRegion(signingRegionSetArray.get(j).expectString());
                     }
-
-                    Value signingRegion = scheme.get(Identifier.of("signingRegion"));
-                    if (signingRegion != null) {
-                        schemeBuilder.signingRegion(signingRegion.expectString());
-                    }
-
-                    Value disableDoubleEncoding = scheme.get(Identifier.of("disableDoubleEncoding"));
-                    if (disableDoubleEncoding != null) {
-                        schemeBuilder.disableDoubleEncoding(disableDoubleEncoding.expectBool());
-                    }
-
-                    authSchemes.add(schemeBuilder.build());
                 }
+
+                Value disableDoubleEncoding = scheme.get(Identifier.of("disableDoubleEncoding"));
+                if (disableDoubleEncoding != null) {
+                    schemeBuilder.disableDoubleEncoding(disableDoubleEncoding.expectBool());
+                }
+
+                authSchemes.add(schemeBuilder.build());
+            }
                 break;
-                default:
-                    LOG.debug(() -> "Ignoring unknown auth scheme: " + authSchemeName);
-                    break;
+            case SIGV4_NAME: {
+                SigV4AuthScheme.Builder schemeBuilder = SigV4AuthScheme.builder();
+
+                Value signingName = scheme.get(Identifier.of("signingName"));
+                if (signingName != null) {
+                    schemeBuilder.signingName(signingName.expectString());
+                }
+
+                Value signingRegion = scheme.get(Identifier.of("signingRegion"));
+                if (signingRegion != null) {
+                    schemeBuilder.signingRegion(signingRegion.expectString());
+                }
+
+                Value disableDoubleEncoding = scheme.get(Identifier.of("disableDoubleEncoding"));
+                if (disableDoubleEncoding != null) {
+                    schemeBuilder.disableDoubleEncoding(disableDoubleEncoding.expectBool());
+                }
+
+                authSchemes.add(schemeBuilder.build());
+            }
+                break;
+            default:
+                LOG.debug(() -> "Ignoring unknown auth scheme: " + authSchemeName);
+                break;
             }
         }
         return authSchemes;
+    }
+
+    public static <T extends Identity> void putSelectedAuthScheme(ExecutionAttributes attributes,
+                                                                  SelectedAuthScheme<T> selectedAuthScheme) {
+        SelectedAuthScheme<?> existingAuthScheme = attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+        if (existingAuthScheme != null) {
+            AuthSchemeOption.Builder selectedOption = selectedAuthScheme.authSchemeOption().toBuilder();
+            existingAuthScheme.authSchemeOption().forEachIdentityProperty(selectedOption::putIdentityPropertyIfAbsent);
+            existingAuthScheme.authSchemeOption().forEachSignerProperty(selectedOption::putSignerPropertyIfAbsent);
+            selectedAuthScheme = new SelectedAuthScheme<>(selectedAuthScheme.identity(),
+                                                          selectedAuthScheme.signer(),
+                                                          selectedOption.build());
+        }
+
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-interceptor.java
@@ -1,18 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package software.amazon.awssdk.services.query.auth.scheme.internal;
 
 import java.time.Duration;
@@ -48,6 +33,7 @@ import software.amazon.awssdk.metrics.SdkMetric;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
+import software.amazon.awssdk.services.query.endpoints.internal.AuthSchemeUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
@@ -60,41 +46,41 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
     public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
         List<AuthSchemeOption> authOptions = resolveAuthOptions(context, executionAttributes);
         SelectedAuthScheme<? extends Identity> selectedAuthScheme = selectAuthScheme(authOptions, executionAttributes);
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme);
+        AuthSchemeUtils.putSelectedAuthScheme(executionAttributes, selectedAuthScheme);
     }
 
     private List<AuthSchemeOption> resolveAuthOptions(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
         QueryAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(QueryAuthSchemeProvider.class,
-                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
-                "Expected an instance of QueryAuthSchemeProvider");
+                                                                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
+                                                                           "Expected an instance of QueryAuthSchemeProvider");
         QueryAuthSchemeParams params = authSchemeParams(context.request(), executionAttributes);
         return authSchemeProvider.resolveAuthScheme(params);
     }
 
     private SelectedAuthScheme<? extends Identity> selectAuthScheme(List<AuthSchemeOption> authOptions,
-            ExecutionAttributes executionAttributes) {
+                                                                    ExecutionAttributes executionAttributes) {
         MetricCollector metricCollector = executionAttributes.getAttribute(SdkExecutionAttribute.API_CALL_METRIC_COLLECTOR);
         Map<String, AuthScheme<?>> authSchemes = executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES);
         IdentityProviderConfiguration identityResolvers = executionAttributes
-                .getAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDER_CONFIGURATION);
+            .getAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDER_CONFIGURATION);
         List<Supplier<String>> discardedReasons = new ArrayList<>();
         for (AuthSchemeOption authOption : authOptions) {
             AuthScheme<?> authScheme = authSchemes.get(authOption.schemeId());
             SelectedAuthScheme<? extends Identity> selectedAuthScheme = trySelectAuthScheme(authOption, authScheme,
-                    identityResolvers, discardedReasons, metricCollector);
+                                                                                            identityResolvers, discardedReasons, metricCollector);
             if (selectedAuthScheme != null) {
                 if (!discardedReasons.isEmpty()) {
                     LOG.debug(() -> String.format("%s auth will be used, discarded: '%s'", authOption.schemeId(),
-                            discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))));
+                                                  discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))));
                 }
                 return selectedAuthScheme;
             }
         }
         throw SdkException
-                .builder()
-                .message(
-                        "Failed to determine how to authenticate the user: "
-                                + discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))).build();
+            .builder()
+            .message(
+                "Failed to determine how to authenticate the user: "
+                + discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))).build();
     }
 
     private QueryAuthSchemeParams authSchemeParams(SdkRequest request, ExecutionAttributes executionAttributes) {
@@ -103,17 +89,17 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
         return QueryAuthSchemeParams.builder().operation(operation).region(region).build();
     }
 
-    private <T extends Identity> SelectedAuthScheme<T> trySelectAuthScheme(
-            AuthSchemeOption authOption, AuthScheme<T> authScheme,
-            IdentityProviderConfiguration identityProviders, List<Supplier<String>> discardedReasons,
-            MetricCollector metricCollector) {
+    private <T extends Identity> SelectedAuthScheme<T> trySelectAuthScheme(AuthSchemeOption authOption, AuthScheme<T> authScheme,
+                                                                           IdentityProviderConfiguration identityProviders, List<Supplier<String>> discardedReasons,
+                                                                           MetricCollector metricCollector) {
         if (authScheme == null) {
             discardedReasons.add(() -> String.format("'%s' is not enabled for this request.", authOption.schemeId()));
             return null;
         }
         IdentityProvider<T> identityProvider = authScheme.identityProvider(identityProviders);
         if (identityProvider == null) {
-            discardedReasons.add(() -> String.format("'%s' does not have an identity provider configured.", authOption.schemeId()));
+            discardedReasons
+                .add(() -> String.format("'%s' does not have an identity provider configured.", authOption.schemeId()));
             return null;
         }
         ResolveIdentityRequest.Builder identityRequestBuilder = ResolveIdentityRequest.builder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-with-allowlist-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-with-allowlist-auth-scheme-interceptor.java
@@ -1,18 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package software.amazon.awssdk.services.query.auth.scheme.internal;
 
 import java.time.Duration;
@@ -47,6 +32,7 @@ import software.amazon.awssdk.metrics.SdkMetric;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
+import software.amazon.awssdk.services.query.endpoints.internal.AuthSchemeUtils;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -60,41 +46,41 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
     public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
         List<AuthSchemeOption> authOptions = resolveAuthOptions(context, executionAttributes);
         SelectedAuthScheme<? extends Identity> selectedAuthScheme = selectAuthScheme(authOptions, executionAttributes);
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme);
+        AuthSchemeUtils.putSelectedAuthScheme(executionAttributes, selectedAuthScheme);
     }
 
     private List<AuthSchemeOption> resolveAuthOptions(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
         QueryAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(QueryAuthSchemeProvider.class,
-                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
-                "Expected an instance of QueryAuthSchemeProvider");
+                                                                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
+                                                                           "Expected an instance of QueryAuthSchemeProvider");
         QueryAuthSchemeParams params = authSchemeParams(context.request(), executionAttributes);
         return authSchemeProvider.resolveAuthScheme(params);
     }
 
     private SelectedAuthScheme<? extends Identity> selectAuthScheme(List<AuthSchemeOption> authOptions,
-            ExecutionAttributes executionAttributes) {
+                                                                    ExecutionAttributes executionAttributes) {
         MetricCollector metricCollector = executionAttributes.getAttribute(SdkExecutionAttribute.API_CALL_METRIC_COLLECTOR);
         Map<String, AuthScheme<?>> authSchemes = executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES);
         IdentityProviderConfiguration identityResolvers = executionAttributes
-                .getAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDER_CONFIGURATION);
+            .getAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDER_CONFIGURATION);
         List<Supplier<String>> discardedReasons = new ArrayList<>();
         for (AuthSchemeOption authOption : authOptions) {
             AuthScheme<?> authScheme = authSchemes.get(authOption.schemeId());
             SelectedAuthScheme<? extends Identity> selectedAuthScheme = trySelectAuthScheme(authOption, authScheme,
-                    identityResolvers, discardedReasons, metricCollector);
+                                                                                            identityResolvers, discardedReasons, metricCollector);
             if (selectedAuthScheme != null) {
                 if (!discardedReasons.isEmpty()) {
                     LOG.debug(() -> String.format("%s auth will be used, discarded: '%s'", authOption.schemeId(),
-                            discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))));
+                                                  discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))));
                 }
                 return selectedAuthScheme;
             }
         }
         throw SdkException
-                .builder()
-                .message(
-                        "Failed to determine how to authenticate the user: "
-                                + discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))).build();
+            .builder()
+            .message(
+                "Failed to determine how to authenticate the user: "
+                + discardedReasons.stream().map(Supplier::get).collect(Collectors.joining(", "))).build();
     }
 
     private QueryAuthSchemeParams authSchemeParams(SdkRequest request, ExecutionAttributes executionAttributes) {
@@ -112,17 +98,17 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
         return builder.build();
     }
 
-    private <T extends Identity> SelectedAuthScheme<T> trySelectAuthScheme(
-            AuthSchemeOption authOption, AuthScheme<T> authScheme,
-            IdentityProviderConfiguration identityProviders, List<Supplier<String>> discardedReasons,
-            MetricCollector metricCollector) {
+    private <T extends Identity> SelectedAuthScheme<T> trySelectAuthScheme(AuthSchemeOption authOption, AuthScheme<T> authScheme,
+                                                                           IdentityProviderConfiguration identityProviders, List<Supplier<String>> discardedReasons,
+                                                                           MetricCollector metricCollector) {
         if (authScheme == null) {
             discardedReasons.add(() -> String.format("'%s' is not enabled for this request.", authOption.schemeId()));
             return null;
         }
         IdentityProvider<T> identityProvider = authScheme.identityProvider(identityProviders);
         if (identityProvider == null) {
-            discardedReasons.add(() -> String.format("'%s' does not have an identity provider configured.", authOption.schemeId()));
+            discardedReasons
+                .add(() -> String.format("'%s' does not have an identity provider configured.", authOption.schemeId()));
             return null;
         }
         ResolveIdentityRequest.Builder identityRequestBuilder = ResolveIdentityRequest.builder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
 import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
@@ -21,14 +20,10 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.aws.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
 import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
 import software.amazon.awssdk.identity.spi.Identity;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.RegionScope;
 import software.amazon.awssdk.services.query.endpoints.QueryClientContextParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
@@ -61,9 +56,6 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
             if (endpointAuthSchemes != null && selectedAuthScheme != null) {
                 selectedAuthScheme = authSchemeWithEndpointSignerProperties(endpointAuthSchemes, selectedAuthScheme);
                 executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme);
-            }
-            if (selectedAuthScheme != null) {
-                copySignerPropertiesToAttributes(selectedAuthScheme.authSchemeOption(), executionAttributes);
             }
             executionAttributes.putAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT, endpoint);
             return result;
@@ -166,39 +158,6 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
                                                + "' cannot be mapped to the SDK auth scheme. Was it declared in the service's model?");
         }
         return selectedAuthScheme;
-    }
-
-    private void copySignerPropertiesToAttributes(AuthSchemeOption authOption, ExecutionAttributes executionAttributes) {
-        if (authOption.schemeId().equals(AwsV4AuthScheme.SCHEME_ID)) {
-            if (authOption.signerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE) != null) {
-                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE,
-                                                 authOption.signerProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE));
-            }
-            if (authOption.signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME) != null) {
-                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME,
-                                                 authOption.signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME));
-            }
-            if (authOption.signerProperty(AwsV4HttpSigner.REGION_NAME) != null) {
-                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION,
-                                                 Region.of(authOption.signerProperty(AwsV4HttpSigner.REGION_NAME)));
-            }
-            return;
-        }
-        if (authOption.schemeId().equals(AwsV4aAuthScheme.SCHEME_ID)) {
-            if (authOption.signerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE) != null) {
-                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE,
-                                                 authOption.signerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE));
-            }
-            if (authOption.signerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME) != null) {
-                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME,
-                                                 authOption.signerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME));
-            }
-            if (authOption.signerProperty(AwsV4aHttpSigner.REGION_NAME) != null) {
-                executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE,
-                                                 RegionScope.create(authOption.signerProperty(AwsV4aHttpSigner.REGION_NAME)));
-            }
-            return;
-        }
     }
 
     private static void setClientContextParams(QueryEndpointParams.Builder params, ExecutionAttributes executionAttributes) {

--- a/core/auth/pom.xml
+++ b/core/auth/pom.xml
@@ -74,6 +74,16 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.eventstream</groupId>
             <artifactId>eventstream</artifactId>
         </dependency>

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
@@ -15,69 +15,457 @@
 
 package software.amazon.awssdk.auth.signer;
 
+import static software.amazon.awssdk.utils.CompletableFutureUtils.joinLikeSync;
+
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.CredentialUtils;
 import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.aws.AwsV4FamilyHttpSigner;
+import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.spi.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.SyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.SyncSignedRequest;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.RegionScope;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * AWS-specific signing attributes attached to the execution. This information is available to {@link ExecutionInterceptor}s and
  * {@link Signer}s.
+ *
+ * @deprecated Signer execution attributes have been deprecated in favor of signer properties, set on the auth scheme's signer
+ * option.
  */
+@Deprecated
 @SdkProtectedApi
 public final class AwsSignerExecutionAttribute extends SdkExecutionAttribute {
     /**
      * The key under which the request credentials are set.
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the credential provider via the {@code SdkRequest}'s
+     * {@code overrideConfiguration.credentialsProvider}. If you're using it to call the SDK's signers, you should migrate to a
+     * subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<AwsCredentials> AWS_CREDENTIALS = new ExecutionAttribute<>("AwsCredentials");
+    @Deprecated
+    public static final ExecutionAttribute<AwsCredentials> AWS_CREDENTIALS =
+        ExecutionAttribute.derivedBuilder("AwsCredentials",
+                                          AwsCredentials.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(AwsSignerExecutionAttribute::awsCredentialsReadMapping)
+                          .writeMapping(AwsSignerExecutionAttribute::awsCredentialsWriteMapping)
+                          .build();
+
+
+
 
     /**
      * The AWS {@link Region} that is used for signing a request. This is not always same as the region configured on the client
      * for global services like IAM.
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the signing region via the {@code AuthSchemeProvider} that
+     * is configured on the SDK client builder. If you're using it to call the SDK's signers, you should migrate to a
+     * subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<Region> SIGNING_REGION = new ExecutionAttribute<>("SigningRegion");
+    @Deprecated
+    public static final ExecutionAttribute<Region> SIGNING_REGION =
+        ExecutionAttribute.derivedBuilder("SigningRegion",
+                                          Region.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(AwsSignerExecutionAttribute::signingRegionReadMapping)
+                          .writeMapping(AwsSignerExecutionAttribute::signingRegionWriteMapping)
+                          .build();
 
     /**
      * The AWS {@link Region} that is used for signing a request. This is not always same as the region configured on the client
      * for global services like IAM.
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the signing region scope via the {@code AuthSchemeProvider}
+     * that is configured on the SDK client builder. If you're using it to call the SDK's signers, you should migrate to a
+     * subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<RegionScope> SIGNING_REGION_SCOPE = new ExecutionAttribute<>("SigningRegionScope");
+    @Deprecated
+    public static final ExecutionAttribute<RegionScope> SIGNING_REGION_SCOPE =
+        ExecutionAttribute.derivedBuilder("SigningRegionScope",
+                                          RegionScope.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(AwsSignerExecutionAttribute::signingRegionScopeReadMapping)
+                          .writeMapping(AwsSignerExecutionAttribute::signingRegionScopeWriteMapping)
+                          .build();
 
     /**
      * The signing name of the service to be using in SigV4 signing
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the signing region name via the {@code AuthSchemeProvider}
+     * that is configured on the SDK client builder. If you're using it to call the SDK's signers, you should migrate to a
+     * subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<String> SERVICE_SIGNING_NAME = new ExecutionAttribute<>("ServiceSigningName");
+    @Deprecated
+    public static final ExecutionAttribute<String> SERVICE_SIGNING_NAME =
+            ExecutionAttribute.derivedBuilder("ServiceSigningName",
+                                              String.class,
+                                              SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                              .readMapping(AwsSignerExecutionAttribute::serviceSigningNameReadMapping)
+                              .writeMapping(AwsSignerExecutionAttribute::serviceSigningNameWriteMapping)
+                              .build();
 
     /**
      * The key to specify whether to use double url encoding during signing.
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the double-url-encode setting via the {@code
+     * AuthSchemeProvider} that is configured on the SDK client builder. If you're using it to call the SDK's signers, you
+     * should migrate to a subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<Boolean> SIGNER_DOUBLE_URL_ENCODE = new ExecutionAttribute<>("DoubleUrlEncode");
+    @Deprecated
+    public static final ExecutionAttribute<Boolean> SIGNER_DOUBLE_URL_ENCODE =
+        ExecutionAttribute.derivedBuilder("DoubleUrlEncode",
+                                          Boolean.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(AwsSignerExecutionAttribute::signerDoubleUrlEncodeReadMapping)
+                          .writeMapping(AwsSignerExecutionAttribute::signerDoubleUrlEncodeWriteMapping)
+                          .build();
 
     /**
      * The key to specify whether to normalize the resource path during signing.
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the normalize-path setting via the {@code
+     * AuthSchemeProvider} that is configured on the SDK client builder. If you're using it to call the SDK's signers, you
+     * should migrate to a subtype of {@code HttpSigner}.
      */
+    @Deprecated
     public static final ExecutionAttribute<Boolean> SIGNER_NORMALIZE_PATH =
-        new ExecutionAttribute<>("NormalizePath");
+        ExecutionAttribute.derivedBuilder("NormalizePath",
+                                          Boolean.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(AwsSignerExecutionAttribute::signerNormalizePathReadMapping)
+                          .writeMapping(AwsSignerExecutionAttribute::signerNormalizePathWriteMapping)
+                          .build();
 
 
     /**
      * An override clock to use during signing.
      * @see Aws4SignerParams.Builder#signingClockOverride(Clock)
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the clock setting via the {@code
+     * AuthSchemeProvider} that is configured on the SDK client builder. If you're using it to call the SDK's signers, you
+     * should migrate to a subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<Clock> SIGNING_CLOCK = new ExecutionAttribute<>("Clock");
+    @Deprecated
+    public static final ExecutionAttribute<Clock> SIGNING_CLOCK =
+        ExecutionAttribute.derivedBuilder("Clock",
+                                          Clock.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(AwsSignerExecutionAttribute::signingClockReadMapping)
+                          .writeMapping(AwsSignerExecutionAttribute::signingClockWriteMapping)
+                          .build();
 
     /**
      * The key to specify the expiration time when pre-signing aws requests.
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the expiration via the {@code AuthSchemeProvider} that is
+     * configured on the SDK client builder. If you're using it to call the SDK's signers, you should migrate to a subtype of
+     * {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<Instant> PRESIGNER_EXPIRATION = new ExecutionAttribute<>("PresignerExpiration");
+    @Deprecated
+    public static final ExecutionAttribute<Instant> PRESIGNER_EXPIRATION =
+        ExecutionAttribute.derivedBuilder("PresignerExpiration",
+                                          Instant.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(AwsSignerExecutionAttribute::presignerExpirationReadMapping)
+                          .writeMapping(AwsSignerExecutionAttribute::presignerExpirationWriteMapping)
+                          .build();
+
 
     private AwsSignerExecutionAttribute() {
+    }
+
+    private static AwsCredentials awsCredentialsReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        Identity identity = joinLikeSync(authScheme.identity());
+        if (!(identity instanceof AwsCredentialsIdentity)) {
+            return null;
+        }
+        return CredentialUtils.toCredentials((AwsCredentialsIdentity) identity);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> awsCredentialsWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                         AwsCredentials awsCredentials) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting the credentials so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than the credentials.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(awsCredentials),
+                                            AwsV4HttpSigner.create(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId(AwsV4AuthScheme.SCHEME_ID)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(CompletableFuture.completedFuture((T) awsCredentials),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption());
+    }
+
+    private static Region signingRegionReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        String regionName = authScheme.authSchemeOption().signerProperty(AwsV4HttpSigner.REGION_NAME);
+        if (regionName == null) {
+            return null;
+        }
+        return Region.of(regionName);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> signingRegionWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                        Region region) {
+        String regionString = region == null ? null : region.id();
+
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting the region so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than the region.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(AwsV4HttpSigner.REGION_NAME,
+                                                                               regionString)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption().copy(o -> o.putSignerProperty(AwsV4HttpSigner.REGION_NAME,
+                                                                                                    regionString)));
+    }
+
+    private static RegionScope signingRegionScopeReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        String regionScope = authScheme.authSchemeOption().signerProperty(AwsV4aHttpSigner.REGION_NAME);
+        if (regionScope == null) {
+            return null;
+        }
+        return RegionScope.create(regionScope);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> signingRegionScopeWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                             RegionScope regionScope) {
+        String regionScopeString = regionScope == null ? null : regionScope.id();
+
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting the region scope so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than the region scope.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(AwsV4aHttpSigner.REGION_NAME,
+                                                                               regionScopeString)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption().copy(o -> o.putSignerProperty(AwsV4aHttpSigner.REGION_NAME,
+                                                                                                    regionScopeString)));
+    }
+
+    private static String serviceSigningNameReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        return authScheme.authSchemeOption().signerProperty(AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> serviceSigningNameWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                             String signingName) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting the signing name so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than the signing name.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME,
+                                                                               signingName)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption()
+                                                  .copy(o -> o.putSignerProperty(AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME,
+                                                                                 signingName)));
+    }
+
+    private static Boolean signerDoubleUrlEncodeReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        AuthSchemeOption authOption = authScheme.authSchemeOption();
+        return authOption.signerProperty(AwsV4FamilyHttpSigner.DOUBLE_URL_ENCODE);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> signerDoubleUrlEncodeWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                                Boolean doubleUrlEncode) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting double-url-encode so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than double-url-encode.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(AwsV4FamilyHttpSigner.DOUBLE_URL_ENCODE,
+                                                                               doubleUrlEncode)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption()
+                                                  .copy(o -> o.putSignerProperty(AwsV4FamilyHttpSigner.DOUBLE_URL_ENCODE,
+                                                                                 doubleUrlEncode)));
+    }
+
+    private static Boolean signerNormalizePathReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        AuthSchemeOption authOption = authScheme.authSchemeOption();
+        return authOption.signerProperty(AwsV4FamilyHttpSigner.NORMALIZE_PATH);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> signerNormalizePathWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                              Boolean normalizePath) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting normalize-path so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than normalize-path.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(AwsV4FamilyHttpSigner.NORMALIZE_PATH,
+                                                                               normalizePath)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption()
+                                                  .copy(o -> o.putSignerProperty(AwsV4FamilyHttpSigner.NORMALIZE_PATH,
+                                                                                 normalizePath)));
+    }
+
+    private static Clock signingClockReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        return authScheme.authSchemeOption().signerProperty(HttpSigner.SIGNING_CLOCK);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> signingClockWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                       Clock clock) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting signing clock so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than the signing clock.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(HttpSigner.SIGNING_CLOCK, clock)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption()
+                                                  .copy(o -> o.putSignerProperty(HttpSigner.SIGNING_CLOCK, clock)));
+    }
+
+    private static Instant presignerExpirationReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        Duration expirationDuration = authScheme.authSchemeOption().signerProperty(AwsV4FamilyHttpSigner.EXPIRATION_DURATION);
+        if (expirationDuration == null) {
+            return null;
+        }
+
+        // This is kind of weird, since reading the value twice will give different values. That seems very unlikely to cause
+        // issues, though.
+        return Instant.now().plus(expirationDuration);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> presignerExpirationWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                              Instant expiration) {
+        Duration expirationDuration = Duration.between(Instant.now(), expiration);
+
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting the expiration so that they can call the presigner directly. If that's true, then it
+            // doesn't really matter what we store other than the expiration.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .putSignerProperty(AwsV4FamilyHttpSigner.EXPIRATION_DURATION,
+                                                                               expirationDuration)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption()
+                                                  .copy(o -> o.putSignerProperty(AwsV4FamilyHttpSigner.EXPIRATION_DURATION,
+                                                                                 expirationDuration)));
+    }
+
+    private static class UnsetIdentity implements Identity {
+    }
+
+    private static class UnsetHttpSigner implements HttpSigner<UnsetIdentity> {
+        @Override
+        public SyncSignedRequest sign(SyncSignRequest<? extends UnsetIdentity> request) {
+            throw new IllegalStateException("A signer was not configured.");
+        }
+
+        @Override
+        public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest<? extends UnsetIdentity> request) {
+            return CompletableFutureUtils.failedFuture(new IllegalStateException("A signer was not configured."));
+        }
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/S3SignerExecutionAttribute.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/S3SignerExecutionAttribute.java
@@ -15,26 +15,141 @@
 
 package software.amazon.awssdk.auth.signer;
 
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.auth.aws.AwsV4FamilyHttpSigner;
+import software.amazon.awssdk.http.auth.spi.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.SyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.SyncSignedRequest;
+import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * S3-specific signing attributes attached to the execution.
+ *
+ * @deprecated Signer execution attributes have been deprecated in favor of signer properties, set on the auth scheme's signer
+ * option.
  */
 @SdkProtectedApi
+@Deprecated
 public final class S3SignerExecutionAttribute extends SdkExecutionAttribute {
-
     /**
      * The key to specify whether to enable chunked encoding or not
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the chunk encoding setting via the {@code AuthSchemeProvider}
+     * that is configured on the SDK client builder. If you're using it to call the SDK's signers, you should migrate to a
+     * subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<Boolean> ENABLE_CHUNKED_ENCODING = new ExecutionAttribute<>("ChunkedEncoding");
+    @Deprecated
+    public static final ExecutionAttribute<Boolean> ENABLE_CHUNKED_ENCODING =
+        ExecutionAttribute.derivedBuilder("ChunkedEncoding",
+                                          Boolean.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(S3SignerExecutionAttribute::enableChunkedEncodingReadMapping)
+                          .writeMapping(S3SignerExecutionAttribute::enableChunkedEncodingWriteMapping)
+                          .build();
+
 
     /**
      * The key to specify whether to enable payload signing or not
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
+     * from execution interceptors, you should instead be overriding the payload signing setting via the {@code
+     * AuthSchemeProvider} that is configured on the SDK client builder. If you're using it to call the SDK's signers, you
+     * should migrate to a subtype of {@code HttpSigner}.
      */
-    public static final ExecutionAttribute<Boolean> ENABLE_PAYLOAD_SIGNING = new ExecutionAttribute<>("PayloadSigning");
+    @Deprecated
+    public static final ExecutionAttribute<Boolean> ENABLE_PAYLOAD_SIGNING =
+        ExecutionAttribute.derivedBuilder("PayloadSigning",
+                                          Boolean.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(S3SignerExecutionAttribute::enablePayloadSigningReadMapping)
+                          .writeMapping(S3SignerExecutionAttribute::enablePayloadSigningWriteMapping)
+                          .build();
 
     private S3SignerExecutionAttribute() {
+    }
+
+    private static Boolean enableChunkedEncodingReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        AuthSchemeOption authOption = authScheme.authSchemeOption();
+        return authOption.signerProperty(AwsV4FamilyHttpSigner.CHUNK_ENCODING_ENABLED);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> enableChunkedEncodingWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                                Boolean enableChunkedEncoding) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting normalize-path so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than normalize-path.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(AwsV4FamilyHttpSigner.CHUNK_ENCODING_ENABLED,
+                                                                               enableChunkedEncoding)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption()
+                                                  .copy(o -> o.putSignerProperty(AwsV4FamilyHttpSigner.CHUNK_ENCODING_ENABLED,
+                                                                                 enableChunkedEncoding)));
+    }
+
+    private static Boolean enablePayloadSigningReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        return authScheme.authSchemeOption().signerProperty(AwsV4FamilyHttpSigner.PAYLOAD_SIGNING_ENABLED);
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> enablePayloadSigningWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                               Boolean payloadSigningEnabled) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're configuring payload signing so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than the payload signing setting.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
+                                            new UnsetHttpSigner(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId("unset")
+                                                            .putSignerProperty(AwsV4FamilyHttpSigner.PAYLOAD_SIGNING_ENABLED,
+                                                                               payloadSigningEnabled)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(authScheme.identity(),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption()
+                                                  .copy(o -> o.putSignerProperty(AwsV4FamilyHttpSigner.PAYLOAD_SIGNING_ENABLED,
+                                                                                 payloadSigningEnabled))
+        );
+    }
+
+    private static class UnsetIdentity implements Identity {
+    }
+
+    private static class UnsetHttpSigner implements HttpSigner<UnsetIdentity> {
+        @Override
+        public SyncSignedRequest sign(SyncSignRequest<? extends UnsetIdentity> request) {
+            throw new IllegalStateException("A signer was not configured.");
+        }
+
+        @Override
+        public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest<? extends UnsetIdentity> request) {
+            return CompletableFutureUtils.failedFuture(new IllegalStateException("A signer was not configured."));
+        }
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/token/signer/SdkTokenExecutionAttribute.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/token/signer/SdkTokenExecutionAttribute.java
@@ -15,21 +15,73 @@
 
 package software.amazon.awssdk.auth.token.signer;
 
+import static software.amazon.awssdk.utils.CompletableFutureUtils.joinLikeSync;
+
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.token.credentials.SdkToken;
+import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.auth.BearerAuthScheme;
+import software.amazon.awssdk.http.auth.BearerHttpSigner;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.identity.spi.Identity;
 
 /**
  * SdkToken authorizing attributes attached to the execution.
+ *
+ * @deprecated Signer execution attributes have been deprecated in favor of signer properties, set on the auth scheme's signer
+ * options.
  */
+@Deprecated
 @SdkProtectedApi
 public final class SdkTokenExecutionAttribute {
 
     /**
      * The token to sign requests using token authorization instead of AWS Credentials.
+     *
+     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it.
      */
-    public static final ExecutionAttribute<SdkToken> SDK_TOKEN = new ExecutionAttribute<>("SdkToken");
+    @Deprecated
+    public static final ExecutionAttribute<SdkToken> SDK_TOKEN =
+        ExecutionAttribute.derivedBuilder("SdkToken",
+                                          SdkToken.class,
+                                          SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                          .readMapping(SdkTokenExecutionAttribute::sdkTokenReadMapping)
+                          .writeMapping(SdkTokenExecutionAttribute::sdkTokenWriteMapping)
+                          .build();
 
     private SdkTokenExecutionAttribute() {
+    }
+
+
+    private static SdkToken sdkTokenReadMapping(SelectedAuthScheme<?> authScheme) {
+        if (authScheme == null) {
+            return null;
+        }
+        Identity identity = joinLikeSync(authScheme.identity());
+        if (!(identity instanceof SdkToken)) {
+            return null;
+        }
+        return (SdkToken) identity;
+    }
+
+    private static <T extends Identity> SelectedAuthScheme<?> sdkTokenWriteMapping(SelectedAuthScheme<T> authScheme,
+                                                                                   SdkToken token) {
+        if (authScheme == null) {
+            // This is an unusual use-case.
+            // Let's assume they're setting the token so that they can call the signer directly. If that's true, then it
+            // doesn't really matter what we store other than the credentials.
+            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(token),
+                                            BearerHttpSigner.create(),
+                                            AuthSchemeOption.builder()
+                                                            .schemeId(BearerAuthScheme.SCHEME_ID)
+                                                            .build());
+        }
+
+        return new SelectedAuthScheme<>(CompletableFuture.completedFuture((T) token),
+                                        authScheme.signer(),
+                                        authScheme.authSchemeOption());
     }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.signer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.core.SelectedAuthScheme;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.auth.aws.AwsV4FamilyHttpSigner;
+import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.SignerProperty;
+import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.RegionScope;
+
+class AwsSignerExecutionAttributeTest {
+    private static final SelectedAuthScheme<Identity> EMPTY_SELECTED_AUTH_SCHEME =
+        new SelectedAuthScheme<>(CompletableFuture.completedFuture(Mockito.mock(Identity.class)),
+                                 (HttpSigner<Identity>) Mockito.mock(HttpSigner.class),
+                                 AuthSchemeOption.builder().schemeId("mock").build());
+
+    private ExecutionAttributes attributes;
+    private Clock testClock;
+
+    @BeforeEach
+    public void setup() {
+        this.attributes = new ExecutionAttributes();
+        this.testClock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+        AwsSignerExecutionAttribute.presignerExpirationClock(testClock);
+    }
+
+    @Test
+    public void awsCredentials_oldAndNewAttributeAreMirrored() {
+        AwsCredentials creds = Mockito.mock(AwsCredentials.class);
+
+        // If selected auth scheme is null, writing non-null old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, creds);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isSameAs(creds);
+
+        // If selected auth scheme is null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, null);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isNull();
+
+        // If selected auth scheme is non-null, writing non-null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, creds);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isSameAs(creds);
+
+        // If selected auth scheme is non-null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, null);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isNull();
+
+        // Writing non-null new property can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                new SelectedAuthScheme<>(CompletableFuture.completedFuture(creds),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption()));
+        assertThat(attributes.getAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS)).isSameAs(creds);
+
+        // Writing null new property can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                new SelectedAuthScheme<>(CompletableFuture.completedFuture(null),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption()));
+        assertThat(attributes.getAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS)).isNull();
+
+        // Null selected auth scheme can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertThat(attributes.getAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS)).isNull();
+    }
+
+    @Test
+    public void signingRegion_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.SIGNING_REGION,
+                                             AwsV4HttpSigner.REGION_NAME,
+                                             Region.US_EAST_1,
+                                             "us-east-1");
+    }
+
+    @Test
+    public void signingRegionScope_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE,
+                                             AwsV4aHttpSigner.REGION_NAME,
+                                             RegionScope.create("foo"),
+                                             "foo");
+    }
+
+    @Test
+    public void signingName_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME,
+                                             AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME,
+                                             "ServiceName");
+    }
+
+    @Test
+    public void doubleUrlEncode_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewBooleanAttributesAreMirrored(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE,
+                                                    AwsV4FamilyHttpSigner.DOUBLE_URL_ENCODE);
+    }
+
+    @Test
+    public void signerNormalizePath_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewBooleanAttributesAreMirrored(AwsSignerExecutionAttribute.SIGNER_NORMALIZE_PATH,
+                                                    AwsV4FamilyHttpSigner.NORMALIZE_PATH);
+    }
+
+    @Test
+    public void signingClock_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.SIGNING_CLOCK,
+                                             HttpSigner.SIGNING_CLOCK,
+                                             Mockito.mock(Clock.class));
+    }
+
+    @Test
+    public void signingExpiration_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.PRESIGNER_EXPIRATION,
+                                             AwsV4FamilyHttpSigner.EXPIRATION_DURATION,
+                                             testClock.instant().plusSeconds(10),
+                                             Duration.ofSeconds(10));
+    }
+
+    private void assertOldAndNewBooleanAttributesAreMirrored(ExecutionAttribute<Boolean> attribute,
+                                                             SignerProperty<Boolean> property) {
+        assertOldAndNewAttributesAreMirrored(attribute, property, true);
+        assertOldAndNewAttributesAreMirrored(attribute, property, false);
+    }
+
+    private <T> void assertOldAndNewAttributesAreMirrored(ExecutionAttribute<T> attributeToWrite,
+                                                          SignerProperty<T> propertyToRead,
+                                                          T valueToWrite) {
+        assertOldAndNewAttributesAreMirrored(attributeToWrite, propertyToRead, valueToWrite, valueToWrite);
+    }
+
+    private <T, U> void assertOldAndNewAttributesAreMirrored(ExecutionAttribute<T> oldAttribute,
+                                                             SignerProperty<U> newProperty,
+                                                             T oldPropertyValue,
+                                                             U newPropertyValue) {
+        // If selected auth scheme is null, writing non-null old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, oldPropertyValue, newPropertyValue);
+
+        // If selected auth scheme is null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, null, null);
+
+        // If selected auth scheme is non-null, writing non-null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, oldPropertyValue, newPropertyValue);
+
+        // If selected auth scheme is non-null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, null, null);
+
+        // Writing non-null new property can be read with old property
+        assertNewPropertyWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, oldPropertyValue, newPropertyValue);
+
+        // Writing null new property can be read with old property
+        assertNewPropertyWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, null, null);
+
+        // Null selected auth scheme can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertThat(attributes.getAttribute(oldAttribute)).isNull();
+    }
+
+    private <T, U> void assertNewPropertyWrite_canBeReadFromNewAttribute(ExecutionAttribute<T> oldAttribute,
+                                                                         SignerProperty<U> newProperty,
+                                                                         T oldPropertyValue,
+                                                                         U newPropertyValue) {
+        AuthSchemeOption newOption =
+            EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption().copy(o -> o.putSignerProperty(newProperty, newPropertyValue));
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                new SelectedAuthScheme<>(EMPTY_SELECTED_AUTH_SCHEME.identity(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         newOption));
+        assertThat(attributes.getAttribute(oldAttribute)).isEqualTo(oldPropertyValue);
+    }
+
+    private <T, U> void assertOldAttributeWrite_canBeReadFromNewAttribute(ExecutionAttribute<T> attributeToWrite,
+                                                                          SignerProperty<U> propertyToRead,
+                                                                          T valueToWrite,
+                                                                          U propertyToExpect) {
+        attributes.putAttribute(attributeToWrite, valueToWrite);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                             .authSchemeOption()
+                             .signerProperty(propertyToRead)).isEqualTo(propertyToExpect);
+    }
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/S3SignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/S3SignerExecutionAttributeTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.signer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.SelectedAuthScheme;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.auth.aws.AwsV4FamilyHttpSigner;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.SignerProperty;
+import software.amazon.awssdk.identity.spi.Identity;
+
+class S3SignerExecutionAttributeTest {
+    private static final SelectedAuthScheme<Identity> EMPTY_SELECTED_AUTH_SCHEME =
+        new SelectedAuthScheme<>(CompletableFuture.completedFuture(Mockito.mock(Identity.class)),
+                                 (HttpSigner<Identity>) Mockito.mock(HttpSigner.class),
+                                 AuthSchemeOption.builder().schemeId("mock").build());
+
+    private ExecutionAttributes attributes;
+
+    @BeforeEach
+    public void setup() {
+        this.attributes = new ExecutionAttributes();
+    }
+
+    @Test
+    public void enableChunkedEncoding_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewBooleanAttributesAreMirrored(S3SignerExecutionAttribute.ENABLE_CHUNKED_ENCODING,
+                                                    AwsV4FamilyHttpSigner.CHUNK_ENCODING_ENABLED);
+    }
+
+    @Test
+    public void enablePayloadSigning_oldAndNewAttributeAreMirrored() {
+        assertOldAndNewBooleanAttributesAreMirrored(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING,
+                                                    AwsV4FamilyHttpSigner.PAYLOAD_SIGNING_ENABLED);
+    }
+
+    private void assertOldAndNewBooleanAttributesAreMirrored(ExecutionAttribute<Boolean> attribute,
+                                                             SignerProperty<Boolean> property) {
+        assertOldAndNewAttributesAreMirrored(attribute, property, true, true);
+        assertOldAndNewAttributesAreMirrored(attribute, property, false, false);
+    }
+
+    private <T, U> void assertOldAndNewAttributesAreMirrored(ExecutionAttribute<T> oldAttribute,
+                                                             SignerProperty<U> newProperty,
+                                                             T oldPropertyValue,
+                                                             U newPropertyValue) {
+        // If selected auth scheme is null, writing non-null old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, oldPropertyValue, newPropertyValue);
+
+        // If selected auth scheme is null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, null, null);
+
+        // If selected auth scheme is non-null, writing non-null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, oldPropertyValue, newPropertyValue);
+
+        // If selected auth scheme is non-null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        assertOldAttributeWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, null, null);
+
+        // Writing non-null new property can be read with old property
+        assertNewPropertyWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, oldPropertyValue, newPropertyValue);
+
+        // Writing null new property can be read with old property
+        assertNewPropertyWrite_canBeReadFromNewAttribute(oldAttribute, newProperty, null, null);
+
+        // Null selected auth scheme can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertThat(attributes.getAttribute(oldAttribute)).isNull();
+    }
+
+    private <T, U> void assertNewPropertyWrite_canBeReadFromNewAttribute(ExecutionAttribute<T> oldAttribute,
+                                                                         SignerProperty<U> newProperty,
+                                                                         T oldPropertyValue,
+                                                                         U newPropertyValue) {
+        AuthSchemeOption newOption =
+            EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption().copy(o -> o.putSignerProperty(newProperty, newPropertyValue));
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                new SelectedAuthScheme<>(EMPTY_SELECTED_AUTH_SCHEME.identity(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         newOption));
+        assertThat(attributes.getAttribute(oldAttribute)).isEqualTo(oldPropertyValue);
+    }
+
+    private <T, U> void assertOldAttributeWrite_canBeReadFromNewAttribute(ExecutionAttribute<T> attributeToWrite,
+                                                                          SignerProperty<U> propertyToRead,
+                                                                          T valueToWrite,
+                                                                          U propertyToExpect) {
+        attributes.putAttribute(attributeToWrite, valueToWrite);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
+                             .authSchemeOption()
+                             .signerProperty(propertyToRead)).isEqualTo(propertyToExpect);
+    }
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/token/signer/SdkTokenExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/token/signer/SdkTokenExecutionAttributeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.token.signer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.token.credentials.SdkToken;
+import software.amazon.awssdk.core.SelectedAuthScheme;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.auth.spi.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
+import software.amazon.awssdk.identity.spi.Identity;
+
+class SdkTokenExecutionAttributeTest {
+    private static final SelectedAuthScheme<Identity> EMPTY_SELECTED_AUTH_SCHEME =
+        new SelectedAuthScheme<>(CompletableFuture.completedFuture(Mockito.mock(Identity.class)),
+                                 (HttpSigner<Identity>) Mockito.mock(HttpSigner.class),
+                                 AuthSchemeOption.builder().schemeId("mock").build());
+
+    private ExecutionAttributes attributes;
+
+    @BeforeEach
+    public void setup() {
+        this.attributes = new ExecutionAttributes();
+    }
+
+    @Test
+    public void awsCredentials_oldAndNewAttributeAreMirrored() {
+        SdkToken token = Mockito.mock(SdkToken.class);
+
+        // If selected auth scheme is null, writing non-null old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        attributes.putAttribute(SdkTokenExecutionAttribute.SDK_TOKEN, token);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isSameAs(token);
+
+        // If selected auth scheme is null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        attributes.putAttribute(SdkTokenExecutionAttribute.SDK_TOKEN, null);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isNull();
+
+        // If selected auth scheme is non-null, writing non-null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        attributes.putAttribute(SdkTokenExecutionAttribute.SDK_TOKEN, token);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isSameAs(token);
+
+        // If selected auth scheme is non-null, writing null to old property can be read with new property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, EMPTY_SELECTED_AUTH_SCHEME);
+        attributes.putAttribute(SdkTokenExecutionAttribute.SDK_TOKEN, null);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME).identity().join()).isNull();
+
+        // Writing non-null new property can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                new SelectedAuthScheme<>(CompletableFuture.completedFuture(token),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption()));
+        assertThat(attributes.getAttribute(SdkTokenExecutionAttribute.SDK_TOKEN)).isSameAs(token);
+
+        // Writing null new property can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                new SelectedAuthScheme<>(CompletableFuture.completedFuture(null),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption()));
+        assertThat(attributes.getAttribute(SdkTokenExecutionAttribute.SDK_TOKEN)).isNull();
+
+        // Null selected auth scheme can be read with old property
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        assertThat(attributes.getAttribute(SdkTokenExecutionAttribute.SDK_TOKEN)).isNull();
+    }
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AuthorizationStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AuthorizationStrategy.java
@@ -22,7 +22,11 @@ import software.amazon.awssdk.core.signer.Signer;
 /**
  * Represents a logical unit for providing instructions on how to authorize a request,
  * including which signer and which credentials to use.
+ *
+ * @deprecated This is only used for compatibility with pre-SRA authorization logic. After we are comfortable that the new code
+ * paths are working, we should migrate old clients to the new code paths (where possible) and delete this code.
  */
+@Deprecated
 @SdkInternalApi
 public interface AuthorizationStrategy {
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AuthorizationStrategyFactory.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AuthorizationStrategyFactory.java
@@ -29,7 +29,11 @@ import software.amazon.awssdk.metrics.MetricCollector;
 
 /**
  * Will create the correct authorization strategy based on provided credential type.
+ *
+ * @deprecated This is only used for compatibility with pre-SRA authorization logic. After we are comfortable that the new code
+ * paths are working, we should migrate old clients to the new code paths (where possible) and delete this code.
  */
+@Deprecated
 @SdkInternalApi
 public final class AuthorizationStrategyFactory {
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AwsCredentialsAuthorizationStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AwsCredentialsAuthorizationStrategy.java
@@ -36,7 +36,11 @@ import software.amazon.awssdk.utils.Validate;
 /**
  * An authorization strategy for AWS Credentials that can resolve a compatible signer as
  * well as provide resolved AWS credentials as an execution attribute.
+ *
+ * @deprecated This is only used for compatibility with pre-SRA authorization logic. After we are comfortable that the new code
+ * paths are working, we should migrate old clients to the new code paths (where possible) and delete this code.
  */
+@Deprecated
 @SdkInternalApi
 public final class AwsCredentialsAuthorizationStrategy implements AuthorizationStrategy {
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/TokenAuthorizationStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/TokenAuthorizationStrategy.java
@@ -35,7 +35,11 @@ import software.amazon.awssdk.utils.Validate;
 /**
  * An authorization strategy for tokens that can resolve a compatible signer as
  * well as provide a resolved token as an execution attribute.
+ *
+ * @deprecated This is only used for compatibility with pre-SRA authorization logic. After we are comfortable that the new code
+ * paths are working, we should migrate old clients to the new code paths (where possible) and delete this code.
  */
+@Deprecated
 @SdkInternalApi
 public final class TokenAuthorizationStrategy implements AuthorizationStrategy {
 

--- a/core/http-auth-aws-crt/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
+++ b/core/http-auth-aws-crt/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
@@ -18,7 +18,8 @@ import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.auth.spi.SignerProperty;
+import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
 import software.amazon.awssdk.http.auth.spi.SyncSignRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 
@@ -43,10 +44,9 @@ public class TestUtils {
                                                      .build()
                                                      .copy(requestOverrides))
                               .payload(() -> new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
-                              .putProperty(SignerProperty.create(String.class, "RegionName"), "aws-global")
-                              .putProperty(SignerProperty.create(String.class, "ServiceSigningName"), "demo")
-                              .putProperty(SignerProperty.create(Clock.class, "SigningClock"),
-                                           new TickingClock(Instant.ofEpochMilli(1596476903000L)))
+                              .putProperty(AwsV4aHttpSigner.REGION_NAME, "aws-global")
+                              .putProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "demo")
+                              .putProperty(HttpSigner.SIGNING_CLOCK, new TickingClock(Instant.ofEpochMilli(1596476903000L)))
                               .build()
                               .copy(signRequestOverrides);
     }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4FamilyHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4FamilyHttpSigner.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.spi.SignerProperty;
+
+/**
+ * An interface shared by {@link AwsV4HttpSigner} and {@link AwsV4aHttpSigner} for defining signer properties that are common
+ * across both signers.
+ */
+@SdkPublicApi
+public interface AwsV4FamilyHttpSigner {
+    /**
+     * The name of the AWS service. This property is required.
+     */
+    SignerProperty<String> SERVICE_SIGNING_NAME =
+        SignerProperty.create(String.class, "ServiceSigningName");
+
+    /**
+     * A boolean to indicate whether to double url-encode the resource path when constructing the canonical request. This property
+     * defaults to true.
+     */
+    SignerProperty<Boolean> DOUBLE_URL_ENCODE =
+        SignerProperty.create(Boolean.class, "DoubleUrlEncode");
+
+    /**
+     * A boolean to indicate whether the resource path should be "normalized" according to RFC3986 when constructing the canonical
+     * request. This property defaults to true.
+     */
+    SignerProperty<Boolean> NORMALIZE_PATH =
+        SignerProperty.create(Boolean.class, "NormalizePath");
+
+    /**
+     * The location where auth-related data is inserted, as a result of signing. This property defaults to HEADER.
+     */
+    SignerProperty<AuthLocation> AUTH_LOCATION =
+        SignerProperty.create(AuthLocation.class, "AuthLocation");
+
+    /**
+     * The duration for the request to be valid. This property defaults to null. This can be set to presign the request for
+     * later use. The maximum allowed value for this property is 7 days. This is only supported when AuthLocation=QUERY.
+     */
+    SignerProperty<Duration> EXPIRATION_DURATION =
+        SignerProperty.create(Duration.class, "ExpirationDuration");
+
+    /**
+     * Whether to indicate that a payload is signed or not. This property defaults to true. This can be set false to disable
+     * payload signing.
+     */
+    SignerProperty<Boolean> PAYLOAD_SIGNING_ENABLED =
+        SignerProperty.create(Boolean.class, "PayloadSigningEnabled");
+
+    /**
+     * Whether to indicate that a payload is chunk-encoded or not. This property defaults to false. This can be set true to
+     * enable the `aws-chunk` content-encoding
+     */
+    SignerProperty<Boolean> CHUNK_ENCODING_ENABLED =
+        SignerProperty.create(Boolean.class, "ChunkEncodingEnabled");
+
+    /**
+     * This enum represents where auth-related data is inserted, as a result of signing.
+     */
+    enum AuthLocation {
+        /**
+         * Indicates auth-related data is inserted in HTTP headers.
+         */
+        HEADER,
+
+        /**
+         * Indicates auth-related data is inserted in HTTP query-parameters.
+         */
+        QUERY_STRING
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4HttpSigner.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.http.auth.aws;
 
-import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.auth.aws.internal.signer.DefaultAwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.spi.HttpSigner;
@@ -29,7 +28,7 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
  * <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html">here</a>.
  */
 @SdkPublicApi
-public interface AwsV4HttpSigner extends HttpSigner<AwsCredentialsIdentity> {
+public interface AwsV4HttpSigner extends AwsV4FamilyHttpSigner, HttpSigner<AwsCredentialsIdentity> {
     /**
      * The AWS region name to be used for computing the signature. This property is required.
      */
@@ -37,72 +36,9 @@ public interface AwsV4HttpSigner extends HttpSigner<AwsCredentialsIdentity> {
         SignerProperty.create(String.class, "RegionName");
 
     /**
-     * The name of the AWS service. This property is required.
-     */
-    SignerProperty<String> SERVICE_SIGNING_NAME =
-        SignerProperty.create(String.class, "ServiceSigningName");
-
-    /**
-     * A boolean to indicate whether to double url-encode the resource path when constructing the canonical request. This property
-     * defaults to true.
-     */
-    SignerProperty<Boolean> DOUBLE_URL_ENCODE =
-        SignerProperty.create(Boolean.class, "DoubleUrlEncode");
-
-    /**
-     * A boolean to indicate whether the resource path should be "normalized" according to RFC3986 when constructing the canonical
-     * request. This property defaults to true.
-     */
-    SignerProperty<Boolean> NORMALIZE_PATH =
-        SignerProperty.create(Boolean.class, "NormalizePath");
-
-    /**
-     * The location where auth-related data is inserted, as a result of signing. This property defaults to HEADER.
-     */
-    SignerProperty<AuthLocation> AUTH_LOCATION =
-        SignerProperty.create(AuthLocation.class, "AuthLocation");
-
-    /**
-     * The duration for the request to be valid. This property defaults to null. This can be set to presign the request for
-     * later use. The maximum allowed value for this property is 7 days. This is only supported when AuthLocation=QUERY.
-     */
-    SignerProperty<Duration> EXPIRATION_DURATION =
-        SignerProperty.create(Duration.class, "ExpirationDuration");
-
-    /**
-     * Whether to indicate that a payload is signed or not. This property defaults to true. This can be set false to disable
-     * payload signing.
-     */
-    SignerProperty<Boolean> PAYLOAD_SIGNING_ENABLED =
-        SignerProperty.create(Boolean.class, "PayloadSigningEnabled");
-
-    /**
-     * Whether to indicate that a payload is chunk-encoded or not. This property defaults to false. This can be set true to
-     * enable the `aws-chunk` content-encoding
-     */
-    SignerProperty<Boolean> CHUNK_ENCODING_ENABLED =
-        SignerProperty.create(Boolean.class, "ChunkEncodingEnabled");
-
-
-    /**
      * Get a default implementation of a {@link AwsV4HttpSigner}
      */
     static AwsV4HttpSigner create() {
         return new DefaultAwsV4HttpSigner();
-    }
-
-    /**
-     * This enum represents where auth-related data is inserted, as a result of signing.
-     */
-    enum AuthLocation {
-        /**
-         * Indicates auth-related data is inserted in HTTP headers.
-         */
-        HEADER,
-
-        /**
-         * Indicates auth-related data is inserted in HTTP query-parameters.
-         */
-        QUERY_STRING
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aHttpSigner.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.http.auth.aws;
 
-import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.auth.aws.internal.signer.SignerLoader;
 import software.amazon.awssdk.http.auth.spi.HttpSigner;
@@ -29,54 +28,13 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
  * <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html">here</a>.
  */
 @SdkPublicApi
-public interface AwsV4aHttpSigner extends HttpSigner<AwsCredentialsIdentity> {
+public interface AwsV4aHttpSigner extends AwsV4FamilyHttpSigner, HttpSigner<AwsCredentialsIdentity> {
     /**
      * The AWS region name to be used for computing the signature. This property is required.
      *
      * TODO(sra-identity-and-auth): Should this be a list or rename to SIGNING_SCOPE?
      */
-    SignerProperty<String> REGION_NAME =
-        SignerProperty.create(String.class, "RegionName");
-
-    /**
-     * The name of the AWS service. This property is required.
-     */
-    SignerProperty<String> SERVICE_SIGNING_NAME =
-        SignerProperty.create(String.class, "ServiceSigningName");
-
-    /**
-     * A boolean to indicate whether to double url-encode the resource path when constructing the canonical request. This property
-     * defaults to true.
-     */
-    SignerProperty<Boolean> DOUBLE_URL_ENCODE =
-        SignerProperty.create(Boolean.class, "DoubleUrlEncode");
-
-    /**
-     * A boolean to indicate whether the resource path should be "normalized" according to RFC3986 when constructing the canonical
-     * request. This property defaults to true.
-     */
-    SignerProperty<Boolean> NORMALIZE_PATH =
-        SignerProperty.create(Boolean.class, "NormalizePath");
-
-    /**
-     * The location where auth-related data is inserted, as a result of signing. This property defaults to HEADER.
-     */
-    SignerProperty<AuthLocation> AUTH_LOCATION =
-        SignerProperty.create(AuthLocation.class, "AuthLocation");
-
-    /**
-     * The duration for the request to be valid. This property defaults to the max valid duration (7 days). This is only used in
-     * the case of a pre-signing implementation.
-     */
-    SignerProperty<Duration> EXPIRATION_DURATION =
-        SignerProperty.create(Duration.class, "ExpirationDuration");
-
-    /**
-     * Whether to indicate that a payload is signed or not. This property defaults to true. This can be set false to disable
-     * payload signing.
-     */
-    SignerProperty<Boolean> PAYLOAD_SIGNING_ENABLED =
-        SignerProperty.create(Boolean.class, "PayloadSigningEnabled");
+    SignerProperty<String> REGION_NAME = SignerProperty.create(String.class, "SigningScope");
 
     /**
      * Whether to indicate that a payload is chunk-encoded or not. This property defaults to false. This can be set true to
@@ -90,20 +48,5 @@ public interface AwsV4aHttpSigner extends HttpSigner<AwsCredentialsIdentity> {
      */
     static AwsV4aHttpSigner create() {
         return SignerLoader.getAwsV4aHttpSigner();
-    }
-
-    /**
-     * This enum represents where auth-related data is inserted, as a result of signing.
-     */
-    enum AuthLocation {
-        /**
-         * Indicates auth-related data is inserted in HTTP headers.
-         */
-        HEADER,
-
-        /**
-         * Indicates auth-related data is inserted in HTTP query-parameters.
-         */
-        QUERY_STRING
     }
 }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -26,7 +26,7 @@ import static software.amazon.awssdk.http.auth.aws.TestUtils.generateBasicReques
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.http.Header;
-import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner.AuthLocation;
+import software.amazon.awssdk.http.auth.aws.AwsV4FamilyHttpSigner.AuthLocation;
 import software.amazon.awssdk.http.auth.aws.TestUtils;
 import software.amazon.awssdk.http.auth.spi.SyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.SyncSignedRequest;

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
@@ -85,7 +85,9 @@ public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Bui
         Builder schemeId(String schemeId);
 
         <T> Builder putIdentityProperty(IdentityProperty<T> key, T value);
+        <T> Builder putIdentityPropertyIfAbsent(IdentityProperty<T> key, T value);
 
         <T> Builder putSignerProperty(SignerProperty<T> key, T value);
+        <T> Builder putSignerPropertyIfAbsent(SignerProperty<T> key, T value);
     }
 }

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
@@ -85,9 +85,11 @@ public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Bui
         Builder schemeId(String schemeId);
 
         <T> Builder putIdentityProperty(IdentityProperty<T> key, T value);
+
         <T> Builder putIdentityPropertyIfAbsent(IdentityProperty<T> key, T value);
 
         <T> Builder putSignerProperty(SignerProperty<T> key, T value);
+        
         <T> Builder putSignerPropertyIfAbsent(SignerProperty<T> key, T value);
     }
 }

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/SignerProperty.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/SignerProperty.java
@@ -16,8 +16,6 @@
 package software.amazon.awssdk.http.auth.spi;
 
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/SignerProperty.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/SignerProperty.java
@@ -32,8 +32,6 @@ import software.amazon.awssdk.utils.Validate;
 @Immutable
 @ThreadSafe
 public final class SignerProperty<T> {
-    private static final ConcurrentMap<String, SignerProperty<?>> NAME_HISTORY = new ConcurrentHashMap<>();
-
     private final Class<T> clazz;
     private final String name;
 
@@ -43,7 +41,6 @@ public final class SignerProperty<T> {
 
         this.clazz = clazz;
         this.name = name;
-        ensureUnique();
     }
 
     /**
@@ -51,19 +48,6 @@ public final class SignerProperty<T> {
      */
     public static <T> SignerProperty<T> create(Class<T> clazz, String name) {
         return new SignerProperty<>(clazz, name);
-    }
-
-    private void ensureUnique() {
-        SignerProperty<?> prev = NAME_HISTORY.putIfAbsent(name, this);
-        if (prev != null) {
-            throw new IllegalArgumentException(String.format("No duplicate SignerProperty names allowed but both "
-                                                             + "SignerProperty %s and %s have the same name: %s. "
-                                                             + "SignerProperty should be referenced from a shared static "
-                                                             + "constant to protect against erroneous or unexpected collisions.",
-                                                             Integer.toHexString(System.identityHashCode(prev)),
-                                                             Integer.toHexString(System.identityHashCode(this)),
-                                                             name));
-        }
     }
 
     @Override

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultAuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultAuthSchemeOption.java
@@ -117,8 +117,20 @@ public final class DefaultAuthSchemeOption implements AuthSchemeOption {
         }
 
         @Override
+        public <T> Builder putIdentityPropertyIfAbsent(IdentityProperty<T> key, T value) {
+            this.identityProperties.putIfAbsent(key, value);
+            return this;
+        }
+
+        @Override
         public <T> Builder putSignerProperty(SignerProperty<T> key, T value) {
             this.signerProperties.put(key, value);
+            return this;
+        }
+
+        @Override
+        public <T> Builder putSignerPropertyIfAbsent(SignerProperty<T> key, T value) {
+            this.signerProperties.putIfAbsent(key, value);
             return this;
         }
 

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOptionTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOptionTest.java
@@ -22,6 +22,10 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.identity.spi.IdentityProperty;
 
 class AuthSchemeOptionTest {
+    private static final IdentityProperty<String> IDENTITY_PROPERTY_1 = IdentityProperty.create(String.class, "identityKey1");
+    private static final SignerProperty<String> SIGNER_PROPERTY_1 = SignerProperty.create(String.class, "signingKey1");
+    private static final IdentityProperty<String> IDENTITY_PROPERTY_2 = IdentityProperty.create(String.class, "identityKey2");
+    private static final SignerProperty<String> SIGNER_PROPERTY_2 = SignerProperty.create(String.class, "signingKey2");
 
     @Test
     public void emptyBuilder_isNotSuccessful() {
@@ -36,59 +40,50 @@ class AuthSchemeOptionTest {
 
     @Test
     public void putProperty_sameProperty_isReplaced() {
-        IdentityProperty<String> identityProperty = IdentityProperty.create(String.class, "identityKey1");
-        SignerProperty<String> signerProperty = SignerProperty.create(String.class, "signingKey1");
 
         AuthSchemeOption authSchemeOption = AuthSchemeOption.builder()
                                                             .schemeId("my.api#myAuth")
-                                                            .putIdentityProperty(identityProperty, "identity-value1")
-                                                            .putIdentityProperty(identityProperty, "identity-value2")
-                                                            .putSignerProperty(signerProperty, "signing-value1")
-                                                            .putSignerProperty(signerProperty, "signing-value2")
+                                                            .putIdentityProperty(IDENTITY_PROPERTY_1, "identity-value1")
+                                                            .putIdentityProperty(IDENTITY_PROPERTY_1, "identity-value2")
+                                                            .putSignerProperty(SIGNER_PROPERTY_1, "signing-value1")
+                                                            .putSignerProperty(SIGNER_PROPERTY_1, "signing-value2")
                                                             .build();
 
-        assertEquals("identity-value2", authSchemeOption.identityProperty(identityProperty));
-        assertEquals("signing-value2", authSchemeOption.signerProperty(signerProperty));
+        assertEquals("identity-value2", authSchemeOption.identityProperty(IDENTITY_PROPERTY_1));
+        assertEquals("signing-value2", authSchemeOption.signerProperty(SIGNER_PROPERTY_1));
     }
 
     @Test
     public void copyBuilder_addProperty_retains() {
-        IdentityProperty<String> identityProperty = IdentityProperty.create(String.class, "identityKey");
-        SignerProperty<String> signerProperty = SignerProperty.create(String.class, "signingKey");
         AuthSchemeOption authSchemeOption = AuthSchemeOption.builder()
                                                             .schemeId("my.api#myAuth")
-                                                            .putIdentityProperty(identityProperty, "identity-value1")
-                                                            .putSignerProperty(signerProperty, "signing-value1")
+                                                            .putIdentityProperty(IDENTITY_PROPERTY_1, "identity-value1")
+                                                            .putSignerProperty(SIGNER_PROPERTY_1, "signing-value1")
                                                             .build();
 
-        IdentityProperty<String> identityProperty2 = IdentityProperty.create(String.class, "identityKey2");
-        SignerProperty<String> signerProperty2 = SignerProperty.create(String.class, "signingKey2");
-
         authSchemeOption =
-            authSchemeOption.copy(builder -> builder.putIdentityProperty(identityProperty2, "identity2-value1")
-                                                    .putSignerProperty(signerProperty2, "signing2-value1"));
+            authSchemeOption.copy(builder -> builder.putIdentityProperty(IDENTITY_PROPERTY_2, "identity2-value1")
+                                                    .putSignerProperty(SIGNER_PROPERTY_2, "signing2-value1"));
 
-        assertEquals("identity-value1", authSchemeOption.identityProperty(identityProperty));
-        assertEquals("identity2-value1", authSchemeOption.identityProperty(identityProperty2));
-        assertEquals("signing-value1", authSchemeOption.signerProperty(signerProperty));
-        assertEquals("signing2-value1", authSchemeOption.signerProperty(signerProperty2));
+        assertEquals("identity-value1", authSchemeOption.identityProperty(IDENTITY_PROPERTY_1));
+        assertEquals("identity2-value1", authSchemeOption.identityProperty(IDENTITY_PROPERTY_2));
+        assertEquals("signing-value1", authSchemeOption.signerProperty(SIGNER_PROPERTY_1));
+        assertEquals("signing2-value1", authSchemeOption.signerProperty(SIGNER_PROPERTY_2));
     }
 
     @Test
     public void copyBuilder_updateProperty_updates() {
-        IdentityProperty<String> identityProperty = IdentityProperty.create(String.class, "identityKey");
-        SignerProperty<String> signerProperty = SignerProperty.create(String.class, "signingKey");
         AuthSchemeOption authSchemeOption = AuthSchemeOption.builder()
                                                             .schemeId("my.api#myAuth")
-                                                            .putIdentityProperty(identityProperty, "identity-value1")
-                                                            .putSignerProperty(signerProperty, "signing-value1")
+                                                            .putIdentityProperty(IDENTITY_PROPERTY_1, "identity-value1")
+                                                            .putSignerProperty(SIGNER_PROPERTY_1, "signing-value1")
                                                             .build();
 
         authSchemeOption =
-            authSchemeOption.copy(builder -> builder.putIdentityProperty(identityProperty, "identity-value2")
-                                                    .putSignerProperty(signerProperty, "signing-value2"));
+            authSchemeOption.copy(builder -> builder.putIdentityProperty(IDENTITY_PROPERTY_1, "identity-value2")
+                                                    .putSignerProperty(SIGNER_PROPERTY_1, "signing-value2"));
 
-        assertEquals("identity-value2", authSchemeOption.identityProperty(identityProperty));
-        assertEquals("signing-value2", authSchemeOption.signerProperty(signerProperty));
+        assertEquals("identity-value2", authSchemeOption.identityProperty(IDENTITY_PROPERTY_1));
+        assertEquals("signing-value2", authSchemeOption.signerProperty(SIGNER_PROPERTY_1));
     }
 }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/IdentityProperty.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/IdentityProperty.java
@@ -31,8 +31,6 @@ import software.amazon.awssdk.utils.Validate;
 @Immutable
 @ThreadSafe
 public final class IdentityProperty<T> {
-    private static final ConcurrentMap<String, IdentityProperty<?>> NAME_HISTORY = new ConcurrentHashMap<>();
-
     private final Class<T> clazz;
     private final String name;
 
@@ -42,24 +40,10 @@ public final class IdentityProperty<T> {
 
         this.clazz = clazz;
         this.name = name;
-        ensureUnique();
     }
 
     public static <T> IdentityProperty<T> create(Class<T> clazz, String name) {
         return new IdentityProperty<>(clazz, name);
-    }
-
-    private void ensureUnique() {
-        IdentityProperty<?> prev = NAME_HISTORY.putIfAbsent(name, this);
-        if (prev != null) {
-            throw new IllegalArgumentException(String.format("No duplicate IdentityProperty names allowed but both "
-                                                             + "IdentityProperty %s and %s have the same name: %s. "
-                                                             + "IdentityProperty should be referenced from a shared static "
-                                                             + "constant to protect against erroneous or unexpected collisions.",
-                                                             Integer.toHexString(System.identityHashCode(prev)),
-                                                             Integer.toHexString(System.identityHashCode(this)),
-                                                             name));
-        }
     }
 
     @Override

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/IdentityProperty.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/IdentityProperty.java
@@ -15,8 +15,6 @@
 
 package software.amazon.awssdk.identity.spi;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.identity.spi.internal.DefaultResolveIdentityRequest;
 
 public class ResolveIdentityRequestTest {
+    private static final IdentityProperty<String> PROPERTY_1 = IdentityProperty.create(String.class, "key_1");
+    private static final IdentityProperty<String> PROPERTY_2 = IdentityProperty.create(String.class, "key_2");
+
     @Test
     public void equalsHashcode() {
         EqualsVerifier.forClass(DefaultResolveIdentityRequest.class)
@@ -37,46 +40,39 @@ public class ResolveIdentityRequestTest {
 
     @Test
     public void build_withProperty_isSuccessful() {
-        IdentityProperty<String> property = IdentityProperty.create(String.class, "key");
         ResolveIdentityRequest request = ResolveIdentityRequest.builder()
-                                                               .putProperty(property, "value")
+                                                               .putProperty(PROPERTY_1, "value")
                                                                .build();
-        assertEquals("value", request.property(property));
+        assertEquals("value", request.property(PROPERTY_1));
     }
 
     @Test
     public void putProperty_sameProperty_isReplaced() {
-        IdentityProperty<String> property = IdentityProperty.create(String.class, "key");
         ResolveIdentityRequest request = ResolveIdentityRequest.builder()
-                                                               .putProperty(property, "value")
-                                                               .putProperty(property, "value2")
+                                                               .putProperty(PROPERTY_1, "value")
+                                                               .putProperty(PROPERTY_1, "value2")
                                                                .build();
-        assertEquals("value2", request.property(property));
+        assertEquals("value2", request.property(PROPERTY_1));
     }
 
     @Test
     public void copyBuilder_addProperty_retains() {
-        IdentityProperty<String> property1 = IdentityProperty.create(String.class, "key1");
         ResolveIdentityRequest request = ResolveIdentityRequest.builder()
-                                                               .putProperty(property1, "key1value1")
+                                                               .putProperty(PROPERTY_1, "key1value1")
                                                                .build();
 
-        IdentityProperty<String> property2 = IdentityProperty.create(String.class, "key2");
-        request = request.copy(builder -> builder.putProperty(property2, "key2value1"));
-        assertEquals("key1value1", request.property(property1));
-        assertEquals("key2value1", request.property(property2));
+        request = request.copy(builder -> builder.putProperty(PROPERTY_2, "key2value1"));
+        assertEquals("key1value1", request.property(PROPERTY_1));
+        assertEquals("key2value1", request.property(PROPERTY_2));
     }
 
     @Test
     public void copyBuilder_updateAddProperty_works() {
-        IdentityProperty<String> property1 = IdentityProperty.create(String.class, "key1");
         ResolveIdentityRequest request = ResolveIdentityRequest.builder()
-                                                               .putProperty(property1, "key1value1")
+                                                               .putProperty(PROPERTY_1, "key1value1")
                                                                .build();
-
-        IdentityProperty<String> property2 = IdentityProperty.create(String.class, "key2");
-        request = request.copy(builder -> builder.putProperty(property1, "key1value2").putProperty(property2, "key2value1"));
-        assertEquals("key1value2", request.property(property1));
-        assertEquals("key2value1", request.property(property2));
+        request = request.copy(builder -> builder.putProperty(PROPERTY_1, "key1value2").putProperty(PROPERTY_2, "key2value1"));
+        assertEquals("key1value2", request.property(PROPERTY_1));
+        assertEquals("key2value1", request.property(PROPERTY_2));
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SelectedAuthScheme.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SelectedAuthScheme.java
@@ -24,6 +24,9 @@ import software.amazon.awssdk.utils.Validate;
 
 /**
  * A container for the identity resolver, signer and auth option that we selected for use with this service call attempt.
+ *
+ * TODO(sra-identity-auth): Should this be made public? People might treat it as such anyway so that they can change the
+ * identity, signer or options from the interceptors. They're doing that already with the existing execution attributes.
  */
 @SdkProtectedApi
 public final class SelectedAuthScheme<T extends Identity> {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
@@ -15,10 +15,14 @@
 
 package software.amazon.awssdk.core.interceptor;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * An attribute attached to a particular execution, stored in {@link ExecutionAttributes}.
@@ -47,6 +51,7 @@ public final class ExecutionAttribute<T> {
     private static final ConcurrentMap<String, ExecutionAttribute<?>> NAME_HISTORY = new ConcurrentHashMap<>();
     
     private final String name;
+    private final ValueStorage<T> storage;
 
     /**
      * Creates a new {@link ExecutionAttribute} bound to the provided type param.
@@ -54,8 +59,31 @@ public final class ExecutionAttribute<T> {
      * @param name Descriptive name for the attribute, used primarily for debugging purposes.
      */
     public ExecutionAttribute(String name) {
+        this(name, null);
+    }
+    private ExecutionAttribute(String name, ValueStorage<T> storage) {
         this.name = name;
+        this.storage = storage == null ? new DefaultValueStorage() : storage;
         ensureUnique();
+    }
+
+    /**
+     * Create an execution attribute whose value is derived from another attribute.
+     *
+     * <p>Whenever this value is read, its value is read from a different "real" attribute, and whenever this value is written its
+     * value is written to the "real" attribute, instead.
+     *
+     * <p>This is useful when new attributes are created to replace old attributes, but for backwards-compatibility those old
+     * attributes still need to be made available.
+     *
+     * @param name The name of the attribute to create
+     * @param attributeType The type of the attribute being created
+     * @param realAttribute The "real" attribute from which this attribute is derived
+     */
+    public static <T, U> DerivedAttributeBuilder<T, U> derivedBuilder(String name,
+                                                                      @SuppressWarnings("unused") Class<T> attributeType,
+                                                                      ExecutionAttribute<U> realAttribute) {
+        return new DerivedAttributeBuilder<>(name, realAttribute);
     }
 
     private void ensureUnique() {
@@ -103,5 +131,122 @@ public final class ExecutionAttribute<T> {
     @Override
     public int hashCode() {
         return Objects.hashCode(name);
+    }
+
+    /**
+     * Visible for {@link ExecutionAttributes} to invoke when writing or reading values for this attribute.
+     */
+    ValueStorage<T> storage() {
+        return storage;
+    }
+
+    public static final class DerivedAttributeBuilder<T, U> {
+        private final String name;
+        private final ExecutionAttribute<U> realAttribute;
+        private Function<U, T> readMapping;
+        private BiFunction<U, T, U> writeMapping;
+
+        private DerivedAttributeBuilder(String name, ExecutionAttribute<U> realAttribute) {
+            this.name = name;
+            this.realAttribute = realAttribute;
+        }
+
+        /**
+         * Set the "read" mapping for this derived attribute. The provided function accepts the current value of the
+         * "real" attribute and returns the value of the derived attribute.
+         */
+        public DerivedAttributeBuilder<T, U> readMapping(Function<U, T> readMapping) {
+            this.readMapping = readMapping;
+            return this;
+        }
+
+        /**
+         * Set the "write" mapping for this derived attribute. The provided function accepts the current value of the "real"
+         * attribute, the value that we're trying to set to the derived attribute, and returns the value to set to the "real"
+         * attribute.
+         */
+        public DerivedAttributeBuilder<T, U> writeMapping(BiFunction<U, T, U> writeMapping) {
+            this.writeMapping = writeMapping;
+            return this;
+        }
+
+        public ExecutionAttribute<T> build() {
+            return new ExecutionAttribute<>(name, new DerivationValueStorage<>(this));
+        }
+    }
+
+    /**
+     * The value storage allows reading or writing values to this attribute. Used by {@link ExecutionAttributes} for storing
+     * attribute values, whether they are "real" or derived.
+     */
+    interface ValueStorage<T> {
+        /**
+         * Retrieve an attribute's value from the provided attribute map.
+         */
+        T get(Map<ExecutionAttribute<?>, Object> attributes);
+
+        /**
+         * Set an attribute's value to the provided attribute map.
+         */
+        void set(Map<ExecutionAttribute<?>, Object> attributes, T value);
+
+        /**
+         * Set an attribute's value to the provided attribute map, if the value is not already in the map.
+         */
+        void setIfAbsent(Map<ExecutionAttribute<?>, Object> attributes, T value);
+    }
+
+    /**
+     * An implementation of {@link ValueStorage} that stores the current execution attribute in the provided attributes map.
+     */
+    private final class DefaultValueStorage implements ValueStorage<T> {
+        @SuppressWarnings("unchecked") // Safe because of the implementation of set()
+        @Override
+        public T get(Map<ExecutionAttribute<?>, Object> attributes) {
+            return (T) attributes.get(ExecutionAttribute.this);
+        }
+
+        @Override
+        public void set(Map<ExecutionAttribute<?>, Object> attributes, T value) {
+            attributes.put(ExecutionAttribute.this, value);
+        }
+
+        @Override
+        public void setIfAbsent(Map<ExecutionAttribute<?>, Object> attributes, T value) {
+            attributes.putIfAbsent(ExecutionAttribute.this, value);
+        }
+    }
+
+    /**
+     * An implementation of {@link ValueStorage} that derives its value from a different execution attribute in the provided
+     * attributes map.
+     */
+    private static final class DerivationValueStorage<T, U> implements ValueStorage<T> {
+        private final ExecutionAttribute<U> realAttribute;
+        private final Function<U, T> readMapping;
+        private final BiFunction<U, T, U> writeMapping;
+
+        private DerivationValueStorage(DerivedAttributeBuilder<T, U> builder) {
+            this.realAttribute = Validate.paramNotNull(builder.realAttribute, "realAttribute");
+            this.readMapping = Validate.paramNotNull(builder.readMapping, "readMapping");
+            this.writeMapping = Validate.paramNotNull(builder.writeMapping, "writeMapping");
+        }
+
+        @SuppressWarnings("unchecked") // Safe because of the implementation of set
+        @Override
+        public T get(Map<ExecutionAttribute<?>, Object> attributes) {
+            return readMapping.apply((U) attributes.get(realAttribute));
+        }
+
+        @SuppressWarnings("unchecked") // Safe because of the implementation of set
+        @Override
+        public void set(Map<ExecutionAttribute<?>, Object> attributes, T value) {
+            attributes.compute(realAttribute, (k, real) -> writeMapping.apply((U) real, value));
+        }
+
+        @Override
+        public void setIfAbsent(Map<ExecutionAttribute<?>, Object> attributes, T value) {
+            attributes.computeIfAbsent(realAttribute, k -> writeMapping.apply(null, value));
+        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
@@ -61,6 +61,7 @@ public final class ExecutionAttribute<T> {
     public ExecutionAttribute(String name) {
         this(name, null);
     }
+
     private ExecutionAttribute(String name, ValueStorage<T> storage) {
         this.name = name;
         this.storage = storage == null ? new DefaultValueStorage() : storage;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
@@ -44,14 +44,12 @@ public class ExecutionAttributes implements ToCopyableBuilder<ExecutionAttribute
     protected ExecutionAttributes(Map<? extends ExecutionAttribute<?>, ?> attributes) {
         this.attributes = new HashMap<>(attributes);
     }
-
     /**
      * Retrieve the current value of the provided attribute in this collection of attributes. This will return null if the value
      * is not set.
      */
-    @SuppressWarnings("unchecked") // Cast is safe due to implementation of {@link #putAttribute}
     public <U> U getAttribute(ExecutionAttribute<U> attribute) {
-        return (U) attributes.get(attribute);
+        return attribute.storage().get(attributes);
     }
 
     /**
@@ -66,14 +64,22 @@ public class ExecutionAttributes implements ToCopyableBuilder<ExecutionAttribute
      * This will return Optional Value.
      */
     public <U> Optional<U> getOptionalAttribute(ExecutionAttribute<U> attribute) {
-        return Optional.ofNullable((U) attributes.get(attribute));
+        return Optional.ofNullable(getAttribute(attribute));
     }
 
     /**
      * Update or set the provided attribute in this collection of attributes.
      */
     public <U> ExecutionAttributes putAttribute(ExecutionAttribute<U> attribute, U value) {
-        this.attributes.put(attribute, value);
+        attribute.storage().set(attributes, value);
+        return this;
+    }
+
+    /**
+     * Set the provided attribute in this collection of attributes if it does not already exist in the collection.
+     */
+    public <U> ExecutionAttributes putAttributeIfAbsent(ExecutionAttribute<U> attribute, U value) {
+        attribute.storage().setIfAbsent(attributes, value);
         return this;
     }
 
@@ -93,14 +99,6 @@ public class ExecutionAttributes implements ToCopyableBuilder<ExecutionAttribute
         if (lowerPrecedenceExecutionAttributes != null) {
             lowerPrecedenceExecutionAttributes.getAttributes().forEach(attributes::putIfAbsent);
         }
-    }
-
-    /**
-     * Set the provided attribute in this collection of attributes if it does not already exist in the collection.
-     */
-    public <U> ExecutionAttributes putAttributeIfAbsent(ExecutionAttribute<U> attribute, U value) {
-        attributes.putIfAbsent(attribute, value);
-        return this;
     }
 
     public static Builder builder() {
@@ -163,15 +161,18 @@ public class ExecutionAttributes implements ToCopyableBuilder<ExecutionAttribute
         }
     }
 
+    /**
+     * TODO: We should deprecate this builder - execution attributes are mutable - why do we need a builder? We can just use
+     * copy() if it's because of {@link #unmodifiableExecutionAttributes(ExecutionAttributes)}.
+     */
     public static final class Builder implements CopyableBuilder<ExecutionAttributes.Builder, ExecutionAttributes> {
-
-        private final Map<ExecutionAttribute<?>, Object> executionAttributes = new HashMap<>();
+        private final Map<ExecutionAttribute<?>, Object> executionAttributes = new HashMap<>(32);
 
         private Builder() {
         }
 
-        private Builder(ExecutionAttributes attributes) {
-            this.executionAttributes.putAll(attributes.attributes);
+        private Builder(ExecutionAttributes source) {
+            this.executionAttributes.putAll(source.attributes);
         }
 
         /**
@@ -179,7 +180,7 @@ public class ExecutionAttributes implements ToCopyableBuilder<ExecutionAttribute
          */
         public <T> ExecutionAttributes.Builder put(ExecutionAttribute<T> key, T value) {
             Validate.notNull(key, "Key to set must not be null.");
-            executionAttributes.put(key, value);
+            key.storage().set(executionAttributes, value);
             return this;
         }
 
@@ -187,8 +188,17 @@ public class ExecutionAttributes implements ToCopyableBuilder<ExecutionAttribute
          * Adds all the attributes from the map provided.
          */
         public ExecutionAttributes.Builder putAll(Map<? extends ExecutionAttribute<?>, ?> attributes) {
-            executionAttributes.putAll(attributes);
+            attributes.forEach(this::unsafePut);
             return this;
+        }
+
+        /**
+         * There is no way to make this safe without runtime checks, which we can't do because we don't have the class of T.
+         * This will just throw an exception at runtime if the types don't match up.
+         */
+        @SuppressWarnings("unchecked")
+        private <T> void unsafePut(ExecutionAttribute<T> key, Object value) {
+            key.storage().set(executionAttributes, (T) value);
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
@@ -44,6 +44,7 @@ public class ExecutionAttributes implements ToCopyableBuilder<ExecutionAttribute
     protected ExecutionAttributes(Map<? extends ExecutionAttribute<?>, ?> attributes) {
         this.attributes = new HashMap<>(attributes);
     }
+    
     /**
      * Retrieve the current value of the provided attribute in this collection of attributes. This will return null if the value
      * is not set.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
@@ -31,7 +31,6 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
-import software.amazon.awssdk.core.internal.http.pipeline.stages.utils.SignerOverrideUtils;
 import software.amazon.awssdk.core.internal.util.MetricUtils;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.signer.AsyncRequestBodySigner;
@@ -65,10 +64,10 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
     @Override
     public CompletableFuture<SdkHttpFullRequest> execute(SdkHttpFullRequest request, RequestExecutionContext context)
             throws Exception {
-        if (shouldDoSraSigning(context)) {
-            return sraSignRequest(request,
-                                  context,
-                                  context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME));
+        SelectedAuthScheme<?> selectedAuthScheme =
+            context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+        if (shouldDoSraSigning(context, selectedAuthScheme)) {
+            return sraSignRequest(request, context, selectedAuthScheme);
         }
         return signRequest(request, context);
     }
@@ -184,7 +183,7 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
         Signer signer = context.signer();
         MetricCollector metricCollector = context.attemptMetricCollector();
 
-        if (!shouldSign(signer)) {
+        if (!shouldSign(context.executionAttributes(), signer)) {
             return CompletableFuture.completedFuture(request);
         }
 
@@ -213,20 +212,19 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
     }
 
     /**
-     * We sign if a signer is provided is not null.
-     *
-     * @return True if request should be signed, false if not.
+     * We sign if it isn't auth=none. This attribute is no longer set in the SRA, so this exists only for old clients. In
+     * addition to this, old clients only set this to false, never true. So, we have to treat null as true.
      */
-    private boolean shouldSign(Signer signer) {
-        return signer != null;
+    private boolean shouldSign(ExecutionAttributes attributes, Signer signer) {
+        return signer != null &&
+               !Boolean.FALSE.equals(attributes.getAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST));
     }
 
     /**
      * Returns true if we should use SRA signing logic.
      */
-    private boolean shouldDoSraSigning(RequestExecutionContext context) {
-        return !SignerOverrideUtils.isSignerOverridden(context)
-               && context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME) != null;
+    private boolean shouldDoSraSigning(RequestExecutionContext context, SelectedAuthScheme<?> selectedAuthScheme) {
+        return context.signer() == null && selectedAuthScheme != null;
     }
 
     /**

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
@@ -115,7 +115,7 @@ public class AsyncSigningStageTest {
                             .schemeId("my.auth#myAuth")
                             .putSignerProperty(SIGNER_PROPERTY, "value")
                             .build());
-        RequestExecutionContext context = createContext(selectedAuthScheme);
+        RequestExecutionContext context = createContext(selectedAuthScheme, (Signer) null);
 
         SdkHttpRequest signedRequest = ValidSdkObjects.sdkHttpFullRequest().build();
         when(signer.sign(Mockito.<SyncSignRequest<? extends Identity>>any()))
@@ -159,7 +159,7 @@ public class AsyncSigningStageTest {
                             .schemeId("my.auth#myAuth")
                             .putSignerProperty(SIGNER_PROPERTY, "value")
                             .build());
-        RequestExecutionContext context = createContext(selectedAuthScheme);
+        RequestExecutionContext context = createContext(selectedAuthScheme, (Signer) null);
 
         // Setup the timeoffset to test that the clock is setup properly.
         httpClientDependencies.updateTimeOffset(TEST_TIME_OFFSET);
@@ -208,7 +208,7 @@ public class AsyncSigningStageTest {
                             .schemeId("my.auth#myAuth")
                             .putSignerProperty(SIGNER_PROPERTY, "value")
                             .build());
-        RequestExecutionContext context = createContext(selectedAuthScheme, asyncPayload);
+        RequestExecutionContext context = createContext(selectedAuthScheme, asyncPayload, null);
 
         SdkHttpRequest signedRequest = ValidSdkObjects.sdkHttpFullRequest().build();
         Publisher<ByteBuffer> signedPayload = AsyncRequestBody.fromString("signed async request body");
@@ -258,7 +258,7 @@ public class AsyncSigningStageTest {
                             .schemeId("smithy.api#noAuth")
                             .putSignerProperty(SIGNER_PROPERTY, "value")
                             .build());
-        RequestExecutionContext context = createContext(selectedAuthScheme, asyncPayload);
+        RequestExecutionContext context = createContext(selectedAuthScheme, asyncPayload, null);
 
         SdkHttpRequest signedRequest = ValidSdkObjects.sdkHttpFullRequest().build();
         Publisher<ByteBuffer> signedPayload = AsyncRequestBody.fromString("signed async request body");

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
@@ -64,7 +64,7 @@ import utils.ValidSdkObjects;
 public class SigningStageTest {
 
     private static final int TEST_TIME_OFFSET = 17;
-    private static final SignerProperty<String> SIGNER_PROPERTY = SignerProperty.create(String.class, "key");
+    private static final SignerProperty<String> SIGNER_PROPERTY = SignerProperty.create(String.class, "SigningStageTest.key");
 
     @Mock
     private Identity identity;
@@ -105,7 +105,7 @@ public class SigningStageTest {
                             .schemeId("my.auth#myAuth")
                             .putSignerProperty(SIGNER_PROPERTY, "value")
                             .build());
-        RequestExecutionContext context = createContext(selectedAuthScheme);
+        RequestExecutionContext context = createContext(selectedAuthScheme, null);
 
         SdkHttpRequest signedRequest = ValidSdkObjects.sdkHttpFullRequest().build();
         when(signer.sign(Mockito.<SyncSignRequest<? extends Identity>>any()))
@@ -146,7 +146,7 @@ public class SigningStageTest {
                             .schemeId("my.auth#myAuth")
                             .putSignerProperty(SIGNER_PROPERTY, "value")
                             .build());
-        RequestExecutionContext context = createContext(selectedAuthScheme);
+        RequestExecutionContext context = createContext(selectedAuthScheme, null);
 
         // Setup the timeoffset to test that the clock is setup properly.
         httpClientDependencies.updateTimeOffset(TEST_TIME_OFFSET);
@@ -192,7 +192,7 @@ public class SigningStageTest {
             AuthSchemeOption.builder()
                             .schemeId("smithy.api#noAuth")
                             .build());
-        RequestExecutionContext context = createContext(selectedAuthScheme);
+        RequestExecutionContext context = createContext(selectedAuthScheme, null);
 
         SdkHttpRequest signedRequest = ValidSdkObjects.sdkHttpFullRequest().build();
         when(signer.sign(Mockito.<SyncSignRequest<? extends Identity>>any()))


### PR DESCRIPTION
These execution attributes do not get stored in the execution attribute map. Instead, they read from or write to OTHER execution attributes in the execution attribute map. This allows us to deprecate old execution attributes and keep them in sync with the execution attributes that have replaced them without needing to read or write to the old attributes.

Included in this PR is adding derived execution attributes for all AwsSignerExecutionAttributes, SdkTokenExecutionAttributes and S3SignerExecutionAttributes, as well as deprecation of those classes and their attributes.

Other notable changes:
1. When the SELECTED_AUTH_SCHEME is already set when we execute the auth scheme interceptor, carry forward any properties that were already set in the selected auth scheme. This allows setting those properties using the old execution attributes early in the request pipeline.
2. Add dependency on http-auth-aws and http-auth from auth. This allows the mapping from old attributes to new properties to be defined where the old attributes are created. This also sets us up for a potential future where our existing signers can return a new-style signer.
3. Simplify the decision of when to use the old signing path or the new signing path. For presigners, always use the old signers. For everything else, use the old signers when the customer has overridden the signer OR we're using an old client that doesn't define any auth schemes.
4. ~~Disallow duplicate signer and identity property names. This prevents weird bugs where setting one property could set another property (e.g. signing name for v4a setting the signing name for v4). This global-uniqueness property already exists in execution attributes.~~