### PR TITLE
Fixed an issue in InputStreamSubscriber that could cause NPE to be thrown when close and o…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-4c44582.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-4c44582.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue in `InputStreamSubscriber` that could cause NPE to be thrown when close and onSubscribed get invoked concurrently. See [#4081](https://github.com/aws/aws-sdk-java-v2/issues/4081)"
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
@@ -45,6 +45,8 @@ public final class InputStreamSubscriber extends InputStream implements Subscrib
     private final AtomicBoolean drainingCallQueue = new AtomicBoolean(false);
     private final Queue<QueueEntry> callQueue = new ConcurrentLinkedQueue<>();
 
+    private final Object subscribeLock = new Object();
+
     private Subscription subscription;
 
     private boolean done = false;
@@ -55,13 +57,15 @@ public final class InputStreamSubscriber extends InputStream implements Subscrib
 
     @Override
     public void onSubscribe(Subscription s) {
-        if (!inputStreamState.compareAndSet(State.UNINITIALIZED, State.READABLE)) {
-            close();
-            return;
-        }
+        synchronized (subscribeLock) {
+            if (!inputStreamState.compareAndSet(State.UNINITIALIZED, State.READABLE)) {
+                close();
+                return;
+            }
 
-        this.subscription = new CancelWatcher(s);
-        delegate.onSubscribe(subscription);
+            this.subscription = new CancelWatcher(s);
+            delegate.onSubscribe(subscription);
+        }
     }
 
     @Override
@@ -120,12 +124,14 @@ public final class InputStreamSubscriber extends InputStream implements Subscrib
 
     @Override
     public void close() {
-        if (inputStreamState.compareAndSet(State.UNINITIALIZED, State.CLOSED)) {
-            delegate.onSubscribe(new NoOpSubscription());
-            delegate.onError(new CancellationException());
-        } else if (inputStreamState.compareAndSet(State.READABLE, State.CLOSED)) {
-            subscription.cancel();
-            onError(new CancellationException());
+        synchronized (subscribeLock) {
+            if (inputStreamState.compareAndSet(State.UNINITIALIZED, State.CLOSED)) {
+                delegate.onSubscribe(new NoOpSubscription());
+                delegate.onError(new CancellationException());
+            } else if (inputStreamState.compareAndSet(State.READABLE, State.CLOSED)) {
+                subscription.cancel();
+                onError(new CancellationException());
+            }
         }
     }
 


### PR DESCRIPTION
…nSubscribed get invoked concurrently.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix #4081 The root cause is a race condition that onSubscribe and close are invoked concurrently, the subscription could be null, causing NPE to be thrown from close method.

## Modifications
Add a lock in onSubscribe and close

## Testing
Tested it locally and verified the test no longer failed with this change. This test is not checked in because it cannot reproduce this issue reliably. 
```
    @Test
    public void closeOnSubscribe_invokeAtSameTime_shouldNotFail() {
        int count = 0;
        for (int i = 0; i < 10000; i++) {
            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> subscriber.close());
            //publisher.subscribe(subscriber);
            subscriber.onSubscribe(new Subscription() {
                @Override
                public void request(long n) {

                }

                @Override
                public void cancel() {

                }
            });
            future.join();
        }

    }
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
