### PR TITLE
Fixed a bug in DynamoDbTable.createTable, where global secondary indi…

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDB-9af3af7.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-9af3af7.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB",
+    "contributor": "",
+    "description": "Fixed a bug in DynamoDbTable.createTable, where global secondary indices with a partition key matching the default partition key of the table would be created as local secondary indices."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
@@ -134,13 +134,12 @@ public class DefaultDynamoDbTable<T> implements DynamoDbTable<T> {
     }
 
     private Map<IndexType, List<IndexMetadata>> splitSecondaryIndicesToLocalAndGlobalOnes() {
-        String primaryPartitionKeyName = tableSchema.tableMetadata().primaryPartitionKey();
         Collection<IndexMetadata> indices = tableSchema.tableMetadata().indices();
         return indices.stream()
                       .filter(index -> !TableMetadata.primaryIndexName().equals(index.name()))
                       .collect(Collectors.groupingBy(metadata -> {
                           String partitionKeyName = metadata.partitionKey().map(KeyAttributeMetadata::name).orElse(null);
-                          if (partitionKeyName == null || primaryPartitionKeyName.equals(partitionKeyName)) {
+                          if (partitionKeyName == null) {
                               return IndexType.LSI;
                           }
                           return IndexType.GSI;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbSecondaryPartitionKey.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbSecondaryPartitionKey.java
@@ -23,9 +23,12 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.BeanTableSchemaAttributeTags;
 
 /**
- * Denotes a partition key for a global secondary index. You must also specify at least one index name, although this
- * name is only referenced internally by the enhanced client to disambiguate the index and does not actually need to
- * match the real name of the index.
+ * Denotes a partition key for a global secondary index.
+ *
+ * <p>You must also specify at least one index name.
+ *
+ * <p>The index name will be used if a table is created from this bean. For data-oriented operations like reads and writes, this
+ * name does not need to match the service-side name of the index.
  */
 @SdkPublicApi
 @Target({ElementType.METHOD})

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbSecondarySortKey.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbSecondarySortKey.java
@@ -23,10 +23,14 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.BeanTableSchemaAttributeTags;
 
 /**
- * Denotes an optional sort key for a global or local secondary index. You must also specify the index name which in the
- * case of a global secondary index must match the index name supplied with the secondary partition key for the same
- * index. This name is only referenced internally by the enhanced client to disambiguate the index and does not actually
- * need to match the real name of the index.
+ * Denotes an optional sort key for a global or local secondary index.
+ *
+ * <p>You must also specify at least one index name. For global secondary indices, this must match an index name specified in
+ * a {@link DynamoDbSecondaryPartitionKey}. Any index names specified that do not have an associated
+ * {@link DynamoDbSecondaryPartitionKey} are treated as local secondary indexes.
+ *
+ * <p>The index name will be used if a table is created from this bean. For data-oriented operations like reads and writes, this
+ * name does not need to match the service-side name of the index.
  */
 @SdkPublicApi
 @Target({ElementType.METHOD})
@@ -35,6 +39,10 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.BeanTableSchemaA
 public @interface DynamoDbSecondarySortKey {
     /**
      * The names of one or more local or global secondary indices that this sort key should participate in.
+     *
+     * <p>For global secondary indices, this must match an index name specified in a {@link DynamoDbSecondaryPartitionKey}. Any
+     * index names specified that do not have an associated {@link DynamoDbSecondaryPartitionKey} are treated as local
+     * secondary indexes.
      */
     String[] indexNames();
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/SecondaryIndexMatchingTableKeyBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/SecondaryIndexMatchingTableKeyBean.java
@@ -22,15 +22,16 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecon
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 
 /**
- * A bean with a local secondary index and a global secondary index.
+ * A bean with a global secondary index that uses the same partition key as the table.
  */
 @DynamoDbBean
-public class SecondaryIndexBean {
+public class SecondaryIndexMatchingTableKeyBean {
     private String id;
     private Integer sort;
     private String attribute;
 
     @DynamoDbPartitionKey
+    @DynamoDbSecondaryPartitionKey(indexNames = "gsi")
     public String getId() {
         return this.id;
     }
@@ -40,7 +41,6 @@ public class SecondaryIndexBean {
     }
 
     @DynamoDbSortKey
-    @DynamoDbSecondaryPartitionKey(indexNames = "gsi")
     public Integer getSort() {
         return sort;
     }
@@ -49,7 +49,7 @@ public class SecondaryIndexBean {
         this.sort = sort;
     }
 
-    @DynamoDbSecondarySortKey(indexNames = {"lsi", "gsi"})
+    @DynamoDbSecondarySortKey(indexNames = "gsi")
     public String getAttribute() {
         return attribute;
     }


### PR DESCRIPTION
…ces with a partition key matching the default partition key of the table would be created as local secondary indices.