### PR TITLE
Support non-Json String payloads

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-36670dc.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-36670dc.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Adds support for non-Json String payloads"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -70,6 +70,13 @@ final class AddOperations {
     }
 
     /**
+     * @return True if shape is a String type. False otherwise
+     */
+    private static boolean isStringShape(Shape shape) {
+        return shape != null && "String".equals(shape.getType());
+    }
+
+    /**
      * If there is a member in the output shape that is explicitly marked as the payload (with the
      * payload trait) this method returns the target shape of that member. Otherwise this method
      * returns null.
@@ -191,6 +198,9 @@ final class AddOperations {
                         new ReturnTypeModel(responseClassName).withDocumentation(documentation));
                 if (isBlobShape(getPayloadShape(c2jShapes, outputShape))) {
                     operationModel.setHasBlobMemberAsPayload(true);
+                }
+                if (isStringShape(getPayloadShape(c2jShapes, outputShape))) {
+                    operationModel.setHasStringMemberAsPayload(true);
                 }
             }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
@@ -48,6 +48,8 @@ public class OperationModel extends DocumentationModel {
 
     private boolean hasBlobMemberAsPayload;
 
+    private boolean hasStringMemberAsPayload;
+
     private boolean isAuthenticated = true;
 
     private AuthType authType;
@@ -209,6 +211,14 @@ public class OperationModel extends DocumentationModel {
 
     public void setHasBlobMemberAsPayload(boolean hasBlobMemberAsPayload) {
         this.hasBlobMemberAsPayload = hasBlobMemberAsPayload;
+    }
+
+    public boolean getHasStringMemberAsPayload() {
+        return this.hasStringMemberAsPayload;
+    }
+
+    public void setHasStringMemberAsPayload(boolean hasStringMemberAsPayload) {
+        this.hasStringMemberAsPayload = hasStringMemberAsPayload;
     }
 
     public boolean hasStreamingInput() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -142,7 +142,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
             CodeBlock.builder()
                      .add("$T operationMetadata = $T.builder()\n", JsonOperationMetadata.class, JsonOperationMetadata.class)
                      .add(".hasStreamingSuccessResponse($L)\n", opModel.hasStreamingOutput())
-                     .add(".isPayloadJson($L)\n", !opModel.getHasBlobMemberAsPayload())
+                     .add(".isPayloadJson($L)\n", !opModel.getHasBlobMemberAsPayload() && !opModel.getHasStringMemberAsPayload())
                      .add(".build();");
 
         if (opModel.hasEventStreamOutput()) {

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -23,6 +23,7 @@ import static software.amazon.awssdk.http.Header.TRANSFER_ENCODING;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -182,6 +183,11 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
                 if (val != null) {
                     request.contentStreamProvider(((SdkBytes) val)::asInputStream);
                 }
+            } else if (isExplicitStringPayload(field)) {
+                if (val != null) {
+                    byte[] content = ((String) val).getBytes(StandardCharsets.UTF_8);
+                    request.contentStreamProvider(() -> new ByteArrayInputStream(content));
+                }
             } else if (isExplicitPayloadMember(field)) {
                 marshallExplicitJsonPayload(field, val);
             } else {
@@ -192,6 +198,10 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
 
     private boolean isExplicitBinaryPayload(SdkField<?> field) {
         return isExplicitPayloadMember(field) && MarshallingType.SDK_BYTES.equals(field.marshallingType());
+    }
+
+    private boolean isExplicitStringPayload(SdkField<?> field) {
+        return isExplicitPayloadMember(field) && MarshallingType.STRING.equals(field.marshallingType());
     }
 
     private boolean isExplicitPayloadMember(SdkField<?> field) {

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.protocols.json.internal.unmarshall;
 import static software.amazon.awssdk.protocols.core.StringToValueConverter.TO_SDK_BYTES;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.EnumMap;
 import java.util.HashMap;

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -247,9 +247,7 @@ public final class JsonProtocolUnmarshaller {
             } else if (isExplicitPayloadMember(field) && field.marshallingType() == MarshallingType.STRING) {
                 Optional<AbortableInputStream> responseContent = context.response().content();
                 if (responseContent.isPresent()) {
-                    InputStream is = responseContent.get();
-                    String payload = SdkBytes.fromInputStream(is).asUtf8String();
-                    field.set(sdkPojo, payload);
+                    field.set(sdkPojo, SdkBytes.fromInputStream(responseContent.get()).asUtf8String());
                 } else {
                     field.set(sdkPojo, "");
                 }

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -248,7 +248,7 @@ public final class JsonProtocolUnmarshaller {
                 Optional<AbortableInputStream> responseContent = context.response().content();
                 if (responseContent.isPresent()) {
                     InputStream is = responseContent.get();
-                    String payload = new String(SdkBytes.fromInputStream(is).asByteArray());
+                    String payload = SdkBytes.fromInputStream(is).asUtf8String();
                     field.set(sdkPojo, payload);
                 } else {
                     field.set(sdkPojo, "");

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
@@ -111,6 +111,15 @@
       "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
       "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
     },
+    "OperationWithExplicitPayloadString":{
+      "name":"OperationWithExplicitPayloadString",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
+      },
+      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
+      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
+    },
     "OperationWithExplicitPayloadStructure":{
       "name":"OperationWithExplicitPayloadStructure",
       "http":{
@@ -694,6 +703,13 @@
       "type":"structure",
       "members":{
         "PayloadMember":{"shape":"BlobType"}
+      },
+      "payload":"PayloadMember"
+    },
+    "OperationWithExplicitPayloadStringInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"String"}
       },
       "payload":"PayloadMember"
     },

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/StringPayloadUnmarshallingTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/StringPayloadUnmarshallingTest.java
@@ -35,6 +35,8 @@ import software.amazon.awssdk.regions.Region;
 
 @WireMockTest
 public class StringPayloadUnmarshallingTest {
+    private static final String TEST_PAYLOAD = "X";
+
     private static List<Arguments> testParameters() {
         List<Arguments> testCases = new ArrayList<>();
         for (ClientType clientType : ClientType.values()) {
@@ -66,7 +68,7 @@ public class StringPayloadUnmarshallingTest {
 
     private enum ContentLength {
         ZERO,
-        CHUNKED_ZERO
+        NOT_PRESENT
     }
 
     @ParameterizedTest
@@ -78,7 +80,7 @@ public class StringPayloadUnmarshallingTest {
                                                            WireMockRuntimeInfo wm) {
         if (contentLength == ContentLength.ZERO) {
             stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withHeader("Content-Length", "0").withBody("")));
-        } else if (contentLength == ContentLength.CHUNKED_ZERO) {
+        } else if (contentLength == ContentLength.NOT_PRESENT) {
             stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("")));
         }
 
@@ -104,16 +106,16 @@ public class StringPayloadUnmarshallingTest {
             stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200)
                                                          .withHeader("Content-Length", Integer.toString(responsePayload.length()))
                                                          .withBody(responsePayload)));
-        } else if (contentLength == ContentLength.CHUNKED_ZERO) {
+        } else if (contentLength == ContentLength.NOT_PRESENT) {
             stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responsePayload)));
         }
 
-        assertThat(callService(wm, clientType, protocol, stringLoc)).isEqualTo("X");
+        assertThat(callService(wm, clientType, protocol, stringLoc)).isEqualTo(TEST_PAYLOAD);
     }
 
     private String presentStringResponse(Protocol protocol, StringLocation stringLoc) {
         switch (stringLoc) {
-            case PAYLOAD: return "X";
+            case PAYLOAD: return TEST_PAYLOAD;
             case FIELD:
                 switch (protocol) {
                     case JSON: return "{\"StringMember\": \"X\"}";

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/StringPayloadUnmarshallingTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/StringPayloadUnmarshallingTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.protocolrestjson;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+@WireMockTest
+public class StringPayloadUnmarshallingTest {
+    private static List<Arguments> testParameters() {
+        List<Arguments> testCases = new ArrayList<>();
+        for (ClientType clientType : ClientType.values()) {
+            for (Protocol protocol : Protocol.values()) {
+                for (StringLocation value : StringLocation.values()) {
+                    for (ContentLength contentLength : ContentLength.values()) {
+                        testCases.add(Arguments.arguments(clientType, protocol, value, contentLength));
+                    }
+                }
+            }
+        }
+        return testCases;
+    }
+
+    private enum ClientType {
+        SYNC,
+        ASYNC
+    }
+
+    private enum Protocol {
+        JSON
+        // TODO - add support for XML
+    }
+
+    private enum StringLocation {
+        PAYLOAD,
+        FIELD
+    }
+
+    private enum ContentLength {
+        ZERO,
+        CHUNKED_ZERO
+    }
+
+    @ParameterizedTest
+    @MethodSource("testParameters")
+    public void missingStringPayload_unmarshalledCorrectly(ClientType clientType,
+                                                           Protocol protocol,
+                                                           StringLocation stringLoc,
+                                                           ContentLength contentLength,
+                                                           WireMockRuntimeInfo wm) {
+        if (contentLength == ContentLength.ZERO) {
+            stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withHeader("Content-Length", "0").withBody("")));
+        } else if (contentLength == ContentLength.CHUNKED_ZERO) {
+            stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("")));
+        }
+
+        String serviceResult = callService(wm, clientType, protocol, stringLoc);
+
+        if (stringLoc == StringLocation.PAYLOAD) {
+            assertThat(serviceResult).isNotNull().isEqualTo("");
+        } else if (stringLoc == StringLocation.FIELD) {
+            assertThat(serviceResult).isNull();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testParameters")
+    public void presentStringPayload_unmarshalledCorrectly(ClientType clientType,
+                                                           Protocol protocol,
+                                                           StringLocation stringLoc,
+                                                           ContentLength contentLength,
+                                                           WireMockRuntimeInfo wm) {
+        String responsePayload = presentStringResponse(protocol, stringLoc);
+
+        if (contentLength == ContentLength.ZERO) {
+            stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200)
+                                                         .withHeader("Content-Length", Integer.toString(responsePayload.length()))
+                                                         .withBody(responsePayload)));
+        } else if (contentLength == ContentLength.CHUNKED_ZERO) {
+            stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responsePayload)));
+        }
+
+        assertThat(callService(wm, clientType, protocol, stringLoc)).isEqualTo("X");
+    }
+
+    private String presentStringResponse(Protocol protocol, StringLocation stringLoc) {
+        switch (stringLoc) {
+            case PAYLOAD: return "X";
+            case FIELD:
+                switch (protocol) {
+                    case JSON: return "{\"StringMember\": \"X\"}";
+                    // TODO - add support for XML
+                    default: throw new UnsupportedOperationException();
+                }
+            default: throw new UnsupportedOperationException();
+        }
+
+    }
+
+    private String callService(WireMockRuntimeInfo wm, ClientType clientType, Protocol protocol, StringLocation stringLoc) {
+        switch (clientType) {
+            case SYNC: return syncCallService(wm, protocol, stringLoc);
+            case ASYNC: return asyncCallService(wm, protocol, stringLoc);
+            default: throw new UnsupportedOperationException();
+        }
+    }
+
+    private String syncCallService(WireMockRuntimeInfo wm, Protocol protocol, StringLocation stringLoc) {
+        switch (protocol) {
+            case JSON: return syncJsonCallService(wm, stringLoc);
+            // TODO - add support for XML
+            default: throw new UnsupportedOperationException();
+        }
+    }
+
+    private String asyncCallService(WireMockRuntimeInfo wm, Protocol protocol, StringLocation stringLoc) {
+        switch (protocol) {
+            case JSON: return asyncJsonCallService(wm, stringLoc);
+            // TODO - add support for XML
+            default: throw new UnsupportedOperationException();
+        }
+    }
+
+    private String syncJsonCallService(WireMockRuntimeInfo wm, StringLocation stringLoc) {
+        ProtocolRestJsonClient client =
+            ProtocolRestJsonClient.builder()
+                                  .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                                  .region(Region.US_EAST_1)
+                                  .endpointOverride(URI.create(wm.getHttpBaseUrl()))
+                                  .build();
+        switch (stringLoc) {
+            case PAYLOAD: return client.operationWithExplicitPayloadString(r -> {}).payloadMember();
+            case FIELD: return client.allTypes(r -> {}).stringMember();
+            default: throw new UnsupportedOperationException();
+        }
+    }
+
+    private String asyncJsonCallService(WireMockRuntimeInfo wm, StringLocation stringLoc) {
+        ProtocolRestJsonAsyncClient client =
+            ProtocolRestJsonAsyncClient.builder()
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                                       .region(Region.US_EAST_1)
+                                       .endpointOverride(URI.create(wm.getHttpBaseUrl()))
+                                       .build();
+
+        switch (stringLoc) {
+            case PAYLOAD: return client.operationWithExplicitPayloadString(r -> {}).join().payloadMember();
+            case FIELD: return client.allTypes(r -> {}).join().stringMember();
+            default: throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
@@ -139,6 +139,33 @@
   }
 },
 {
+  "description": "TestStringPayload",
+  "given": {
+    "input": {
+      "data": "1234",
+      "contentType": "text/plain"
+    }
+  },
+  "when": {
+    "action": "marshall",
+    "operation": "TestStringPayload"
+  },
+  "then": {
+    "serializedAs": {
+      "uri": "/string-payload",
+      "method": "POST",
+      "headers": {
+        "contains": {
+          "Content-Type": "text/plain"
+        }
+      },
+      "body": {
+        "equals": "1234"
+      }
+    }
+  }
+},
+{
   "description": "TestBlobPayloadNoParams",
   "given": {
     "input": {
@@ -151,6 +178,31 @@
   "then": {
     "serializedAs": {
       "uri": "/blob-payload",
+      "method": "POST",
+      "headers": {
+        "doesNotContain": [
+          "Content-Type"
+        ]
+      },
+      "body": {
+        "equals": ""
+      }
+    }
+  }
+},
+{
+  "description": "TestStringPayloadNoParams",
+  "given": {
+    "input": {
+    }
+  },
+  "when": {
+    "action": "marshall",
+    "operation": "TestStringPayload"
+  },
+  "then": {
+    "serializedAs": {
+      "uri": "/string-payload",
       "method": "POST",
       "headers": {
         "doesNotContain": [

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/contenttype/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/contenttype/service-2.json
@@ -36,6 +36,14 @@
       },
       "input": {"shape": "TestBlobPayloadRequest"}
     },
+    "TestStringPayload": {
+      "name": "TestStringPayload",
+      "http": {
+        "method": "POST",
+        "requestUri": "/string-payload"
+      },
+      "input": {"shape": "TestStringPayloadRequest"}
+    },
     "NoPayload": {
       "name": "NoPayload",
       "http": {
@@ -173,6 +181,24 @@
       "documentation":"<p> The request structure for a blob payload request. </p>",
       "payload":"data"
     },
+    "TestStringPayloadRequest":{
+      "type":"structure",
+      "required":[],
+      "members":{
+        "data":{
+          "shape":"String",
+          "documentation":"<p> String payload to post </p>"
+        },
+        "contentType":{
+          "shape":"String",
+          "documentation":"<p> Optional content-type header </p>",
+          "location":"header",
+          "locationName":"Content-Type"
+        }
+      },
+      "documentation":"<p> The request structure for a String payload request. </p>",
+      "payload":"data"
+    },
     "TestEventStreamRequest": {
       "type": "structure",
       "required": [
@@ -191,6 +217,9 @@
         "BlobAndHeadersEvent": {
           "shape": "BlobAndHeadersEvent"
         },
+        "StringAndHeadersEvent": {
+          "shape": "StringAndHeadersEvent"
+        },
         "HeadersOnlyEvent": {
           "shape": "HeadersOnlyEvent"
         },
@@ -205,6 +234,20 @@
       "members": {
         "BlobPayloadMember": {
           "shape":"BlobPayloadMember",
+          "eventpayload":true
+        },
+        "HeaderMember": {
+          "shape": "String",
+          "eventheader": true
+        }
+      },
+      "event": true
+    },
+    "StringAndHeadersEvent": {
+      "type": "structure",
+      "members": {
+        "StringPayloadMember": {
+          "shape":"String",
           "eventpayload":true
         },
         "HeaderMember": {

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
@@ -131,6 +131,15 @@
       "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
       "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
     },
+    "OperationWithExplicitPayloadString":{
+      "name":"OperationWithExplicitPayloadString",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
+      },
+      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
+      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
+    },
     "OperationWithExplicitPayloadStructure":{
       "name":"OperationWithExplicitPayloadStructure",
       "http":{
@@ -212,6 +221,19 @@
       },
       "input": {
         "shape": "EventStreamOperationRequest"
+      },
+      "output": {
+        "shape": "EventStreamOutput"
+      }
+    },
+    "EventStreamStringPayloadOperation": {
+      "name": "EventStreamStringPayloadOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/eventStreamStringPayloadOperation"
+      },
+      "input": {
+        "shape": "EventStreamStringPayloadOperationRequest"
       },
       "output": {
         "shape": "EventStreamOutput"
@@ -669,6 +691,13 @@
       },
       "payload":"PayloadMember"
     },
+    "OperationWithExplicitPayloadStringInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"String"}
+      },
+      "payload":"PayloadMember"
+    },
     "OperationWithExplicitPayloadStructureInput":{
       "type":"structure",
       "members":{
@@ -815,6 +844,18 @@
       },
       "payload":"InputEventStream"
     },
+    "EventStreamStringPayloadOperationRequest": {
+      "type": "structure",
+      "required": [
+        "InputEventStream"
+      ],
+      "members": {
+        "InputEventStreamStringPayload": {
+          "shape": "InputEventStreamStringPayload"
+        }
+      },
+      "payload":"InputEventStreamStringPayload"
+    },
     "EventStreamOutput": {
       "type": "structure",
       "required": [
@@ -835,11 +876,34 @@
       },
       "eventstream": true
     },
+    "InputEventStreamStringPayload": {
+      "type": "structure",
+      "members": {
+        "InputEvent": {
+          "shape": "InputEventStringPayload"
+        }
+      },
+      "eventstream": true
+    },
     "InputEvent": {
       "type": "structure",
       "members": {
         "ExplicitPayloadMember": {
           "shape":"ExplicitPayloadMember",
+          "eventpayload":true
+        },
+        "HeaderMember": {
+          "shape": "String",
+          "eventheader": true
+        }
+      },
+      "event": true
+    },
+    "InputEventStringPayload": {
+      "type": "structure",
+      "members": {
+        "ExplicitPayloadStringMember": {
+          "shape":"String",
           "eventpayload":true
         },
         "HeaderMember": {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/RestJsonEventStreamProtocolTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/RestJsonEventStreamProtocolTest.java
@@ -32,9 +32,11 @@ import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.Headers
 import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.ImplicitPayloadAndHeadersEvent;
 import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.InputEventStream;
 import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.ProtocolRestJsonContentTypeException;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.StringAndHeadersEvent;
 import software.amazon.awssdk.services.protocolrestjsoncontenttype.transform.BlobAndHeadersEventMarshaller;
 import software.amazon.awssdk.services.protocolrestjsoncontenttype.transform.HeadersOnlyEventMarshaller;
 import software.amazon.awssdk.services.protocolrestjsoncontenttype.transform.ImplicitPayloadAndHeadersEventMarshaller;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.transform.StringAndHeadersEventMarshaller;
 
 public class RestJsonEventStreamProtocolTest {
     private static final String EVENT_CONTENT_TYPE_HEADER = ":content-type";
@@ -85,6 +87,22 @@ public class RestJsonEventStreamProtocolTest {
 
         assertThat(marshalledEvent.headers().get(EVENT_CONTENT_TYPE_HEADER)).containsExactly("application/octet-stream");
 
+        String content = contentAsString(marshalledEvent);
+        assertThat(content).isEqualTo("hello rest-json");
+    }
+
+    @Test
+    public void stringAndHeadersEvent() {
+        StringAndHeadersEventMarshaller marshaller = new StringAndHeadersEventMarshaller(protocolFactory());
+
+        StringAndHeadersEvent event = InputEventStream.stringAndHeadersEventBuilder()
+                                                      .headerMember("hello rest-json")
+                                                      .stringPayloadMember("hello rest-json")
+                                                      .build();
+
+        SdkHttpFullRequest marshalledEvent = marshaller.marshall(event);
+
+        assertThat(marshalledEvent.headers().get(EVENT_CONTENT_TYPE_HEADER)).containsExactly("text/plain");
         String content = contentAsString(marshalledEvent);
         assertThat(content).isEqualTo("hello rest-json");
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
To support non-Json String payloads

## Modifications
<!--- Describe your changes in detail -->
Update Json marshaller/unmarshaller to support explicit String payloads, including non-Json Strings

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
