### PR TITLE
Fixing Java S3 Client Transfer Manager issue with transferComplete() not called for AsyncRequestBody.fromFile

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-433e16a.json
+++ b/.changes/next-release/bugfix-S3TransferManager-433e16a.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Fix [3839](https://github.com/aws/aws-sdk-java-v2/issues/3839) S3 Transfer Manager issue with transferComplete() not called for AsyncRequestBody.fromFile()"
+}

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
@@ -56,7 +56,8 @@ public class S3IntegrationTestBase extends AwsTestBase {
 
     protected static S3AsyncClient s3CrtAsync;
 
-    protected static S3TransferManager tm;
+    protected static S3TransferManager tmCrt;
+    protected static S3TransferManager tmJava;
 
     /**
      * Loads the AWS account info for the integration tests and creates an S3
@@ -72,9 +73,13 @@ public class S3IntegrationTestBase extends AwsTestBase {
                                      .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                      .region(DEFAULT_REGION)
                                      .build();
-        tm = S3TransferManager.builder()
+        tmCrt = S3TransferManager.builder()
                               .s3Client(s3CrtAsync)
                               .build();
+        tmJava = S3TransferManager.builder()
+                                 .s3Client(s3Async)
+                                 .build();
+
     }
 
     @AfterAll
@@ -82,7 +87,7 @@ public class S3IntegrationTestBase extends AwsTestBase {
         s3.close();
         s3Async.close();
         s3CrtAsync.close();
-        tm.close();
+        tmCrt.close();
         CrtResource.waitForNoResources();
     }
 

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerCopyIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerCopyIntegrationTest.java
@@ -73,7 +73,7 @@ public class S3TransferManagerCopyIntegrationTest extends S3IntegrationTestBase 
     }
 
     private void copyObject(String original, String destination) {
-        Copy copy = tm.copy(c -> c
+        Copy copy = tmCrt.copy(c -> c
             .copyObjectRequest(r -> r
                 .sourceBucket(BUCKET)
                 .sourceKey(original)

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadDirectoryIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadDirectoryIntegrationTest.java
@@ -58,12 +58,12 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
         createBucket(TEST_BUCKET_CUSTOM_DELIMITER);
         sourceDirectory = createLocalTestDirectory();
 
-        tm.uploadDirectory(u -> u.source(sourceDirectory).bucket(TEST_BUCKET)).completionFuture().join();
+        tmCrt.uploadDirectory(u -> u.source(sourceDirectory).bucket(TEST_BUCKET)).completionFuture().join();
 
-        tm.uploadDirectory(u -> u.source(sourceDirectory)
-                                 .s3Delimiter(CUSTOM_DELIMITER)
-                                 .bucket(TEST_BUCKET_CUSTOM_DELIMITER))
-          .completionFuture().join();
+        tmCrt.uploadDirectory(u -> u.source(sourceDirectory)
+                                    .s3Delimiter(CUSTOM_DELIMITER)
+                                    .bucket(TEST_BUCKET_CUSTOM_DELIMITER))
+             .completionFuture().join();
     }
 
     @BeforeEach
@@ -96,7 +96,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
             log.warn(() -> "Failed to delete s3 bucket " + TEST_BUCKET_CUSTOM_DELIMITER, exception);
         }
 
-        closeQuietly(tm, log.logger());
+        closeQuietly(tmCrt, log.logger());
     }
 
     /**
@@ -118,8 +118,8 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
      */
     @Test
     public void downloadDirectory() throws Exception {
-        DirectoryDownload downloadDirectory = tm.downloadDirectory(u -> u.destination(directory)
-                                                                         .bucket(TEST_BUCKET));
+        DirectoryDownload downloadDirectory = tmCrt.downloadDirectory(u -> u.destination(directory)
+                                                                            .bucket(TEST_BUCKET));
         CompletedDirectoryDownload completedDirectoryDownload = downloadDirectory.completionFuture().get(5, TimeUnit.SECONDS);
         assertThat(completedDirectoryDownload.failedTransfers()).isEmpty();
         assertTwoDirectoriesHaveSameStructure(sourceDirectory, directory);
@@ -128,9 +128,9 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
     @ParameterizedTest
     @ValueSource(strings = {"notes/2021", "notes/2021/"})
     void downloadDirectory_withPrefix(String prefix) throws Exception {
-        DirectoryDownload downloadDirectory = tm.downloadDirectory(u -> u.destination(directory)
-                                                                         .listObjectsV2RequestTransformer(r -> r.prefix(prefix))
-                                                                         .bucket(TEST_BUCKET));
+        DirectoryDownload downloadDirectory = tmCrt.downloadDirectory(u -> u.destination(directory)
+                                                                            .listObjectsV2RequestTransformer(r -> r.prefix(prefix))
+                                                                            .bucket(TEST_BUCKET));
         CompletedDirectoryDownload completedDirectoryDownload = downloadDirectory.completionFuture().get(5, TimeUnit.SECONDS);
         assertThat(completedDirectoryDownload.failedTransfers()).isEmpty();
 
@@ -155,9 +155,9 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
     @Test
     void downloadDirectory_containsObjectWithPrefixInTheKey_shouldResolveCorrectly() throws Exception {
         String prefix = "notes";
-        DirectoryDownload downloadDirectory = tm.downloadDirectory(u -> u.destination(directory)
-                                                                         .listObjectsV2RequestTransformer(r -> r.prefix(prefix))
-                                                                         .bucket(TEST_BUCKET));
+        DirectoryDownload downloadDirectory = tmCrt.downloadDirectory(u -> u.destination(directory)
+                                                                            .listObjectsV2RequestTransformer(r -> r.prefix(prefix))
+                                                                            .bucket(TEST_BUCKET));
         CompletedDirectoryDownload completedDirectoryDownload = downloadDirectory.completionFuture().get(5, TimeUnit.SECONDS);
         assertThat(completedDirectoryDownload.failedTransfers()).isEmpty();
 
@@ -186,10 +186,10 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
     public void downloadDirectory_withPrefixAndDelimiter() throws Exception {
         String prefix = "notes-2021";
         DirectoryDownload downloadDirectory =
-            tm.downloadDirectory(u -> u.destination(directory)
-                                       .listObjectsV2RequestTransformer(r -> r.delimiter(CUSTOM_DELIMITER)
+            tmCrt.downloadDirectory(u -> u.destination(directory)
+                                          .listObjectsV2RequestTransformer(r -> r.delimiter(CUSTOM_DELIMITER)
                                                                               .prefix(prefix))
-                                       .bucket(TEST_BUCKET_CUSTOM_DELIMITER));
+                                          .bucket(TEST_BUCKET_CUSTOM_DELIMITER));
         CompletedDirectoryDownload completedDirectoryDownload = downloadDirectory.completionFuture().get(5, TimeUnit.SECONDS);
         assertThat(completedDirectoryDownload.failedTransfers()).isEmpty();
         assertTwoDirectoriesHaveSameStructure(sourceDirectory.resolve("notes").resolve("2021"), directory);
@@ -208,7 +208,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
      */
     @Test
     public void downloadDirectory_withFilter() throws Exception {
-        DirectoryDownload downloadDirectory = tm.downloadDirectory(u -> u
+        DirectoryDownload downloadDirectory = tmCrt.downloadDirectory(u -> u
             .destination(directory)
             .bucket(TEST_BUCKET)
             .filter(s3Object -> s3Object.key().startsWith("notes/2021/2")));

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadIntegrationTest.java
@@ -70,7 +70,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     void download_toFile() throws Exception {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
         FileDownload download =
-            tm.downloadFile(DownloadFileRequest.builder()
+            tmCrt.downloadFile(DownloadFileRequest.builder()
                                                .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
                                                .destination(path)
                                                .addTransferListener(LoggingTransferListener.create())
@@ -86,11 +86,11 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
         Files.write(path, RandomStringUtils.random(1024).getBytes(StandardCharsets.UTF_8));
         assertThat(path).exists();
         FileDownload download =
-            tm.downloadFile(DownloadFileRequest.builder()
-                                               .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
-                                               .destination(path)
-                                               .addTransferListener(LoggingTransferListener.create())
-                                               .build());
+            tmCrt.downloadFile(DownloadFileRequest.builder()
+                                                  .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
+                                                  .destination(path)
+                                                  .addTransferListener(LoggingTransferListener.create())
+                                                  .build());
         CompletedFileDownload completedFileDownload = download.completionFuture().join();
         assertThat(Md5Utils.md5AsBase64(path.toFile())).isEqualTo(Md5Utils.md5AsBase64(file));
         assertThat(completedFileDownload.response().responseMetadata().requestId()).isNotNull();
@@ -99,11 +99,11 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     @Test
     void download_toBytes() throws Exception {
         Download<ResponseBytes<GetObjectResponse>> download =
-            tm.download(DownloadRequest.builder()
-                                       .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
-                                       .responseTransformer(AsyncResponseTransformer.toBytes())
-                                       .addTransferListener(LoggingTransferListener.create())
-                                       .build());
+            tmCrt.download(DownloadRequest.builder()
+                                          .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
+                                          .responseTransformer(AsyncResponseTransformer.toBytes())
+                                          .addTransferListener(LoggingTransferListener.create())
+                                          .build());
         CompletedDownload<ResponseBytes<GetObjectResponse>> completedDownload = download.completionFuture().join();
         ResponseBytes<GetObjectResponse> result = completedDownload.result();
         assertThat(Md5Utils.md5AsBase64(result.asByteArray())).isEqualTo(Md5Utils.md5AsBase64(file));
@@ -113,11 +113,11 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     @Test
     void download_toPublisher() throws Exception {
         Download<ResponsePublisher<GetObjectResponse>> download =
-            tm.download(DownloadRequest.builder()
-                                       .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
-                                       .responseTransformer(AsyncResponseTransformer.toPublisher())
-                                       .addTransferListener(LoggingTransferListener.create())
-                                       .build());
+            tmCrt.download(DownloadRequest.builder()
+                                          .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
+                                          .responseTransformer(AsyncResponseTransformer.toPublisher())
+                                          .addTransferListener(LoggingTransferListener.create())
+                                          .build());
         CompletedDownload<ResponsePublisher<GetObjectResponse>> completedDownload = download.completionFuture().join();
         ResponsePublisher<GetObjectResponse> responsePublisher = completedDownload.result();
         ByteBuffer buf = ByteBuffer.allocate(Math.toIntExact(responsePublisher.response().contentLength()));

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadPauseResumeIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadPauseResumeIntegrationTest.java
@@ -34,7 +34,6 @@ import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.waiters.Waiter;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.testutils.RandomTempFile;
@@ -78,7 +77,7 @@ public class S3TransferManagerDownloadPauseResumeIntegrationTest extends S3Integ
                                                          .destination(path)
                                                          .addTransferListener(testDownloadListener)
                                                          .build();
-        FileDownload download = tm.downloadFile(request);
+        FileDownload download = tmCrt.downloadFile(request);
         waitUntilFirstByteBufferDelivered(download);
 
         ResumableFileDownload resumableFileDownload = download.pause();
@@ -105,7 +104,7 @@ public class S3TransferManagerDownloadPauseResumeIntegrationTest extends S3Integ
                                                              .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
                                                              .destination(path)
                                                              .build();
-            FileDownload download = tm.downloadFile(request);
+            FileDownload download = tmCrt.downloadFile(request);
             waitUntilFirstByteBufferDelivered(download);
 
             ResumableFileDownload resumableFileDownload = download.pause();
@@ -119,7 +118,7 @@ public class S3TransferManagerDownloadPauseResumeIntegrationTest extends S3Integ
                                          .build(), RequestBody.fromString(newObject));
 
             log.debug(() -> "Resuming download ");
-            FileDownload resumedFileDownload = tm.resumeDownloadFile(resumableFileDownload);
+            FileDownload resumedFileDownload = tmCrt.resumeDownloadFile(resumableFileDownload);
             resumedFileDownload.progress().snapshot();
             resumedFileDownload.completionFuture().join();
             assertThat(path.toFile()).hasContent(newObject);
@@ -139,7 +138,7 @@ public class S3TransferManagerDownloadPauseResumeIntegrationTest extends S3Integ
                                                          .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
                                                          .destination(path)
                                                          .build();
-        FileDownload download = tm.downloadFile(request);
+        FileDownload download = tmCrt.downloadFile(request);
         waitUntilFirstByteBufferDelivered(download);
 
         ResumableFileDownload resumableFileDownload = download.pause();
@@ -149,7 +148,7 @@ public class S3TransferManagerDownloadPauseResumeIntegrationTest extends S3Integ
     }
 
     private static void verifyFileDownload(Path path, ResumableFileDownload resumableFileDownload, long expectedBytesTransferred) {
-        FileDownload resumedFileDownload = tm.resumeDownloadFile(resumableFileDownload);
+        FileDownload resumedFileDownload = tmCrt.resumeDownloadFile(resumableFileDownload);
         resumedFileDownload.completionFuture().join();
         assertThat(resumedFileDownload.progress().snapshot().totalBytes()).hasValue(expectedBytesTransferred);
         assertThat(path.toFile()).hasSameBinaryContentAs(sourceFile);

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryIntegrationTest.java
@@ -80,9 +80,9 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
     @Test
     void uploadDirectory_filesSentCorrectly() {
         String prefix = "yolo";
-        DirectoryUpload uploadDirectory = tm.uploadDirectory(u -> u.source(directory)
-                                                                   .bucket(TEST_BUCKET)
-                                                                   .s3Prefix(prefix));
+        DirectoryUpload uploadDirectory = tmCrt.uploadDirectory(u -> u.source(directory)
+                                                                      .bucket(TEST_BUCKET)
+                                                                      .s3Prefix(prefix));
         CompletedDirectoryUpload completedDirectoryUpload = uploadDirectory.completionFuture().join();
         assertThat(completedDirectoryUpload.failedTransfers()).isEmpty();
 
@@ -98,9 +98,9 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
     @Test
     void uploadDirectory_nonExistsBucket_shouldAddFailedRequest() {
         String prefix = "yolo";
-        DirectoryUpload uploadDirectory = tm.uploadDirectory(u -> u.source(directory)
-                                                                   .bucket("nonExistingTestBucket" + UUID.randomUUID())
-                                                                   .s3Prefix(prefix));
+        DirectoryUpload uploadDirectory = tmCrt.uploadDirectory(u -> u.source(directory)
+                                                                      .bucket("nonExistingTestBucket" + UUID.randomUUID())
+                                                                      .s3Prefix(prefix));
         CompletedDirectoryUpload completedDirectoryUpload = uploadDirectory.completionFuture().join();
         assertThat(completedDirectoryUpload.failedTransfers()).hasSize(3).allSatisfy(f ->
             assertThat(f.exception()).isInstanceOf(NoSuchBucketException.class));
@@ -110,10 +110,10 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
     void uploadDirectory_withDelimiter_filesSentCorrectly() {
         String prefix = "hello";
         String delimiter = "0";
-        DirectoryUpload uploadDirectory = tm.uploadDirectory(u -> u.source(directory)
-                                                                          .bucket(TEST_BUCKET)
-                                                                          .s3Delimiter(delimiter)
-                                                                          .s3Prefix(prefix));
+        DirectoryUpload uploadDirectory = tmCrt.uploadDirectory(u -> u.source(directory)
+                                                                      .bucket(TEST_BUCKET)
+                                                                      .s3Delimiter(delimiter)
+                                                                      .s3Prefix(prefix));
         CompletedDirectoryUpload completedDirectoryUpload = uploadDirectory.completionFuture().join();
         assertThat(completedDirectoryUpload.failedTransfers()).isEmpty();
 
@@ -134,12 +134,12 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
         Path newSourceForEachUpload = Paths.get(directory.toString(), "bar.txt");
 
         CompletedDirectoryUpload result =
-            tm.uploadDirectory(r -> r.source(directory)
-                                     .bucket(TEST_BUCKET)
-                                     .s3Prefix(prefix)
-                                     .uploadFileRequestTransformer(f -> f.source(newSourceForEachUpload)))
-              .completionFuture()
-              .get(10, TimeUnit.SECONDS);
+            tmCrt.uploadDirectory(r -> r.source(directory)
+                                        .bucket(TEST_BUCKET)
+                                        .s3Prefix(prefix)
+                                        .uploadFileRequestTransformer(f -> f.source(newSourceForEachUpload)))
+                 .completionFuture()
+                 .get(10, TimeUnit.SECONDS);
         assertThat(result.failedTransfers()).isEmpty();
 
         s3.listObjectsV2Paginator(b -> b.bucket(TEST_BUCKET).prefix(prefix)).contents().forEach(object -> {
@@ -179,8 +179,8 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
             testDirectory = createLocalTestDirectory(directoryPrefix);
 
             Path finalTestDirectory = testDirectory;
-            DirectoryUpload uploadDirectory = tm.uploadDirectory(u -> u.source(finalTestDirectory)
-                                                                       .bucket(TEST_BUCKET));
+            DirectoryUpload uploadDirectory = tmCrt.uploadDirectory(u -> u.source(finalTestDirectory)
+                                                                          .bucket(TEST_BUCKET));
             CompletedDirectoryUpload completedDirectoryUpload = uploadDirectory.completionFuture().join();
             assertThat(completedDirectoryUpload.failedTransfers()).isEmpty();
 

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadIntegrationTest.java
@@ -111,7 +111,7 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
 
     @ParameterizedTest
     @MethodSource("transferManagers")
-    void upload_asyncRequestBody_SentCorrectly(S3TransferManager transferManager) throws IOException {
+    void upload_asyncRequestBodyFromString_SentCorrectly(S3TransferManager transferManager) throws IOException {
         String content = UUID.randomUUID().toString();
         CaptureTransferListener transferListener = new CaptureTransferListener();
 

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadIntegrationTest.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.transfer.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
 import java.io.IOException;
@@ -26,11 +25,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.internal.async.FileAsyncRequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -63,17 +66,24 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
         deleteBucketAndAllContents(TEST_BUCKET);
     }
 
-   @Test
-    void upload_file_SentCorrectly() throws IOException {
+    private static Stream<Arguments> transferManagers() {
+        return Stream.of(
+            Arguments.of(tmCrt),
+            Arguments.of(tmJava));
+    }
+
+    @ParameterizedTest
+    @MethodSource("transferManagers")
+    void upload_file_SentCorrectly(S3TransferManager transferManager) throws IOException {
         Map<String, String> metadata = new HashMap<>();
        CaptureTransferListener transferListener = new CaptureTransferListener();
        metadata.put("x-amz-meta-foobar", "FOO BAR");
         FileUpload fileUpload =
-            tm.uploadFile(u -> u.putObjectRequest(p -> p.bucket(TEST_BUCKET).key(TEST_KEY).metadata(metadata).checksumAlgorithm(ChecksumAlgorithm.CRC32))
-                                .source(testFile.toPath())
-                                .addTransferListener(LoggingTransferListener.create())
-                .addTransferListener(transferListener)
-                                .build());
+            transferManager.uploadFile(u -> u.putObjectRequest(p -> p.bucket(TEST_BUCKET).key(TEST_KEY).metadata(metadata).checksumAlgorithm(ChecksumAlgorithm.CRC32))
+                                   .source(testFile.toPath())
+                                   .addTransferListener(LoggingTransferListener.create())
+                                   .addTransferListener(transferListener)
+                                   .build());
 
         CompletedFileUpload completedFileUpload = fileUpload.completionFuture().join();
         assertThat(completedFileUpload.response().responseMetadata().requestId()).isNotNull();
@@ -92,25 +102,26 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
 
     private static void assertListenerForSuccessfulTransferComplete(CaptureTransferListener transferListener) {
         assertThat(transferListener.isTransferInitiated()).isTrue();
-        assertThat(transferListener.isTransferInitiated()).isTrue();
+        assertThat(transferListener.isTransferComplete()).isTrue();
         assertThat(transferListener.getRatioTransferredList()).isNotEmpty();
         assertThat(transferListener.getRatioTransferredList().contains(0.0));
         assertThat(transferListener.getRatioTransferredList().contains(100.0));
         assertThat(transferListener.getExceptionCaught()).isNull();
     }
 
-    @Test
-    void upload_asyncRequestBody_SentCorrectly() throws IOException {
+    @ParameterizedTest
+    @MethodSource("transferManagers")
+    void upload_asyncRequestBody_SentCorrectly(S3TransferManager transferManager) throws IOException {
         String content = UUID.randomUUID().toString();
         CaptureTransferListener transferListener = new CaptureTransferListener();
 
         Upload upload =
-            tm.upload(UploadRequest.builder()
-                                   .putObjectRequest(b -> b.bucket(TEST_BUCKET).key(TEST_KEY))
-                                   .requestBody(AsyncRequestBody.fromString(content))
-                                   .addTransferListener(LoggingTransferListener.create())
-                                   .addTransferListener(transferListener)
-                                   .build());
+            transferManager.upload(UploadRequest.builder()
+                                      .putObjectRequest(b -> b.bucket(TEST_BUCKET).key(TEST_KEY))
+                                      .requestBody(AsyncRequestBody.fromString(content))
+                                      .addTransferListener(LoggingTransferListener.create())
+                                      .addTransferListener(transferListener)
+                                      .build());
 
         CompletedUpload completedUpload = upload.completionFuture().join();
         assertThat(completedUpload.response().responseMetadata().requestId()).isNotNull();
@@ -127,17 +138,47 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
 
     }
 
-    @Test
-    void upload_file_Interupted_CancelsTheListener() throws IOException, InterruptedException {
+    @ParameterizedTest
+    @MethodSource("transferManagers")
+    void upload_asyncRequestBodyFromFile_SentCorrectly(S3TransferManager transferManager) throws IOException {
+        CaptureTransferListener transferListener = new CaptureTransferListener();
+
+        Upload upload =
+            transferManager.upload(UploadRequest.builder()
+                                                .putObjectRequest(b -> b.bucket(TEST_BUCKET).key(TEST_KEY))
+                                                .requestBody(FileAsyncRequestBody.builder().chunkSizeInBytes(1024).path(testFile.toPath()).build())
+                                                .addTransferListener(LoggingTransferListener.create())
+                                                .addTransferListener(transferListener)
+                                                .build());
+
+        CompletedUpload completedUpload = upload.completionFuture().join();
+        assertThat(completedUpload.response().responseMetadata().requestId()).isNotNull();
+        assertThat(completedUpload.response().sdkHttpResponse()).isNotNull();
+
+        ResponseInputStream<GetObjectResponse> obj = s3.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY),
+                                                                  ResponseTransformer.toInputStream());
+
+        assertThat(ChecksumUtils.computeCheckSum(Files.newInputStream(testFile.toPath())))
+            .isEqualTo(ChecksumUtils.computeCheckSum(obj));
+        assertThat(obj.response().responseMetadata().requestId()).isNotNull();
+        assertThat(upload.progress().snapshot().sdkResponse()).isPresent();
+        assertListenerForSuccessfulTransferComplete(transferListener);
+
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("transferManagers")
+    void upload_file_Interupted_CancelsTheListener(S3TransferManager transferManager) throws IOException, InterruptedException {
         Map<String, String> metadata = new HashMap<>();
         CaptureTransferListener transferListener = new CaptureTransferListener();
         metadata.put("x-amz-meta-foobar", "FOO BAR");
         FileUpload fileUpload =
-            tm.uploadFile(u -> u.putObjectRequest(p -> p.bucket(TEST_BUCKET).key(TEST_KEY).metadata(metadata).checksumAlgorithm(ChecksumAlgorithm.CRC32))
-                                .source(testFile.toPath())
-                                .addTransferListener(LoggingTransferListener.create())
-                                .addTransferListener(transferListener)
-                                .build());
+            transferManager.uploadFile(u -> u.putObjectRequest(p -> p.bucket(TEST_BUCKET).key(TEST_KEY).metadata(metadata).checksumAlgorithm(ChecksumAlgorithm.CRC32))
+                                   .source(testFile.toPath())
+                                   .addTransferListener(LoggingTransferListener.create())
+                                   .addTransferListener(transferListener)
+                                   .build());
 
         fileUpload.completionFuture().cancel(true);
         assertThat(transferListener.isTransferInitiated()).isTrue();

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadPauseResumeIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadPauseResumeIntegrationTest.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.jupiter.api.AfterAll;
@@ -76,13 +75,13 @@ public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3Integra
                                                      .putObjectRequest(b -> b.bucket(BUCKET).key(KEY))
                                                      .source(smallFile)
                                                      .build();
-        FileUpload fileUpload = tm.uploadFile(request);
+        FileUpload fileUpload = tmCrt.uploadFile(request);
         ResumableFileUpload resumableFileUpload = fileUpload.pause();
         log.debug(() -> "Paused: " + resumableFileUpload);
 
         validateEmptyResumeToken(resumableFileUpload);
 
-        FileUpload resumedUpload = tm.resumeUploadFile(resumableFileUpload);
+        FileUpload resumedUpload = tmCrt.resumeUploadFile(resumableFileUpload);
         resumedUpload.completionFuture().join();
     }
 
@@ -93,7 +92,7 @@ public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3Integra
                                                      .addTransferListener(LoggingTransferListener.create())
                                                      .source(largeFile)
                                                      .build();
-        FileUpload fileUpload = tm.uploadFile(request);
+        FileUpload fileUpload = tmCrt.uploadFile(request);
         waitUntilMultipartUploadExists();
         ResumableFileUpload resumableFileUpload = fileUpload.pause();
         log.debug(() -> "Paused: " + resumableFileUpload);
@@ -104,7 +103,7 @@ public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3Integra
 
         verifyMultipartUploadIdExists(resumableFileUpload);
 
-        FileUpload resumedUpload = tm.resumeUploadFile(resumableFileUpload);
+        FileUpload resumedUpload = tmCrt.resumeUploadFile(resumableFileUpload);
         resumedUpload.completionFuture().join();
     }
 
@@ -114,13 +113,13 @@ public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3Integra
                                                    .putObjectRequest(b -> b.bucket(BUCKET).key(KEY))
                                                    .source(largeFile)
                                                    .build();
-        FileUpload fileUpload = tm.uploadFile(request);
+        FileUpload fileUpload = tmCrt.uploadFile(request);
         ResumableFileUpload resumableFileUpload = fileUpload.pause();
         log.debug(() -> "Paused: " + resumableFileUpload);
 
         validateEmptyResumeToken(resumableFileUpload);
 
-        FileUpload resumedUpload = tm.resumeUploadFile(resumableFileUpload);
+        FileUpload resumedUpload = tmCrt.resumeUploadFile(resumableFileUpload);
         resumedUpload.completionFuture().join();
     }
 
@@ -130,7 +129,7 @@ public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3Integra
                                                      .putObjectRequest(b -> b.bucket(BUCKET).key(KEY))
                                                      .source(largeFile)
                                                      .build();
-        FileUpload fileUpload = tm.uploadFile(request);
+        FileUpload fileUpload = tmCrt.uploadFile(request);
         waitUntilMultipartUploadExists();
         ResumableFileUpload resumableFileUpload = fileUpload.pause();
         log.debug(() -> "Paused: " + resumableFileUpload);
@@ -143,7 +142,7 @@ public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3Integra
         byte[] bytes = "helloworld".getBytes(StandardCharsets.UTF_8);
         Files.write(largeFile.toPath(), bytes);
 
-        FileUpload resumedUpload = tm.resumeUploadFile(resumableFileUpload);
+        FileUpload resumedUpload = tmCrt.resumeUploadFile(resumableFileUpload);
         resumedUpload.completionFuture().join();
         verifyMultipartUploadIdNotExist(resumableFileUpload);
         assertThat(resumedUpload.progress().snapshot().totalBytes()).hasValue(bytes.length);

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferProgressUpdaterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferProgressUpdaterTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.transfer.s3.SizeConstant.MB;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.http.async.SimpleSubscriber;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.transfer.s3.CaptureTransferListener;
+import software.amazon.awssdk.transfer.s3.internal.progress.TransferProgressUpdater;
+import software.amazon.awssdk.transfer.s3.model.CompletedObjectTransfer;
+import software.amazon.awssdk.transfer.s3.model.TransferObjectRequest;
+import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
+
+class TransferProgressUpdaterTest {
+    private static final long OBJ_SIZE = 16 * MB;
+    private static File sourceFile;
+    private CaptureTransferListener captureTransferListener;
+
+    private static Stream<Arguments> contentLength() {
+
+        return Stream.of(
+            // When bytesTransfer ration reaches 1.0
+            Arguments.of(OBJ_SIZE),
+            // When bytesTransfer ration reaches  more than1.0
+            Arguments.of(OBJ_SIZE / 2),
+            // When mbytesTransfer ratio never reaches 100 , but subscription competes
+            Arguments.of(OBJ_SIZE * 2));
+    }
+
+    private static CompletableFuture<CompletedObjectTransfer> completedObjectResponse(long millis) {
+        return CompletableFuture.supplyAsync(() -> {
+            quietSleep(millis);
+            return new CompletedObjectTransfer() {
+                @Override
+                public SdkResponse response() {
+                    return PutObjectResponse.builder().eTag("ABCD").build();
+                }
+            };
+        });
+    }
+
+    private static void quietSleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // Restore interrupted status
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeEach
+    void initiate() {
+        captureTransferListener = new CaptureTransferListener();
+    }
+
+    @ParameterizedTest
+    @MethodSource("contentLength")
+    void transferCompleteBasedOnBytesRatioWhenCompleted(Long adjustedContentLength) throws Exception {
+        TransferObjectRequest transferRequest = Mockito.mock(TransferObjectRequest.class);
+        CaptureTransferListener mockListener = Mockito.mock(CaptureTransferListener.class);
+        when(transferRequest.transferListeners()).thenReturn(Arrays.asList(LoggingTransferListener.create(), mockListener,
+                                                                           captureTransferListener));
+
+        sourceFile = new RandomTempFile(OBJ_SIZE);
+        AsyncRequestBody requestBody = AsyncRequestBody.fromFile(sourceFile);
+        TransferProgressUpdater transferProgressUpdater = new TransferProgressUpdater(transferRequest, adjustedContentLength);
+        AsyncRequestBody asyncRequestBody = transferProgressUpdater.wrapRequestBody(requestBody);
+
+        CompletableFuture<CompletedObjectTransfer> completionFuture = completedObjectResponse(10);
+        transferProgressUpdater.registerCompletion(completionFuture);
+
+        AtomicReference<ByteBuffer> publishedBuffer = new AtomicReference<>();
+        Subscriber<ByteBuffer> subscriber = new SimpleSubscriber(publishedBuffer::set);
+        asyncRequestBody.subscribe(subscriber);
+
+        captureTransferListener.getCompletionFuture().get(5, TimeUnit.SECONDS);
+
+        Mockito.verify(mockListener, never()).transferFailed(ArgumentMatchers.any(TransferListener.Context.TransferFailed.class));
+        Mockito.verify(mockListener, times(1)).transferComplete(ArgumentMatchers.any(TransferListener.Context.TransferComplete.class));
+    }
+
+
+    @Test
+    void transferFailedWhenSubscriptionErrors() throws Exception {
+        Long contentLength = 51L;
+        String inputString = RandomStringUtils.randomAlphanumeric(contentLength.intValue());
+
+        TransferObjectRequest transferRequest = Mockito.mock(TransferObjectRequest.class);
+        CaptureTransferListener mockListener = Mockito.mock(CaptureTransferListener.class);
+        when(transferRequest.transferListeners()).thenReturn(Arrays.asList(LoggingTransferListener.create(),
+                                                                           mockListener,
+                                                                           captureTransferListener));
+
+        sourceFile = new RandomTempFile(OBJ_SIZE);
+        AsyncRequestBody requestFileBody = AsyncRequestBody.fromInputStream(
+            new ExceptionThrowingByteArrayInputStream(inputString.getBytes(), 3), contentLength,
+            Executors.newSingleThreadExecutor());
+
+        TransferProgressUpdater transferProgressUpdater = new TransferProgressUpdater(transferRequest, contentLength);
+        AsyncRequestBody asyncRequestBody = transferProgressUpdater.wrapRequestBody(requestFileBody);
+
+        CompletableFuture<CompletedObjectTransfer> future = completedObjectResponse(10);
+        transferProgressUpdater.registerCompletion(future);
+
+        AtomicReference<ByteBuffer> publishedBuffer = new AtomicReference<>();
+        Subscriber<ByteBuffer> subscriber = new SimpleSubscriber(publishedBuffer::set);
+        asyncRequestBody.subscribe(subscriber);
+
+        assertThatExceptionOfType(ExecutionException.class).isThrownBy(
+            () -> captureTransferListener.getCompletionFuture().get(5, TimeUnit.SECONDS));
+
+        Mockito.verify(mockListener, times(1)).transferFailed(ArgumentMatchers.any(TransferListener.Context.TransferFailed.class));
+        Mockito.verify(mockListener, never()).transferComplete(ArgumentMatchers.any(TransferListener.Context.TransferComplete.class));
+    }
+
+
+    private static class ExceptionThrowingByteArrayInputStream extends ByteArrayInputStream {
+        private final int exceptionPosition;
+
+        public ExceptionThrowingByteArrayInputStream(byte[] buf, int exceptionPosition) {
+            super(buf);
+            this.exceptionPosition = exceptionPosition;
+        }
+
+        @Override
+        public int read() {
+            return (exceptionPosition == pos + 1) ? exceptionThrowingRead() : super.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            return (exceptionPosition >= pos && exceptionPosition < (pos + len)) ?
+                   exceptionThrowingReadByteArr(b, off, len) : super.read(b, off, len);
+        }
+
+        private int exceptionThrowingRead() {
+            throw new RuntimeException("Exception occurred at position " + (pos + 1));
+        }
+
+        private int exceptionThrowingReadByteArr(byte[] b, int off, int len) {
+            throw new RuntimeException("Exception occurred in read(byte[]) at position " + exceptionPosition);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixing Java S3 Client Transfer Manager issue with transferComplete() not called for AsyncRequestBody.fromFile

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

- Fix for issue https://github.com/aws/aws-sdk-java-v2/issues/3839
-
## Root Cause
- [NettyRequestExecutor](https://github.com/aws/aws-sdk-java-v2/blob/df4753216daeb119408f7378ec68c3cb1d0824d7/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java#L496) prematurely cancels the subscription when the last chunk is sent.
- The logic of `shouldContinuePublishing` after [DoneCheck-OnNext](https://github.com/aws/aws-sdk-java-v2/blob/df4753216daeb119408f7378ec68c3cb1d0824d7/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java#L442) checks `<` instead of `<=` in `shouldContinuePublishing()`.

## Modifications
<!--- Describe your changes in detail -->
<!--- Describe your changes in detail -->
- The actual fix would be to move `shouldContinuePublishing` before the `isDone` check and then update `<` to `<=` in `shouldContinuePublishing()`.
- However, we had an internal discussion, and the outcome was not to modify this but to update the TransferManager Code to ensure that we send the `transferComplete` once all the bytes are received.
- Added a `done` flag to ensure that `transferComplete` is not called more than once.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added JUnit tests.
- Included integration tests for the Java client since this issue is primarily observed in the Java S3 client Transfer Manager.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
