### PR TITLE
Update AwsV4aHttpSigner to use RegionSet

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/EndpointBasedAuthSchemeProviderSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/EndpointBasedAuthSchemeProviderSpec.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
@@ -174,11 +173,7 @@ public class EndpointBasedAuthSchemeProviderSpec implements ClassSpec {
                           SigV4aAuthScheme.class, Validate.class, SigV4aAuthScheme.class,
                           "Expecting auth scheme of class SigV4AuthScheme, got instead object of class %s");
 
-        spec.addStatement("$T signingRegionSet = sigv4aAuthScheme.signingRegionSet()", ParameterizedTypeName.get(List.class,
-                                                                                                                 String.class));
-        spec.addStatement("$1T regionSet = $1T.create(signingRegionSet.stream().collect($2T.joining(\",\")))",
-                          RegionSet.class, Collectors.class
-        );
+        spec.addStatement("$1T regionSet = $1T.create(sigv4aAuthScheme.signingRegionSet())", RegionSet.class);
 
         spec.addCode("options.add($T.builder().schemeId($S)", AuthSchemeOption.class, AwsV4aAuthScheme.SCHEME_ID)
             .addCode(".putSignerProperty($T.SERVICE_SIGNING_NAME, sigv4aAuthScheme.signingName())", AwsV4aHttpSigner.class)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/EndpointBasedAuthSchemeProviderSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/EndpointBasedAuthSchemeProviderSpec.java
@@ -37,7 +37,6 @@ import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
@@ -180,10 +179,6 @@ public class EndpointBasedAuthSchemeProviderSpec implements ClassSpec {
         spec.addStatement("$1T regionSet = $1T.create(signingRegionSet.stream().collect($2T.joining(\",\")))",
                           RegionSet.class, Collectors.class
         );
-
-        spec.beginControlFlow("if (regionSet.toString().isEmpty())")
-            .addStatement("throw $T.create($S)", SdkClientException.class, "Signing region set is empty")
-            .endControlFlow();
 
         spec.addCode("options.add($T.builder().schemeId($S)", AuthSchemeOption.class, AwsV4aAuthScheme.SCHEME_ID)
             .addCode(".putSignerProperty($T.SERVICE_SIGNING_NAME, sigv4aAuthScheme.signingName())", AwsV4aHttpSigner.class)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
@@ -598,9 +597,7 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         code.endControlFlow();
 
         code.beginControlFlow("if (v4aAuthScheme.signingRegionSet() != null)");
-        code.addStatement("$1T regionSet = $1T.create(v4aAuthScheme.signingRegionSet().stream().collect($2T.joining(\",\")))",
-                          RegionSet.class, Collectors.class
-        );
+        code.addStatement("$1T regionSet = $1T.create(v4aAuthScheme.signingRegionSet())", RegionSet.class);
 
         code.addStatement("option.putSignerProperty($T.REGION_SET, regionSet)", AwsV4aHttpSigner.class);
         code.endControlFlow();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
@@ -64,6 +65,7 @@ import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -596,8 +598,11 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         code.endControlFlow();
 
         code.beginControlFlow("if (v4aAuthScheme.signingRegionSet() != null)");
-        code.addStatement("option.putSignerProperty($T.REGION_NAME, $T.join(\",\", v4aAuthScheme.signingRegionSet()))",
-                          AwsV4aHttpSigner.class, String.class);
+        code.addStatement("$1T regionSet = $1T.create(v4aAuthScheme.signingRegionSet().stream().collect($2T.joining(\",\")))",
+                          RegionSet.class, Collectors.class
+        );
+
+        code.addStatement("option.putSignerProperty($T.REGION_SET, regionSet)", AwsV4aHttpSigner.class);
         code.endControlFlow();
 
         code.beginControlFlow("if (v4aAuthScheme.signingName() != null)");

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
@@ -3,7 +3,6 @@ package software.amazon.awssdk.services.query.auth.scheme.internal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
@@ -68,8 +67,7 @@ public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProv
                     SigV4aAuthScheme sigv4aAuthScheme = Validate.isInstanceOf(SigV4aAuthScheme.class, authScheme,
                                                                               "Expecting auth scheme of class SigV4AuthScheme, got instead object of class %s", authScheme.getClass()
                                                                                                                                                                           .getName());
-                    List<String> signingRegionSet = sigv4aAuthScheme.signingRegionSet();
-                    RegionSet regionSet = RegionSet.create(signingRegionSet.stream().collect(Collectors.joining(",")));
+                    RegionSet regionSet = RegionSet.create(sigv4aAuthScheme.signingRegionSet());
                     options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4a")
                                                 .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, sigv4aAuthScheme.signingName())
                                                 .putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet)

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
@@ -10,7 +10,6 @@ import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
 import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
@@ -71,9 +70,6 @@ public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProv
                                                                                                                                                                           .getName());
                     List<String> signingRegionSet = sigv4aAuthScheme.signingRegionSet();
                     RegionSet regionSet = RegionSet.create(signingRegionSet.stream().collect(Collectors.joining(",")));
-                    if (regionSet.toString().isEmpty()) {
-                        throw SdkClientException.create("Signing region set is empty");
-                    }
                     options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4a")
                                                 .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, sigv4aAuthScheme.signingName())
                                                 .putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet)

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider.java
@@ -3,7 +3,6 @@ package software.amazon.awssdk.services.query.auth.scheme.internal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
@@ -66,8 +65,7 @@ public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProv
                     SigV4aAuthScheme sigv4aAuthScheme = Validate.isInstanceOf(SigV4aAuthScheme.class, authScheme,
                                                                               "Expecting auth scheme of class SigV4AuthScheme, got instead object of class %s", authScheme.getClass()
                                                                                                                                                                           .getName());
-                    List<String> signingRegionSet = sigv4aAuthScheme.signingRegionSet();
-                    RegionSet regionSet = RegionSet.create(signingRegionSet.stream().collect(Collectors.joining(",")));
+                    RegionSet regionSet = RegionSet.create(sigv4aAuthScheme.signingRegionSet());
                     options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4a")
                                                 .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, sigv4aAuthScheme.signingName())
                                                 .putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet)

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider.java
@@ -10,7 +10,6 @@ import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
 import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
@@ -69,9 +68,6 @@ public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProv
                                                                                                                                                                           .getName());
                     List<String> signingRegionSet = sigv4aAuthScheme.signingRegionSet();
                     RegionSet regionSet = RegionSet.create(signingRegionSet.stream().collect(Collectors.joining(",")));
-                    if (regionSet.toString().isEmpty()) {
-                        throw SdkClientException.create("Signing region set is empty");
-                    }
                     options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4a")
                                                 .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, sigv4aAuthScheme.signingName())
                                                 .putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet)

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.query.auth.scheme.internal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
@@ -13,6 +14,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
@@ -66,15 +68,13 @@ public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProv
                                                                               "Expecting auth scheme of class SigV4AuthScheme, got instead object of class %s", authScheme.getClass()
                                                                                                                                                                           .getName());
                     List<String> signingRegionSet = sigv4aAuthScheme.signingRegionSet();
-                    if (signingRegionSet.size() == 0) {
+                    RegionSet regionSet = RegionSet.create(signingRegionSet.stream().collect(Collectors.joining(",")));
+                    if (regionSet.toString().isEmpty()) {
                         throw SdkClientException.create("Signing region set is empty");
-                    }
-                    if (signingRegionSet.size() > 1) {
-                        throw SdkClientException.create("Don't know how to set scope of > 1 region");
                     }
                     options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4a")
                                                 .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, sigv4aAuthScheme.signingName())
-                                                .putSignerProperty(AwsV4aHttpSigner.REGION_NAME, signingRegionSet.get(0))
+                                                .putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet)
                                                 .putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, !sigv4aAuthScheme.disableDoubleEncoding()).build());
                     break;
                 default:

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -3,7 +3,6 @@ package software.amazon.awssdk.services.query.endpoints.internal;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
@@ -149,8 +148,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
                     option.putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, !v4aAuthScheme.disableDoubleEncoding());
                 }
                 if (v4aAuthScheme.signingRegionSet() != null) {
-                    RegionSet regionSet = RegionSet.create(v4aAuthScheme.signingRegionSet().stream()
-                                                                        .collect(Collectors.joining(",")));
+                    RegionSet regionSet = RegionSet.create(v4aAuthScheme.signingRegionSet());
                     option.putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet);
                 }
                 if (v4aAuthScheme.signingName() != null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.query.endpoints.internal;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
@@ -22,6 +23,7 @@ import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.services.query.endpoints.QueryClientContextParams;
@@ -147,7 +149,9 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
                     option.putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, !v4aAuthScheme.disableDoubleEncoding());
                 }
                 if (v4aAuthScheme.signingRegionSet() != null) {
-                    option.putSignerProperty(AwsV4aHttpSigner.REGION_NAME, String.join(",", v4aAuthScheme.signingRegionSet()));
+                    RegionSet regionSet = RegionSet.create(v4aAuthScheme.signingRegionSet().stream()
+                                                                        .collect(Collectors.joining(",")));
+                    option.putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet);
                 }
                 if (v4aAuthScheme.signingName() != null) {
                     option.putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, v4aAuthScheme.signingName());

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
@@ -272,11 +272,11 @@ public final class AwsSignerExecutionAttribute extends SdkExecutionAttribute {
             return null;
         }
         RegionSet regionSet = authScheme.authSchemeOption().signerProperty(AwsV4aHttpSigner.REGION_SET);
-        if (regionSet == null || regionSet.id().isEmpty()) {
+        if (regionSet == null || regionSet.asString().isEmpty()) {
             return null;
         }
 
-        return RegionScope.create(regionSet.id());
+        return RegionScope.create(regionSet.asString());
     }
 
     private static <T extends Identity> SelectedAuthScheme<?> signingRegionScopeWriteMapping(SelectedAuthScheme<T> authScheme,

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
@@ -272,11 +272,11 @@ public final class AwsSignerExecutionAttribute extends SdkExecutionAttribute {
             return null;
         }
         RegionSet regionSet = authScheme.authSchemeOption().signerProperty(AwsV4aHttpSigner.REGION_SET);
-        if (regionSet == null || regionSet.toString().isEmpty()) {
+        if (regionSet == null || regionSet.id().isEmpty()) {
             return null;
         }
 
-        return RegionScope.create(regionSet.toString());
+        return RegionScope.create(regionSet.id());
     }
 
     private static <T extends Identity> SelectedAuthScheme<?> signingRegionScopeWriteMapping(SelectedAuthScheme<T> authScheme,

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttribute.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
@@ -270,16 +271,17 @@ public final class AwsSignerExecutionAttribute extends SdkExecutionAttribute {
         if (authScheme == null) {
             return null;
         }
-        String regionScope = authScheme.authSchemeOption().signerProperty(AwsV4aHttpSigner.REGION_NAME);
-        if (regionScope == null) {
+        RegionSet regionSet = authScheme.authSchemeOption().signerProperty(AwsV4aHttpSigner.REGION_SET);
+        if (regionSet == null || regionSet.toString().isEmpty()) {
             return null;
         }
-        return RegionScope.create(regionScope);
+
+        return RegionScope.create(regionSet.toString());
     }
 
     private static <T extends Identity> SelectedAuthScheme<?> signingRegionScopeWriteMapping(SelectedAuthScheme<T> authScheme,
                                                                                              RegionScope regionScope) {
-        String regionScopeString = regionScope == null ? null : regionScope.id();
+        RegionSet regionSet = regionScope != null ? RegionSet.create(regionScope.id()) : null;
 
         if (authScheme == null) {
             // This is an unusual use-case.
@@ -289,15 +291,14 @@ public final class AwsSignerExecutionAttribute extends SdkExecutionAttribute {
                                             new UnsetHttpSigner(),
                                             AuthSchemeOption.builder()
                                                             .schemeId("unset")
-                                                            .putSignerProperty(AwsV4aHttpSigner.REGION_NAME,
-                                                                               regionScopeString)
+                                                            .putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet)
                                                             .build());
         }
 
         return new SelectedAuthScheme<>(authScheme.identity(),
                                         authScheme.signer(),
-                                        authScheme.authSchemeOption().copy(o -> o.putSignerProperty(AwsV4aHttpSigner.REGION_NAME,
-                                                                                                    regionScopeString)));
+                                        authScheme.authSchemeOption().copy(o -> o.putSignerProperty(AwsV4aHttpSigner.REGION_SET,
+                                                                                                    regionSet)));
     }
 
     private static String serviceSigningNameReadMapping(SelectedAuthScheme<?> authScheme) {

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
@@ -127,7 +127,7 @@ class AwsSignerExecutionAttributeTest {
                                 new SelectedAuthScheme<>(EMPTY_SELECTED_AUTH_SCHEME.identity(),
                                                          EMPTY_SELECTED_AUTH_SCHEME.signer(),
                                                          newOption));
-        assertThrows(UnsupportedOperationException.class, () -> attributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE));
+        assertThrows(IllegalArgumentException.class, () -> attributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE));
     }
 
     @Test

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.auth.signer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -33,6 +34,7 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
 import software.amazon.awssdk.http.auth.spi.signer.SignerProperty;
@@ -110,9 +112,22 @@ class AwsSignerExecutionAttributeTest {
     @Test
     public void signingRegionScope_oldAndNewAttributeAreMirrored() {
         assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE,
-                                             AwsV4aHttpSigner.REGION_NAME,
+                                             AwsV4aHttpSigner.REGION_SET,
                                              RegionScope.create("foo"),
-                                             "foo");
+                                             RegionSet.create("foo")
+        );
+    }
+
+    @Test
+    public void signingRegionScope_mappingToOldWithMoreThanOneRegionScopeThrows() {
+        RegionSet regionSet = RegionSet.create("foo1,foo2");
+        AuthSchemeOption newOption =
+            EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption().copy(o -> o.putSignerProperty(AwsV4aHttpSigner.REGION_SET, regionSet));
+        attributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                new SelectedAuthScheme<>(EMPTY_SELECTED_AUTH_SCHEME.identity(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         newOption));
+        assertThrows(UnsupportedOperationException.class, () -> attributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION_SCOPE));
     }
 
     @Test

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -67,7 +67,7 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
         AwsCredentialsIdentity credentials = sanitizeCredentials(request.identity());
         RegionSet regionSet = request.requireProperty(REGION_SET, RegionSet.GLOBAL);
         String serviceSigningName = request.requireProperty(SERVICE_SIGNING_NAME);
-        CredentialScope credentialScope = new CredentialScope(regionSet.id(), serviceSigningName, signingInstant);
+        CredentialScope credentialScope = new CredentialScope(regionSet.asString(), serviceSigningName, signingInstant);
         boolean doubleUrlEncode = request.requireProperty(DOUBLE_URL_ENCODE, true);
         boolean normalizePath = request.requireProperty(NORMALIZE_PATH, true);
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -25,6 +25,7 @@ import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignin
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtHttpRequestConverter.toRequest;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.sanitizeRequest;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.toCredentials;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.CredentialUtils.isAnonymous;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.CredentialUtils.sanitizeCredentials;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.PRESIGN_URL_MAX_EXPIRATION_DURATION;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_TRAILER;
@@ -41,8 +42,8 @@ import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
-import software.amazon.awssdk.http.auth.aws.internal.signer.util.CredentialUtils;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
 import software.amazon.awssdk.http.auth.spi.signer.BaseSignRequest;
@@ -64,9 +65,9 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
         Clock signingClock = request.requireProperty(SIGNING_CLOCK, Clock.systemUTC());
         Instant signingInstant = signingClock.instant();
         AwsCredentialsIdentity credentials = sanitizeCredentials(request.identity());
-        String regionName = request.requireProperty(REGION_NAME);
+        RegionSet regionSet = request.requireProperty(REGION_SET, RegionSet.GLOBAL);
         String serviceSigningName = request.requireProperty(SERVICE_SIGNING_NAME);
-        CredentialScope credentialScope = new CredentialScope(regionName, serviceSigningName, signingInstant);
+        CredentialScope credentialScope = new CredentialScope(regionSet.toString(), serviceSigningName, signingInstant);
         boolean doubleUrlEncode = request.requireProperty(DOUBLE_URL_ENCODE, true);
         boolean normalizePath = request.requireProperty(NORMALIZE_PATH, true);
 
@@ -183,7 +184,7 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
     private static SignedRequest doSign(SignRequest<? extends AwsCredentialsIdentity> request,
                                         AwsSigningConfig signingConfig,
                                         V4aPayloadSigner payloadSigner) {
-        if (CredentialUtils.isAnonymous(request.identity())) {
+        if (isAnonymous(request.identity())) {
             return SignedRequest.builder()
                                 .request(request.request())
                                 .payload(request.payload().orElse(null))

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -67,7 +67,7 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
         AwsCredentialsIdentity credentials = sanitizeCredentials(request.identity());
         RegionSet regionSet = request.requireProperty(REGION_SET, RegionSet.GLOBAL);
         String serviceSigningName = request.requireProperty(SERVICE_SIGNING_NAME);
-        CredentialScope credentialScope = new CredentialScope(regionSet.toString(), serviceSigningName, signingInstant);
+        CredentialScope credentialScope = new CredentialScope(regionSet.id(), serviceSigningName, signingInstant);
         boolean doubleUrlEncode = request.requireProperty(DOUBLE_URL_ENCODE, true);
         boolean normalizePath = request.requireProperty(NORMALIZE_PATH, true);
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4aHttpSigner.java
@@ -31,10 +31,9 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 @SdkPublicApi
 public interface AwsV4aHttpSigner extends AwsV4FamilyHttpSigner, HttpSigner<AwsCredentialsIdentity> {
     /**
-     * The AWS region name to be used for computing the signature. This property is required.
-     * TODO(sra-identity-and-auth): Should this be a list or rename to SIGNING_SCOPE?
+     * The AWS region-set to be used for computing the signature. This property is required.
      */
-    SignerProperty<String> REGION_NAME = SignerProperty.create(String.class, "SigningScope");
+    SignerProperty<RegionSet> REGION_SET = SignerProperty.create("RegionSet");
 
     /**
      * Get a default implementation of a {@link AwsV4aHttpSigner}
@@ -42,4 +41,5 @@ public interface AwsV4aHttpSigner extends AwsV4FamilyHttpSigner, HttpSigner<AwsC
     static AwsV4aHttpSigner create() {
         return getDefaultAwsCrtV4aHttpSigner();
     }
+
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
@@ -23,13 +23,13 @@ import software.amazon.awssdk.utils.Validate;
 /**
  * This class represents the concept of a set of regions.
  * <p>
- * A Re
+ * A region-set can contain one or more comma-separated AWS regions, or a single wildcard to represent all regions ("global").
  * <p>
- * Examples of a valid region set:
+ * Examples of a valid region-set:
  * <ul>
- *     <li>'*' - Represents all regions, i.e. a global scope</li>
- *     <li>'us-west-2,us-east-1' - Represents 2 regions, us-west-2 and us-east-1</li>
+ *     <li>'*' - Represents all regions, global</li>
  *     <li>'eu-west-1' - Represents a single region, eu-west-1</li>
+ *     <li>'us-west-2,us-east-1' - Represents 2 regions, us-west-2 and us-east-1</li>
  * </ul>
  * <p>
  * Example of an invalid region set:
@@ -91,12 +91,12 @@ public final class RegionSet {
         return 31 * (1 + (regionSet != null ? regionSet.hashCode() : 0));
     }
 
-    private void validateFormat(String regionScope) {
-        Matcher matcher = REGION_SCOPE_PATTERN.matcher(regionScope.trim());
+    private void validateFormat(String regionSet) {
+        Matcher matcher = REGION_SCOPE_PATTERN.matcher(regionSet.trim());
         if (!matcher.matches()) {
-            throw new IllegalArgumentException("Invalid region '" + regionScope + "'. A region within the region-set must "
-                                               + "be a complete region, such as 'us-east-1', or the wildcard ('*') to "
-                                               + "represent all regions.");
+            throw new IllegalArgumentException("Invalid region-set '" + regionSet + "'. The region-set must be one or more "
+                                               + "complete regions, such as 'us-east-1' or 'us-west-2, us-east-1', or the " 
+                                               + "wildcard ('*') to represent all regions.");
         }
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
@@ -59,8 +59,7 @@ public final class RegionSet {
     /**
      * Gets the string representation of this RegionSet.
      */
-    @Override
-    public String toString() {
+    public String id() {
         return this.regionSet;
     }
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.signer;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * This class represents the concept of a set of regions.
+ * <p>
+ * A Re
+ * <p>
+ * Examples of a valid region set:
+ * <ul>
+ *     <li>'*' - Represents all regions, i.e. a global scope</li>
+ *     <li>'us-west-2,us-east-1' - Represents 2 regions, us-west-2 and us-east-1</li>
+ *     <li>'eu-west-1' - Represents a single region, eu-west-1</li>
+ * </ul>
+ * <p>
+ * Example of an invalid region set:
+ * <ul>
+ *     <li>'us-*-1,eu-west-1' - A wildcard must be its own item.</li>
+ * </ul>
+ */
+@SdkPublicApi
+public final class RegionSet {
+
+    public static final RegionSet GLOBAL;
+
+    private static final Pattern REGION_SCOPE_PATTERN;
+
+    static {
+        REGION_SCOPE_PATTERN = Pattern.compile("^([a-z0-9-])*|([*])$");
+        GLOBAL = create("*");
+    }
+
+    private final String regionSet;
+
+    private RegionSet(String regionSet) {
+        this.regionSet = Validate.paramNotBlank(regionSet, "regionSet");
+        validateFormat(regionSet);
+    }
+
+    /**
+     * Gets the string representation of this RegionSet.
+     */
+    @Override
+    public String toString() {
+        return this.regionSet;
+    }
+
+    /**
+     * Creates a RegionSet with the supplied value.
+     *
+     * @param value See class documentation {@link RegionSet} for the expected format.
+     */
+    public static RegionSet create(String value) {
+        return new RegionSet(value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RegionSet that = (RegionSet) o;
+
+        return regionSet.equals(that.regionSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * (1 + (regionSet != null ? regionSet.hashCode() : 0));
+    }
+
+    private void validateFormat(String regionScope) {
+        for (String region : regionScope.split(",")) {
+            Matcher matcher = REGION_SCOPE_PATTERN.matcher(region);
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Invalid region '" + region + "'. A region within the region-set must "
+                                                   + "be a complete region, such as 'us-east-1', or the wildcard ('*') to "
+                                                   + "represent all regions.");
+            }
+        }
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/RegionSet.java
@@ -45,7 +45,7 @@ public final class RegionSet {
     private static final Pattern REGION_SCOPE_PATTERN;
 
     static {
-        REGION_SCOPE_PATTERN = Pattern.compile("^([a-z0-9-])*|([*])$");
+        REGION_SCOPE_PATTERN = Pattern.compile("^(\\*|([a-zA-Z0-9-]+)(\\s*,\\s*[a-zA-Z0-9-]+)*)$");
         GLOBAL = create("*");
     }
 
@@ -93,13 +93,11 @@ public final class RegionSet {
     }
 
     private void validateFormat(String regionScope) {
-        for (String region : regionScope.split(",")) {
-            Matcher matcher = REGION_SCOPE_PATTERN.matcher(region);
-            if (!matcher.matches()) {
-                throw new IllegalArgumentException("Invalid region '" + region + "'. A region within the region-set must "
-                                                   + "be a complete region, such as 'us-east-1', or the wildcard ('*') to "
-                                                   + "represent all regions.");
-            }
+        Matcher matcher = REGION_SCOPE_PATTERN.matcher(regionScope.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid region '" + regionScope + "'. A region within the region-set must "
+                                               + "be a complete region, such as 'us-east-1', or the wildcard ('*') to "
+                                               + "represent all regions.");
         }
     }
 }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/RegionSetTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/RegionSetTest.java
@@ -15,9 +15,8 @@
 
 package software.amazon.awssdk.http.auth.aws;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,32 +24,32 @@ import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 
 public class RegionSetTest {
 
-    private static final List<String> passList = Arrays.asList(
+    private static final List<String> stringList = Arrays.asList(
         "*", "us-west-2", "us-east-1,us-west-2", " us-west-2 ", " us-east-1, us-west-2  ", " a,b  ,c ,d ,e ,f ,  g "
     );
 
-    private static final List<String> failList = Arrays.asList(
-        "", "**", "#$%#^", "*-west-2", "eu-west-*", "*-*", "us-*-1", "*-*-*", ",,,", "us-west-2, *", "*, us-east-1", "*, *",
-        "us - west - 2", "us-we st-2", "us-west-2,,"
+    private static final List<Collection<String>> collectionList = Arrays.asList(
+        Arrays.asList("us-west-1"), Arrays.asList("us-west-1", "us-west-2"), Arrays.asList("us-west-2", "us-west-2"),
+        Arrays.asList("*"), Arrays.asList("us-west-2", "us-west-2", "*")
     );
 
-    private static List<String> passInputs() {
-        return passList;
+    private static List<String> stringInputs() {
+        return stringList;
     }
 
-    private static List<String> failInputs() {
-        return failList;
+    private static List<Collection<String>> collectionInputs() {
+        return collectionList;
     }
 
     @ParameterizedTest
-    @MethodSource("passInputs")
-    public void create_withValidInput_succeeds(String input) {
+    @MethodSource("stringInputs")
+    public void create_withStringInput_succeeds(String input) {
         RegionSet.create(input);
     }
 
     @ParameterizedTest
-    @MethodSource("failInputs")
-    public void create_withInvalidInput_throws(String input) {
-        assertThrows(IllegalArgumentException.class, () -> RegionSet.create(input));
+    @MethodSource("collectionInputs")
+    public void create_withCollectionInput_succeeds(Collection<String> input) {
+        RegionSet.create(input);
     }
 }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/RegionSetTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/RegionSetTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
+
+public class RegionSetTest {
+
+    private static final List<String> passList = Arrays.asList(
+        "*", "us-west-2", "us-east-1,us-west-2", " us-west-2 ", " us-east-1, us-west-2  ", " a,b  ,c ,d ,e ,f ,  g "
+    );
+
+    private static final List<String> failList = Arrays.asList(
+        "", "**", "#$%#^", "*-west-2", "eu-west-*", "*-*", "us-*-1", "*-*-*", ",,,", "us-west-2, *", "*, us-east-1", "*, *",
+        "us - west - 2", "us-we st-2", "us-west-2,,"
+    );
+
+    private static List<String> passInputs() {
+        return passList;
+    }
+
+    private static List<String> failInputs() {
+        return failList;
+    }
+
+    @ParameterizedTest
+    @MethodSource("passInputs")
+    public void create_withValidInput_succeeds(String input) {
+        RegionSet.create(input);
+    }
+
+    @ParameterizedTest
+    @MethodSource("failInputs")
+    public void create_withInvalidInput_throws(String input) {
+        assertThrows(IllegalArgumentException.class, () -> RegionSet.create(input));
+    }
+}

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
@@ -15,12 +15,12 @@
 
 package software.amazon.awssdk.http.auth.aws.crt;
 
+import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.REGION_SET;
+import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.SERVICE_SIGNING_NAME;
 import static software.amazon.awssdk.http.auth.aws.TestUtils.TickingClock;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtHttpRequestConverter.toRequest;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.sanitizeRequest;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.toCredentials;
-import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.REGION_NAME;
-import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.SERVICE_SIGNING_NAME;
 import static software.amazon.awssdk.http.auth.spi.signer.HttpSigner.SIGNING_CLOCK;
 
 import java.io.ByteArrayInputStream;
@@ -33,6 +33,7 @@ import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 
@@ -60,7 +61,7 @@ public final class TestUtils {
                                                      .build()
                                                      .copy(requestOverrides))
                           .payload(() -> new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
-                          .putProperty(REGION_NAME, "aws-global")
+                          .putProperty(REGION_SET, RegionSet.create("aws-global"))
                           .putProperty(SERVICE_SIGNING_NAME, "demo")
                           .putProperty(SIGNING_CLOCK, new TickingClock(Instant.ofEpochMilli(1596476903000L)))
                           .build()

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/SignerProperty.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/SignerProperty.java
@@ -48,6 +48,14 @@ public final class SignerProperty<T> {
         return new SignerProperty<>(clazz, name);
     }
 
+    /**
+     * Create an instance of a property with a given type and name.
+     * TODO(sra-identity-auth): replace useage of other create method with this one
+     */
+    public static <T> SignerProperty<T> create(String name) {
+        return new SignerProperty<>((Class<T>) Object.class, name);
+    }
+
     @Override
     public String toString() {
         return ToString.builder("SignerProperty")

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
@@ -283,8 +283,8 @@ public class EndpointInterceptorTests {
             .putAuthScheme(authScheme("aws.auth#sigv4a", signer))
             .authSchemeProvider(p -> singletonList(AuthSchemeOption.builder()
                                                                    .schemeId("aws.auth#sigv4a")
-                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_SET,
-                                                                                      RegionSet.create("us-east-1"))
+                                                                   .putSignerProperty(
+                                                                       AwsV4aHttpSigner.REGION_SET, RegionSet.create("us-east-1"))
                                                                    .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "Y")
                                                                    .putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, true)
                                                                    .build()))

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
@@ -282,7 +283,8 @@ public class EndpointInterceptorTests {
             .putAuthScheme(authScheme("aws.auth#sigv4a", signer))
             .authSchemeProvider(p -> singletonList(AuthSchemeOption.builder()
                                                                    .schemeId("aws.auth#sigv4a")
-                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_NAME, "X")
+                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_SET,
+                                                                                      RegionSet.create("us-east-1"))
                                                                    .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "Y")
                                                                    .putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, true)
                                                                    .build()))
@@ -291,7 +293,7 @@ public class EndpointInterceptorTests {
         assertThatThrownBy(() -> client.operationWithHostPrefix(r -> {}))
             .hasMessageContaining("stop");
 
-        assertThat(signer.request.property(AwsV4aHttpSigner.REGION_NAME)).isEqualTo("region-1-from-ep");
+        assertThat(signer.request.property(AwsV4aHttpSigner.REGION_SET)).isEqualTo(RegionSet.create("region-1-from-ep"));
         assertThat(signer.request.property(AwsV4aHttpSigner.SERVICE_SIGNING_NAME)).isEqualTo("name-from-ep");
         assertThat(signer.request.property(AwsV4aHttpSigner.DOUBLE_URL_ENCODE)).isEqualTo(false);
     }
@@ -318,7 +320,8 @@ public class EndpointInterceptorTests {
             .putAuthScheme(authScheme("aws.auth#sigv4a", signer))
             .authSchemeProvider(p -> singletonList(AuthSchemeOption.builder()
                                                                    .schemeId("aws.auth#sigv4a")
-                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_NAME, "X")
+                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_SET,
+                                                                                      RegionSet.create("us-east-1"))
                                                                    .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "Y")
                                                                    .putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, true)
                                                                    .build()))
@@ -327,7 +330,7 @@ public class EndpointInterceptorTests {
         assertThatThrownBy(() -> client.operationWithHostPrefix(r -> {}).join())
             .hasMessageContaining("stop");
 
-        assertThat(signer.request.property(AwsV4aHttpSigner.REGION_NAME)).isEqualTo("region-1-from-ep");
+        assertThat(signer.request.property(AwsV4aHttpSigner.REGION_SET)).isEqualTo(RegionSet.create("region-1-from-ep"));
         assertThat(signer.request.property(AwsV4aHttpSigner.SERVICE_SIGNING_NAME)).isEqualTo("name-from-ep");
         assertThat(signer.request.property(AwsV4aHttpSigner.DOUBLE_URL_ENCODE)).isEqualTo(false);
     }
@@ -405,7 +408,8 @@ public class EndpointInterceptorTests {
             .overrideConfiguration(c -> c.addExecutionInterceptor(interceptor))
             .authSchemeProvider(p -> singletonList(AuthSchemeOption.builder()
                                                                    .schemeId("aws.auth#sigv4a")
-                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_NAME, "region-from-ap")
+                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_SET,
+                                                                                      RegionSet.create("region-from-ap"))
                                                                    .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "Y")
                                                                    .putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, true)
                                                                    .build()))
@@ -445,7 +449,8 @@ public class EndpointInterceptorTests {
                                                                            .build()))
             .authSchemeProvider(p -> singletonList(AuthSchemeOption.builder()
                                                                    .schemeId("aws.auth#sigv4a")
-                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_NAME, "X")
+                                                                   .putSignerProperty(AwsV4aHttpSigner.REGION_SET,
+                                                                                      RegionSet.create("us-east-1"))
                                                                    .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "Y")
                                                                    .putSignerProperty(AwsV4aHttpSigner.DOUBLE_URL_ENCODE, false)
                                                                    .build()))


### PR DESCRIPTION
## Motivation and Context
- V4a signers have a concept of "set of regions" that a signature is valid for, as opposed to a singular region with v4 signers
- The current code could technically support a set of regions in the form of a comma-separated string, but this could error-prone for a caller as there would be no validation of that string
- These changes update the interface to use a stronger typed `RegionSet`, which enables up-front validation on the inputs

## Modifications
- Create a `RegionSet` class, Update interface to use `RegionSet`
- Update codegen to form the correct input, and update codegen tests
- Update attribute-property adapter code to use region-set instead of region-name

## Testing
- Run new and existing tests, make sure pass

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
