### PR TITLE
Remove unnecessary <T> from forEach*Property methods

### DIFF
--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/scheme/DefaultAuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/scheme/DefaultAuthSchemeOption.java
@@ -60,26 +60,22 @@ public final class DefaultAuthSchemeOption implements AuthSchemeOption {
         return (T) signerProperties.get(property);
     }
 
-    @SuppressWarnings("unchecked") // Cast added to use type <T> so the property and property value types match
     @Override
-    public <T> void forEachIdentityProperty(IdentityPropertyConsumer consumer) {
-        for (IdentityProperty<?> p : identityProperties.keySet()) {
-            // Note, <T> is added to this method signature to facilitate this cast below which is just to define a type, so that
-            // this.identityProperty() can rely on that type too, and consumer.accept relies on the matching type.
-            IdentityProperty<T> property = (IdentityProperty<T>) p;
-            consumer.accept(property, this.identityProperty(property));
-        }
+    public void forEachIdentityProperty(IdentityPropertyConsumer consumer) {
+        identityProperties.keySet().forEach(property -> consumeProperty(property, consumer));
     }
 
-    @SuppressWarnings("unchecked") // Cast added to use type <T> so the property and property value types match
+    private <T> void consumeProperty(IdentityProperty<T> property, IdentityPropertyConsumer consumer) {
+        consumer.accept(property, this.identityProperty(property));
+    }
+
     @Override
-    public <T> void forEachSignerProperty(SignerPropertyConsumer consumer) {
-        for (SignerProperty<?> p : signerProperties.keySet()) {
-            // Note, <T> is added to this method signature to facilitate this cast below which is just to define a type, so that
-            // this.identityProperty() can rely on that type too, and consumer.accept relies on the matching type.
-            SignerProperty<T> property = (SignerProperty<T>) p;
-            consumer.accept(property, this.signerProperty(property));
-        }
+    public void forEachSignerProperty(SignerPropertyConsumer consumer) {
+        signerProperties.keySet().forEach(property -> consumeProperty(property, consumer));
+    }
+
+    private <T> void consumeProperty(SignerProperty<T> property, SignerPropertyConsumer consumer) {
+        consumer.accept(property, this.signerProperty(property));
     }
 
     @Override

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/scheme/AuthSchemeOption.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/scheme/AuthSchemeOption.java
@@ -63,16 +63,14 @@ public interface AuthSchemeOption extends ToCopyableBuilder<AuthSchemeOption.Bui
     /**
      * A method to operate on all {@link IdentityProperty} values of this AuthSchemeOption.
      * @param consumer The method to apply to each IdentityProperty.
-     * @param <T> To represent the type for each IdentityProperty. Note the actual type can be different for each property.
      */
-    <T> void forEachIdentityProperty(IdentityPropertyConsumer consumer);
+    void forEachIdentityProperty(IdentityPropertyConsumer consumer);
 
     /**
      * A method to operate on all {@link SignerProperty} values of this AuthSchemeOption.
      * @param consumer The method to apply to each SignerProperty.
-     * @param <T> To represent the type for each SignerProperty. Note the actual type can be different for each property.
      */
-    <T> void forEachSignerProperty(SignerPropertyConsumer consumer);
+    void forEachSignerProperty(SignerPropertyConsumer consumer);
 
     /**
      * Interface for operating on an {@link IdentityProperty} value.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
AuthSchemeOption.forEach*Property methods were defined with <T> that is unnecessary. I tried some things earlier and ended up with in https://github.com/aws/aws-sdk-java-v2/pull/4411. But thanks to @millems for this suggestion.

## Modifications
<!--- Describe your changes in detail -->
Added a private method for <T> and removed <T> from the interface method. Code got simpler too!
