### PR TITLE
Add namespacing to Signer and Identity properties

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4FamilyHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4FamilyHttpSigner.java
@@ -32,54 +32,54 @@ public interface AwsV4FamilyHttpSigner<T extends Identity> extends HttpSigner<T>
      * The name of the AWS service. This property is required.
      */
     SignerProperty<String> SERVICE_SIGNING_NAME =
-        SignerProperty.create(String.class, "ServiceSigningName");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "ServiceSigningName");
 
     /**
      * A boolean to indicate whether to double url-encode the resource path when constructing the canonical request. This property
      * defaults to true.
      */
     SignerProperty<Boolean> DOUBLE_URL_ENCODE =
-        SignerProperty.create(Boolean.class, "DoubleUrlEncode");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "DoubleUrlEncode");
 
     /**
      * A boolean to indicate whether the resource path should be "normalized" according to RFC3986 when constructing the canonical
      * request. This property defaults to true.
      */
     SignerProperty<Boolean> NORMALIZE_PATH =
-        SignerProperty.create(Boolean.class, "NormalizePath");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "NormalizePath");
 
     /**
      * The location where auth-related data is inserted, as a result of signing. This property defaults to HEADER.
      */
     SignerProperty<AuthLocation> AUTH_LOCATION =
-        SignerProperty.create(AuthLocation.class, "AuthLocation");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "AuthLocation");
 
     /**
      * The duration for the request to be valid. This property defaults to null. This can be set to presign the request for
      * later use. The maximum allowed value for this property is 7 days. This is only supported when AuthLocation=QUERY.
      */
     SignerProperty<Duration> EXPIRATION_DURATION =
-        SignerProperty.create(Duration.class, "ExpirationDuration");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "ExpirationDuration");
 
     /**
      * Whether to indicate that a payload is signed or not. This property defaults to true. This can be set false to disable
      * payload signing.
      */
     SignerProperty<Boolean> PAYLOAD_SIGNING_ENABLED =
-        SignerProperty.create(Boolean.class, "PayloadSigningEnabled");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "PayloadSigningEnabled");
 
     /**
      * Whether to indicate that a payload is chunk-encoded or not. This property defaults to false. This can be set true to
      * enable the `aws-chunk` content-encoding
      */
     SignerProperty<Boolean> CHUNK_ENCODING_ENABLED =
-        SignerProperty.create(Boolean.class, "ChunkEncodingEnabled");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "ChunkEncodingEnabled");
 
     /**
      * The algorithm to use for calculating a "flexible" checksum. This property is optional.
      */
     SignerProperty<ChecksumAlgorithm> CHECKSUM_ALGORITHM =
-        SignerProperty.create(ChecksumAlgorithm.class, "ChecksumAlgorithm");
+        SignerProperty.create(AwsV4FamilyHttpSigner.class, "ChecksumAlgorithm");
 
     /**
      * This enum represents where auth-related data is inserted, as a result of signing.

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4HttpSigner.java
@@ -33,7 +33,7 @@ public interface AwsV4HttpSigner extends AwsV4FamilyHttpSigner<AwsCredentialsIde
      * The AWS region name to be used for computing the signature. This property is required.
      */
     SignerProperty<String> REGION_NAME =
-        SignerProperty.create(String.class, "RegionName");
+        SignerProperty.create(AwsV4HttpSigner.class, "RegionName");
 
     /**
      * Get a default implementation of a {@link AwsV4HttpSigner}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4aHttpSigner.java
@@ -33,7 +33,7 @@ public interface AwsV4aHttpSigner extends AwsV4FamilyHttpSigner<AwsCredentialsId
     /**
      * The AWS region-set to be used for computing the signature. This property is required.
      */
-    SignerProperty<RegionSet> REGION_SET = SignerProperty.create("RegionSet");
+    SignerProperty<RegionSet> REGION_SET = SignerProperty.create(AwsV4aHttpSigner.class, "RegionSet");
 
     /**
      * Get a default implementation of a {@link AwsV4aHttpSigner}

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/AwsV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/AwsV4aHttpSignerTest.java
@@ -29,7 +29,7 @@ public class AwsV4aHttpSignerTest {
     @Test
     public void create_WithoutHttpAuthAwsCrtModule_throws() {
         try (MockedStatic<ClassLoaderHelper> utilities = Mockito.mockStatic(ClassLoaderHelper.class)) {
-            utilities.when(() ->ClassLoaderHelper.loadClass(
+            utilities.when(() -> ClassLoaderHelper.loadClass(
                 "software.amazon.awssdk.http.auth.aws.crt.HttpAuthAwsCrt",
                 false)
             ).thenThrow(new ClassNotFoundException("boom!"));

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/HttpSigner.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/HttpSigner.java
@@ -37,7 +37,7 @@ public interface HttpSigner<IdentityT extends Identity> {
      *
      * <p>Note, signing time may not be relevant to some signers.
      */
-    SignerProperty<Clock> SIGNING_CLOCK = SignerProperty.create(Clock.class, "SigningClock");
+    SignerProperty<Clock> SIGNING_CLOCK = SignerProperty.create(HttpSigner.class, "SigningClock");
 
     /**
      * Method that takes in inputs to sign a request with sync payload and returns a signed version of the request.

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/SignerProperty.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/SignerProperty.java
@@ -30,36 +30,32 @@ import software.amazon.awssdk.utils.Validate;
 @Immutable
 @ThreadSafe
 public final class SignerProperty<T> {
-    private final Class<T> clazz;
+    private final String namespace;
     private final String name;
 
-    private SignerProperty(Class<T> clazz, String name) {
-        Validate.paramNotNull(clazz, "clazz");
+    private SignerProperty(String namespace, String name) {
+        Validate.paramNotBlank(namespace, "namespace");
         Validate.paramNotBlank(name, "name");
 
-        this.clazz = clazz;
+        this.namespace = namespace;
         this.name = name;
     }
 
     /**
-     * Create an instance of a property with a given type and name.
+     * Create a property.
+     *
+     * @param <T> the type of the property.
+     * @param namespace the class *where* the property is being defined
+     * @param name the name for the propety
      */
-    public static <T> SignerProperty<T> create(Class<T> clazz, String name) {
-        return new SignerProperty<>(clazz, name);
-    }
-
-    /**
-     * Create an instance of a property with a given type and name.
-     * TODO(sra-identity-auth): replace useage of other create method with this one
-     */
-    public static <T> SignerProperty<T> create(String name) {
-        return new SignerProperty<>((Class<T>) Object.class, name);
+    public static <T> SignerProperty<T> create(Class<?> namespace, String name) {
+        return new SignerProperty<>(namespace.getName(), name);
     }
 
     @Override
     public String toString() {
         return ToString.builder("SignerProperty")
-                       .add("clazz", clazz)
+                       .add("namespace", namespace)
                        .add("name", name)
                        .build();
     }
@@ -75,14 +71,14 @@ public final class SignerProperty<T> {
 
         SignerProperty<?> that = (SignerProperty<?>) o;
 
-        return Objects.equals(clazz, that.clazz) &&
+        return Objects.equals(namespace, that.namespace) &&
                Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
         int hashCode = 1;
-        hashCode = 31 * hashCode + Objects.hashCode(clazz);
+        hashCode = 31 * hashCode + Objects.hashCode(namespace);
         hashCode = 31 * hashCode + Objects.hashCode(name);
         return hashCode;
     }

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/scheme/AuthSchemeOptionTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/scheme/AuthSchemeOptionTest.java
@@ -23,10 +23,10 @@ import software.amazon.awssdk.http.auth.spi.signer.SignerProperty;
 import software.amazon.awssdk.identity.spi.IdentityProperty;
 
 class AuthSchemeOptionTest {
-    private static final IdentityProperty<String> IDENTITY_PROPERTY_1 = IdentityProperty.create(String.class, "identityKey1");
-    private static final SignerProperty<String> SIGNER_PROPERTY_1 = SignerProperty.create(String.class, "signingKey1");
-    private static final IdentityProperty<String> IDENTITY_PROPERTY_2 = IdentityProperty.create(String.class, "identityKey2");
-    private static final SignerProperty<String> SIGNER_PROPERTY_2 = SignerProperty.create(String.class, "signingKey2");
+    private static final IdentityProperty<String> IDENTITY_PROPERTY_1 = IdentityProperty.create(AuthSchemeOptionTest.class, "identityKey1");
+    private static final SignerProperty<String> SIGNER_PROPERTY_1 = SignerProperty.create(AuthSchemeOptionTest.class, "signingKey1");
+    private static final IdentityProperty<String> IDENTITY_PROPERTY_2 = IdentityProperty.create(AuthSchemeOptionTest.class, "identityKey2");
+    private static final SignerProperty<String> SIGNER_PROPERTY_2 = SignerProperty.create(AuthSchemeOptionTest.class, "signingKey2");
 
     @Test
     public void emptyBuilder_isNotSuccessful() {

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/HttpSignerTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/HttpSignerTest.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.identity.spi.TokenIdentity;
 
 public class HttpSignerTest {
 
-    private static final SignerProperty<String> KEY = SignerProperty.create(String.class, "key");
+    private static final SignerProperty<String> KEY = SignerProperty.create(HttpSignerTest.class, "key");
     private static final String VALUE = "value";
     private static final TokenIdentity IDENTITY = TokenIdentity.create("token");
 

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/SignerPropertyTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/SignerPropertyTest.java
@@ -23,7 +23,7 @@ public class SignerPropertyTest {
     @Test
     public void equalsHashcode() {
         EqualsVerifier.forClass(SignerProperty.class)
-                      .withNonnullFields("clazz", "name")
+                      .withNonnullFields("namespace", "name")
                       .verify();
     }
 }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/IdentityProperty.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/IdentityProperty.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.identity.spi;
 
+import java.util.Objects;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
@@ -29,25 +30,32 @@ import software.amazon.awssdk.utils.Validate;
 @Immutable
 @ThreadSafe
 public final class IdentityProperty<T> {
-    private final Class<T> clazz;
+    private final String namespace;
     private final String name;
 
-    private IdentityProperty(Class<T> clazz, String name) {
-        Validate.paramNotNull(clazz, "clazz");
+    private IdentityProperty(String namespace, String name) {
+        Validate.paramNotBlank(namespace, "namespace");
         Validate.paramNotBlank(name, "name");
 
-        this.clazz = clazz;
+        this.namespace = namespace;
         this.name = name;
     }
 
-    public static <T> IdentityProperty<T> create(Class<T> clazz, String name) {
-        return new IdentityProperty<>(clazz, name);
+    /**
+     * Create a property.
+     *
+     * @param <T> the type of the property.
+     * @param namespace the class *where* the property is being defined
+     * @param name the name for the propety
+     */
+    public static <T> IdentityProperty<T> create(Class<?> namespace, String name) {
+        return new IdentityProperty<>(namespace.getName(), name);
     }
 
     @Override
     public String toString() {
         return ToString.builder("IdentityProperty")
-                       .add("clazz", clazz)
+                       .add("namespace", namespace)
                        .add("name", name)
                        .build();
     }
@@ -63,16 +71,15 @@ public final class IdentityProperty<T> {
 
         IdentityProperty<?> that = (IdentityProperty<?>) o;
 
-        if (!clazz.equals(that.clazz)) {
-            return false;
-        }
-        return name.equals(that.name);
+        return Objects.equals(namespace, that.namespace) &&
+               Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        int result = clazz.hashCode();
-        result = 31 * result + name.hashCode();
-        return result;
+        int hashCode = 1;
+        hashCode = 31 * hashCode + Objects.hashCode(namespace);
+        hashCode = 31 * hashCode + Objects.hashCode(name);
+        return hashCode;
     }
 }

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/IdentityPropertyTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/IdentityPropertyTest.java
@@ -23,7 +23,7 @@ public class IdentityPropertyTest {
     @Test
     public void equalsHashcode() {
         EqualsVerifier.forClass(IdentityProperty.class)
-                      .withNonnullFields("clazz", "name")
+                      .withNonnullFields("namespace", "name")
                       .verify();
     }
 }

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/ResolveIdentityRequestTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.identity.spi.internal.DefaultResolveIdentityRequest;
 
 public class ResolveIdentityRequestTest {
-    private static final IdentityProperty<String> PROPERTY_1 = IdentityProperty.create(String.class, "key_1");
-    private static final IdentityProperty<String> PROPERTY_2 = IdentityProperty.create(String.class, "key_2");
+    private static final IdentityProperty<String> PROPERTY_1 =
+        IdentityProperty.create(ResolveIdentityRequestTest.class, "key_1");
+    private static final IdentityProperty<String> PROPERTY_2 =
+        IdentityProperty.create(ResolveIdentityRequestTest.class, "key_2");
 
     @Test
     public void equalsHashcode() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
@@ -69,7 +69,7 @@ import utils.ValidSdkObjects;
 @RunWith(MockitoJUnitRunner.class)
 public class AsyncSigningStageTest {
     private static final int TEST_TIME_OFFSET = 17;
-    private static final SignerProperty<String> SIGNER_PROPERTY = SignerProperty.create(String.class, "key");
+    private static final SignerProperty<String> SIGNER_PROPERTY = SignerProperty.create(AsyncSigningStageTest.class, "key");
 
     @Mock
     private Identity identity;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
@@ -63,7 +63,8 @@ import utils.ValidSdkObjects;
 public class SigningStageTest {
 
     private static final int TEST_TIME_OFFSET = 17;
-    private static final SignerProperty<String> SIGNER_PROPERTY = SignerProperty.create(String.class, "SigningStageTest.key");
+    private static final SignerProperty<String> SIGNER_PROPERTY =
+        SignerProperty.create(SigningStageTest.class, "key");
 
     @Mock
     private Identity identity;


### PR DESCRIPTION
## Motivation and Context
- To ensure uniqueness of properties, we can add the concept on namespacing when properties are defined

## Modifications
- Add namespace to property definitions, which is derived from a class' name when `create()` is called
- Updates all places where properties are defined and tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
