### PR TITLE
Fix for Cross-region calls failure due to AuthorizationHeaderMalformed errors while using clients with configured region as us-east-1

### DIFF
--- a/.changes/next-release/bugfix-AmazonSimpleStorageServic-acc4919.json
+++ b/.changes/next-release/bugfix-AmazonSimpleStorageServic-acc4919.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "Amazon Simple Storage Servic",
     "contributor": "",
-    "description": "ddd"
+    "description": "Fix for Cross-region calls failure due to AuthorizationHeaderMalformed errors while using clients with configured region as us-east-1."
 }

--- a/.changes/next-release/bugfix-AmazonSimpleStorageServic-acc4919.json
+++ b/.changes/next-release/bugfix-AmazonSimpleStorageServic-acc4919.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon Simple Storage Servic",
+    "contributor": "",
+    "description": "ddd"
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionIntegrationTestBase.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionIntegrationTestBase.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.s3.crossregion;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
@@ -111,7 +112,7 @@ public abstract class S3CrossRegionIntegrationTestBase extends S3IntegrationTest
                  );
         ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder().bucket(bucketName()).maxKeys(maxKeys).build();
         List<S3Object> s3ObjectList = paginatedAPICall(listObjectsV2Request);
-        assertThat(s3ObjectList).hasSize(totalKeys);
+        assertThat(s3ObjectList.stream().filter( g -> g.key().contains(KEY+ "_")).collect(Collectors.toList())).hasSize(totalKeys);
         IntStream.range(0, totalKeys ).forEach(i -> s3.deleteObject(p -> p.bucket(bucketName()).key(KEY + "_" + i)));
     }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
@@ -36,7 +36,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 
-public class S3CrossRegionAsyncClientRedirectTest extends S3DecoratorRedirectTestBase {
+public class S3CrossRegionAsyncClientRedirectTest extends S3CrossRegionRedirectTestBase {
     private static S3AsyncClient mockDelegateAsyncClient;
     private S3AsyncClient decoratedS3AsyncClient;
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
@@ -77,8 +77,7 @@ public class S3CrossRegionAsyncClientRedirectTest extends S3DecoratorRedirectTes
     @Override
     protected void stubClientAPICallWithFirstRedirectThenSuccessWithRegionInErrorResponse(Integer redirect) {
         when(mockDelegateAsyncClient.listObjects(any(ListObjectsRequest.class)))
-           .thenReturn(CompletableFutureUtils.failedFuture(new CompletionException(redirectException(redirect, CROSS_REGION.id(), null,
-                                                                                                     null))))
+           .thenReturn(CompletableFutureUtils.failedFuture(new CompletionException(redirectException(redirect, CROSS_REGION.id(), null, null))))
             .thenReturn(CompletableFuture.completedFuture(ListObjectsResponse.builder().contents(S3_OBJECTS).build()
             ));
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
@@ -133,6 +133,35 @@ public class S3CrossRegionAsyncClientRedirectTest extends S3DecoratorRedirectTes
     }
 
     @Override
+    protected void stubApiWithAuthorizationHeaderMalformedError() {
+        when(mockDelegateAsyncClient.listObjects(any(ListObjectsRequest.class)))
+            .thenReturn(CompletableFutureUtils.failedFuture(
+                new CompletionException(redirectException(400, null, "AuthorizationHeaderMalformed", null))))
+            .thenReturn(CompletableFuture.completedFuture(ListObjectsResponse.builder().contents(S3_OBJECTS).build()));
+    }
+
+    @Override
+    protected void stubApiWithAuthorizationHeaderWithInternalSoftwareError() {
+
+        when(mockDelegateAsyncClient.headBucket(any(HeadBucketRequest.class)))
+            .thenReturn(CompletableFutureUtils.failedFuture(
+                new CompletionException(redirectException(500,null, "InternalError", null))));
+        when(mockDelegateAsyncClient.headBucket(any(Consumer.class)))
+            .thenReturn(CompletableFutureUtils.failedFuture(new CompletionException(redirectException(500,null,
+                                                                                                      "InternalError", null))));
+    }
+
+    @Override
+    protected void stubHeadBucketRedirectWithAuthorizationHeaderMalformed() {
+        when(mockDelegateAsyncClient.headBucket(any(HeadBucketRequest.class)))
+            .thenReturn(CompletableFutureUtils.failedFuture(
+                new CompletionException(redirectException(400,CROSS_REGION.id(), "AuthorizationHeaderMalformed", null))));
+        when(mockDelegateAsyncClient.headBucket(any(Consumer.class)))
+            .thenReturn(CompletableFutureUtils.failedFuture(
+                new CompletionException(redirectException(400,CROSS_REGION.id(), "AuthorizationHeaderMalformed", null))));
+    }
+
+    @Override
     protected void verifyNoBucketCall() {
         assertThatExceptionOfType(CompletionException.class)
             .isThrownBy(

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
@@ -17,11 +17,11 @@ package software.amazon.awssdk.services.s3.internal.crossregion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.CHANGED_CROSS_REGION;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.CROSS_REGION;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.CROSS_REGION_BUCKET;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.OVERRIDE_CONFIGURED_REGION;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.X_AMZ_BUCKET_REGION;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.CHANGED_CROSS_REGION;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.CROSS_REGION;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.CROSS_REGION_BUCKET;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.OVERRIDE_CONFIGURED_REGION;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.X_AMZ_BUCKET_REGION;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -159,7 +159,7 @@ class S3CrossRegionAsyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void standardOp_crossRegionClient_noOverrideConfig_SuccessfullyIntercepts(Consumer<MockAsyncHttpClient> stubConsumer,
+    void given_CrossRegionClientWithNoOverrideConfig_when_StandardOperationIsPerformed_then_SuccessfullyIntercepts(Consumer<MockAsyncHttpClient> stubConsumer,
                                                                               Class<?> endpointProviderType,
                                                                               String testCase) {
         stubConsumer.accept(mockAsyncHttpClient);
@@ -170,7 +170,7 @@ class S3CrossRegionAsyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void standardOp_crossRegionClient_existingOverrideConfig_SuccessfullyIntercepts(Consumer<MockAsyncHttpClient> stubConsumer,
+    void given_CrossRegionClientWithExistingOverrideConfig_when_StandardOperationIsPerformed_then_SuccessfullyIntercepts(Consumer<MockAsyncHttpClient> stubConsumer,
                                                                                     Class<?> endpointProviderType,
                                                                                     String testCase) {
         stubConsumer.accept(mockAsyncHttpClient);
@@ -187,7 +187,7 @@ class S3CrossRegionAsyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void paginatedOp_crossRegionClient_DoesIntercept(Consumer<MockAsyncHttpClient> stubConsumer,
+    void given_CrossRegionClient_when_PaginatedOperationIsPerformed_then_DoesNotIntercept(Consumer<MockAsyncHttpClient> stubConsumer,
                                                      Class<?> endpointProviderType,
                                                      String testCase) throws Exception {
         stubConsumer.accept(mockAsyncHttpClient);
@@ -201,7 +201,7 @@ class S3CrossRegionAsyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void crossRegionClient_createdWithWrapping_SuccessfullyIntercepts(Consumer<MockAsyncHttpClient> stubConsumer,
+    void given_CrossRegionClientCreatedWithWrapping_when_OperationIsPerformed_then_SuccessfullyIntercepts(Consumer<MockAsyncHttpClient> stubConsumer,
                                                                       Class<?> endpointProviderType,
                                                                       String testCase) {
         stubConsumer.accept(mockAsyncHttpClient);
@@ -211,7 +211,7 @@ class S3CrossRegionAsyncClientTest {
     }
 
     @Test
-    void crossRegionClient_CallsHeadObject_when_regionNameNotPresentInFallBackCall() {
+    void given_CrossRegionClient_when_CallsHeadObjectWithRegionNameNotPresentInFallbackCall_then_RegionNameExtractedFromHeadBucket() {
         mockAsyncHttpClient.reset();
         mockAsyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301, null),
                                           customHttpResponseWithUnknownErrorCode(301, CROSS_REGION.id()),
@@ -251,7 +251,7 @@ class S3CrossRegionAsyncClientTest {
 
     @ParameterizedTest(name = "{index} - Status code = {1} with HeadBucket bucket regions {3}.")
     @MethodSource("stubFailureResponses")
-    void crossRegionClient_CallsHeadObjectErrors_shouldTerminateTheAPI(
+    void given_CrossRegionClient_when_CallsHeadObjectErrors_then_ShouldTerminateTheAPI(
         Consumer<MockAsyncHttpClient> stubFailureResponses,
         Integer statusCode, Integer numberOfRequests,
         List<String> redirectedBuckets,
@@ -263,10 +263,9 @@ class S3CrossRegionAsyncClientTest {
             clientBuilder().endpointOverride(null).region(OVERRIDE_CONFIGURED_REGION)
                            .crossRegionAccessEnabled(true).build();
 
-        String errorMessage = String.format("software.amazon.awssdk.services.s3.model.S3Exception: null (Service: S3, Status "
-                                            + "Code: "
-                                            + "%d, "
-                                            + "Request ID: null)", statusCode);
+        String errorMessage = String.format("software.amazon.awssdk.services.s3.model.S3Exception: null "
+                                            + "(Service: S3, Status Code: %d, Request ID: null)"
+                , statusCode);
         assertThatExceptionOfType(CompletionException.class)
             .isThrownBy(() -> crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes()).join())
             .withMessageContaining(errorMessage);
@@ -282,7 +281,7 @@ class S3CrossRegionAsyncClientTest {
     }
 
     @Test
-    void crossRegionClient_CallsHeadObjectWithNoRegion_shouldTerminateHeadBucketAPI() {
+    void given_CrossRegionClient_when_CallsHeadObjectWithNoRegion_then_ShouldTerminateHeadBucketAPI() {
         mockAsyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301, null),
                                           customHttpResponseWithUnknownErrorCode(301, null),
                                           successHttpResponse(), successHttpResponse());
@@ -309,23 +308,23 @@ class S3CrossRegionAsyncClientTest {
     }
 
     @Test
-    void crossRegionClient_cancelsTheThread_when_futureIsCancelled() {
+    void given_CrossRegionClient_when_FutureIsCancelled_then_ShouldCancelTheThread() {
         mockAsyncHttpClient.reset();
         mockAsyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301, null),
                                           customHttpResponseWithUnknownErrorCode(301, CROSS_REGION.id()),
                                           successHttpResponse(), successHttpResponse());
         S3AsyncClient crossRegionClient =
             clientBuilder().endpointOverride(null).region(OVERRIDE_CONFIGURED_REGION).crossRegionAccessEnabled(true).build();
+
         CompletableFuture<ResponseBytes<GetObjectResponse>> completableFuture =
-            crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY)
-            , AsyncResponseTransformer.toBytes());
+            crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes());
 
         completableFuture.cancel(true);
         assertThat(completableFuture.isCancelled()).isTrue();
     }
 
     @Test
-    void crossRegionClient_when_redirectsAfterCaching() {
+    void given_CrossRegionClient_when_RedirectsAfterCaching_then_ExpectedBehaviorOccurs() {
         mockAsyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301, CROSS_REGION.id()),
                                           successHttpResponse(),
                                           successHttpResponse(),
@@ -355,7 +354,7 @@ class S3CrossRegionAsyncClientTest {
     }
 
     @Test
-    void crossRegionClient_when_redirectsAfterCaching_withFallBackRedirectWithNoRegion() {
+    void given_CrossRegionClient_when_RedirectsAfterCaching_withFallbackRedirectWithNoRegion_then_RetriedCallWithRegionSucceeds() {
         mockAsyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301, null),
                                           customHttpResponseWithUnknownErrorCode(301, CROSS_REGION.id()),
                                           successHttpResponse(),
@@ -388,7 +387,7 @@ class S3CrossRegionAsyncClientTest {
     }
 
     @Test
-    void standardOp_crossRegionClient_containUserAgent() {
+    void given_CrossRegionClient_when_StandardOperation_then_ContainsUserAgent() {
         mockAsyncHttpClient.stubResponses(successHttpResponse());
 
         S3AsyncClient crossRegionClient = clientBuilder().crossRegionAccessEnabled(true).build();
@@ -396,17 +395,11 @@ class S3CrossRegionAsyncClientTest {
         assertThat(mockAsyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get()).contains("hll/cross-region");
     }
 
-    @Test
-    void standardOp_crossRegionClient_FromContextParamBuilder_containUserAgent() {
-        mockAsyncHttpClient.stubResponses(successHttpResponse());
-        S3AsyncClient crossRegionClient = clientBuilder().crossRegionAccessEnabled(true).build();
-        crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes()).join();
-        assertThat(mockAsyncHttpClient.getLastRequest().firstMatchingHeader("User-Agent").get()).contains("hll/cross-region");
-    }
+
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void crossRegionClient_fromParamBuilder_createdWithWrapping_SuccessfullyIntercepts(Consumer<MockAsyncHttpClient> stubConsumer,
+    void given_CrossRegionAccessEnabled_when_SuccessfulResponse_then_EndpointIsUpdated(Consumer<MockAsyncHttpClient> stubConsumer,
                                                                                        Class<?> endpointProviderType,
                                                                                        String testCase) {
         stubConsumer.accept(mockAsyncHttpClient);
@@ -416,7 +409,7 @@ class S3CrossRegionAsyncClientTest {
     }
 
     @Test
-    void standardOp_simpleClient_doesNotContainCrossRegionUserAgent() {
+    void given_SimpleClient_when_StandardOperation_then_DoesNotContainCrossRegionUserAgent() {
         mockAsyncHttpClient.stubResponses(successHttpResponse());
         S3AsyncClient crossRegionClient = clientBuilder().crossRegionAccessEnabled(false).build();
         crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes()).join();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionRedirectTestBase.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionRedirectTestBase.java
@@ -39,7 +39,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
-public abstract class S3DecoratorRedirectTestBase {
+public abstract class S3CrossRegionRedirectTestBase {
 
     public static final String X_AMZ_BUCKET_REGION = "x-amz-bucket-region";
     protected static final String CROSS_REGION_BUCKET = "anyBucket";
@@ -77,11 +77,11 @@ public abstract class S3DecoratorRedirectTestBase {
         stubServiceClientConfiguration();
         stubRedirectSuccessSuccess(redirect);
 
-        ListObjectsResponse listObjectsResponse = apiCallToService();
-        assertThat(listObjectsResponse.contents()).isEqualTo(S3_OBJECTS);
+        ListObjectsResponse firstListObjectCall = apiCallToService();
+        assertThat(firstListObjectCall.contents()).isEqualTo(S3_OBJECTS);
 
-        ListObjectsResponse listObjectsResponseSecondCall = apiCallToService();
-        assertThat(listObjectsResponseSecondCall.contents()).isEqualTo(S3_OBJECTS);
+        ListObjectsResponse secondListObjectCall = apiCallToService();
+        assertThat(secondListObjectCall.contents()).isEqualTo(S3_OBJECTS);
 
         ArgumentCaptor<ListObjectsRequest> requestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(3, requestArgumentCaptor);
@@ -131,15 +131,16 @@ public abstract class S3DecoratorRedirectTestBase {
         stubServiceClientConfiguration();
         stubRedirectWithNoRegionAndThenSuccess(redirect);
         stubHeadBucketRedirect();
-        ListObjectsResponse listObjectsResponse = apiCallToService();
-        assertThat(listObjectsResponse.contents()).isEqualTo(S3_OBJECTS);
 
+        ListObjectsResponse firstListObjectCall = apiCallToService();
+        assertThat(firstListObjectCall.contents()).isEqualTo(S3_OBJECTS);
         ArgumentCaptor<ListObjectsRequest> preCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(2, preCacheCaptor);
         // We need to get the BucketEndpointProvider in order to update the cache
         verifyTheEndPointProviderOverridden(1, preCacheCaptor, CROSS_REGION.id());
-        listObjectsResponse = apiCallToService();
-        assertThat(listObjectsResponse.contents()).isEqualTo(S3_OBJECTS);
+
+        ListObjectsResponse secondListObjectCall  = apiCallToService();
+        assertThat(secondListObjectCall.contents()).isEqualTo(S3_OBJECTS);
         // We need to captor again so that we get the args used in second API Call
         ArgumentCaptor<ListObjectsRequest> overAllPostCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(3, overAllPostCacheCaptor);
@@ -163,19 +164,21 @@ public abstract class S3DecoratorRedirectTestBase {
     }
 
     @Test
-    void authorizationHeaderMalformedError_AndThen_redirect() throws Throwable {
+    void given_CrossRegionClient_when_AuthorizationFailureInMainCall_then_RegionRetrievedFromHeadBucketFailureResponse() throws Throwable {
         stubServiceClientConfiguration();
         stubApiWithAuthorizationHeaderMalformedError() ;
         stubHeadBucketRedirect();
-        ListObjectsResponse listObjectsResponse = apiCallToService();
-        assertThat(listObjectsResponse.contents()).isEqualTo(S3_OBJECTS);
+        ListObjectsResponse firstListObjectCall = apiCallToService();
+        assertThat(firstListObjectCall.contents()).isEqualTo(S3_OBJECTS);
 
         ArgumentCaptor<ListObjectsRequest> preCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(2, preCacheCaptor);
         // We need to get the BucketEndpointProvider in order to update the cache
         verifyTheEndPointProviderOverridden(1, preCacheCaptor, CROSS_REGION.id());
-        listObjectsResponse = apiCallToService();
-        assertThat(listObjectsResponse.contents()).isEqualTo(S3_OBJECTS);
+
+
+        ListObjectsResponse secondListObjectCall = apiCallToService();
+        assertThat(secondListObjectCall.contents()).isEqualTo(S3_OBJECTS);
         // We need to captor again so that we get the args used in second API Call
         ArgumentCaptor<ListObjectsRequest> overAllPostCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(3, overAllPostCacheCaptor);
@@ -187,19 +190,19 @@ public abstract class S3DecoratorRedirectTestBase {
 
 
     @Test
-    void headBucketCall_WithAuthorizationFailureError() throws Throwable {
+    void given_CrossRegionClient_when_AuthorizationFailureInHeadBucketWithRegion_then_CrossRegionCallSucceeds() throws Throwable {
         stubServiceClientConfiguration();
         stubApiWithAuthorizationHeaderMalformedError() ;
         stubHeadBucketRedirectWithAuthorizationHeaderMalformed();
-        ListObjectsResponse listObjectsResponse = apiCallToService();
-        assertThat(listObjectsResponse.contents()).isEqualTo(S3_OBJECTS);
+        ListObjectsResponse firstListObjectCall = apiCallToService();
+        assertThat(firstListObjectCall.contents()).isEqualTo(S3_OBJECTS);
 
         ArgumentCaptor<ListObjectsRequest> preCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(2, preCacheCaptor);
         // We need to get the BucketEndpointProvider in order to update the cache
         verifyTheEndPointProviderOverridden(1, preCacheCaptor, CROSS_REGION.id());
-        listObjectsResponse = apiCallToService();
-        assertThat(listObjectsResponse.contents()).isEqualTo(S3_OBJECTS);
+        ListObjectsResponse secondListObjectCall = apiCallToService();
+        assertThat(secondListObjectCall.contents()).isEqualTo(S3_OBJECTS);
         // We need to captor again so that we get the args used in second API Call
         ArgumentCaptor<ListObjectsRequest> overAllPostCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(3, overAllPostCacheCaptor);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
-public class S3CrossRegionSyncClientRedirectTest extends S3DecoratorRedirectTestBase {
+public class S3CrossRegionSyncClientRedirectTest extends S3CrossRegionRedirectTestBase {
 
     private static S3Client mockDelegateClient;
     private S3Client decoratedS3Client;

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
@@ -45,6 +45,26 @@ public class S3CrossRegionSyncClientRedirectTest extends S3DecoratorRedirectTest
     }
 
     @Override
+    protected void stubApiWithAuthorizationHeaderWithInternalSoftwareError() {
+        when(mockDelegateClient.headBucket(any(HeadBucketRequest.class)))
+            .thenThrow(redirectException(500, null, "InternalError", null));
+    }
+
+    @Override
+    protected void stubHeadBucketRedirectWithAuthorizationHeaderMalformed() {
+        when(mockDelegateClient.headBucket(any(HeadBucketRequest.class)))
+            .thenThrow(redirectException(400, CROSS_REGION.id(), "AuthorizationHeaderMalformed", null))
+            .thenReturn(HeadBucketResponse.builder().build());
+    }
+
+    @Override
+    protected void stubApiWithAuthorizationHeaderMalformedError() {
+        when(mockDelegateClient.listObjects(any(ListObjectsRequest.class)))
+            .thenThrow(redirectException(400, null, "AuthorizationHeaderMalformed", null))
+            .thenReturn(ListObjectsResponse.builder().contents(S3_OBJECTS).build());
+    }
+
+    @Override
     protected void verifyNoBucketCall() {
         assertThatExceptionOfType(S3Exception.class)
             .isThrownBy(

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
@@ -49,7 +49,6 @@ public class S3CrossRegionSyncClientRedirectTest extends S3DecoratorRedirectTest
         when(mockDelegateClient.headBucket(any(HeadBucketRequest.class)))
             .thenThrow(redirectException(500, null, "InternalError", null));
     }
-
     @Override
     protected void stubHeadBucketRedirectWithAuthorizationHeaderMalformed() {
         when(mockDelegateClient.headBucket(any(HeadBucketRequest.class)))

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
@@ -20,10 +20,10 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClientTest.customHttpResponse;
 import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClientTest.customHttpResponseWithUnknownErrorCode;
 import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionAsyncClientTest.successHttpResponse;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.CHANGED_CROSS_REGION;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.CROSS_REGION;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.CROSS_REGION_BUCKET;
-import static software.amazon.awssdk.services.s3.internal.crossregion.S3DecoratorRedirectTestBase.OVERRIDE_CONFIGURED_REGION;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.CHANGED_CROSS_REGION;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.CROSS_REGION;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.CROSS_REGION_BUCKET;
+import static software.amazon.awssdk.services.s3.internal.crossregion.S3CrossRegionRedirectTestBase.OVERRIDE_CONFIGURED_REGION;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,7 +64,7 @@ class S3CrossRegionSyncClientTest {
     private S3Client defaultS3Client;
 
     @BeforeEach
-    void before() {
+    void setUp() {
         mockSyncHttpClient = new MockSyncHttpClient();
         captureInterceptor = new CaptureInterceptor();
         defaultS3Client = clientBuilder().build();
@@ -163,9 +163,10 @@ class S3CrossRegionSyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void standardOp_crossRegionClient_noOverrideConfig_SuccessfullyIntercepts(Consumer<MockSyncHttpClient> stubConsumer,
-                                                                              Class<?> endpointProviderType,
-                                                                              String testCaseName) {
+    void given_CrossRegionClientWithNoOverrideConfig_when_StandardOperationIsPerformed_then_SuccessfullyIntercepts(
+        Consumer<MockSyncHttpClient> stubConsumer,
+        Class<?> endpointProviderType,
+        String testCaseName) {
         stubConsumer.accept(mockSyncHttpClient);
         S3Client crossRegionClient = new S3CrossRegionSyncClient(defaultS3Client);
         crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));
@@ -174,9 +175,10 @@ class S3CrossRegionSyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void standardOp_crossRegionClient_existingOverrideConfig_SuccessfullyIntercepts(Consumer<MockSyncHttpClient> stubConsumer,
-                                                                                    Class<?> endpointProviderType,
-                                                                                    String testCaseName) {
+    void given_CrossRegionClientWithExistingOverrideConfig_when_StandardOperationIsPerformed_then_SuccessfullyIntercepts(
+        Consumer<MockSyncHttpClient> stubConsumer,
+        Class<?> endpointProviderType,
+        String testCaseName) {
         stubConsumer.accept(mockSyncHttpClient);
         S3Client crossRegionClient = new S3CrossRegionSyncClient(defaultS3Client);
         GetObjectRequest request = GetObjectRequest.builder()
@@ -191,7 +193,7 @@ class S3CrossRegionSyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void paginatedOp_crossRegionClient_DoesNotIntercept(Consumer<MockSyncHttpClient> stubConsumer,
+    void given_CrossRegionClient_when_PaginatedOperationIsPerformed_then_DoesNotIntercept(Consumer<MockSyncHttpClient> stubConsumer,
                                                         Class<?> endpointProviderType,
                                                         String testCaseName)  {
         stubConsumer.accept(mockSyncHttpClient);
@@ -204,12 +206,12 @@ class S3CrossRegionSyncClientTest {
 
     @ParameterizedTest(name = "{index} - {2}.")
     @MethodSource("stubSuccessfulRedirectResponses")
-    void crossRegionClient_createdWithWrapping_SuccessfullyIntercepts(Consumer<MockSyncHttpClient> stubConsumer,
+    void given_CrossRegionClientCreatedWithWrapping_when_OperationIsPerformed_then_SuccessfullyIntercepts(Consumer<MockSyncHttpClient> stubConsumer,
                                                                       Class<?> endpointProviderType,
                                                                       String testCaseName) {
         stubConsumer.accept(mockSyncHttpClient);
-        
-        
+
+
         S3Client crossRegionClient = clientBuilder().crossRegionAccessEnabled(true).build();
         crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));
         assertThat(captureInterceptor.endpointProvider).isInstanceOf(endpointProviderType);
@@ -217,7 +219,7 @@ class S3CrossRegionSyncClientTest {
 
     @ParameterizedTest(name = "{index} - {3}.")
     @MethodSource("stubOverriddenEndpointProviderResponses")
-    void standardOp_crossRegionClient_takesCustomEndpointProviderInRequest(Consumer<MockSyncHttpClient> stubConsumer,
+    void given_CrossRegionClientWithCustomEndpointProvider_when_StandardOperationIsPerformed_then_UsesCustomEndpoint(Consumer<MockSyncHttpClient> stubConsumer,
                                                                            Class<?> endpointProviderType,
                                                                            Region region,
                                                                            String testCaseName) {
@@ -241,7 +243,7 @@ class S3CrossRegionSyncClientTest {
 
     @ParameterizedTest(name = "{index} - {3}.")
     @MethodSource("stubOverriddenEndpointProviderResponses")
-    void standardOp_crossRegionClient_takesCustomEndpointProviderInClient(Consumer<MockSyncHttpClient> stubConsumer,
+    void given_CrossRegionClientWithCustomEndpointProvider_when_StandardOperationIsPerformed_then_UsesCustomEndpointInClient(Consumer<MockSyncHttpClient> stubConsumer,
                                                                           Class<?> endpointProviderType,
                                                                           Region region,
                                                                           String testCaseName) {
@@ -263,7 +265,7 @@ class S3CrossRegionSyncClientTest {
     }
 
     @Test
-    void crossRegionClient_CallsHeadObject_when_regionNameNotPresentInFallBackCall() {
+    void given_CrossRegionClientWithFallbackCall_when_RegionNameNotPresent_then_CallsHeadObject() {
         mockSyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301,  null ),
                                          customHttpResponseWithUnknownErrorCode(301,  CROSS_REGION.id() ),
                                          successHttpResponse(), successHttpResponse());
@@ -302,7 +304,7 @@ class S3CrossRegionSyncClientTest {
     }
 
     @Test
-    void crossRegionClient_when_redirectsAfterCaching() {
+    void given_crossRegionClient_when_redirectError_then_redirectsAfterCaching() {
         mockSyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301, CROSS_REGION.id()),
                                          successHttpResponse(),
                                          successHttpResponse(),
@@ -330,7 +332,7 @@ class S3CrossRegionSyncClientTest {
     }
 
     @Test
-    void crossRegionClient_when_redirectsAfterCaching_withFallBackRedirectWithNoRegion() {
+    void given_CrossRegionClient_when_noRegionInHeader_thenFallBackToRegionInHeadBucket() {
         mockSyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301,  null ),
                                          customHttpResponseWithUnknownErrorCode(301,  CROSS_REGION.id() ),
                                          successHttpResponse(),
@@ -363,7 +365,7 @@ class S3CrossRegionSyncClientTest {
 
     @ParameterizedTest(name = "{index} - Status code = {1} with HeadBucket bucket regions {3}.")
     @MethodSource("stubFailureResponses")
-    void crossRegionClient_CallsHeadObjectErrors_shouldTerminateTheAPI(
+    void given_CrossRegionClient_when_CallsHeadObjectErrors_then_ShouldTerminateTheAPI(
         Consumer<MockSyncHttpClient> stubFailureResponses,
         Integer statusCode, Integer numberOfRequests,
         List<String> redirectedBucketRegions,
@@ -389,7 +391,7 @@ class S3CrossRegionSyncClientTest {
     }
 
     @Test
-    void crossRegionClient_CallsHeadObjectWithNoRegion_shouldTerminateHeadBucketAPI() {
+    void given_CrossRegionClient_when_CallsHeadObjectWithNoRegion_then_ShouldTerminateHeadBucketAPI() {
         mockSyncHttpClient.stubResponses(customHttpResponseWithUnknownErrorCode(301,  null ),
                                          customHttpResponseWithUnknownErrorCode(301,  null ),
                                          successHttpResponse(), successHttpResponse());
@@ -414,7 +416,7 @@ class S3CrossRegionSyncClientTest {
 
 
     @Test
-    void standardOp_crossRegionClient_containUserAgent() {
+    void given_CrossRegionClient_when_StandardOperation_then_ContainsUserAgent() {
         mockSyncHttpClient.stubResponses(successHttpResponse());
         S3Client crossRegionClient = clientBuilder().crossRegionAccessEnabled(true).build();
         crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));
@@ -422,7 +424,7 @@ class S3CrossRegionSyncClientTest {
     }
 
     @Test
-    void standardOp_simpleClient_doesNotContainCrossRegionUserAgent() {
+    void given_SimpleClient_when_StandardOperation_then_DoesNotContainCrossRegionUserAgent() {
         mockSyncHttpClient.stubResponses(successHttpResponse());
         S3Client crossRegionClient = clientBuilder().crossRegionAccessEnabled(false).build();
         crossRegionClient.getObject(r -> r.bucket(BUCKET).key(KEY));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Cross region feature fails to do Cross region calls when US_EAST_1 as client region and trying to access Bucket which were created in other regions.
- Note that we already had Integ test for this , yet this issue was not reproucible in Integ since we are creating New Buckets in cross regions and testing the US_EAST_1 immediately
- This issue is reproducible only if Buckets existed for a long time more than 48 hour.

## Modifications
<!--- Describe your changes in detail -->
- Updated the logic to consider as redirect when we Get AuthorizationHeaderMalformed error.
- When we get AuthorizationHeaderMalformed we will do a HeadBucket Call and AuthorizationHeaderMalformed for HeadBucket always contains x-amz-bucket headers and thus we will get the Cross region bucket
- For any Error if we find x-amzn-bucket-region in the response then this Region will be used in doing cross region calls


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added Junits 
- Tested on integ by accessing an Old cross region. bucket from US_EAST_1 and making sure its redirected

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
