### PR TITLE
Validate that SignerProperty and IdentityProperty namespaces/names are unique.

### DIFF
--- a/core/http-auth-spi/pom.xml
+++ b/core/http-auth-spi/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/SignerPropertyTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/SignerPropertyTest.java
@@ -15,6 +15,9 @@
 
 package software.amazon.awssdk.http.auth.spi.signer;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
@@ -25,5 +28,16 @@ public class SignerPropertyTest {
         EqualsVerifier.forClass(SignerProperty.class)
                       .withNonnullFields("namespace", "name")
                       .verify();
+    }
+
+    @Test
+    public void namesMustBeUnique() {
+        String propertyName = UUID.randomUUID().toString();
+
+        SignerProperty.create(getClass(), propertyName);
+        assertThatThrownBy(() -> SignerProperty.create(getClass(), propertyName))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(getClass().getName())
+            .hasMessageContaining(propertyName);
     }
 }

--- a/core/identity-spi/pom.xml
+++ b/core/identity-spi/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>equalsverifier</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/IdentityPropertyTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/IdentityPropertyTest.java
@@ -15,6 +15,9 @@
 
 package software.amazon.awssdk.identity.spi;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
@@ -25,5 +28,16 @@ public class IdentityPropertyTest {
         EqualsVerifier.forClass(IdentityProperty.class)
                       .withNonnullFields("namespace", "name")
                       .verify();
+    }
+
+    @Test
+    public void namesMustBeUnique() {
+        String propertyName = UUID.randomUUID().toString();
+
+        IdentityProperty.create(getClass(), propertyName);
+        assertThatThrownBy(() -> IdentityProperty.create(getClass(), propertyName))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(getClass().getName())
+            .hasMessageContaining(propertyName);
     }
 }


### PR DESCRIPTION
This ensures that users won't unintentionally define two separate properties that are equal.