### PR TITLE
Fail UpdateGitHubMasterv2 if error occurs

### DIFF
--- a/buildspecs/update-master-from-release.yml
+++ b/buildspecs/update-master-from-release.yml
@@ -26,13 +26,15 @@ phases:
     - MINOR=$(echo $RELEASE_VERSION | cut -d'.' -f2)
     - POINT=$(echo $RELEASE_VERSION | cut -d'.' -f3)
     - NEW_VERSION_SNAPSHOT="$MAJOR.$MINOR.$((POINT + 1))-SNAPSHOT"
-    - echo "New shapshot version - $NEW_VERSION_SNAPSHOT"
+    - echo "New snapshot version - $NEW_VERSION_SNAPSHOT"
     -
     - git checkout master
     - git merge public/release --no-edit
     -
     - MASTER_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
     - echo "Master version - $MASTER_VERSION"
+    -
+    - trap 'echo "Error: Failed to update versions"; exit 1' ERR
     - |
       if [ "$MASTER_VERSION" != "$NEW_VERSION_SNAPSHOT" ]; then
 
@@ -43,4 +45,5 @@ phases:
         git commit -am "Update to next snapshot version: $NEW_VERSION_SNAPSHOT"
       fi
     -
+    - git status
     - git push


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
`UpdateGithubMasterv2` fails silently when connection reset occurs during `mvn versions:set` , leading to failed `release-automation-v2` the following day

## Modifications
<!--- Describe your changes in detail -->
Add error handling to fail build if error occurs

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
