### PR TITLE
AuthSchemeOption changes based on surface review

### DIFF
--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthSchemeOption.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.http.auth.spi;
 
-import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.auth.spi.internal.DefaultAuthSchemeOption;
 import software.amazon.awssdk.identity.spi.IdentityProperty;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -30,7 +30,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  *
  * @see AuthScheme
  */
-@SdkProtectedApi
+@SdkPublicApi
 public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Builder, AuthSchemeOption> {
 
     /**
@@ -47,21 +47,29 @@ public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Bui
 
     /**
      * Retrieve the value of an {@link IdentityProperty}.
+     * @param property The IdentityProperty to retrieve the value of.
+     * @param <T> The type of the IdentityProperty.
      */
     <T> T identityProperty(IdentityProperty<T> property);
 
     /**
      * Retrieve the value of an {@link SignerProperty}.
+     * @param property The SignerProperty to retrieve the value of.
+     * @param <T> The type of the SignerProperty.
      */
     <T> T signerProperty(SignerProperty<T> property);
 
     /**
      * A method to operate on all {@link IdentityProperty} values of this AuthSchemeOption.
+     * @param consumer The method to apply to each IdentityProperty.
+     * @param <T> To represent the type for each IdentityProperty. Note the actual type can be different for each property.
      */
     <T> void forEachIdentityProperty(IdentityPropertyConsumer consumer);
 
     /**
      * A method to operate on all {@link SignerProperty} values of this AuthSchemeOption.
+     * @param consumer The method to apply to each SignerProperty.
+     * @param <T> To represent the type for each SignerProperty. Note the actual type can be different for each property.
      */
     <T> void forEachSignerProperty(SignerPropertyConsumer consumer);
 
@@ -70,6 +78,12 @@ public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Bui
      */
     @FunctionalInterface
     interface IdentityPropertyConsumer {
+        /**
+         * A method to operate on an {@link IdentityProperty} and it's value.
+         * @param propertyKey The IdentityProperty.
+         * @param propertyValue The value of the IdentityProperty.
+         * @param <T> The type of the IdentityProperty.
+         */
         <T> void accept(IdentityProperty<T> propertyKey, T propertyValue);
     }
 
@@ -78,18 +92,43 @@ public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Bui
      */
     @FunctionalInterface
     interface SignerPropertyConsumer {
+        /**
+         * A method to operate on a {@link SignerProperty} and it's value.
+         * @param propertyKey The SignerProperty.
+         * @param propertyValue The value of the SignerProperty.
+         * @param <T> The type of the SignerProperty.
+         */
         <T> void accept(SignerProperty<T> propertyKey, T propertyValue);
     }
 
+    /**
+     * A builder for a {@link AuthSchemeOption}.
+     */
     interface Builder extends CopyableBuilder<Builder, AuthSchemeOption> {
+
+        /**
+         * Set the scheme ID.
+         */
         Builder schemeId(String schemeId);
 
+        /**
+         * Update or add the provided property value.
+         */
         <T> Builder putIdentityProperty(IdentityProperty<T> key, T value);
 
+        /**
+         * Add the provided property value if the property does not already exist.
+         */
         <T> Builder putIdentityPropertyIfAbsent(IdentityProperty<T> key, T value);
 
+        /**
+         * Update or add the provided property value.
+         */
         <T> Builder putSignerProperty(SignerProperty<T> key, T value);
-        
+
+        /**
+         * Add the provided property value if the property does not already exist.
+         */
         <T> Builder putSignerPropertyIfAbsent(SignerProperty<T> key, T value);
     }
 }

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultAuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/DefaultAuthSchemeOption.java
@@ -48,32 +48,39 @@ public final class DefaultAuthSchemeOption implements AuthSchemeOption {
         return schemeId;
     }
 
+    @SuppressWarnings("unchecked") // Safe because of the implementation of putIdentityProperty
     @Override
     public <T> T identityProperty(IdentityProperty<T> property) {
         return (T) identityProperties.get(property);
     }
 
+    @SuppressWarnings("unchecked") // Safe because of the implementation of putSignerProperty
     @Override
     public <T> T signerProperty(SignerProperty<T> property) {
         return (T) signerProperties.get(property);
     }
 
+    @SuppressWarnings("unchecked") // Cast added to use type <T> so the property and property value types match
     @Override
     public <T> void forEachIdentityProperty(IdentityPropertyConsumer consumer) {
         for (IdentityProperty<?> p : identityProperties.keySet()) {
+            // Note, <T> is added to this method signature to facilitate this cast below which is just to define a type, so that
+            // this.identityProperty() can rely on that type too, and consumer.accept relies on the matching type.
             IdentityProperty<T> property = (IdentityProperty<T>) p;
             consumer.accept(property, this.identityProperty(property));
         }
     }
 
+    @SuppressWarnings("unchecked") // Cast added to use type <T> so the property and property value types match
     @Override
     public <T> void forEachSignerProperty(SignerPropertyConsumer consumer) {
         for (SignerProperty<?> p : signerProperties.keySet()) {
+            // Note, <T> is added to this method signature to facilitate this cast below which is just to define a type, so that
+            // this.identityProperty() can rely on that type too, and consumer.accept relies on the matching type.
             SignerProperty<T> property = (SignerProperty<T>) p;
             consumer.accept(property, this.signerProperty(property));
         }
     }
-
 
     @Override
     public Builder toBuilder() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
These are follow up changes for AuthSchemeOption from the surface area review. 

The topics for potential changes included:
* Do we need the forEach*Property methods instead of returning the Collection/Iterable?
* Removing `<T>` from forEach*Property method declaration

I worked on a few options and discussed with Dongie, but couldn't come up with better alternatives, so have kept things as-is for the above. While making the other changes listed below.

## Modifications
<!--- Describe your changes in detail -->
* Make AuthSchemeOption SdkPublicApi
* Add SuppressWarning for unchecked casts
* Add javadocs and some comments explaining not intuitive use of <T>
