### PR TITLE
Rename http-auth-aws-event-stream module to http-auth-aws-eventstream

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -39,7 +39,7 @@
         "http-auth": { "packageName": "AwsJavaSdk-Core-HttpAuth" },
         "http-auth-aws": { "packageName": "AwsJavaSdk-Core-HttpAuthAws" },
         "http-auth-aws-crt": { "packageName": "AwsJavaSdk-Core-HttpAuthAwsCrt" },
-        "http-auth-aws-event-stream": { "packageName": "AwsJavaSdk-Core-HttpAuthAwsEventStream" },
+        "http-auth-aws-eventstream": { "packageName": "AwsJavaSdk-Core-HttpAuthAwsEventStream" },
 
         "dynamodb": { "packageName": "AwsJavaSdk-DynamoDb" },
         "waf": { "packageName": "AwsJavaSdk-Waf" },

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -159,7 +159,7 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
-                <artifactId>http-auth-aws-event-stream</artifactId>
+                <artifactId>http-auth-aws-eventstream</artifactId>
                 <version>${awsjavasdk.version}</version>
             </dependency>
             <dependency>

--- a/core/http-auth-aws-eventstream/pom.xml
+++ b/core/http-auth-aws-eventstream/pom.xml
@@ -25,7 +25,7 @@
         <version>2.20.144-SNAPSHOT</version>
     </parent>
 
-    <artifactId>http-auth-aws-event-stream</artifactId>
+    <artifactId>http-auth-aws-eventstream</artifactId>
     <name>AWS Java SDK :: HTTP Auth Event Stream</name>
     <description>
         The AWS SDK for Java - HTTP Auth AWS Event Stream module contains interfaces and implementations for AWS

--- a/core/http-auth-aws-eventstream/src/main/java/software/amazon/awssdk/http/auth/aws/eventstream/HttpAuthAwsEventStream.java
+++ b/core/http-auth-aws-eventstream/src/main/java/software/amazon/awssdk/http/auth/aws/eventstream/HttpAuthAwsEventStream.java
@@ -18,7 +18,7 @@ package software.amazon.awssdk.http.auth.aws.eventstream;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
- * This is a place-holder class for this module, http-auth-aws-event-stream. In the event that we decide to move back
+ * This is a place-holder class for this module, http-auth-aws-eventstream. In the event that we decide to move back
  * event-stream signer logic back to this dedicated module, no issues will arise. This module should be an optional
  * dependency in consumers (http-auth-aws), and should bring in the required dependencies (eventstream).
  */

--- a/core/http-auth-aws/pom.xml
+++ b/core/http-auth-aws/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>http-auth-aws-event-stream</artifactId>
+            <artifactId>http-auth-aws-eventstream</artifactId>
             <version>${awsjavasdk.version}</version>
             <optional>true</optional>
         </dependency>

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/util/OptionalDependencyLoaderUtil.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/util/OptionalDependencyLoaderUtil.java
@@ -37,7 +37,7 @@ public final class OptionalDependencyLoaderUtil {
     private static final String HTTP_AUTH_AWS_CRT_MODULE = "software.amazon.awssdk:http-auth-aws-crt";
     private static final String HTTP_AUTH_AWS_EVENT_STREAM_PATH =
         "software.amazon.awssdk.http.auth.aws.eventstream.HttpAuthAwsEventStream";
-    private static final String HTTP_AUTH_AWS_EVENT_STREAM_MODULE = "software.amazon.awssdk:http-auth-aws-event-stream";
+    private static final String HTTP_AUTH_AWS_EVENT_STREAM_MODULE = "software.amazon.awssdk:http-auth-aws-eventstream";
 
     private OptionalDependencyLoaderUtil() {
     }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -155,7 +155,7 @@ public class DefaultAwsV4HttpSignerTest {
                 false)
             ).thenThrow(new ClassNotFoundException("boom!"));
             Exception e = assertThrows(RuntimeException.class, () -> signer.sign(request));
-            assertThat(e).hasMessageContaining("http-auth-aws-event-stream");
+            assertThat(e).hasMessageContaining("http-auth-aws-eventstream");
         }
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
         <module>http-auth</module>
         <module>http-auth-aws</module>
         <module>http-auth-aws-crt</module>
-        <module>http-auth-aws-event-stream</module>
+        <module>http-auth-aws-eventstream</module>
         <module>auth-crt</module>
         <module>sdk-core</module>
         <module>aws-core</module>

--- a/test/tests-coverage-reporting/pom.xml
+++ b/test/tests-coverage-reporting/pom.xml
@@ -83,7 +83,7 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <artifactId>http-auth-aws-event-stream</artifactId>
+            <artifactId>http-auth-aws-eventstream</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>
         </dependency>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
We are currently using `software.amazon.awssdk.http.auth.aws.eventstream` as the java package name and the module name is `http-auth-aws-event-stream`. The event stream dependency is:
```
<groupId>software.amazon.eventstream</groupId>
<artifactId>eventstream</artifactId>
```
in repo https://github.com/awslabs/aws-eventstream-java/.

So renaming the module to http-auth-aws-eventstream to be consistent with other usage.

## Modifications
<!--- Describe your changes in detail -->
 Rename http-auth-aws-event-stream module to http-auth-aws-eventstream #4436 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI rebuild
