### PR TITLE
[Bug bash] Apache HTTP client: Prevent proxyPort NumberFormatException 

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-4013cfc.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-4013cfc.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Apache HTTP client: Prevent NumberFormatException if proxyPort is empty when useSystemPropertyValues is also set to false"
+}

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -144,6 +144,9 @@ public final class ApacheHttpClient implements SdkHttpClient {
                                                           AttributeMap standardOptions) {
         ApacheConnectionManagerFactory cmFactory = new ApacheConnectionManagerFactory();
 
+        configuration.proxyConfiguration = Validate.getOrDefault(configuration.proxyConfiguration,
+                                                                 ProxyConfiguration.builder()::build);
+
         HttpClientBuilder builder = HttpClients.custom();
         // Note that it is important we register the original connection manager with the
         // IdleConnectionReaper as it's required for the successful deregistration of managers
@@ -455,7 +458,7 @@ public final class ApacheHttpClient implements SdkHttpClient {
 
     private static final class DefaultBuilder implements Builder {
         private final AttributeMap.Builder standardOptions = AttributeMap.builder();
-        private ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder().build();
+        private ProxyConfiguration proxyConfiguration;
         private InetAddress localAddress;
         private Boolean expectContinueEnabled;
         private HttpRoutePlanner httpRoutePlanner;

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.apache;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetAddress;
@@ -27,6 +28,7 @@ import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.http.SdkHttpClient;
 
 /**
  * @see ApacheHttpClientWireMockTest
@@ -144,5 +146,25 @@ public class ApacheHttpClientTest {
                         .dnsResolver(dnsResolver)
                         .build()
                         .close();
+    }
+
+
+    @Test
+    void emptyProxyPort_shouldThrowNumberFormatException() {
+        System.setProperty("http.proxyPort", "");
+        assertThatThrownBy(ApacheHttpClient.builder()::build)
+            .isInstanceOf(NumberFormatException.class)
+            .hasMessageContaining("For input string: \"\"");
+    }
+
+    @Test
+    void emptyProxyPort_whenUseSystemPropertyIsFalse_shouldNotThrowException() {
+        System.setProperty("http.proxyPort", "");
+        SdkHttpClient client = ApacheHttpClient.builder()
+                                               .proxyConfiguration(ProxyConfiguration.builder()
+                                                                                     .useSystemPropertyValues(false)
+                                                                                     .build())
+                                               .build();
+        assertThat(client).isNotNull();
     }
 }

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ProxyConfigurationTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ProxyConfigurationTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.apache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -152,6 +153,21 @@ public class ProxyConfigurationTest {
                               .build();
 
         assertThat(proxyConfiguration.toBuilder()).isNotNull();
+    }
+
+    @Test
+    void emptyProxyPort_shouldThrowNumberFormatException() {
+        System.setProperty("http.proxyPort", "");
+        assertThatThrownBy(ProxyConfiguration.builder()::build)
+            .isInstanceOf(NumberFormatException.class)
+            .hasMessageContaining("For input string: \"\"");
+    }
+
+    @Test
+    void emptyProxyPort_whenUseSystemPropertyIsFalse_shouldNotThrowException() {
+        System.setProperty("http.proxyPort", "");
+        ProxyConfiguration configuration = ProxyConfiguration.builder().useSystemPropertyValues(false).build();
+        assertThat(configuration).isNotNull();
     }
 
     private static void clearProxyProperties() {


### PR DESCRIPTION
Fixes 4385

For the Apache Http client, prevent a `NumberFormatException` to be thrown if the `http.proxyPort` system property is set to an empty string when `useSystemPropertyValues(boolean)` is also set to false.

## Motivation and Context
see https://github.com/aws/aws-sdk-java-v2/issues/4385

## Modifications
Do not always instantiate ProxyConfiguration every time, instead instantiate only if no ProxyConfiguration is passed to the Http client builder.

## Testing
Added unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
