### PR TITLE
Add read-after-write S3 integration tests using old S3 clients and new core modules.

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -82,6 +82,7 @@
         "http-clients": { "skipImport": true },
         "metric-publishers": { "skipImport": true },
         "module-path-tests": { "skipImport": true },
+        "old-client-version-compatibility-test": { "skipImport": true },
         "protocol-tests": { "skipImport": true },
         "protocol-tests-core": { "skipImport": true },
         "protocols": { "skipImport": true },

--- a/buildspecs/release-javadoc.yml
+++ b/buildspecs/release-javadoc.yml
@@ -18,7 +18,7 @@ phases:
     commands:
     - python ./scripts/doc_crosslinks/generate_cross_link_data.py --apiDefinitionsBasePath ./services/ --apiDefinitionsRelativeFilePath src/main/resources/codegen-resources/service-2.json  --templateFilePath ./scripts/doc_crosslinks/crosslink_redirect.html --outputFilePath ./scripts/crosslink_redirect.html
     - mvn install -P quick -T1C
-    - mvn clean install javadoc:aggregate -B -Ppublic-javadoc -Dcheckstyle.skip -Dspotbugs.skip -DskipTests -Ddoclint=none -pl '!:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:s3-benchmarks,!:module-path-tests,!:test-utils,!:http-client-tests,!:tests-coverage-reporting,!:sdk-native-image-test,!:ruleset-testing-core'
+    - mvn clean install javadoc:aggregate -B -Ppublic-javadoc -Dcheckstyle.skip -Dspotbugs.skip -DskipTests -Ddoclint=none -pl '!:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:s3-benchmarks,!:module-path-tests,!:test-utils,!:http-client-tests,!:tests-coverage-reporting,!:sdk-native-image-test,!:ruleset-testing-core!:old-client-version-compatibility-testing'
     - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
     -
     - aws s3 sync target/site/apidocs/ $DOC_PATH/$RELEASE_VERSION/

--- a/buildspecs/release-to-maven.yml
+++ b/buildspecs/release-to-maven.yml
@@ -40,7 +40,7 @@ phases:
             awk 'BEGIN { var=ENVIRON["SDK_SIGNING_GPG_KEYNAME"] } { gsub("\\$SDK_SIGNING_GPG_KEYNAME", var, $0); print }' > \
             $SETTINGS_XML
 
-          mvn clean deploy -B -s $SETTINGS_XML -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests,!:sdk-native-image-test,!:auth-tests,!:s3-benchmarks,!:region-testing -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30
+          mvn clean deploy -B -s $SETTINGS_XML -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests,!:sdk-native-image-test,!:auth-tests,!:s3-benchmarks,!:region-testing!:old-client-version-compatibility-testing -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30
         else
           echo "This version was already released."
         fi

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <module>test/auth-tests</module>
         <module>test/region-testing</module>
         <module>test/ruleset-testing-core</module>
+        <module>test/old-client-version-compatibility-test</module>
     </modules>
     <scm>
         <url>${scm.github.url}</url>

--- a/test/old-client-version-compatibility-test/pom.xml
+++ b/test/old-client-version-compatibility-test/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>aws-sdk-java-pom</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.20.154-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>old-client-version-compatibility-test</artifactId>
+    <name>AWS Java SDK :: Test :: Old Client Version Compatibility Test</name>
+    <description>
+        Tests for old client versions with the latest "core" package versions.
+    </description>
+    <url>https://aws.amazon.com/sdkforjava</url>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom-internal</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Old Clients -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.20.136</version> <!-- Pre-SRA version -->
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>service-test-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/test/old-client-version-compatibility-test/pom.xml
+++ b/test/old-client-version-compatibility-test/pom.xml
@@ -52,6 +52,38 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Newer core dependencies -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-xml-protocol</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>protocol-core</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>crt-core</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+
         <!-- Old Clients -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/test/old-client-version-compatibility-test/src/it/java/software/amazon/awssdk/services/oldclient/S3PutGetIntegrationTest.java
+++ b/test/old-client-version-compatibility-test/src/it/java/software/amazon/awssdk/services/oldclient/S3PutGetIntegrationTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.oldclient;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.testutils.service.AwsTestBase;
+
+public class S3PutGetIntegrationTest extends AwsTestBase {
+    private static final S3Client S3 =
+        s3ClientBuilder().build();
+    private static final S3Client S3_CUSTOM_SIGNER =
+        s3ClientBuilder().overrideConfiguration(c -> c.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
+                                                                         AwsS3V4Signer.create()))
+                         .build();
+    private static final S3Client S3_NO_CREDS =
+        s3ClientBuilder().credentialsProvider(AnonymousCredentialsProvider.create())
+                         .build();
+
+    private static final S3AsyncClient S3_ASYNC =
+        getS3AsyncClientBuilder().build();
+    private static final S3AsyncClient S3_ASYNC_CUSTOM_SIGNER =
+        getS3AsyncClientBuilder().overrideConfiguration(c -> c.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
+                                                                                 AwsS3V4Signer.create()))
+                                 .build();
+    private static final S3AsyncClient S3_ASYNC_NO_CREDS =
+        getS3AsyncClientBuilder().credentialsProvider(AnonymousCredentialsProvider.create())
+                                 .build();
+
+    private static final String BUCKET = "sra-get-put-integ-" + System.currentTimeMillis();
+    private static final String BODY = "foo";
+    private static final String BODY_CRC32 = "jHNlIQ==";
+
+    private String key;
+
+    @BeforeAll
+    public static void setup() {
+        S3.createBucket(r -> r.bucket(BUCKET));
+    }
+
+    @BeforeEach
+    public void setupTest() {
+        key = UUID.randomUUID().toString();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        TestUtils.deleteBucketAndAllContents(S3, BUCKET);
+    }
+
+    @Test
+    public void putGet() {
+        S3.putObject(r -> r.bucket(BUCKET).key(key), RequestBody.fromString(BODY));
+        assertThat(S3.getObjectAsBytes(r -> r.bucket(BUCKET).key(key)).asUtf8String()).isEqualTo(BODY);
+    }
+
+    @Test
+    public void putGet_async() {
+        S3_ASYNC.putObject(r -> r.bucket(BUCKET).key(key), AsyncRequestBody.fromString(BODY)).join();
+        assertThat(S3_ASYNC.getObject(r -> r.bucket(BUCKET).key(key),
+                                      AsyncResponseTransformer.toBytes())
+                           .join()
+                           .asUtf8String()).isEqualTo(BODY);
+    }
+
+    @Test
+    public void putGet_requestLevelCreds() {
+        S3_NO_CREDS.putObject(r -> r.bucket(BUCKET)
+                                    .key(key)
+                                    .overrideConfiguration(c -> c.credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)),
+                              RequestBody.fromString(BODY));
+        assertThat(S3_NO_CREDS.getObjectAsBytes(r -> r.bucket(BUCKET)
+                                                      .key(key)
+                                                      .overrideConfiguration(c -> c.credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)))
+                              .asUtf8String()).isEqualTo(BODY);
+    }
+
+    @Test
+    public void putGet_async_requestLevelCreds() {
+        S3_ASYNC_NO_CREDS.putObject(r -> r.bucket(BUCKET)
+                                          .key(key)
+                                          .overrideConfiguration(c -> c.credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)),
+                           AsyncRequestBody.fromString(BODY))
+                .join();
+        assertThat(S3_ASYNC_NO_CREDS.getObject(r -> r.bucket(BUCKET)
+                                                     .key(key)
+                                                     .overrideConfiguration(c -> c.credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)),
+                                               AsyncResponseTransformer.toBytes())
+                                    .join()
+                                    .asUtf8String()).isEqualTo(BODY);
+    }
+
+    @Test
+    public void putGet_flexibleChecksums() {
+        S3.putObject(r -> r.bucket(BUCKET).key(key).checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                     RequestBody.fromString(BODY));
+        ResponseBytes<GetObjectResponse> response =
+            S3.getObjectAsBytes(r -> r.bucket(BUCKET).key(key).checksumMode(ChecksumMode.ENABLED));
+        assertThat(response.asUtf8String()).isEqualTo(BODY);
+        assertThat(response.response().checksumCRC32()).isEqualTo(BODY_CRC32);
+    }
+
+    @Test
+    public void putGet_async_flexibleChecksums() {
+        S3_ASYNC.putObject(r -> r.bucket(BUCKET).key(key).checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                           AsyncRequestBody.fromString(BODY)).join();
+        ResponseBytes<GetObjectResponse> response = S3_ASYNC.getObject(r -> r.bucket(BUCKET).key(key).checksumMode(ChecksumMode.ENABLED),
+                                                                       AsyncResponseTransformer.toBytes())
+                                                            .join();
+        assertThat(response.asUtf8String()).isEqualTo(BODY);
+        assertThat(response.response().checksumCRC32()).isEqualTo(BODY_CRC32);
+    }
+
+    @Test
+    public void putGet_customSigner_flexibleChecksums() {
+        S3_CUSTOM_SIGNER.putObject(r -> r.bucket(BUCKET).key(key).checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                                   RequestBody.fromString(BODY));
+        ResponseBytes<GetObjectResponse> response =
+            S3_CUSTOM_SIGNER.getObjectAsBytes(r -> r.bucket(BUCKET).key(key).checksumMode(ChecksumMode.ENABLED));
+        assertThat(response.asUtf8String()).isEqualTo(BODY);
+        assertThat(response.response().checksumCRC32()).isEqualTo(BODY_CRC32);
+    }
+
+    @Test
+    public void putGet_async_customSigner_flexibleChecksums() {
+        S3_ASYNC_CUSTOM_SIGNER.putObject(r -> r.bucket(BUCKET).key(key).checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                                         AsyncRequestBody.fromString(BODY))
+                              .join();
+        ResponseBytes<GetObjectResponse> response =
+            S3_ASYNC_CUSTOM_SIGNER.getObject(r -> r.bucket(BUCKET).key(key).checksumMode(ChecksumMode.ENABLED),
+                                             AsyncResponseTransformer.toBytes())
+                                  .join();
+        assertThat(response.asUtf8String()).isEqualTo(BODY);
+        assertThat(response.response().checksumCRC32()).isEqualTo(BODY_CRC32);
+    }
+
+    private static S3ClientBuilder s3ClientBuilder() {
+        return S3Client.builder()
+                       .region(Region.US_WEST_2)
+                       .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN);
+    }
+
+    private static S3AsyncClientBuilder getS3AsyncClientBuilder() {
+        return S3AsyncClient.builder()
+                            .region(Region.US_WEST_2)
+                            .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN);
+    }
+}

--- a/test/old-client-version-compatibility-test/src/it/java/software/amazon/awssdk/services/oldclient/TestUtils.java
+++ b/test/old-client-version-compatibility-test/src/it/java/software/amazon/awssdk/services/oldclient/TestUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.oldclient;
+
+import java.util.Iterator;
+import java.util.List;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.testutils.Waiter;
+
+public class TestUtils {
+
+    public static void deleteBucketAndAllContents(S3Client s3, String bucketName) {
+        try {
+            System.out.println("Deleting S3 bucket: " + bucketName);
+            ListObjectsResponse response = Waiter.run(() -> s3.listObjects(r -> r.bucket(bucketName)))
+                                                 .ignoringException(NoSuchBucketException.class)
+                                                 .orFail();
+            List<S3Object> objectListing = response.contents();
+
+            if (objectListing != null) {
+                while (true) {
+                    for (Iterator<?> iterator = objectListing.iterator(); iterator.hasNext(); ) {
+                        S3Object objectSummary = (S3Object) iterator.next();
+                        s3.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(objectSummary.key()).build());
+                    }
+
+                    if (response.isTruncated()) {
+                        objectListing = s3.listObjects(ListObjectsRequest.builder()
+                                                                         .bucket(bucketName)
+                                                                         .marker(response.marker())
+                                                                         .build())
+                                          .contents();
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+
+            ListObjectVersionsResponse versions = s3
+                .listObjectVersions(ListObjectVersionsRequest.builder().bucket(bucketName).build());
+
+            if (versions.deleteMarkers() != null) {
+                versions.deleteMarkers().forEach(v -> s3.deleteObject(DeleteObjectRequest.builder()
+                                                                                         .versionId(v.versionId())
+                                                                                         .bucket(bucketName)
+                                                                                         .key(v.key())
+                                                                                         .build()));
+            }
+
+            if (versions.versions() != null) {
+                versions.versions().forEach(v -> s3.deleteObject(DeleteObjectRequest.builder()
+                                                                                    .versionId(v.versionId())
+                                                                                    .bucket(bucketName)
+                                                                                    .key(v.key())
+                                                                                    .build()));
+            }
+
+            s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build());
+        } catch (Exception e) {
+            System.err.println("Failed to delete bucket: " + bucketName);
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/old-client-version-compatibility-test/src/it/resources/log4j2.properties
+++ b/test/old-client-version-compatibility-test/src/it/resources/log4j2.properties
@@ -1,0 +1,38 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+status = warn
+
+appender.console.type = Console
+appender.console.name = ConsoleAppender
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n%throwable
+
+rootLogger.level = debug
+rootLogger.appenderRef.stdout.ref = ConsoleAppender
+
+# Uncomment below to enable more specific logging
+#
+#logger.sdk.name = software.amazon.awssdk
+#logger.sdk.level = debug
+#
+#logger.request.name = software.amazon.awssdk.request
+#logger.request.level = debug
+#
+#logger.apache.name = org.apache.http.wire
+#logger.apache.level = debug
+#
+#logger.netty.name = io.netty.handler.logging
+#logger.netty.level = debug

--- a/test/tests-coverage-reporting/pom.xml
+++ b/test/tests-coverage-reporting/pom.xml
@@ -198,6 +198,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <artifactId>old-client-version-compatibility-test</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>dynamodb-enhanced</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>


### PR DESCRIPTION
Dependency tree, validating the package versions:
```
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ old-client-version-compatibility-test ---
[INFO] software.amazon.awssdk:old-client-version-compatibility-test:jar:2.20.154-SNAPSHOT
[INFO] +- software.amazon.awssdk:s3:jar:2.20.136:compile
[INFO] |  +- software.amazon.awssdk:aws-xml-protocol:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  \- software.amazon.awssdk:aws-query-protocol:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:protocol-core:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:arns:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:profiles:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:crt-core:jar:2.20.136:compile
[INFO] |  +- software.amazon.awssdk:sdk-core:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  +- software.amazon.awssdk:http-auth-spi:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  +- software.amazon.awssdk:http-auth-aws:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  +- software.amazon.awssdk:checksums-spi:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  +- software.amazon.awssdk:checksums:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  \- org.reactivestreams:reactive-streams:jar:1.0.4:compile
[INFO] |  +- software.amazon.awssdk:auth:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  +- software.amazon.awssdk:http-auth:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  \- software.amazon.eventstream:eventstream:jar:1.0.1:compile
[INFO] |  +- software.amazon.awssdk:http-client-spi:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:regions:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:annotations:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:utils:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:aws-core:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:metrics-spi:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:json-utils:jar:2.20.154-SNAPSHOT:compile
[INFO] |  |  \- software.amazon.awssdk:third-party-jackson-core:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:endpoints-spi:jar:2.20.136:compile
[INFO] |  +- software.amazon.awssdk:apache-client:jar:2.20.154-SNAPSHOT:runtime
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.13:runtime
[INFO] |  |  |  \- commons-logging:commons-logging:jar:1.2:runtime
[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.13:runtime
[INFO] |  |  \- commons-codec:commons-codec:jar:1.15:runtime
[INFO] |  \- software.amazon.awssdk:netty-nio-client:jar:2.20.154-SNAPSHOT:runtime
[INFO] |     +- io.netty:netty-codec-http:jar:4.1.94.Final:runtime
[INFO] |     +- io.netty:netty-codec-http2:jar:4.1.94.Final:runtime
[INFO] |     +- io.netty:netty-codec:jar:4.1.94.Final:runtime
[INFO] |     +- io.netty:netty-transport:jar:4.1.94.Final:runtime
[INFO] |     +- io.netty:netty-common:jar:4.1.94.Final:runtime
[INFO] |     +- io.netty:netty-buffer:jar:4.1.94.Final:runtime
[INFO] |     +- io.netty:netty-handler:jar:4.1.94.Final:runtime
[INFO] |     |  \- io.netty:netty-transport-native-unix-common:jar:4.1.94.Final:runtime
[INFO] |     +- io.netty:netty-transport-classes-epoll:jar:4.1.94.Final:runtime
[INFO] |     \- io.netty:netty-resolver:jar:4.1.94.Final:runtime
[INFO] +- software.amazon.awssdk:service-test-utils:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- software.amazon.awssdk:identity-spi:jar:2.20.154-SNAPSHOT:compile
[INFO] |  +- org.junit.vintage:junit-vintage-engine:jar:5.8.1:test
[INFO] |  |  +- org.junit.platform:junit-platform-engine:jar:1.8.1:test
[INFO] |  |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] |  +- junit:junit:jar:4.13.2:test
[INFO] |  +- io.projectreactor.tools:blockhound:jar:1.0.6.RELEASE:compile
[INFO] |  +- io.projectreactor.tools:blockhound-junit-platform:jar:1.0.6.RELEASE:compile
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.junit.jupiter:junit-jupiter:jar:5.8.1:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.8.1:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.8.1:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-params:jar:5.8.1:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.8.1:test
[INFO] +- com.github.tomakehurst:wiremock-jre8:jar:2.32.0:test
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:9.4.45.v20220203:test
[INFO] |  |  +- javax.servlet:javax.servlet-api:jar:3.1.0:test
[INFO] |  |  +- org.eclipse.jetty:jetty-http:jar:9.4.45.v20220203:test
[INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:9.4.45.v20220203:test
[INFO] |  |  +- org.eclipse.jetty:jetty-security:jar:9.4.45.v20220203:test
[INFO] |  |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.45.v20220203:test
[INFO] |  |  +- org.eclipse.jetty:jetty-continuation:jar:9.4.45.v20220203:test
[INFO] |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-webapp:jar:9.4.45.v20220203:test
[INFO] |  |  \- org.eclipse.jetty:jetty-xml:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-proxy:jar:9.4.45.v20220203:test
[INFO] |  |  \- org.eclipse.jetty:jetty-client:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty.http2:http2-server:jar:9.4.45.v20220203:test
[INFO] |  |  \- org.eclipse.jetty.http2:http2-common:jar:9.4.45.v20220203:test
[INFO] |  |     \- org.eclipse.jetty.http2:http2-hpack:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-openjdk8-server:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.45.v20220203:test
[INFO] |  |  \- org.eclipse.jetty:jetty-alpn-client:jar:9.4.45.v20220203:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-openjdk8-client:jar:9.4.45.v20220203:test
[INFO] |  +- com.google.guava:guava:jar:29.0-jre:test
[INFO] |  |  +- com.google.guava:failureaccess:jar:1.0.1:test
[INFO] |  |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:test
[INFO] |  |  +- com.google.code.findbugs:jsr305:jar:3.0.2:test
[INFO] |  |  +- org.checkerframework:checker-qual:jar:2.11.1:test
[INFO] |  |  +- com.google.errorprone:error_prone_annotations:jar:2.3.4:test
[INFO] |  |  \- com.google.j2objc:j2objc-annotations:jar:1.3:test
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.15.2:test
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:test
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:test
[INFO] |  +- org.apache.httpcomponents.client5:httpclient5:jar:5.1:test
[INFO] |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.1.1:test
[INFO] |  |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.1.1:test
[INFO] |  +- org.xmlunit:xmlunit-core:jar:2.8.3:test
[INFO] |  +- org.xmlunit:xmlunit-legacy:jar:2.8.3:test
[INFO] |  +- org.xmlunit:xmlunit-placeholders:jar:2.8.3:test
[INFO] |  +- net.javacrumbs.json-unit:json-unit-core:jar:2.28.0:test
[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.6.0:test
[INFO] |  |  \- net.minidev:json-smart:jar:2.4.7:test
[INFO] |  |     \- net.minidev:accessors-smart:jar:2.4.7:test
[INFO] |  +- org.ow2.asm:asm:jar:9.2:test
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO] |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.12.0:test
[INFO] |  +- com.github.jknack:handlebars:jar:4.3.0:test
[INFO] |  +- com.github.jknack:handlebars-helpers:jar:4.3.0:test
[INFO] |  +- commons-fileupload:commons-fileupload:jar:1.4:test
[INFO] |  \- commons-io:commons-io:jar:2.11.0:test
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.17.1:test
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.17.1:test
[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.17.1:test
[INFO] +- org.mockito:mockito-core:jar:4.3.1:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.12.7:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.12.7:test
[INFO] |  \- org.objenesis:objenesis:jar:3.2:test
[INFO] +- org.slf4j:jcl-over-slf4j:jar:1.7.30:test
[INFO] +- org.assertj:assertj-core:jar:3.20.2:test
[INFO] \- software.amazon.awssdk:test-utils:jar:2.20.154-SNAPSHOT:test
```