### PR TITLE
Add ReturnConsumedCapacity to BatchGetItemEnhancedRequest

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-ee18d70.json
+++ b/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-ee18d70.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "psnilesh",
+    "description": "This commit introduces returnConsumedCapacity input to BatchGetItemEnhancedRequest that allows customers to find out exactly how much read units were consumed by the operation."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperation.java
@@ -62,6 +62,7 @@ public class BatchGetItemOperation
 
         return BatchGetItemRequest.builder()
                                   .requestItems(Collections.unmodifiableMap(requestItems))
+                                  .returnConsumedCapacity(request.returnConsumedCapacityAsString())
                                   .build();
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetItemEnhancedRequest.java
@@ -20,10 +20,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity;
 
 /**
  * Defines parameters used for the batchGetItem() operation (such as
@@ -36,9 +40,11 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 public final class BatchGetItemEnhancedRequest {
 
     private final List<ReadBatch> readBatches;
+    private final String returnConsumedCapacity;
 
     private BatchGetItemEnhancedRequest(Builder builder) {
         this.readBatches = getListIfExist(builder.readBatches);
+        this.returnConsumedCapacity = builder.returnConsumedCapacity;
     }
 
     /**
@@ -52,7 +58,7 @@ public final class BatchGetItemEnhancedRequest {
      * Returns a builder initialized with all existing values on the request object.
      */
     public Builder toBuilder() {
-        return new Builder().readBatches(readBatches);
+        return new Builder().readBatches(readBatches).returnConsumedCapacity(this.returnConsumedCapacity);
     }
 
     /**
@@ -60,6 +66,25 @@ public final class BatchGetItemEnhancedRequest {
      */
     public Collection<ReadBatch> readBatches() {
         return readBatches;
+    }
+
+    /**
+     * Whether to return the capacity consumed by this operation.
+     *
+     * @see GetItemRequest#returnConsumedCapacity()
+     */
+    public ReturnConsumedCapacity returnConsumedCapacity() {
+        return ReturnConsumedCapacity.fromValue(returnConsumedCapacity);
+    }
+
+    /**
+     * Whether to return the capacity consumed by this operation.
+     * <p>
+     * Similar to {@link #returnConsumedCapacity()} but return the value as a string. This is useful in situations where the
+     * value is not defined in {@link ReturnConsumedCapacity}.
+     */
+    public String returnConsumedCapacityAsString() {
+        return returnConsumedCapacity;
     }
 
     @Override
@@ -73,12 +98,15 @@ public final class BatchGetItemEnhancedRequest {
 
         BatchGetItemEnhancedRequest that = (BatchGetItemEnhancedRequest) o;
 
-        return readBatches != null ? readBatches.equals(that.readBatches) : that.readBatches == null;
+        return Objects.equals(this.readBatches, that.readBatches) &&
+               Objects.equals(this.returnConsumedCapacity, that.returnConsumedCapacity);
     }
 
     @Override
     public int hashCode() {
-        return readBatches != null ? readBatches.hashCode() : 0;
+        int hc = readBatches != null ? readBatches.hashCode() : 0;
+        hc = 31 * hc + (returnConsumedCapacity != null ? returnConsumedCapacity.hashCode() : 0);
+        return hc;
     }
 
     private static List<ReadBatch> getListIfExist(List<ReadBatch> readBatches) {
@@ -91,6 +119,7 @@ public final class BatchGetItemEnhancedRequest {
     @NotThreadSafe
     public static final class Builder {
         private List<ReadBatch> readBatches;
+        private String returnConsumedCapacity;
 
         private Builder() {
         }
@@ -132,9 +161,30 @@ public final class BatchGetItemEnhancedRequest {
             return this;
         }
 
+        /**
+         * Whether to return the capacity consumed by this operation.
+         *
+         * @see BatchGetItemRequest.Builder#returnConsumedCapacity(ReturnConsumedCapacity)
+         * @return a builder of this type
+         */
+        public Builder returnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) {
+            this.returnConsumedCapacity = returnConsumedCapacity == null ? null : returnConsumedCapacity.toString();
+            return this;
+        }
+
+        /**
+         * Whether to return the capacity consumed by this operation.
+         *
+         * @see BatchGetItemRequest.Builder#returnConsumedCapacity(String)
+         * @return a builder of this type
+         */
+        public Builder returnConsumedCapacity(String returnConsumedCapacity) {
+            this.returnConsumedCapacity = returnConsumedCapacity;
+            return this;
+        }
+
         public BatchGetItemEnhancedRequest build() {
             return new BatchGetItemEnhancedRequest(this);
         }
     }
-
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPage.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPage.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.DefaultOperationContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 
 /**
@@ -109,6 +110,10 @@ public final class BatchGetResultPage {
                                               .sortValue(sortValue)
                                               .build(); })
                                 .collect(Collectors.toList());
+    }
+
+    public List<ConsumedCapacity> consumedCapacity() {
+        return this.batchGetItemResponse.consumedCapacity();
     }
 
     /**


### PR DESCRIPTION
## Motivation and Context
Add ReturnConsumedCapacity to BatchGetItemEnhancedRequest so callers can determine exactly how much RCUs BatchGetItem request consumed. 

Related to feature request https://github.com/aws/aws-sdk-java-v2/issues/4372

## Modifications
1. Add `returnConsumedCapacity` to `BatchGetItemEnhancedRequest`
2. Changes to `BatchGetItemOperation` to honor `returnConsumedCapacity` 
3. Unit and functional tests to verify the new param

## Testing
Added new unit and functional tests, and ran them succcesfully

`./mvnw clean install -pl :dynamodb-enhanced  --am`

## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
