### PR TITLE
Resettable Chunked Encoding streams and other TODOs

### DIFF
--- a/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/HttpAuthAwsCrt.java
+++ b/core/http-auth-aws-crt/src/main/java/software/amazon/awssdk/http/auth/aws/crt/HttpAuthAwsCrt.java
@@ -23,5 +23,5 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * (http-auth-aws), and should bring in the required dependencies (aws-crt).
  */
 @SdkProtectedApi
-public class HttpAuthAwsCrt {
+public final class HttpAuthAwsCrt {
 }

--- a/core/http-auth-aws-eventstream/src/main/java/software/amazon/awssdk/http/auth/aws/eventstream/HttpAuthAwsEventStream.java
+++ b/core/http-auth-aws-eventstream/src/main/java/software/amazon/awssdk/http/auth/aws/eventstream/HttpAuthAwsEventStream.java
@@ -23,5 +23,5 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * dependency in consumers (http-auth-aws), and should bring in the required dependencies (eventstream).
  */
 @SdkProtectedApi
-public class HttpAuthAwsEventStream {
+public final class HttpAuthAwsEventStream {
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/RollingSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/RollingSigner.java
@@ -73,7 +73,7 @@ public final class RollingSigner {
 
     public byte[] sign(Map<String, List<String>> headerMap) {
         AwsSigningResult result = signTrailerHeaders(headerMap, previousSignature, signingConfig);
-        return result != null ? result.getSignature() : null;
+        return result != null ? result.getSignature() : new byte[0];
     }
 
     public void reset() {

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aChunkExtensionProvider.java
@@ -17,8 +17,8 @@ package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
 
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.ChunkExtensionProvider;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
+import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.ChunkExtensionProvider;
 import software.amazon.awssdk.utils.Pair;
 
 @SdkInternalApi

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aChunkExtensionProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
+
+import java.nio.charset.StandardCharsets;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.ChunkExtensionProvider;
+import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
+import software.amazon.awssdk.utils.Pair;
+
+@SdkInternalApi
+public class SigV4aChunkExtensionProvider implements ChunkExtensionProvider {
+
+    private final RollingSigner signer;
+    private final CredentialScope credentialScope;
+
+    public SigV4aChunkExtensionProvider(RollingSigner signer, CredentialScope credentialScope) {
+        this.signer = signer;
+        this.credentialScope = credentialScope;
+    }
+
+    @Override
+    public void reset() {
+        signer.reset();
+    }
+
+    @Override
+    public Pair<byte[], byte[]> get(byte[] chunk) {
+        byte[] chunkSig = signer.sign(chunk);
+        return Pair.of(
+            "chunk-signature".getBytes(StandardCharsets.UTF_8),
+            chunkSig
+        );
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aTrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aTrailerProvider.java
@@ -22,8 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.TrailerProvider;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
+import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.TrailerProvider;
 import software.amazon.awssdk.utils.Pair;
 
 @SdkInternalApi

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aTrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aTrailerProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.TrailerProvider;
+import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
+import software.amazon.awssdk.utils.Pair;
+
+@SdkInternalApi
+public class SigV4aTrailerProvider implements TrailerProvider {
+
+    private final List<TrailerProvider> trailerProviders = new ArrayList<>();
+    private final RollingSigner signer;
+    private final CredentialScope credentialScope;
+
+    public SigV4aTrailerProvider(List<TrailerProvider> trailerProviders, RollingSigner signer, CredentialScope credentialScope) {
+        this.trailerProviders.addAll(trailerProviders);
+        this.signer = signer;
+        this.credentialScope = credentialScope;
+    }
+
+    @Override
+    public void reset() {
+        trailerProviders.forEach(TrailerProvider::reset);
+        signer.reset();
+    }
+
+    @Override
+    public Pair<String, List<String>> get() {
+        byte[] trailerSig = signer.sign(getTrailers());
+        return Pair.of(
+            "x-amz-trailer-signature",
+            Collections.singletonList(new String(trailerSig, StandardCharsets.UTF_8))
+        );
+    }
+
+    private Map<String, List<String>> getTrailers() {
+        // Get the headers by calling get() on each of the trailers
+        return trailerProviders.stream().map(TrailerProvider::get).collect(Collectors.toMap(Pair::left, Pair::right));
+
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
@@ -15,39 +15,33 @@
 
 package software.amazon.awssdk.http.auth.aws.internal.signer;
 
-import static software.amazon.awssdk.http.auth.aws.internal.signer.V4CanonicalRequest.getCanonicalHeaders;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.V4CanonicalRequest.getCanonicalHeadersString;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.checksumHeaderName;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.fromChecksumAlgorithm;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.STREAMING_SIGNED_PAYLOAD;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.STREAMING_SIGNED_PAYLOAD_TRAILER;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.STREAMING_UNSIGNED_PAYLOAD_TRAILER;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_CONTENT_SHA256;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_TRAILER;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerUtils.hash;
-import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerUtils.moveContentLength;
-import static software.amazon.awssdk.utils.BinaryUtils.toHex;
+import static software.amazon.awssdk.http.auth.aws.internal.util.ChecksumUtil.checksumHeaderName;
+import static software.amazon.awssdk.http.auth.aws.internal.util.ChecksumUtil.fromChecksumAlgorithm;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.STREAMING_SIGNED_PAYLOAD;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.STREAMING_SIGNED_PAYLOAD_TRAILER;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.STREAMING_UNSIGNED_PAYLOAD_TRAILER;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.X_AMZ_CONTENT_SHA256;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerConstant.X_AMZ_TRAILER;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerUtils.moveContentLength;
 
-import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.SdkChecksum;
-import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.ChunkedEncodedInputStream;
-import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.TrailerProvider;
-import software.amazon.awssdk.http.auth.aws.internal.signer.io.ChecksumInputStream;
+import software.amazon.awssdk.http.auth.aws.internal.checksums.SdkChecksum;
+import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.ChecksumTrailerProvider;
+import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.ChunkedEncodedInputStream;
+import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.SigV4ChunkExtensionProvider;
+import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.SigV4TrailerProvider;
+import software.amazon.awssdk.http.auth.aws.internal.chunkedencoding.TrailerProvider;
+import software.amazon.awssdk.http.auth.aws.internal.io.ChecksumInputStream;
+import software.amazon.awssdk.http.auth.aws.internal.io.ResettableContentStreamProvider;
 import software.amazon.awssdk.utils.Pair;
-import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -56,8 +50,6 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkInternalApi
 public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
-
-    private static final String EMPTY_HASH = toHex(hash(""));
 
     private final CredentialScope credentialScope;
     private final int chunkSize;
@@ -82,10 +74,9 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
             () -> new IllegalArgumentException(X_AMZ_CONTENT_SHA256 + " must be set!")
         );
 
-        InputStream inputStream = payload != null ? payload.newStream() : new StringInputStream("");
         ChunkedEncodedInputStream.Builder chunkedEncodedInputStreamBuilder = ChunkedEncodedInputStream
             .builder()
-            .inputStream(inputStream)
+            .inputStream(payload.newStream())
             .chunkSize(chunkSize)
             .header(chunk -> Integer.toHexString(chunk.length).getBytes(StandardCharsets.UTF_8));
         setupPreExistingTrailers(chunkedEncodedInputStreamBuilder, request);
@@ -110,7 +101,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
                 throw new UnsupportedOperationException();
         }
 
-        return chunkedEncodedInputStreamBuilder::build;
+        return new ResettableContentStreamProvider(chunkedEncodedInputStreamBuilder::build);
     }
 
     @Override
@@ -125,24 +116,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
      * signature is dependent on the request signature ("seed" signature).
      */
     private void setupSigExt(ChunkedEncodedInputStream.Builder builder, RollingSigner rollingSigner) {
-        Function<byte[], String> extTemplate = chunk -> rollingSigner.sign(
-            previousSignature ->
-                String.join("\n",
-                            "AWS4-HMAC-SHA256-PAYLOAD",
-                            credentialScope.getDatetime(),
-                            credentialScope.scope(),
-                            previousSignature,
-                            EMPTY_HASH,
-                            toHex(hash(chunk))
-                )
-        );
-
-        builder.addExtension(
-            chunk -> Pair.of(
-                "chunk-signature".getBytes(StandardCharsets.UTF_8),
-                extTemplate.apply(chunk).getBytes(StandardCharsets.UTF_8)
-            )
-        );
+        builder.addExtension(new SigV4ChunkExtensionProvider(rollingSigner, credentialScope));
     }
 
     /**
@@ -153,39 +127,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
      */
     private void setupSigTrailer(ChunkedEncodedInputStream.Builder builder, RollingSigner rollingSigner) {
         List<TrailerProvider> trailers = builder.trailers();
-
-        Supplier<String> sigSupplier = () -> rollingSigner.sign(
-            previousSignature -> {
-                // Get the headers by calling get() on each of the trailers
-                Map<String, List<String>> headers =
-                    trailers.stream().map(TrailerProvider::get).collect(
-                        Collectors.toMap(
-                            Pair::left,
-                            Pair::right
-                        )
-                    );
-
-                String canonicalHeadersString = getCanonicalHeadersString(getCanonicalHeaders(headers));
-                String canonicalHashHex = toHex(hash(canonicalHeadersString));
-
-                // build the string-to-sign template for the rolling-signer to sign
-                return String.join("\n",
-                                   "AWS4-HMAC-SHA256-TRAILER",
-                                   credentialScope.getDatetime(),
-                                   credentialScope.scope(),
-                                   previousSignature,
-                                   canonicalHashHex
-                );
-            }
-
-        );
-
-        builder.addTrailer(
-            () -> Pair.of(
-                "x-amz-trailer-signature",
-                Collections.singletonList(sigSupplier.get())
-            )
-        );
+        builder.addTrailer(new SigV4TrailerProvider(trailers, rollingSigner, credentialScope));
     }
 
     /**
@@ -204,10 +146,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
         );
         String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
 
-        TrailerProvider checksumTrailer = () -> Pair.of(
-            checksumHeaderName,
-            Collections.singletonList(sdkChecksum.getChecksum())
-        );
+        TrailerProvider checksumTrailer = new ChecksumTrailerProvider(sdkChecksum, checksumHeaderName);
 
         request.appendHeader(X_AMZ_TRAILER, checksumHeaderName);
         builder.inputStream(checksumInputStream).addTrailer(checksumTrailer);

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProvider.java
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 
 import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.http.auth.aws.internal.checksums.SdkChecksum;
+import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.SdkChecksum;
 import software.amazon.awssdk.utils.Pair;
 
 @SdkInternalApi

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
+
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.internal.checksums.SdkChecksum;
+import software.amazon.awssdk.utils.Pair;
+
+@SdkInternalApi
+public class ChecksumTrailerProvider implements TrailerProvider {
+
+    private final SdkChecksum checksum;
+    private final String checksumName;
+
+    public ChecksumTrailerProvider(SdkChecksum checksum, String checksumName) {
+        this.checksum = checksum;
+        this.checksumName = checksumName;
+    }
+
+    @Override
+    public void reset() {
+        checksum.reset();
+    }
+
+    @Override
+    public Pair<String, List<String>> get() {
+        return Pair.of(
+            checksumName,
+            Collections.singletonList(checksum.getChecksum())
+        );
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkExtensionProvider.java
@@ -31,6 +31,6 @@ import software.amazon.awssdk.utils.Pair;
  */
 @FunctionalInterface
 @SdkInternalApi
-public interface ChunkExtensionProvider {
+public interface ChunkExtensionProvider extends Resettable {
     Pair<byte[], byte[]> get(byte[] chunk);
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java
@@ -188,15 +188,18 @@ public final class ChunkedEncodedInputStream extends InputStream {
     }
 
     @Override
-    public synchronized void mark(int readlimit) {
-        // TODO(sra-identity-and-auth): Implement this, likely needed for retries
-        throw new UnsupportedOperationException();
+    public void reset() throws IOException {
+        trailers.forEach(TrailerProvider::reset);
+        extensions.forEach(ChunkExtensionProvider::reset);
+        header.reset();
+        inputStream.reset();
+        isFinished = false;
+        currentChunk = null;
     }
 
     @Override
-    public synchronized void reset() {
-        // TODO(sra-identity-and-auth): Implement this, likely needed for retries
-        throw new UnsupportedOperationException();
+    public void close() throws IOException {
+        inputStream.close();
     }
 
     public static class Builder {

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/Resettable.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/Resettable.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 
 import software.amazon.awssdk.annotations.SdkInternalApi;
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/Resettable.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/Resettable.java
@@ -13,19 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
+package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
 
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
-/**
- * A functional interface for defining a header of a chunk.
- * <p>
- * The header usually depends on the chunk-data itself (hex-size), but is not required to. In <a
- * href="https://datatracker.ietf.org/doc/html/rfc7230#section-4.1">RFC-7230</a>, the chunk-header is specifically the
- * {@code chunk-size}, but this interface can give us greater flexibility.
- */
-@FunctionalInterface
 @SdkInternalApi
-public interface ChunkHeaderProvider extends Resettable {
-    byte[] get(byte[] chunk);
+public interface Resettable {
+    default void reset() {
+    }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4ChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4ChunkExtensionProvider.java
@@ -13,9 +13,9 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 
-import static software.amazon.awssdk.http.auth.aws.internal.util.SignerUtils.hash;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerUtils.hash;
 import static software.amazon.awssdk.utils.BinaryUtils.toHex;
 
 import java.nio.charset.StandardCharsets;

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4ChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4ChunkExtensionProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
+
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerUtils.hash;
+import static software.amazon.awssdk.utils.BinaryUtils.toHex;
+
+import java.nio.charset.StandardCharsets;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
+import software.amazon.awssdk.http.auth.aws.internal.signer.RollingSigner;
+import software.amazon.awssdk.utils.Pair;
+
+@SdkInternalApi
+public class SigV4ChunkExtensionProvider implements ChunkExtensionProvider {
+
+    private static final String EMPTY_HASH = toHex(hash(""));
+
+    private final RollingSigner signer;
+    private final CredentialScope credentialScope;
+
+    public SigV4ChunkExtensionProvider(RollingSigner signer, CredentialScope credentialScope) {
+        this.signer = signer;
+        this.credentialScope = credentialScope;
+    }
+
+    @Override
+    public void reset() {
+        signer.reset();
+    }
+
+    private String getStringToSign(String previousSignature, byte[] chunk) {
+        // build the string-to-sign template for the rolling-signer to sign
+        return String.join("\n",
+                           "AWS4-HMAC-SHA256-PAYLOAD",
+                           credentialScope.getDatetime(),
+                           credentialScope.scope(),
+                           previousSignature,
+                           EMPTY_HASH,
+                           toHex(hash(chunk))
+        );
+    }
+
+    @Override
+    public Pair<byte[], byte[]> get(byte[] chunk) {
+        String chunkSig = signer.sign(previousSig -> getStringToSign(previousSig, chunk));
+        return Pair.of(
+            "chunk-signature".getBytes(StandardCharsets.UTF_8),
+            chunkSig.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4TrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4TrailerProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
+
+import static software.amazon.awssdk.http.auth.aws.internal.signer.V4CanonicalRequest.getCanonicalHeaders;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.V4CanonicalRequest.getCanonicalHeadersString;
+import static software.amazon.awssdk.http.auth.aws.internal.util.SignerUtils.hash;
+import static software.amazon.awssdk.utils.BinaryUtils.toHex;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
+import software.amazon.awssdk.http.auth.aws.internal.signer.RollingSigner;
+import software.amazon.awssdk.utils.Pair;
+
+@SdkInternalApi
+public class SigV4TrailerProvider implements TrailerProvider {
+
+    private final List<TrailerProvider> trailerProviders = new ArrayList<>();
+    private final RollingSigner signer;
+    private final CredentialScope credentialScope;
+
+    public SigV4TrailerProvider(List<TrailerProvider> trailerProviders, RollingSigner signer, CredentialScope credentialScope) {
+        this.trailerProviders.addAll(trailerProviders);
+        this.signer = signer;
+        this.credentialScope = credentialScope;
+    }
+
+    @Override
+    public void reset() {
+        trailerProviders.forEach(TrailerProvider::reset);
+        signer.reset();
+    }
+
+    @Override
+    public Pair<String, List<String>> get() {
+        String trailerSig = signer.sign(this::getTrailersStringToSign);
+        return Pair.of(
+            "x-amz-trailer-signature",
+            Collections.singletonList(trailerSig)
+        );
+    }
+
+    private String getTrailersStringToSign(String previousSignature) {
+        // Get the headers by calling get() on each of the trailers
+        Map<String, List<String>> headers =
+            trailerProviders.stream().map(TrailerProvider::get).collect(
+                Collectors.toMap(
+                    Pair::left,
+                    Pair::right
+                )
+            );
+
+        String canonicalHeadersString = getCanonicalHeadersString(getCanonicalHeaders(headers));
+        String canonicalHashHex = toHex(hash(canonicalHeadersString));
+
+        // build the string-to-sign template for the rolling-signer to sign
+        return String.join("\n",
+                           "AWS4-HMAC-SHA256-TRAILER",
+                           credentialScope.getDatetime(),
+                           credentialScope.scope(),
+                           previousSignature,
+                           canonicalHashHex
+        );
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4TrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4TrailerProvider.java
@@ -13,11 +13,11 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.auth.aws.internal.chunkedencoding;
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 
 import static software.amazon.awssdk.http.auth.aws.internal.signer.V4CanonicalRequest.getCanonicalHeaders;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.V4CanonicalRequest.getCanonicalHeadersString;
-import static software.amazon.awssdk.http.auth.aws.internal.util.SignerUtils.hash;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerUtils.hash;
 import static software.amazon.awssdk.utils.BinaryUtils.toHex;
 
 import java.util.ArrayList;

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/TrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/TrailerProvider.java
@@ -32,6 +32,6 @@ import software.amazon.awssdk.utils.Pair;
  */
 @FunctionalInterface
 @SdkInternalApi
-public interface TrailerProvider {
+public interface TrailerProvider extends Resettable {
     Pair<String, List<String>> get();
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/io/ResettableContentStreamProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/io/ResettableContentStreamProvider.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.auth.aws.internal.io;
+package software.amazon.awssdk.http.auth.aws.internal.signer.io;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/io/ResettableContentStreamProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/io/ResettableContentStreamProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.ContentStreamProvider;
+
+@SdkInternalApi
+public class ResettableContentStreamProvider implements ContentStreamProvider {
+    private final Supplier<InputStream> streamSupplier;
+    private InputStream currentStream;
+
+    public ResettableContentStreamProvider(Supplier<InputStream> streamSupplier) {
+        this.streamSupplier = streamSupplier;
+    }
+
+    @Override
+    public InputStream newStream() {
+        try {
+            reset();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create new stream: ", e);
+        }
+        return currentStream;
+    }
+
+    private void reset() throws IOException {
+        if (currentStream != null) {
+            currentStream.reset();
+        } else {
+            currentStream = streamSupplier.get();
+        }
+    }
+}


### PR DESCRIPTION
## Modifications
- Fixes a bug where the stream provider returned from signing is not resettable (via `newStream`)
- Refactors some of the chunk-encoding logic so that resetting is possible
- Adds `reset()` implementation to `ChunkedEncodedInputStream`, `mark()` is not supported (and is made clear through `markSupported` returning false)
- Makes signer module classes final

## Testing
- Run new and existing tests, make sure pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
