### PR TITLE
Fixed the issue where SdkException is unnecessarily re-wrapped with S…

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-9202e1b.json
+++ b/.changes/next-release/bugfix-AmazonS3-9202e1b.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fixed the issue where SdkException is unnecessarily re-wrapped with SdkClientException in S3 multipart client and AWS CRT-based S3 client. See[#4356](https://github.com/aws/aws-sdk-java-v2/issues/4356)"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/GenericMultipartHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/GenericMultipartHelper.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
@@ -59,7 +60,8 @@ public final class GenericMultipartHelper<RequestT extends S3Request, ResponseT 
                                 Throwable throwable) {
         Throwable cause = throwable instanceof CompletionException ? throwable.getCause() : throwable;
 
-        if (cause instanceof Error) {
+        if (cause instanceof Error || cause instanceof SdkException) {
+            cause.addSuppressed(SdkClientException.create(message.get()));
             returnFuture.completeExceptionally(cause);
         } else {
             SdkClientException exception = SdkClientException.create(message.get(), cause);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -82,8 +82,8 @@ class CopyObjectHelperTest {
         CompletableFuture<CopyObjectResponse> future =
             copyHelper.copyObject(copyObjectRequest());
 
-        assertThatThrownBy(future::join).hasCauseInstanceOf(SdkClientException.class)
-                                        .hasMessageContaining("Failed to retrieve metadata")
+        assertThatThrownBy(future::join).hasCauseInstanceOf(NoSuchBucketException.class)
+                                        .hasStackTraceContaining("Failed to retrieve metadata")
                                         .hasRootCause(exception);
     }
 
@@ -199,7 +199,7 @@ class CopyObjectHelperTest {
 
         CompletableFuture<CopyObjectResponse> future = copyHelper.copyObject(copyObjectRequest);
 
-        assertThatThrownBy(future::join).hasMessageContaining("Failed to send multipart requests").hasRootCause(exception);
+        assertThatThrownBy(future::join).hasStackTraceContaining("Failed to send multipart requests").hasCause(exception);
 
         verify(s3AsyncClient, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
 
@@ -237,7 +237,7 @@ class CopyObjectHelperTest {
         CompletableFuture<CopyObjectResponse> future =
             copyHelper.copyObject(copyObjectRequest);
 
-        assertThatThrownBy(future::join).hasMessageContaining("Failed to send multipart requests").hasRootCause(exception);
+        assertThatThrownBy(future::join).hasStackTraceContaining("Failed to send multipart requests").hasCause(exception);
 
         ArgumentCaptor<AbortMultipartUploadRequest> argumentCaptor = ArgumentCaptor.forClass(AbortMultipartUploadRequest.class);
         verify(s3AsyncClient).abortMultipartUpload(argumentCaptor.capture());

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadObjectHelperTest.java
@@ -195,7 +195,7 @@ public class UploadObjectHelperTest {
                                                                                 asyncRequestBody);
 
         assertThatThrownBy(() -> future.get(100, TimeUnit.MILLISECONDS))
-            .hasMessageContaining("Failed to send multipart upload requests").hasRootCause(exception);
+            .hasStackTraceContaining("Failed to send multipart upload requests").hasCause(exception);
 
         verify(s3AsyncClient, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
 
@@ -277,8 +277,8 @@ public class UploadObjectHelperTest {
 
         CompletableFuture<PutObjectResponse> future = uploadHelper.uploadObject(putObjectRequest,
                                                                                 asyncRequestBody);
-        assertThatThrownBy(future::join).hasMessageContaining("Failed to initiate multipart upload")
-                                        .hasRootCause(exception);
+        assertThatThrownBy(future::join).hasStackTraceContaining("Failed to initiate multipart upload")
+                                        .hasCause(exception);
     }
 
     @ParameterizedTest
@@ -302,8 +302,8 @@ public class UploadObjectHelperTest {
 
         CompletableFuture<PutObjectResponse> future = uploadHelper.uploadObject(putObjectRequest,
                                                                                 asyncRequestBody);
-        assertThatThrownBy(future::join).hasMessageContaining("Failed to send multipart requests")
-                                        .hasRootCause(exception);
+        assertThatThrownBy(future::join).hasCause(exception)
+                                        .hasStackTraceContaining("Failed to send multipart requests");
     }
 
     @ParameterizedTest()


### PR DESCRIPTION
…dkClientException in S3 multipart client and AWS CRT-based S3 client.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix #4356 

In the existing implementation, SdkExceptions are re-wrapped with SdkClientException, which is unnecessary and makes it harder for users to handle the exception programmatically. 

## Modifications
- Updated the code to not wrap the cause with SdkClientException if the cause is already an instance of SdkException
- To preserve the stacktrace, a new SdkClientException with current stacktrace is added as a suppressed exception 

## Testing
Existing test passed

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
