### PR TITLE
Add flexible checksums to chunk-encoding in CRT

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4FamilyHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4FamilyHttpSigner.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.http.auth.aws;
 
 import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.auth.spi.SignerProperty;
 
 /**
@@ -71,6 +72,12 @@ public interface AwsV4FamilyHttpSigner {
      */
     SignerProperty<Boolean> CHUNK_ENCODING_ENABLED =
         SignerProperty.create(Boolean.class, "ChunkEncodingEnabled");
+
+    /**
+     * The algorithm to use for calculating a "flexible" checksum. This property is optional.
+     */
+    SignerProperty<ChecksumAlgorithm> CHECKSUM_ALGORITHM =
+        SignerProperty.create(ChecksumAlgorithm.class, "ChecksumAlgorithm");
 
     /**
      * This enum represents where auth-related data is inserted, as a result of signing.

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4HttpSigner.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.http.auth.aws;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.auth.aws.internal.signer.DefaultAwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.spi.HttpSigner;
 import software.amazon.awssdk.http.auth.spi.SignerProperty;
@@ -35,12 +34,6 @@ public interface AwsV4HttpSigner extends AwsV4FamilyHttpSigner, HttpSigner<AwsCr
      */
     SignerProperty<String> REGION_NAME =
         SignerProperty.create(String.class, "RegionName");
-
-    /**
-     * The algorithm to use for calculating a "flexible" checksum. This property is optional.
-     */
-    SignerProperty<ChecksumAlgorithm> CHECKSUM_ALGORITHM =
-        SignerProperty.create(ChecksumAlgorithm.class, "ChecksumAlgorithm");
 
     /**
      * Get a default implementation of a {@link AwsV4HttpSigner}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aHttpSigner.java
@@ -37,13 +37,6 @@ public interface AwsV4aHttpSigner extends AwsV4FamilyHttpSigner, HttpSigner<AwsC
     SignerProperty<String> REGION_NAME = SignerProperty.create(String.class, "SigningScope");
 
     /**
-     * Whether to indicate that a payload is chunk-encoded or not. This property defaults to false. This can be set true to
-     * enable the `aws-chunk` content-encoding
-     */
-    SignerProperty<Boolean> CHUNK_ENCODING_ENABLED =
-        SignerProperty.create(Boolean.class, "ChunkEncodingEnabled");
-
-    /**
      * Get a default implementation of a {@link AwsV4aHttpSigner}
      */
     static AwsV4aHttpSigner create() {

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
@@ -15,9 +15,12 @@
 
 package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
 
+import static software.amazon.awssdk.http.auth.aws.internal.util.ChecksumUtil.checksumHeaderName;
+import static software.amazon.awssdk.http.auth.aws.internal.util.ChecksumUtil.fromChecksumAlgorithm;
 import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.STREAMING_ECDSA_SIGNED_PAYLOAD;
 import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.STREAMING_ECDSA_SIGNED_PAYLOAD_TRAILER;
 import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.STREAMING_UNSIGNED_PAYLOAD_TRAILER;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.X_AMZ_TRAILER;
 import static software.amazon.awssdk.http.auth.aws.internal.util.SignerUtils.moveContentLength;
 
 import java.io.InputStream;
@@ -25,28 +28,36 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.aws.internal.checksums.SdkChecksum;
 import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.ChunkedEncodedInputStream;
 import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.TrailerProvider;
+import software.amazon.awssdk.http.auth.aws.internal.io.ChecksumInputStream;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
 import software.amazon.awssdk.utils.Pair;
 import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.Validate;
 
 /**
- * A default implementation of a payload signer that is a no-op, since payloads are most commonly unsigned.
+ * An implementation of a V4aPayloadSigner which chunk-encodes a payload, optionally adding a chunk-signature chunk-extension,
+ * and/or trailers representing trailing headers with their signature at the end.
  */
 @SdkInternalApi
-public class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
+public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
 
     private final CredentialScope credentialScope;
     private final int chunkSize;
+    private final ChecksumAlgorithm checksumAlgorithm;
 
-    public AwsChunkedV4aPayloadSigner(CredentialScope credentialScope, int chunkSize) {
-        this.credentialScope = credentialScope;
-        this.chunkSize = chunkSize;
+    private AwsChunkedV4aPayloadSigner(Builder builder) {
+        this.credentialScope = Validate.paramNotNull(builder.credentialScope, "CredentialScope");
+        this.chunkSize = Validate.isPositive(builder.chunkSize, "ChunkSize");
+        this.checksumAlgorithm = builder.checksumAlgorithm;
     }
 
     @Override
@@ -60,6 +71,7 @@ public class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
             .inputStream(inputStream)
             .chunkSize(chunkSize)
             .header(chunk -> Integer.toHexString(chunk.length).getBytes(StandardCharsets.UTF_8));
+        setupPreExistingTrailers(chunkedEncodedInputStreamBuilder, request);
 
         switch (v4aContext.getSigningConfig().getSignedBodyValue()) {
             case STREAMING_ECDSA_SIGNED_PAYLOAD: {
@@ -68,13 +80,13 @@ public class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
                 break;
             }
             case STREAMING_UNSIGNED_PAYLOAD_TRAILER:
-                setupChecksumTrailer(chunkedEncodedInputStreamBuilder);
+                setupChecksumTrailerIfNeeded(chunkedEncodedInputStreamBuilder, request);
                 break;
             case STREAMING_ECDSA_SIGNED_PAYLOAD_TRAILER: {
                 RollingSigner rollingSigner = new RollingSigner(v4aContext.getSignature(), v4aContext.getSigningConfig());
                 setupSigExt(chunkedEncodedInputStreamBuilder, rollingSigner);
+                setupChecksumTrailerIfNeeded(chunkedEncodedInputStreamBuilder, request);
                 setupSigTrailer(chunkedEncodedInputStreamBuilder, rollingSigner);
-                setupChecksumTrailer(chunkedEncodedInputStreamBuilder);
                 break;
             }
             default:
@@ -84,6 +96,12 @@ public class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
         return chunkedEncodedInputStreamBuilder::build;
     }
 
+    /**
+     * Add the chunk signature as a chunk-extension.
+     * <p>
+     * An instance of a rolling-signer is required, since each chunk's signature is dependent on the last. The first chunk
+     * signature is dependent on the request signature ("seed" signature).
+     */
     private void setupSigExt(ChunkedEncodedInputStream.Builder builder, RollingSigner rollingSigner) {
         builder.addExtension(
             chunk -> Pair.of(
@@ -93,19 +111,98 @@ public class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
         );
     }
 
+    /**
+     * Add the trailer signature as a chunk-trailer.
+     * <p>
+     * In order for this to work, the instance of the rolling-signer MUST be the same instance used to provide a chunk signature
+     * chunk-extension. The trailer signature depends on the rolling calculation of all previous chunks.
+     */
     private void setupSigTrailer(ChunkedEncodedInputStream.Builder builder, RollingSigner rollingSigner) {
-        Map<String, List<String>> trailers =
-            builder.trailers().stream().map(TrailerProvider::get).collect(Collectors.toMap(Pair::left, Pair::right));
+        List<TrailerProvider> trailers = builder.trailers();
+        Supplier<Map<String, List<String>>> headersSupplier =
+            () -> trailers.stream().map(TrailerProvider::get).collect(Collectors.toMap(Pair::left, Pair::right));
+        Supplier<byte[]> sigSupplier = () -> rollingSigner.sign(headersSupplier.get());
 
         builder.addTrailer(
             () -> Pair.of(
                 "x-amz-trailer-signature",
-                Collections.singletonList(new String(rollingSigner.sign(trailers), StandardCharsets.UTF_8))
+                Collections.singletonList(new String(sigSupplier.get(), StandardCharsets.UTF_8))
             )
         );
     }
 
-    private void setupChecksumTrailer(ChunkedEncodedInputStream.Builder builder) {
-        // TODO(sra-identity-and-auth): Set up checksumming of chunks and add as a trailer
+    /**
+     * Add the checksum as a chunk-trailer and add it to the request's trailer header.
+     * <p>
+     * The checksum-algorithm MUST be set if this is called, otherwise it will throw.
+     */
+    private void setupChecksumTrailerIfNeeded(ChunkedEncodedInputStream.Builder builder, SdkHttpRequest.Builder request) {
+        if (checksumAlgorithm == null) {
+            return;
+        }
+        SdkChecksum sdkChecksum = fromChecksumAlgorithm(checksumAlgorithm);
+        ChecksumInputStream checksumInputStream = new ChecksumInputStream(
+            builder.inputStream(),
+            Collections.singleton(sdkChecksum)
+        );
+        String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
+
+        TrailerProvider checksumTrailer = () -> Pair.of(
+            checksumHeaderName,
+            Collections.singletonList(sdkChecksum.getChecksum())
+        );
+
+        request.appendHeader(X_AMZ_TRAILER, checksumHeaderName);
+        builder.inputStream(checksumInputStream).addTrailer(checksumTrailer);
+    }
+
+    /**
+     * Create chunk-trailers for each pre-existing trailer given in the request.
+     * <p>
+     * However, we need to validate that these are valid trailers. Since aws-chunked encoding adds the checksum as a trailer, it
+     * isn't part of the request headers, but other trailers MUST be present in the request-headers.
+     */
+    private void setupPreExistingTrailers(ChunkedEncodedInputStream.Builder builder, SdkHttpRequest.Builder request) {
+        List<String> trailerHeaders = request.matchingHeaders(X_AMZ_TRAILER);
+
+        for (String header : trailerHeaders) {
+            List<String> values = request.matchingHeaders(header);
+            if (values.isEmpty()) {
+                throw new IllegalArgumentException(header + " must be present in the request headers to be a valid trailer.");
+            }
+
+            // Add the trailer to the aws-chunked stream-builder, and remove it from the request headers
+            builder.addTrailer(() -> Pair.of(header, values));
+            request.removeHeader(header);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    static class Builder {
+        private CredentialScope credentialScope;
+        private Integer chunkSize;
+        private ChecksumAlgorithm checksumAlgorithm;
+
+        public Builder credentialScope(CredentialScope credentialScope) {
+            this.credentialScope = credentialScope;
+            return this;
+        }
+
+        public Builder chunkSize(Integer chunkSize) {
+            this.chunkSize = chunkSize;
+            return this;
+        }
+
+        public Builder checksumAlgorithm(ChecksumAlgorithm checksumAlgorithm) {
+            this.checksumAlgorithm = checksumAlgorithm;
+            return this;
+        }
+
+        public AwsChunkedV4aPayloadSigner build() {
+            return new AwsChunkedV4aPayloadSigner(this);
+        }
     }
 }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSignerTest.java
@@ -45,15 +45,15 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
  */
 public class AwsChunkedV4aPayloadSignerTest {
 
-    int chunkSize = 4;
+    private static final int CHUNK_SIZE = 4;
 
-    CredentialScope credentialScope = new CredentialScope("us-east-1", "s3", Instant.EPOCH);
+    private static final CredentialScope CREDENTIAL_SCOPE = new CredentialScope("us-east-1", "s3", Instant.EPOCH);
 
-    byte[] data = "{\"TableName\": \"foo\"}".getBytes();
+    private static final byte[] DATA = "{\"TableName\": \"foo\"}".getBytes();
 
-    ContentStreamProvider payload = () -> new ByteArrayInputStream(data);
+    private static final ContentStreamProvider PAYLOAD = () -> new ByteArrayInputStream(DATA);
 
-    SdkHttpRequest.Builder requestBuilder;
+    private SdkHttpRequest.Builder requestBuilder;
 
     @BeforeEach
     public void setUp() {
@@ -62,7 +62,7 @@ public class AwsChunkedV4aPayloadSignerTest {
             .method(SdkHttpMethod.POST)
             .putHeader("Host", "demo.us-east-1.amazonaws.com")
             .putHeader("x-amz-archive-description", "test  test")
-            .putHeader(Header.CONTENT_LENGTH, Integer.toString(data.length))
+            .putHeader(Header.CONTENT_LENGTH, Integer.toString(DATA.length))
             .encodedPath("/")
             .uri(URI.create("http://demo.us-east-1.amazonaws.com"));
     }
@@ -77,19 +77,19 @@ public class AwsChunkedV4aPayloadSignerTest {
             signingConfig
         );
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
-                                                                      .credentialScope(credentialScope)
-                                                                      .chunkSize(chunkSize)
+                                                                      .credentialScope(CREDENTIAL_SCOPE)
+                                                                      .chunkSize(CHUNK_SIZE)
                                                                       .build();
 
-        ContentStreamProvider signedPayload = signer.sign(payload, v4aContext);
+        ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
 
         byte[] tmp = new byte[2048];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
-        int expectedBytes = expectedByteCount(data, chunkSize);
+        int expectedBytes = expectedByteCount(DATA, CHUNK_SIZE);
         assertEquals(expectedBytes, actualBytes);
     }
 
@@ -103,20 +103,20 @@ public class AwsChunkedV4aPayloadSignerTest {
             signingConfig
         );
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
-                                                                      .credentialScope(credentialScope)
-                                                                      .chunkSize(chunkSize)
+                                                                      .credentialScope(CREDENTIAL_SCOPE)
+                                                                      .chunkSize(CHUNK_SIZE)
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
-        ContentStreamProvider signedPayload = signer.sign(payload, v4aContext);
+        ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
 
         byte[] tmp = new byte[2048];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
-        int expectedBytes = expectedByteCount(data, chunkSize);
+        int expectedBytes = expectedByteCount(DATA, CHUNK_SIZE);
         // include trailer bytes in the count:
         // (checksum-header + checksum-value + \r\n + trailer-sig-header + trailer-sig + \r\n)
         expectedBytes += 21 + 8 + 2 + 24 + 144 + 2;
@@ -134,20 +134,20 @@ public class AwsChunkedV4aPayloadSignerTest {
             signingConfig
         );
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
-                                                                      .credentialScope(credentialScope)
-                                                                      .chunkSize(chunkSize)
+                                                                      .credentialScope(CREDENTIAL_SCOPE)
+                                                                      .chunkSize(CHUNK_SIZE)
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
-        ContentStreamProvider signedPayload = signer.sign(payload, v4aContext);
+        ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
 
         byte[] tmp = new byte[2048];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
-        int expectedBytes = expectedByteCountUnsigned(data, chunkSize);
+        int expectedBytes = expectedByteCountUnsigned(DATA, CHUNK_SIZE);
         // include trailer bytes in the count:
         // (checksum-header + checksum-value + \r\n)
         expectedBytes += 21 + 8 + 2;
@@ -167,20 +167,20 @@ public class AwsChunkedV4aPayloadSignerTest {
             signingConfig
         );
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
-                                                                      .credentialScope(credentialScope)
-                                                                      .chunkSize(chunkSize)
+                                                                      .credentialScope(CREDENTIAL_SCOPE)
+                                                                      .chunkSize(CHUNK_SIZE)
                                                                       .build();
 
-        ContentStreamProvider signedPayload = signer.sign(payload, v4aContext);
+        ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("aTrailer")).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("aTrailer");
 
         byte[] tmp = new byte[2048];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
-        int expectedBytes = expectedByteCountUnsigned(data, chunkSize);
+        int expectedBytes = expectedByteCountUnsigned(DATA, CHUNK_SIZE);
         // include trailer bytes in the count:
         // (aTrailer: + aValue + \r\n)
         expectedBytes += 9 + 6 + 2;
@@ -199,21 +199,21 @@ public class AwsChunkedV4aPayloadSignerTest {
             signingConfig
         );
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
-                                                                      .credentialScope(credentialScope)
-                                                                      .chunkSize(chunkSize)
+                                                                      .credentialScope(CREDENTIAL_SCOPE)
+                                                                      .chunkSize(CHUNK_SIZE)
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
-        ContentStreamProvider signedPayload = signer.sign(payload, v4aContext);
+        ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("aTrailer")).isNotPresent();
         assertThat(requestBuilder.matchingHeaders("x-amz-trailer")).contains("aTrailer", "x-amz-checksum-crc32");
 
         byte[] tmp = new byte[2048];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
-        int expectedBytes = expectedByteCountUnsigned(data, chunkSize);
+        int expectedBytes = expectedByteCountUnsigned(DATA, CHUNK_SIZE);
         // include trailer bytes in the count:
         // (aTrailer: + aValue + \r\n + checksum-header + checksum-value + \r\n)
         expectedBytes += 9 + 6 + 2 + 21 + 8 + 2;
@@ -232,21 +232,21 @@ public class AwsChunkedV4aPayloadSignerTest {
             signingConfig
         );
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
-                                                                      .credentialScope(credentialScope)
-                                                                      .chunkSize(chunkSize)
+                                                                      .credentialScope(CREDENTIAL_SCOPE)
+                                                                      .chunkSize(CHUNK_SIZE)
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
-        ContentStreamProvider signedPayload = signer.sign(payload, v4aContext);
+        ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("aTrailer")).isNotPresent();
         assertThat(requestBuilder.matchingHeaders("x-amz-trailer")).contains("aTrailer", "x-amz-checksum-crc32");
 
         byte[] tmp = new byte[2048];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
-        int expectedBytes = expectedByteCount(data, chunkSize);
+        int expectedBytes = expectedByteCount(DATA, CHUNK_SIZE);
         // include trailer bytes in the count:
         // (aTrailer: + aValue + \r\n + checksum-header + checksum-value + \r\n + trailer-sig-header + trailer-sig + \r\n)
         expectedBytes += 9 + 6 + 2 + 21 + 8 + 2 + 24 + 144 + 2;
@@ -262,11 +262,11 @@ public class AwsChunkedV4aPayloadSignerTest {
         );
         requestBuilder.removeHeader(Header.CONTENT_LENGTH);
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
-                                                                      .credentialScope(credentialScope)
-                                                                      .chunkSize(chunkSize)
+                                                                      .credentialScope(CREDENTIAL_SCOPE)
+                                                                      .chunkSize(CHUNK_SIZE)
                                                                       .build();
 
-        assertThrows(IllegalArgumentException.class, () -> signer.sign(payload, v4aContext));
+        assertThrows(IllegalArgumentException.class, () -> signer.sign(PAYLOAD, v4aContext));
     }
 
     private int readAll(InputStream src, byte[] dst) throws IOException {

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -18,6 +18,15 @@ package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.CRC32;
+import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_HEADERS;
+import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS;
+import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignedBodyValue.STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD;
+import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignedBodyValue.STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD_TRAILER;
+import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignedBodyValue.STREAMING_UNSIGNED_PAYLOAD_TRAILER;
+import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignedBodyValue.UNSIGNED_PAYLOAD;
+import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSigningAlgorithm.SIGV4_ASYMMETRIC;
+import static software.amazon.awssdk.http.auth.aws.AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM;
 import static software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner.AUTH_LOCATION;
 import static software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner.AuthLocation;
 import static software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner.CHUNK_ENCODING_ENABLED;
@@ -28,11 +37,9 @@ import static software.amazon.awssdk.http.auth.aws.crt.TestUtils.generateBasicRe
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.toCredentials;
 
 import java.time.Duration;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.crt.auth.signing.AwsSigningConfig;
 import software.amazon.awssdk.http.Header;
-import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.spi.AsyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.SyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.SyncSignedRequest;
@@ -61,11 +68,11 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         expectedSigningConfig.setCredentials(toCredentials(request.identity()));
         expectedSigningConfig.setService("demo");
         expectedSigningConfig.setRegion("aws-global");
-        expectedSigningConfig.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4_ASYMMETRIC);
+        expectedSigningConfig.setAlgorithm(SIGV4_ASYMMETRIC);
         expectedSigningConfig.setTime(1596476903000L);
         expectedSigningConfig.setUseDoubleUriEncode(true);
         expectedSigningConfig.setShouldNormalizeUriPath(true);
-        expectedSigningConfig.setSignatureType(AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_HEADERS);
+        expectedSigningConfig.setSignatureType(HTTP_REQUEST_VIA_HEADERS);
 
         SyncSignedRequest signedRequest = signer.sign(request);
 
@@ -91,11 +98,11 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         expectedSigningConfig.setCredentials(toCredentials(request.identity()));
         expectedSigningConfig.setService("demo");
         expectedSigningConfig.setRegion("aws-global");
-        expectedSigningConfig.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4_ASYMMETRIC);
+        expectedSigningConfig.setAlgorithm(SIGV4_ASYMMETRIC);
         expectedSigningConfig.setTime(1596476903000L);
         expectedSigningConfig.setUseDoubleUriEncode(true);
         expectedSigningConfig.setShouldNormalizeUriPath(true);
-        expectedSigningConfig.setSignatureType(AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS);
+        expectedSigningConfig.setSignatureType(HTTP_REQUEST_VIA_QUERY_PARAMS);
 
         SyncSignedRequest signedRequest = signer.sign(request);
 
@@ -126,11 +133,11 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         expectedSigningConfig.setCredentials(toCredentials(request.identity()));
         expectedSigningConfig.setService("demo");
         expectedSigningConfig.setRegion("aws-global");
-        expectedSigningConfig.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4_ASYMMETRIC);
+        expectedSigningConfig.setAlgorithm(SIGV4_ASYMMETRIC);
         expectedSigningConfig.setTime(1596476903000L);
         expectedSigningConfig.setUseDoubleUriEncode(true);
         expectedSigningConfig.setShouldNormalizeUriPath(true);
-        expectedSigningConfig.setSignatureType(AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS);
+        expectedSigningConfig.setSignatureType(HTTP_REQUEST_VIA_QUERY_PARAMS);
         expectedSigningConfig.setExpirationInSeconds(1);
 
         SyncSignedRequest signedRequest = signer.sign(request);
@@ -163,12 +170,12 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         expectedSigningConfig.setCredentials(toCredentials(request.identity()));
         expectedSigningConfig.setService("demo");
         expectedSigningConfig.setRegion("aws-global");
-        expectedSigningConfig.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4_ASYMMETRIC);
+        expectedSigningConfig.setAlgorithm(SIGV4_ASYMMETRIC);
         expectedSigningConfig.setTime(1596476903000L);
         expectedSigningConfig.setUseDoubleUriEncode(true);
         expectedSigningConfig.setShouldNormalizeUriPath(true);
-        expectedSigningConfig.setSignatureType(AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_HEADERS);
-        expectedSigningConfig.setSignedBodyValue(AwsSigningConfig.AwsSignedBodyValue.UNSIGNED_PAYLOAD);
+        expectedSigningConfig.setSignatureType(HTTP_REQUEST_VIA_HEADERS);
+        expectedSigningConfig.setSignedBodyValue(UNSIGNED_PAYLOAD);
 
         SyncSignedRequest signedRequest = signer.sign(request);
 
@@ -211,47 +218,30 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         SyncSignedRequest signedRequest = signer.sign(request);
 
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
-                               .hasValue(AwsSigningConfig.AwsSignedBodyValue.STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD);
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
+                               .hasValue(STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD);
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
     }
 
     @Test
-    public void sign_WithChunkEncodingTrueWithout_DelegatesToAwsChunkedPayloadSigner() {
+    public void sign_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner() {
         SyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
                 .putHeader(Header.CONTENT_LENGTH, "20"),
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
         );
 
         SyncSignedRequest signedRequest = signer.sign(request);
 
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
-                               .hasValue(AwsSigningConfig.AwsSignedBodyValue.STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD);
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
-    }
-
-    @Test
-    public void sign_ChunkEncodingTrueAndTrailer_DelegatesToAwsChunkedPayloadSigner() {
-        SyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
-            AwsCredentialsIdentity.create("access", "secret"),
-            httpRequest -> httpRequest
-                .putHeader(Header.CONTENT_LENGTH, "20")
-                .putHeader("x-amz-trailer", "aTrailer"),
-            signRequest -> signRequest
-                .putProperty(CHUNK_ENCODING_ENABLED, true)
-        );
-
-        SyncSignedRequest signedRequest = signer.sign(request);
-
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
-                               .hasValue(AwsSigningConfig.AwsSignedBodyValue.STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD_TRAILER);
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
+                               .hasValue(STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD_TRAILER);
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
     }
 
     @Test
@@ -259,19 +249,20 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         SyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
-                .putHeader(Header.CONTENT_LENGTH, "20")
-                .putHeader("x-amz-trailer", "aTrailer"),
+                .putHeader(Header.CONTENT_LENGTH, "20"),
             signRequest -> signRequest
-                .putProperty(AwsV4HttpSigner.PAYLOAD_SIGNING_ENABLED, false)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
         );
 
         SyncSignedRequest signedRequest = signer.sign(request);
 
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
-                               .hasValue(AwsSigningConfig.AwsSignedBodyValue.STREAMING_UNSIGNED_PAYLOAD_TRAILER);
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
-        AssertionsForClassTypes.assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
+                               .hasValue(STREAMING_UNSIGNED_PAYLOAD_TRAILER);
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
     }
 
     @Test
@@ -281,7 +272,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
             httpRequest -> httpRequest
                 .putHeader(Header.CONTENT_LENGTH, "20"),
             signRequest -> signRequest
-                .putProperty(AwsV4HttpSigner.PAYLOAD_SIGNING_ENABLED, false)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
         );
 


### PR DESCRIPTION
## Motivation and Context
- Almost entirely the same as #4383, but for CRT case
- Dependent on #4403

## Modifications
- Add common property, `CHECKSUM_ALGORITHM`
- Update `AwsChunkedV4aPayloadSigner` to use flexible checksums
- Add tests to cover checksums and trailer cases

## Testing
- Run new and existing tests, make sure pass

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
