### PR TITLE
Allow IamPolicy to read json policies where the principal value itself an array

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-72bd387.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-72bd387.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Allow IamPolicy to read json policies where the principal value is itself an array"
+}

--- a/services-custom/iam-policy-builder/src/main/java/software/amazon/awssdk/policybuilder/iam/internal/DefaultIamPolicyReader.java
+++ b/services-custom/iam-policy-builder/src/main/java/software/amazon/awssdk/policybuilder/iam/internal/DefaultIamPolicyReader.java
@@ -132,9 +132,10 @@ public final class DefaultIamPolicyReader implements IamPolicyReader {
 
         if (principalsNode.isObject()) {
             List<IamPrincipal> result = new ArrayList<>();
-            principalsNode.asObject().forEach((id, value) -> {
-                result.add(IamPrincipal.create(id, expectString(value, name + " entry value")));
-            });
+            Map<String, JsonNode> principalsNodeObject = principalsNode.asObject();
+            principalsNodeObject.keySet().forEach(
+                k -> result.addAll(IamPrincipal.createAll(k, readStringArray(principalsNodeObject, k)))
+            );
             return result;
         }
 

--- a/services-custom/iam-policy-builder/src/main/java/software/amazon/awssdk/policybuilder/iam/internal/DefaultIamPolicyReader.java
+++ b/services-custom/iam-policy-builder/src/main/java/software/amazon/awssdk/policybuilder/iam/internal/DefaultIamPolicyReader.java
@@ -111,10 +111,10 @@ public final class DefaultIamPolicyReader implements IamPolicyReader {
                            .effect(getString(statementObject, "Effect"))
                            .principals(readPrincipals(statementObject, "Principal"))
                            .notPrincipals(readPrincipals(statementObject, "NotPrincipal"))
-                           .actionIds(readStringArray(statementObject, "Action"))
-                           .notActionIds(readStringArray(statementObject, "NotAction"))
-                           .resourceIds(readStringArray(statementObject, "Resource"))
-                           .notResourceIds(readStringArray(statementObject, "NotResource"))
+                           .actionIds(readStringOrArrayAsList(statementObject, "Action"))
+                           .notActionIds(readStringOrArrayAsList(statementObject, "NotAction"))
+                           .resourceIds(readStringOrArrayAsList(statementObject, "Resource"))
+                           .notResourceIds(readStringOrArrayAsList(statementObject, "NotResource"))
                            .conditions(readConditions(statementObject.get("Condition")))
                            .build();
     }
@@ -134,7 +134,7 @@ public final class DefaultIamPolicyReader implements IamPolicyReader {
             List<IamPrincipal> result = new ArrayList<>();
             Map<String, JsonNode> principalsNodeObject = principalsNode.asObject();
             principalsNodeObject.keySet().forEach(
-                k -> result.addAll(IamPrincipal.createAll(k, readStringArray(principalsNodeObject, k)))
+                k -> result.addAll(IamPrincipal.createAll(k, readStringOrArrayAsList(principalsNodeObject, k)))
             );
             return result;
         }
@@ -171,7 +171,7 @@ public final class DefaultIamPolicyReader implements IamPolicyReader {
         return result;
     }
 
-    private List<String> readStringArray(Map<String, JsonNode> statementObject, String nodeKey) {
+    private List<String> readStringOrArrayAsList(Map<String, JsonNode> statementObject, String nodeKey) {
         JsonNode node = statementObject.get(nodeKey);
 
         if (node == null) {

--- a/services-custom/iam-policy-builder/src/test/java/software/amazon/awssdk/policybuilder/iam/IamPolicyReaderTest.java
+++ b/services-custom/iam-policy-builder/src/test/java/software/amazon/awssdk/policybuilder/iam/IamPolicyReaderTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.Test;
 
 class IamPolicyReaderTest {
     private static final IamPrincipal PRINCIPAL_1 = IamPrincipal.create("P1", "*");
+    private static final IamPrincipal PRINCIPAL_1B = IamPrincipal.create("P1", "B");
     private static final IamPrincipal PRINCIPAL_2 = IamPrincipal.create("P2", "*");
     private static final IamPrincipal NOT_PRINCIPAL_1 = IamPrincipal.create("NP1", "*");
+    private static final IamPrincipal NOT_PRINCIPAL_1B = IamPrincipal.create("NP1", "B");
     private static final IamPrincipal NOT_PRINCIPAL_2 = IamPrincipal.create("NP2", "*");
     private static final IamResource RESOURCE_1 = IamResource.create("R1");
     private static final IamResource RESOURCE_2 = IamResource.create("R2");
@@ -85,6 +87,20 @@ class IamPolicyReaderTest {
         IamPolicy.builder()
                  .version("Version")
                  .statements(singletonList(ONE_ELEMENT_LISTS_STATEMENT))
+                 .build();
+
+    private static final IamStatement COMPOUND_PRINCIPAL_STATEMENT =
+        IamStatement.builder()
+                    .effect(ALLOW)
+                    .sid("Sid")
+                    .principals(asList(PRINCIPAL_1, PRINCIPAL_1B))
+                    .notPrincipals(asList(NOT_PRINCIPAL_1, NOT_PRINCIPAL_1B))
+                    .build();
+
+    private static final IamPolicy COMPOUND_PRINCIPAL_POLICY =
+        IamPolicy.builder()
+                 .version("Version")
+                 .statements(singletonList(COMPOUND_PRINCIPAL_STATEMENT))
                  .build();
 
     private static final IamPolicyReader READER = IamPolicyReader.create();
@@ -156,6 +172,31 @@ class IamPolicyReaderTest {
                                + "  }\n"
                                + "}"))
             .isEqualTo(MINIMAL_POLICY);
+    }
+
+    @Test
+    public void readCompoundPrincipalsWorks() {
+        assertThat(READER.read("{\n" +
+                           "    \"Version\": \"Version\",\n" +
+                           "    \"Statement\": [\n" +
+                           "        {\n" +
+                           "            \"Sid\": \"Sid\",\n" +
+                           "            \"Effect\": \"Allow\",\n" +
+                           "            \"Principal\": {\n" +
+                           "                \"P1\": [\n" +
+                           "                    \"*\",\n" +
+                           "                    \"B\"\n" +
+                           "                ]\n" +
+                           "            },\n" +
+                           "            \"NotPrincipal\": {\n" +
+                           "                \"NP1\": [\n" +
+                           "                    \"*\",\n" +
+                           "                    \"B\"\n" +
+                           "                ]\n" +
+                           "            }\n" +
+                           "        }\n" +
+                           "    ]\n" +
+                           "}")).isEqualTo(COMPOUND_PRINCIPAL_POLICY);
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
The [IamPolicy](https://github.com/aws/aws-sdk-java-v2/blob/master/services-custom/iam-policy-builder/src/main/java/software/amazon/awssdk/policybuilder/iam/IamPolicy.java) class represents an IAM policy. You can serialize/deserialize this class to json. A principal is represented as a type/value in [IamPrincipal](https://github.com/aws/aws-sdk-java-v2/blob/master/services-custom/iam-policy-builder/src/main/java/software/amazon/awssdk/policybuilder/iam/IamPrincipal.java). 

If you have a principal of for instance "AWS" and it contains more than one value, you can create it by doing
`IamPrincipal.createAll("AWS", asList("arn1", "arn2"))`, which yields a list of `IamPrincipal` with the same type and the two different values. When reading from json, the principal is correctly interpreted if supplied in this format. 

However a valid representation of principals in the console for instance is as "AWS" : ["arn1", "arn1"]. This format cannot be parsed into a valid IamPolicy. This PR allows the IamPolicy to parse compound principals. Note they will still be represented in the list format above

## Modifications
Use `IamPrincipal.createAll()` which can handle duplicates.

## Testing
Unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
