### PR TITLE
Add auth scheme default impl classes

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4AuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4AuthScheme.java
@@ -42,14 +42,6 @@ public interface AwsV4AuthScheme extends AuthScheme<AwsCredentialsIdentity> {
     }
 
     /**
-     * Retrieve the scheme ID.
-     */
-    @Override
-    default String schemeId() {
-        return SCHEME_ID;
-    }
-
-    /**
      * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4AuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4AuthScheme.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.auth.aws;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.aws.internal.DefaultAwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
@@ -37,8 +38,7 @@ public interface AwsV4AuthScheme extends AuthScheme<AwsCredentialsIdentity> {
      * Get a default implementation of a {@link AwsV4AuthScheme}
      */
     static AwsV4AuthScheme create() {
-        return new AwsV4AuthScheme() {
-        };
+        return DefaultAwsV4AuthScheme.create();
     }
 
     /**
@@ -53,15 +53,11 @@ public interface AwsV4AuthScheme extends AuthScheme<AwsCredentialsIdentity> {
      * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override
-    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
-        return providers.identityProvider(AwsCredentialsIdentity.class);
-    }
+    IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers);
 
     /**
      * Retrieve the {@link AwsV4HttpSigner} associated with this authentication scheme.
      */
     @Override
-    default AwsV4HttpSigner signer() {
-        return AwsV4HttpSigner.create();
-    }
+    AwsV4HttpSigner signer();
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aAuthScheme.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.http.auth.aws;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.auth.aws.internal.DefaultAwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
-import software.amazon.awssdk.http.auth.spi.HttpSigner;
 import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
@@ -60,5 +59,5 @@ public interface AwsV4aAuthScheme extends AuthScheme<AwsCredentialsIdentity> {
      * Retrieve the {@link AwsV4aHttpSigner} associated with this authentication scheme.
      */
     @Override
-    HttpSigner<AwsCredentialsIdentity> signer();
+    AwsV4aHttpSigner signer();
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aAuthScheme.java
@@ -42,14 +42,6 @@ public interface AwsV4aAuthScheme extends AuthScheme<AwsCredentialsIdentity> {
     }
 
     /**
-     * Retrieve the scheme ID.
-     */
-    @Override
-    default String schemeId() {
-        return SCHEME_ID;
-    }
-
-    /**
      * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/AwsV4aAuthScheme.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.auth.aws;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.aws.internal.DefaultAwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.HttpSigner;
 import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
@@ -38,8 +39,7 @@ public interface AwsV4aAuthScheme extends AuthScheme<AwsCredentialsIdentity> {
      * Get a default implementation of a {@link AwsV4aAuthScheme}
      */
     static AwsV4aAuthScheme create() {
-        return new AwsV4aAuthScheme() {
-        };
+        return DefaultAwsV4aAuthScheme.create();
     }
 
     /**
@@ -54,15 +54,11 @@ public interface AwsV4aAuthScheme extends AuthScheme<AwsCredentialsIdentity> {
      * Retrieve the {@link AwsCredentialsIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override
-    default IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
-        return providers.identityProvider(AwsCredentialsIdentity.class);
-    }
+    IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers);
 
     /**
      * Retrieve the {@link AwsV4aHttpSigner} associated with this authentication scheme.
      */
     @Override
-    default HttpSigner<AwsCredentialsIdentity> signer() {
-        return AwsV4aHttpSigner.create();
-    }
+    HttpSigner<AwsCredentialsIdentity> signer();
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4AuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4AuthScheme.java
@@ -18,9 +18,9 @@ package software.amazon.awssdk.http.auth.aws.internal;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
 
 /**
  * A default implementation of {@link AwsV4AuthScheme}.
@@ -43,7 +43,7 @@ public final class DefaultAwsV4AuthScheme implements AwsV4AuthScheme {
     }
 
     @Override
-    public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+    public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviders providers) {
         return providers.identityProvider(AwsCredentialsIdentity.class);
     }
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4AuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4AuthScheme.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.aws.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * A default implementation of {@link AwsV4AuthScheme}.
+ */
+@SdkInternalApi
+public final class DefaultAwsV4AuthScheme implements AwsV4AuthScheme {
+    private static final DefaultAwsV4AuthScheme DEFAULT = new DefaultAwsV4AuthScheme();
+    private static final AwsV4HttpSigner DEFAULT_SIGNER = AwsV4HttpSigner.create();
+
+    /**
+     * Returns an instance of the {@link DefaultAwsV4AuthScheme}.
+     */
+    public static DefaultAwsV4AuthScheme create() {
+        return DEFAULT;
+    }
+
+    @Override
+    public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    @Override
+    public AwsV4HttpSigner signer() {
+        return DEFAULT_SIGNER;
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4AuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4AuthScheme.java
@@ -38,6 +38,11 @@ public final class DefaultAwsV4AuthScheme implements AwsV4AuthScheme {
     }
 
     @Override
+    public String schemeId() {
+        return SCHEME_ID;
+    }
+
+    @Override
     public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
         return providers.identityProvider(AwsCredentialsIdentity.class);
     }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
@@ -18,9 +18,9 @@ package software.amazon.awssdk.http.auth.aws.internal;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.auth.aws.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
-import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
 
 /**
  * A default implementation of {@link AwsV4aAuthScheme}.
@@ -42,7 +42,7 @@ public final class DefaultAwsV4aAuthScheme implements AwsV4aAuthScheme {
     }
 
     @Override
-    public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+    public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviders providers) {
         return providers.identityProvider(AwsCredentialsIdentity.class);
     }
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
@@ -41,6 +41,10 @@ public final class DefaultAwsV4aAuthScheme implements AwsV4aAuthScheme {
         return providers.identityProvider(AwsCredentialsIdentity.class);
     }
 
+    /**
+     * AwsV4aHttpSigner.create() returns the CRT implementation and requires the optional dependency http-auth-aws-crt to be
+     * added. So lazily creating the instance only when this method is called.
+     */
     @Override
     public AwsV4aHttpSigner signer() {
         return SignerSingletonHolder.INSTANCE;

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
@@ -37,6 +37,11 @@ public final class DefaultAwsV4aAuthScheme implements AwsV4aAuthScheme {
     }
 
     @Override
+    public String schemeId() {
+        return SCHEME_ID;
+    }
+
+    @Override
     public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
         return providers.identityProvider(AwsCredentialsIdentity.class);
     }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.AwsV4aAuthScheme;
+import software.amazon.awssdk.http.auth.aws.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+
+/**
+ * A default implementation of {@link AwsV4aAuthScheme}.
+ */
+@SdkInternalApi
+public final class DefaultAwsV4aAuthScheme implements AwsV4aAuthScheme {
+    private static final DefaultAwsV4aAuthScheme DEFAULT = new DefaultAwsV4aAuthScheme();
+    private static final AwsV4aHttpSigner DEFAULT_SIGNER = AwsV4aHttpSigner.create();
+
+    /**
+     * Returns an instance of the {@link DefaultAwsV4aAuthScheme}.
+     */
+    public static DefaultAwsV4aAuthScheme create() {
+        return DEFAULT;
+    }
+
+    @Override
+    public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(AwsCredentialsIdentity.class);
+    }
+
+    @Override
+    public AwsV4aHttpSigner signer() {
+        return DEFAULT_SIGNER;
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/DefaultAwsV4aAuthScheme.java
@@ -28,7 +28,6 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 @SdkInternalApi
 public final class DefaultAwsV4aAuthScheme implements AwsV4aAuthScheme {
     private static final DefaultAwsV4aAuthScheme DEFAULT = new DefaultAwsV4aAuthScheme();
-    private static final AwsV4aHttpSigner DEFAULT_SIGNER = AwsV4aHttpSigner.create();
 
     /**
      * Returns an instance of the {@link DefaultAwsV4aAuthScheme}.
@@ -44,6 +43,10 @@ public final class DefaultAwsV4aAuthScheme implements AwsV4aAuthScheme {
 
     @Override
     public AwsV4aHttpSigner signer() {
-        return DEFAULT_SIGNER;
+        return SignerSingletonHolder.INSTANCE;
+    }
+
+    private static class SignerSingletonHolder {
+        private static final AwsV4aHttpSigner INSTANCE = AwsV4aHttpSigner.create();
     }
 }

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthScheme.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/AuthScheme.java
@@ -29,6 +29,8 @@ import software.amazon.awssdk.identity.spi.TokenIdentity;
  *     <li>A signer - An API that can be used to sign HTTP requests.</li>
  * </ol>
  *
+ * See example auth schemes defined <a href="https://smithy.io/2.0/spec/authentication-traits.html">here</a>.
+ *
  * @param <T> The type of the {@link Identity} used by this authentication scheme.
  * @see IdentityProvider
  * @see HttpSigner
@@ -37,7 +39,7 @@ import software.amazon.awssdk.identity.spi.TokenIdentity;
 public interface AuthScheme<T extends Identity> {
 
     /**
-     * Retrieve the scheme ID, a unique identifier for the authentication scheme (aws.auth#sigv4, smithy.api#httpBearerAuth).
+     * Retrieve the scheme ID, a unique identifier for the authentication scheme.
      */
     String schemeId();
 

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerAuthScheme.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.auth;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.internal.DefaultBearerAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
@@ -37,8 +38,7 @@ public interface BearerAuthScheme extends AuthScheme<TokenIdentity> {
      * Get a default implementation of a {@link BearerAuthScheme}
      */
     static BearerAuthScheme create() {
-        return new BearerAuthScheme() {
-        };
+        return DefaultBearerAuthScheme.create();
     }
 
     /**
@@ -53,15 +53,11 @@ public interface BearerAuthScheme extends AuthScheme<TokenIdentity> {
      * Retrieve the {@link TokenIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override
-    default IdentityProvider<TokenIdentity> identityProvider(IdentityProviderConfiguration providers) {
-        return providers.identityProvider(TokenIdentity.class);
-    }
+    IdentityProvider<TokenIdentity> identityProvider(IdentityProviderConfiguration providers);
 
     /**
      * Retrieve the {@link BearerHttpSigner} associated with this authentication scheme.
      */
     @Override
-    default BearerHttpSigner signer() {
-        return BearerHttpSigner.create();
-    }
+    BearerHttpSigner signer();
 }

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/BearerAuthScheme.java
@@ -42,14 +42,6 @@ public interface BearerAuthScheme extends AuthScheme<TokenIdentity> {
     }
 
     /**
-     * Retrieve the scheme ID.
-     */
-    @Override
-    default String schemeId() {
-        return SCHEME_ID;
-    }
-
-    /**
      * Retrieve the {@link TokenIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/NoAuthAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/NoAuthAuthScheme.java
@@ -19,9 +19,9 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.auth.internal.DefaultNoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.HttpSigner;
-import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
 
 /**
  * An auth scheme that represents no authentication.
@@ -41,7 +41,7 @@ public interface NoAuthAuthScheme extends AuthScheme<NoAuthAuthScheme.AnonymousI
      * Retrieve the {@link AnonymousIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override
-    IdentityProvider<AnonymousIdentity> identityProvider(IdentityProviderConfiguration providers);
+    IdentityProvider<AnonymousIdentity> identityProvider(IdentityProviders providers);
 
     /**
      * Retrieve the {@link HttpSigner} associated with this authentication scheme.

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/NoAuthAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/NoAuthAuthScheme.java
@@ -35,6 +35,14 @@ public interface NoAuthAuthScheme extends AuthScheme<NoAuthAuthScheme.AnonymousI
     }
 
     /**
+     * Retrieve the scheme ID.
+     */
+    @Override
+    default String schemeId() {
+        return SCHEME_ID;
+    }
+
+    /**
      * An anonymous identity used by the no-auth auth scheme.
      */
     interface AnonymousIdentity extends Identity {

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/NoAuthAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/NoAuthAuthScheme.java
@@ -18,7 +18,10 @@ package software.amazon.awssdk.http.auth;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.auth.internal.DefaultNoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.AuthScheme;
+import software.amazon.awssdk.http.auth.spi.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
 
 /**
  * An auth scheme that represents no authentication.
@@ -35,12 +38,16 @@ public interface NoAuthAuthScheme extends AuthScheme<NoAuthAuthScheme.AnonymousI
     }
 
     /**
-     * Retrieve the scheme ID.
+     * Retrieve the {@link AnonymousIdentity} based {@link IdentityProvider} associated with this authentication scheme.
      */
     @Override
-    default String schemeId() {
-        return SCHEME_ID;
-    }
+    IdentityProvider<AnonymousIdentity> identityProvider(IdentityProviderConfiguration providers);
+
+    /**
+     * Retrieve the {@link HttpSigner} associated with this authentication scheme.
+     */
+    @Override
+    HttpSigner<AnonymousIdentity> signer();
 
     /**
      * An anonymous identity used by the no-auth auth scheme.

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultBearerAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultBearerAuthScheme.java
@@ -38,6 +38,11 @@ public final class DefaultBearerAuthScheme implements BearerAuthScheme {
     }
 
     @Override
+    public String schemeId() {
+        return SCHEME_ID;
+    }
+
+    @Override
     public IdentityProvider<TokenIdentity> identityProvider(IdentityProviderConfiguration providers) {
         return providers.identityProvider(TokenIdentity.class);
     }

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultBearerAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultBearerAuthScheme.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.BearerAuthScheme;
+import software.amazon.awssdk.http.auth.BearerHttpSigner;
+import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.TokenIdentity;
+
+/**
+ * A default implementation of {@link BearerAuthScheme}.
+ */
+@SdkInternalApi
+public final class DefaultBearerAuthScheme implements BearerAuthScheme {
+    private static final DefaultBearerAuthScheme DEFAULT = new DefaultBearerAuthScheme();
+    private static final BearerHttpSigner DEFAULT_SIGNER = BearerHttpSigner.create();
+
+    /**
+     * Returns an instance of the {@link DefaultBearerAuthScheme}.
+     */
+    public static DefaultBearerAuthScheme create() {
+        return DEFAULT;
+    }
+
+    @Override
+    public IdentityProvider<TokenIdentity> identityProvider(IdentityProviderConfiguration providers) {
+        return providers.identityProvider(TokenIdentity.class);
+    }
+
+    @Override
+    public BearerHttpSigner signer() {
+        return DEFAULT_SIGNER;
+    }
+}

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultBearerAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultBearerAuthScheme.java
@@ -18,8 +18,8 @@ package software.amazon.awssdk.http.auth.internal;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.auth.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.BearerHttpSigner;
-import software.amazon.awssdk.http.auth.spi.IdentityProviderConfiguration;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 
 /**
@@ -43,7 +43,7 @@ public final class DefaultBearerAuthScheme implements BearerAuthScheme {
     }
 
     @Override
-    public IdentityProvider<TokenIdentity> identityProvider(IdentityProviderConfiguration providers) {
+    public IdentityProvider<TokenIdentity> identityProvider(IdentityProviders providers) {
         return providers.identityProvider(TokenIdentity.class);
     }
 

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultNoAuthAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultNoAuthAuthScheme.java
@@ -56,6 +56,11 @@ public final class DefaultNoAuthAuthScheme implements NoAuthAuthScheme {
     }
 
     @Override
+    public String schemeId() {
+        return SCHEME_ID;
+    }
+
+    @Override
     public IdentityProvider<AnonymousIdentity> identityProvider(IdentityProviderConfiguration providers) {
         return DEFAULT_IDENTITY_PROVIDER;
     }

--- a/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultNoAuthAuthScheme.java
+++ b/core/http-auth/src/main/java/software/amazon/awssdk/http/auth/internal/DefaultNoAuthAuthScheme.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
 
 /**
- * A default, no-op implementation of {@link NoAuthAuthScheme}. This implementation always:
+ * A default implementation of {@link NoAuthAuthScheme}. This implementation always:
  *
  * <ul>
  *     <li>Returns an {@link IdentityProvider} that always returns the same static instance that implements the
@@ -42,7 +42,7 @@ import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
  * </ul>
  */
 @SdkInternalApi
-public class DefaultNoAuthAuthScheme implements NoAuthAuthScheme {
+public final class DefaultNoAuthAuthScheme implements NoAuthAuthScheme {
     private static final DefaultNoAuthAuthScheme DEFAULT = new DefaultNoAuthAuthScheme();
     private static final IdentityProvider<AnonymousIdentity> DEFAULT_IDENTITY_PROVIDER = noAuthIdentityProvider();
     private static final HttpSigner<AnonymousIdentity> DEFAULT_SIGNER = noAuthSigner();
@@ -53,11 +53,6 @@ public class DefaultNoAuthAuthScheme implements NoAuthAuthScheme {
      */
     public static NoAuthAuthScheme create() {
         return DEFAULT;
-    }
-
-    @Override
-    public String schemeId() {
-        return SCHEME_ID;
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Instead of anonymous inner classes.

## Modifications
<!--- Describe your changes in detail -->
Add auth scheme default impl classes instead of anonymous inner classes.
Note https://github.com/aws/aws-sdk-java-v2/pull/4416/commits/5c170777e1a125317afbe9acbb104f5cabf532d8 which creates sigv4a signer instance lazily as that depends on optional dependency http-auth-aws-crt. Whereas other signer instance are created eagerly in static block in AuthScheme impls.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
s3-transfer-manager was failing earlier because of eager loading of crt signer. fixed with lazy loading.