### PR TITLE
Refactor to use AddingTrailingDataSubscriber

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
@@ -75,12 +75,9 @@ public class CompressionAsyncRequestBody implements AsyncRequestBody {
     }
 
     private Iterable<ByteBuffer> getBufferedDataIfPresent() {
-        Optional<ByteBuffer> byteBuffer = chunkBuffer.getBufferedData();
-        if (byteBuffer.isPresent()) {
-            return Collections.singletonList(byteBuffer.get());
-        }
-        return Collections.emptyList();
-
+        return chunkBuffer.getBufferedData()
+                          .map(Collections::singletonList)
+                          .orElse(Collections.emptyList());
     }
 
     private SdkPublisher<ByteBuffer> flattening(SdkPublisher<Iterable<ByteBuffer>> source) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
@@ -71,7 +71,7 @@ public class CompressionAsyncRequestBody implements AsyncRequestBody {
     }
 
     private SdkPublisher<Iterable<ByteBuffer>> split(SdkPublisher<ByteBuffer> source) {
-        return subscriber -> source.subscribe(new SplittingSubscriber(subscriber, chunkBuffer));
+        return subscriber -> source.subscribe(new SplittingSubscriber(subscriber));
     }
 
     private Iterable<ByteBuffer> getBufferedDataIfPresent() {
@@ -148,12 +148,10 @@ public class CompressionAsyncRequestBody implements AsyncRequestBody {
         }
     }
 
-    private static final class SplittingSubscriber extends DelegatingSubscriber<ByteBuffer, Iterable<ByteBuffer>> {
-        private final ChunkBuffer chunkBuffer;
+    private final class SplittingSubscriber extends DelegatingSubscriber<ByteBuffer, Iterable<ByteBuffer>> {
 
-        protected SplittingSubscriber(Subscriber<? super Iterable<ByteBuffer>> subscriber, ChunkBuffer chunkBuffer) {
+        protected SplittingSubscriber(Subscriber<? super Iterable<ByteBuffer>> subscriber) {
             super(subscriber);
-            this.chunkBuffer = chunkBuffer;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
@@ -20,10 +20,7 @@ import static software.amazon.awssdk.core.internal.io.AwsChunkedInputStream.DEFA
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.SdkPublisher;
@@ -42,19 +39,23 @@ public class CompressionAsyncRequestBody implements AsyncRequestBody {
 
     private final AsyncRequestBody wrapped;
     private final Compressor compressor;
-    private final int chunkSize;
+    private final ChunkBuffer chunkBuffer;
 
     private CompressionAsyncRequestBody(DefaultBuilder builder) {
         this.wrapped = Validate.paramNotNull(builder.asyncRequestBody, "asyncRequestBody");
         this.compressor = Validate.paramNotNull(builder.compressor, "compressor");
-        this.chunkSize = builder.chunkSize != null ? builder.chunkSize : DEFAULT_CHUNK_SIZE;
+        int chunkSize = builder.chunkSize != null ? builder.chunkSize : DEFAULT_CHUNK_SIZE;
+        this.chunkBuffer = ChunkBuffer.builder()
+                                      .bufferSize(chunkSize)
+                                      .build();
     }
 
     @Override
     public void subscribe(Subscriber<? super ByteBuffer> s) {
         Validate.notNull(s, "Subscription MUST NOT be null.");
 
-        SdkPublisher<Iterable<ByteBuffer>> split = split(wrapped);
+        SdkPublisher<Iterable<ByteBuffer>> split =
+            split(wrapped).addTrailingData(() -> Collections.singleton(getBufferedDataIfPresent()));
         SdkPublisher<ByteBuffer> flattening = flattening(split);
         flattening.map(compressor::compress).subscribe(s);
     }
@@ -70,7 +71,16 @@ public class CompressionAsyncRequestBody implements AsyncRequestBody {
     }
 
     private SdkPublisher<Iterable<ByteBuffer>> split(SdkPublisher<ByteBuffer> source) {
-        return subscriber -> source.subscribe(new SplittingSubscriber(subscriber, chunkSize));
+        return subscriber -> source.subscribe(new SplittingSubscriber(subscriber, chunkBuffer));
+    }
+
+    private Iterable<ByteBuffer> getBufferedDataIfPresent() {
+        Optional<ByteBuffer> byteBuffer = chunkBuffer.getBufferedData();
+        if (byteBuffer.isPresent()) {
+            return Collections.singletonList(byteBuffer.get());
+        }
+        return Collections.emptyList();
+
     }
 
     private SdkPublisher<ByteBuffer> flattening(SdkPublisher<Iterable<ByteBuffer>> source) {
@@ -140,73 +150,16 @@ public class CompressionAsyncRequestBody implements AsyncRequestBody {
 
     private static final class SplittingSubscriber extends DelegatingSubscriber<ByteBuffer, Iterable<ByteBuffer>> {
         private final ChunkBuffer chunkBuffer;
-        private final AtomicBoolean upstreamDone = new AtomicBoolean(false);
-        private final AtomicLong downstreamDemand = new AtomicLong();
-        private final Object lock = new Object();
-        private volatile boolean sentFinalChunk = false;
 
-        protected SplittingSubscriber(Subscriber<? super Iterable<ByteBuffer>> subscriber, int chunkSize) {
+        protected SplittingSubscriber(Subscriber<? super Iterable<ByteBuffer>> subscriber, ChunkBuffer chunkBuffer) {
             super(subscriber);
-            this.chunkBuffer = ChunkBuffer.builder()
-                                          .bufferSize(chunkSize)
-                                          .build();
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            subscriber.onSubscribe(new Subscription() {
-                @Override
-                public void request(long n) {
-                    if (n <= 0) {
-                        throw new IllegalArgumentException("n > 0 required but it was " + n);
-                    }
-
-                    downstreamDemand.getAndAdd(n);
-
-                    if (upstreamDone.get()) {
-                        sendFinalChunk();
-                    } else {
-                        s.request(n);
-                    }
-                }
-
-                @Override
-                public void cancel() {
-                    s.cancel();
-                }
-            });
+            this.chunkBuffer = chunkBuffer;
         }
 
         @Override
         public void onNext(ByteBuffer byteBuffer) {
-            downstreamDemand.decrementAndGet();
             Iterable<ByteBuffer> buffers = chunkBuffer.split(byteBuffer);
             subscriber.onNext(buffers);
-        }
-
-        @Override
-        public void onComplete() {
-            upstreamDone.compareAndSet(false, true);
-            if (downstreamDemand.get() > 0) {
-                sendFinalChunk();
-            }
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            upstreamDone.compareAndSet(false, true);
-            super.onError(t);
-        }
-
-        private void sendFinalChunk() {
-            synchronized (lock) {
-                if (!sentFinalChunk) {
-                    sentFinalChunk = true;
-                    Optional<ByteBuffer> byteBuffer = chunkBuffer.getBufferedData();
-                    byteBuffer.ifPresent(buffer -> subscriber.onNext(Collections.singletonList(buffer)));
-                    subscriber.onComplete();
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Refactor `CompressionAsyncRequestBody` to use [`AddingTrailingDataSubscriber`](https://github.com/aws/aws-sdk-java-v2/pull/4366/) and remove duplicate logic

## Modifications
<!--- Describe your changes in detail -->
Replace existing logic to send buffered data with `addTrailingData()`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All current tests pass

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
