### PR TITLE
Fix isClientSignerOverridden to check actual value

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
@@ -66,12 +66,14 @@ public final class SignerOverrideUtils {
      * @deprecated No longer used by modern clients after migration to reference architecture
      */
     @Deprecated
+    // TODO(sra-identity-and-auth): These used to be used by EndpointsAuthSchemeInterceptor, which has now been removed, but
+    //  this method is still used  from AwsExecutionContextBuilder. Should @Deprecated be removed?
     public static boolean isSignerOverridden(SdkRequest request, ExecutionAttributes executionAttributes) {
-        Optional<Boolean> isClientSignerOverridden = Optional.ofNullable(
-            executionAttributes.getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
+        boolean isClientSignerOverridden =
+            Boolean.TRUE.equals(executionAttributes.getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));
         Optional<Signer> requestSigner = request.overrideConfiguration()
                                                 .flatMap(RequestOverrideConfiguration::signer);
-        return isClientSignerOverridden.isPresent() || requestSigner.isPresent();
+        return isClientSignerOverridden || requestSigner.isPresent();
     }
 
     /**

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/util/SignerOverrideUtils.java
@@ -30,11 +30,8 @@ import software.amazon.awssdk.core.signer.Signer;
 /**
  * Utility to override a given {@link SdkRequest}'s {@link Signer}. Typically used by {@link ExecutionInterceptor}s that wish to
  * dynamically enable particular signing methods, like SigV4a for multi-region endpoints.
- *
- * @deprecated No longer used by modern clients after migration to reference architecture
  */
 @SdkProtectedApi
-@Deprecated
 public final class SignerOverrideUtils {
     private SignerOverrideUtils() {
     }
@@ -62,12 +59,6 @@ public final class SignerOverrideUtils {
         return overrideSigner(request, signer.get());
     }
 
-    /**
-     * @deprecated No longer used by modern clients after migration to reference architecture
-     */
-    @Deprecated
-    // TODO(sra-identity-and-auth): These used to be used by EndpointsAuthSchemeInterceptor, which has now been removed, but
-    //  this method is still used  from AwsExecutionContextBuilder. Should @Deprecated be removed?
     public static boolean isSignerOverridden(SdkRequest request, ExecutionAttributes executionAttributes) {
         boolean isClientSignerOverridden =
             Boolean.TRUE.equals(executionAttributes.getAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN));

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SraIdentityResolutionTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SraIdentityResolutionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SraIdentityResolutionTest {
+
+    @Mock
+    private AwsCredentialsProvider credsProvider;
+
+    @Test
+    public void testIdentityPropertyBasedResolutionIsUsedAndNotAnotherIdentityResolution() {
+        when(credsProvider.identityType()).thenReturn(AwsCredentialsIdentity.class);
+        when(credsProvider.resolveIdentity(any(ResolveIdentityRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(AwsBasicCredentials.create("akid1", "skid2")));
+        ProtocolRestJsonClient syncClient = ProtocolRestJsonClient
+            .builder()
+            .credentialsProvider(credsProvider)
+            // Below is necessary to create the test case where, addCredentialsToExecutionAttributes was getting called before
+            .overrideConfiguration(ClientOverrideConfiguration.builder().build())
+            .build();
+
+        try {
+            syncClient.allTypes();
+        } catch (Exception expected) {
+        }
+
+        verify(credsProvider, times(2)).identityType();
+
+        // This asserts that the identity used is the one from resolveIdentity() called by SRA AuthSchemeInterceptor and not from
+        // from another call like from AwsCredentialsAuthorizationStrategy.addCredentialsToExecutionAttributes, asserted by
+        // combination of times(1) and verifyNoMoreInteractions.
+        verify(credsProvider, times(1)).resolveIdentity(any(ResolveIdentityRequest.class));
+        verifyNoMoreInteractions(credsProvider);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
isSignerOverridden is used in AwsExecutionContextBuilder. 

The SIGNER_OVERRIDDEN ExecutionAttribute is set here
https://github.com/aws/aws-sdk-java-v2/blob/32390a25048bdae15b4cac319af8805759dd1aa6/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java#L110

And isSignerOverridden is called here
https://github.com/aws/aws-sdk-java-v2/blob/32390a25048bdae15b4cac319af8805759dd1aa6/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java#L156
which is called here
https://github.com/aws/aws-sdk-java-v2/blob/32390a25048bdae15b4cac319af8805759dd1aa6/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java#L129-L136

So when the client is configured if SIGNER_OVERRIDDEN is non-null, loadSigner would have been true. In master branch,  SIGNER_OVERRIDDEN was always null or true. In the SRA branch now, it can be null or true or false. See [comment in]( https://github.com/aws/aws-sdk-java-v2/pull/4438).

In SRA branch now, Signer is always null, so even if loadSigner is called, the ExecutionContext.signer [here](https://github.com/aws/aws-sdk-java-v2/blob/32390a25048bdae15b4cac319af8805759dd1aa6/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java#L147) will be null, so the SRA HttpSigner gets used, which is all fine. However, the call to `addCredentialsToExecutionAttributes` means identity resolution happens there a second time (1st time happened in AuthSchemeInterceptor, which happens before this point). More than the issue of happening twice (which adds a small risk of that call failing), because of the derived attribute logic from https://github.com/aws/aws-sdk-java-v2/pull/4396, addCredentialsToExecutionAttributes will result in the identity to be updated in SelectedAuthScheme, which would break identity property based auth resolution for an upcoming service.

## Modifications
<!--- Describe your changes in detail -->
Check that the value of SIGNER_OVERRIDDEN is present instead of just isPresent.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I realized this issue while stepping through the debugger for some other testing I was doing and noticed going into loadSigner branch unexpectedly. Verified after this change, it doesn't go into that branch.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
