### PR TITLE
Use JDK 21 to build javadocs and enable search button

### DIFF
--- a/buildspecs/release-javadoc.yml
+++ b/buildspecs/release-javadoc.yml
@@ -1,11 +1,11 @@
 version: 0.2
 env:
   variables:
-    JAVA_HOME: "/usr/lib/jvm/java-18-amazon-corretto/"
+    JAVA_HOME: "/usr/lib/jvm/java-21-amazon-corretto/"
 phases:
   install:
     commands:
-    - apt-get update; apt-get install -y java-18-amazon-corretto-jdk
+    - apt-get update; apt-get install -y java-21-amazon-corretto-jdk
     - update-alternatives --auto javac
     - update-alternatives --auto java
     - pip install awscli==1.19.34 --upgrade --user

--- a/pom.xml
+++ b/pom.xml
@@ -1002,9 +1002,8 @@
                             <show>public</show>
                             <author>false</author>
                             <version>true</version>
-                            <!-- Disable index because jquery-ui version used is old -->
-                            <!-- Re-enable it when it's fixed in newer versions of JDK -->
-                            <noindex>true</noindex>
+                            <!-- Whether to enable search button -->
+                            <noindex>false</noindex>
                             <use>false</use>
                             <source>8</source>
                             <notree>true</notree>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Use JDK 21 to build javadocs so that we can enable search button

Verified jquery version is up-to-date with JDK 21 https://docs.oracle.com/en/java/javase/21/docs/api/script-dir/jquery-ui.min.js 



## Testing
Tested locally and verified it worked