### PR TITLE
Fix Content-Length requirement, header updates in payload signer, http fallback to signed

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
@@ -25,11 +25,13 @@ import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerUt
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.Header;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
 import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.SdkChecksum;
@@ -52,6 +54,7 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
     private final CredentialScope credentialScope;
     private final int chunkSize;
     private final ChecksumAlgorithm checksumAlgorithm;
+    private final List<Pair<String, List<String>>> preExistingTrailers = new ArrayList<>();
 
     private AwsChunkedV4aPayloadSigner(Builder builder) {
         this.credentialScope = Validate.paramNotNull(builder.credentialScope, "CredentialScope");
@@ -65,16 +68,14 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
 
     @Override
     public ContentStreamProvider sign(ContentStreamProvider payload, V4aContext v4aContext) {
-        SdkHttpRequest.Builder request = v4aContext.getSignedRequest();
-        moveContentLength(request);
-
         InputStream inputStream = payload != null ? payload.newStream() : new StringInputStream("");
         ChunkedEncodedInputStream.Builder chunkedEncodedInputStreamBuilder = ChunkedEncodedInputStream
             .builder()
             .inputStream(inputStream)
             .chunkSize(chunkSize)
             .header(chunk -> Integer.toHexString(chunk.length).getBytes(StandardCharsets.UTF_8));
-        setupPreExistingTrailers(chunkedEncodedInputStreamBuilder, request);
+
+        preExistingTrailers.forEach(trailer -> chunkedEncodedInputStreamBuilder.addTrailer(() -> trailer));
 
         switch (v4aContext.getSigningConfig().getSignedBodyValue()) {
             case STREAMING_ECDSA_SIGNED_PAYLOAD: {
@@ -83,12 +84,12 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
                 break;
             }
             case STREAMING_UNSIGNED_PAYLOAD_TRAILER:
-                setupChecksumTrailerIfNeeded(chunkedEncodedInputStreamBuilder, request);
+                setupChecksumTrailerIfNeeded(chunkedEncodedInputStreamBuilder);
                 break;
             case STREAMING_ECDSA_SIGNED_PAYLOAD_TRAILER: {
                 RollingSigner rollingSigner = new RollingSigner(v4aContext.getSignature(), v4aContext.getSigningConfig());
                 chunkedEncodedInputStreamBuilder.addExtension(new SigV4aChunkExtensionProvider(rollingSigner, credentialScope));
-                setupChecksumTrailerIfNeeded(chunkedEncodedInputStreamBuilder, request);
+                setupChecksumTrailerIfNeeded(chunkedEncodedInputStreamBuilder);
                 chunkedEncodedInputStreamBuilder.addTrailer(
                     new SigV4aTrailerProvider(chunkedEncodedInputStreamBuilder.trailers(), rollingSigner, credentialScope)
                 );
@@ -101,47 +102,150 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
         return new ResettableContentStreamProvider(chunkedEncodedInputStreamBuilder::build);
     }
 
+    @Override
+    public void beforeSigning(SdkHttpRequest.Builder request, ContentStreamProvider payload, String checksum) {
+        long encodedContentLength = 0;
+        long contentLength = moveContentLength(request, payload != null ? payload.newStream() : new StringInputStream(""));
+        setupPreExistingTrailers(request);
+
+        // pre-existing trailers
+        encodedContentLength += calculateExistingTrailersLength();
+
+        switch (checksum) {
+            case STREAMING_ECDSA_SIGNED_PAYLOAD: {
+                long extensionsLength = 161; // ;chunk-signature:<sigv4a-ecsda hex signature, 64 bytes>
+                encodedContentLength += calculateChunksLength(contentLength, extensionsLength);
+                break;
+            }
+            case STREAMING_UNSIGNED_PAYLOAD_TRAILER:
+                if (checksumAlgorithm != null) {
+                    encodedContentLength += calculateChecksumTrailerLength(checksumHeaderName(checksumAlgorithm));
+                }
+                encodedContentLength += calculateChunksLength(contentLength, 0);
+                break;
+            case STREAMING_ECDSA_SIGNED_PAYLOAD_TRAILER: {
+                long extensionsLength = 161; // ;chunk-signature:<sigv4a-ecsda hex signature, 64 bytes>
+                encodedContentLength += calculateChunksLength(contentLength, extensionsLength);
+                if (checksumAlgorithm != null) {
+                    encodedContentLength += calculateChecksumTrailerLength(checksumHeaderName(checksumAlgorithm));
+                }
+                encodedContentLength += 170; // x-amz-trailer-signature:<sigv4a-ecsda hex signature, 64 bytes>\r\n
+                break;
+            }
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        // terminating \r\n
+        encodedContentLength += 2;
+
+        if (checksumAlgorithm != null) {
+            String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
+            request.appendHeader(X_AMZ_TRAILER, checksumHeaderName);
+        }
+        request.putHeader(Header.CONTENT_LENGTH, Long.toString(encodedContentLength));
+    }
+
     /**
-     * Add the checksum as a chunk-trailer and add it to the request's trailer header.
+     * Set up a map of pre-existing trailer (headers) for the given request to be used when chunk-encoding the payload.
      * <p>
-     * The checksum-algorithm MUST be set if this is called, otherwise it will throw.
+     * However, we need to validate that these are valid trailers. Since aws-chunked encoding adds the checksum as a trailer, it
+     * isn't part of the request headers, but other trailers MUST be present in the request-headers.
      */
-    private void setupChecksumTrailerIfNeeded(ChunkedEncodedInputStream.Builder builder, SdkHttpRequest.Builder request) {
+    private void setupPreExistingTrailers(SdkHttpRequest.Builder request) {
+        for (String header : request.matchingHeaders(X_AMZ_TRAILER)) {
+            List<String> values = request.matchingHeaders(header);
+            if (values.isEmpty()) {
+                throw new IllegalArgumentException(header + " must be present in the request headers to be a valid trailer.");
+            }
+            preExistingTrailers.add(Pair.of(header, values));
+            request.removeHeader(header);
+        }
+    }
+
+    private long calculateChunksLength(long contentLength, long extensionsLength) {
+        long lengthInBytes = 0;
+        long chunkHeaderLength = Integer.toHexString(chunkSize).length();
+        long numChunks = contentLength / chunkSize;
+
+        // normal chunks
+        // x<metadata>\r\n<data>\r\n
+        lengthInBytes += numChunks * (chunkHeaderLength + extensionsLength + 2 + chunkSize + 2);
+
+        // remaining chunk
+        // x<metadata>\r\n<data>\r\n
+        long remainingBytes = contentLength % chunkSize;
+        if (remainingBytes > 0) {
+            long remainingChunkHeaderLength = Long.toHexString(remainingBytes).length();
+            lengthInBytes += remainingChunkHeaderLength + 1 + extensionsLength + 2 + remainingBytes + 2;
+        }
+
+        // final chunk
+        // 0<metadata>\r\n
+        lengthInBytes += 1 + extensionsLength + 2;
+
+        return lengthInBytes;
+    }
+
+    private long calculateExistingTrailersLength() {
+        long lengthInBytes = 0;
+
+        for (Pair<String, List<String>> trailer : preExistingTrailers) {
+            // size of trailer
+            lengthInBytes += calculateTrailerLength(trailer);
+        }
+
+        return lengthInBytes;
+    }
+
+    private long calculateTrailerLength(Pair<String, List<String>> trailer) {
+        // size of trailer-header and colon
+        long lengthInBytes = trailer.left().length() + 1;
+
+        // size of trailer-values
+        for (String value : trailer.right()) {
+            lengthInBytes += value.length();
+        }
+
+        // size of commas between trailer-values, 1 less comma than # of values
+        lengthInBytes += trailer.right().size() - 1;
+
+        // terminating \r\n
+        return lengthInBytes + 2;
+    }
+
+    private long calculateChecksumTrailerLength(String checksumHeaderName) {
+        // size of checksum trailer-header and colon
+        long lengthInBytes = checksumHeaderName.length() + 1;
+
+        // get the base checksum for the algorithm
+        SdkChecksum sdkChecksum = fromChecksumAlgorithm(checksumAlgorithm);
+        // size of checksum value as hex-string
+        lengthInBytes += sdkChecksum.getChecksum().length();
+
+        // terminating \r\n
+        return lengthInBytes + 2;
+    }
+
+    /**
+     * Add the checksum as a trailer to the chunk-encoded stream.
+     * <p>
+     * If the checksum-algorithm is not present, then nothing is done.
+     */
+    private void setupChecksumTrailerIfNeeded(ChunkedEncodedInputStream.Builder builder) {
         if (checksumAlgorithm == null) {
             return;
         }
+        String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
         SdkChecksum sdkChecksum = fromChecksumAlgorithm(checksumAlgorithm);
         ChecksumInputStream checksumInputStream = new ChecksumInputStream(
             builder.inputStream(),
             Collections.singleton(sdkChecksum)
         );
-        String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
 
         TrailerProvider checksumTrailer = new ChecksumTrailerProvider(sdkChecksum, checksumHeaderName);
 
-        request.appendHeader(X_AMZ_TRAILER, checksumHeaderName);
         builder.inputStream(checksumInputStream).addTrailer(checksumTrailer);
-    }
-
-    /**
-     * Create chunk-trailers for each pre-existing trailer given in the request.
-     * <p>
-     * However, we need to validate that these are valid trailers. Since aws-chunked encoding adds the checksum as a trailer, it
-     * isn't part of the request headers, but other trailers MUST be present in the request-headers.
-     */
-    private void setupPreExistingTrailers(ChunkedEncodedInputStream.Builder builder, SdkHttpRequest.Builder request) {
-        List<String> trailerHeaders = request.matchingHeaders(X_AMZ_TRAILER);
-
-        for (String header : trailerHeaders) {
-            List<String> values = request.matchingHeaders(header);
-            if (values.isEmpty()) {
-                throw new IllegalArgumentException(header + " must be present in the request headers to be a valid trailer.");
-            }
-
-            // Add the trailer to the aws-chunked stream-builder, and remove it from the request headers
-            builder.addTrailer(() -> Pair.of(header, values));
-            request.removeHeader(header);
-        }
     }
 
     static final class Builder {

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
@@ -113,7 +113,7 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
 
         switch (checksum) {
             case STREAMING_ECDSA_SIGNED_PAYLOAD: {
-                long extensionsLength = 161; // ;chunk-signature:<sigv4a-ecsda hex signature, 64 bytes>
+                long extensionsLength = 161; // ;chunk-signature:<sigv4a-ecsda hex signature, 144 bytes>
                 encodedContentLength += calculateChunksLength(contentLength, extensionsLength);
                 break;
             }
@@ -124,12 +124,12 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
                 encodedContentLength += calculateChunksLength(contentLength, 0);
                 break;
             case STREAMING_ECDSA_SIGNED_PAYLOAD_TRAILER: {
-                long extensionsLength = 161; // ;chunk-signature:<sigv4a-ecsda hex signature, 64 bytes>
+                long extensionsLength = 161; // ;chunk-signature:<sigv4a-ecsda hex signature, 144 bytes>
                 encodedContentLength += calculateChunksLength(contentLength, extensionsLength);
                 if (checksumAlgorithm != null) {
                     encodedContentLength += calculateChecksumTrailerLength(checksumHeaderName(checksumAlgorithm));
                 }
-                encodedContentLength += 170; // x-amz-trailer-signature:<sigv4a-ecsda hex signature, 64 bytes>\r\n
+                encodedContentLength += 170; // x-amz-trailer-signature:<sigv4a-ecsda hex signature, 144 bytes>\r\n
                 break;
             }
             default:
@@ -177,7 +177,7 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
         long remainingBytes = contentLength % chunkSize;
         if (remainingBytes > 0) {
             long remainingChunkHeaderLength = Long.toHexString(remainingBytes).length();
-            lengthInBytes += remainingChunkHeaderLength + 1 + extensionsLength + 2 + remainingBytes + 2;
+            lengthInBytes += remainingChunkHeaderLength + extensionsLength + 2 + remainingBytes + 2;
         }
 
         // final chunk

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -191,7 +191,11 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
                                 .build();
         }
 
-        SdkHttpRequest sanitizedRequest = sanitizeRequest(request.request());
+        SdkHttpRequest.Builder requestBuilder = request.request().toBuilder();
+
+        payloadSigner.beforeSigning(requestBuilder, request.payload().orElse(null), signingConfig.getSignedBodyValue());
+
+        SdkHttpRequest sanitizedRequest = sanitizeRequest(requestBuilder.build());
 
         HttpRequest crtRequest = toRequest(sanitizedRequest, request.payload().orElse(null));
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/RollingSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/RollingSigner.java
@@ -46,8 +46,12 @@ public final class RollingSigner {
     }
 
     private static byte[] signChunk(byte[] chunkBody, byte[] previousSignature, AwsSigningConfig signingConfig) {
+        // All the config remains the same as signing config except the Signature Type.
+        AwsSigningConfig configCopy = signingConfig.clone();
+        configCopy.setSignatureType(AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_CHUNK);
+
         HttpRequestBodyStream crtBody = new CrtInputStream(() -> new ByteArrayInputStream(chunkBody));
-        return CompletableFutureUtils.joinLikeSync(AwsSigner.signChunk(crtBody, previousSignature, signingConfig));
+        return CompletableFutureUtils.joinLikeSync(AwsSigner.signChunk(crtBody, previousSignature, configCopy));
     }
 
     private static AwsSigningResult signTrailerHeaders(Map<String, List<String>> headerMap, byte[] previousSignature,

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/V4aPayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/V4aPayloadSigner.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
 
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 /**
  * An interface for defining how to sign a payload via SigV4a.
@@ -34,4 +35,10 @@ public interface V4aPayloadSigner {
      * Given a payload and v4a-context, sign the payload via the SigV4a process.
      */
     ContentStreamProvider sign(ContentStreamProvider payload, V4aContext v4Context);
+
+    /**
+     * Modify a request before it is signed, such as changing headers or query-parameters.
+     */
+    default void beforeSigning(SdkHttpRequest.Builder request, ContentStreamProvider payload, String checksum) {
+    }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
@@ -194,7 +194,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
         long remainingBytes = contentLength % chunkSize;
         if (remainingBytes > 0) {
             long remainingChunkHeaderLength = Long.toHexString(remainingBytes).length();
-            lengthInBytes += remainingChunkHeaderLength + 1 + extensionsLength + 2 + remainingBytes + 2;
+            lengthInBytes += remainingChunkHeaderLength + extensionsLength + 2 + remainingBytes + 2;
         }
 
         // final chunk

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
@@ -183,7 +183,7 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
 
         checksummer.checksum(request.payload().orElse(null), requestBuilder);
 
-        payloadSigner.beforeSigning(requestBuilder);
+        payloadSigner.beforeSigning(requestBuilder, request.payload().orElse(null));
 
         V4Context v4Context = requestSigner.sign(requestBuilder);
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4PayloadSigner.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 /**
  * An interface for defining how to sign a payload via SigV4.
@@ -41,4 +42,10 @@ public interface V4PayloadSigner {
      * Given a payload and v4-context, sign the payload via the SigV4 process.
      */
     Publisher<ByteBuffer> signAsync(Publisher<ByteBuffer> payload, V4Context v4Context);
+
+    /**
+     * Modify a request before it is signed, such as changing headers or query-parameters.
+     */
+    default void beforeSigning(SdkHttpRequest.Builder request) {
+    }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4PayloadSigner.java
@@ -46,6 +46,6 @@ public interface V4PayloadSigner {
     /**
      * Modify a request before it is signed, such as changing headers or query-parameters.
      */
-    default void beforeSigning(SdkHttpRequest.Builder request) {
+    default void beforeSigning(SdkHttpRequest.Builder request, ContentStreamProvider payload) {
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java
@@ -182,7 +182,7 @@ public final class ChunkedEncodedInputStream extends InputStream {
             Pair<String, List<String>> tlr = trailer.get();
             outputStream.write(tlr.left().getBytes(StandardCharsets.UTF_8));
             outputStream.write((byte) ':');
-            outputStream.write(String.join(", ", tlr.right()).getBytes(StandardCharsets.UTF_8));
+            outputStream.write(String.join(",", tlr.right()).getBytes(StandardCharsets.UTF_8));
             outputStream.write(CRLF);
         }
     }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
@@ -185,22 +185,24 @@ public final class SignerUtils {
     }
 
     /**
-     * Move `Content-Length` to `x-amz-decoded-content-length` if not already present. If neither header is present, an exception
-     * is thrown.
+     * Move `Content-Length` to `x-amz-decoded-content-length` if not already present. If `Content-Length` is not present, then
+     * the payload is read in its entirety to calculate the length.
      */
-    public static void moveContentLength(SdkHttpRequest.Builder request) {
+    public static long moveContentLength(SdkHttpRequest.Builder request, InputStream payload) {
         if (!request.firstMatchingHeader(X_AMZ_DECODED_CONTENT_LENGTH).isPresent()) {
             // if the decoded length isn't present, content-length must be there
-            String contentLength = request
-                .firstMatchingHeader(Header.CONTENT_LENGTH)
-                .orElseThrow(() -> new IllegalArgumentException(Header.CONTENT_LENGTH + " must be specified!"));
+            String contentLength = request.firstMatchingHeader(Header.CONTENT_LENGTH).orElseGet(
+                () -> String.valueOf(readAll(payload))
+            );
 
             request.putHeader(X_AMZ_DECODED_CONTENT_LENGTH, contentLength)
                    .removeHeader(Header.CONTENT_LENGTH);
-        } else {
-            // decoded header is already there, so remove content-length just to be sure it's gone
-            request.removeHeader(Header.CONTENT_LENGTH);
+            return Long.parseLong(contentLength);
         }
+
+        // decoded header is already there, so remove content-length just to be sure it's gone
+        request.removeHeader(Header.CONTENT_LENGTH);
+        return Long.parseLong(request.firstMatchingHeader(X_AMZ_DECODED_CONTENT_LENGTH).get());
     }
 
     private static MessageDigest getMessageDigestInstance() {
@@ -251,5 +253,22 @@ public final class SignerUtils {
 
     public static byte[] hash(String text) {
         return hash(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static int readAll(InputStream inputStream) {
+        try {
+            byte[] buffer = new byte[4096];
+            int read = 0;
+            int offset = 0;
+            while (read >= 0) {
+                read = inputStream.read(buffer);
+                if (read >= 0) {
+                    offset += read;
+                }
+            }
+            return offset;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not finish reading stream: ", e);
+        }
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
@@ -255,6 +255,10 @@ public final class SignerUtils {
         return hash(text.getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * Consume entire stream and return the number of bytes - the stream will NOT be reset upon completion, so if it needs to
+     * be read again, the caller MUST reset the stream.
+     */
     private static int readAll(InputStream inputStream) {
         try {
             byte[] buffer = new byte[4096];

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/TestUtils.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/TestUtils.java
@@ -21,6 +21,10 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.utils.async.SimplePublisher;
 
 public final class TestUtils {
+
+    private TestUtils() {
+    }
+
     // Helpers for generating test requests
     public static <T extends AwsCredentialsIdentity> SignRequest<T> generateBasicRequest(
         T credentials,
@@ -33,7 +37,7 @@ public final class TestUtils {
                                                      .putHeader("Host", "demo.us-east-1.amazonaws.com")
                                                      .putHeader("x-amz-archive-description", "test  test")
                                                      .encodedPath("/")
-                                                     .uri(URI.create("http://demo.us-east-1.amazonaws.com"))
+                                                     .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
                                                      .build()
                                                      .copy(requestOverrides))
                           .payload(() -> new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
@@ -57,11 +61,12 @@ public final class TestUtils {
 
         return AsyncSignRequest.builder(credentials)
                                .request(SdkHttpRequest.builder()
+                                                      .protocol("https")
                                                       .method(SdkHttpMethod.POST)
                                                       .putHeader("Host", "demo.us-east-1.amazonaws.com")
                                                       .putHeader("x-amz-archive-description", "test  test")
                                                       .encodedPath("/")
-                                                      .uri(URI.create("http://demo.us-east-1.amazonaws.com"))
+                                                      .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
                                                       .build()
                                                       .copy(requestOverrides))
                                .payload(publisher)

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSignerTest.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.CRC32;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.toCredentials;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.STREAMING_ECDSA_SIGNED_PAYLOAD;
@@ -81,15 +80,16 @@ public class AwsChunkedV4aPayloadSignerTest {
                                                                       .chunkSize(CHUNK_SIZE)
                                                                       .build();
 
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
         ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
 
         byte[] tmp = new byte[2048];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
         int expectedBytes = expectedByteCount(DATA, CHUNK_SIZE);
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedBytes, actualBytes);
     }
 
@@ -108,9 +108,9 @@ public class AwsChunkedV4aPayloadSignerTest {
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
         ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
 
@@ -121,6 +121,7 @@ public class AwsChunkedV4aPayloadSignerTest {
         // (checksum-header + checksum-value + \r\n + trailer-sig-header + trailer-sig + \r\n)
         expectedBytes += 21 + 8 + 2 + 24 + 144 + 2;
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedBytes, actualBytes);
     }
 
@@ -139,9 +140,9 @@ public class AwsChunkedV4aPayloadSignerTest {
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
         ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
 
@@ -152,6 +153,7 @@ public class AwsChunkedV4aPayloadSignerTest {
         // (checksum-header + checksum-value + \r\n)
         expectedBytes += 21 + 8 + 2;
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedBytes, actualBytes);
     }
 
@@ -171,9 +173,9 @@ public class AwsChunkedV4aPayloadSignerTest {
                                                                       .chunkSize(CHUNK_SIZE)
                                                                       .build();
 
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
         ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("aTrailer")).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("aTrailer");
@@ -184,6 +186,8 @@ public class AwsChunkedV4aPayloadSignerTest {
         // include trailer bytes in the count:
         // (aTrailer: + aValue + \r\n)
         expectedBytes += 9 + 6 + 2;
+
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedBytes, actualBytes);
     }
 
@@ -204,9 +208,9 @@ public class AwsChunkedV4aPayloadSignerTest {
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
         ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("aTrailer")).isNotPresent();
         assertThat(requestBuilder.matchingHeaders("x-amz-trailer")).contains("aTrailer", "x-amz-checksum-crc32");
@@ -217,6 +221,8 @@ public class AwsChunkedV4aPayloadSignerTest {
         // include trailer bytes in the count:
         // (aTrailer: + aValue + \r\n + checksum-header + checksum-value + \r\n)
         expectedBytes += 9 + 6 + 2 + 21 + 8 + 2;
+
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedBytes, actualBytes);
     }
 
@@ -237,9 +243,9 @@ public class AwsChunkedV4aPayloadSignerTest {
                                                                       .checksumAlgorithm(CRC32)
                                                                       .build();
 
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
         ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
         assertThat(requestBuilder.firstMatchingHeader("aTrailer")).isNotPresent();
         assertThat(requestBuilder.matchingHeaders("x-amz-trailer")).contains("aTrailer", "x-amz-checksum-crc32");
@@ -250,23 +256,42 @@ public class AwsChunkedV4aPayloadSignerTest {
         // include trailer bytes in the count:
         // (aTrailer: + aValue + \r\n + checksum-header + checksum-value + \r\n + trailer-sig-header + trailer-sig + \r\n)
         expectedBytes += 9 + 6 + 2 + 21 + 8 + 2 + 24 + 144 + 2;
+
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedBytes, actualBytes);
     }
 
     @Test
-    public void sign_withoutContentLength_throws() {
+    public void sign_withoutContentLength_calculatesContentLengthFromPayload() throws IOException {
+        AwsSigningConfig signingConfig = basicSigningConfig();
+        signingConfig.setSignedBodyValue(STREAMING_UNSIGNED_PAYLOAD_TRAILER);
         V4aContext v4aContext = new V4aContext(
             requestBuilder,
             "sig".getBytes(StandardCharsets.UTF_8),
-            null
+            signingConfig
         );
-        requestBuilder.removeHeader(Header.CONTENT_LENGTH);
         AwsChunkedV4aPayloadSigner signer = AwsChunkedV4aPayloadSigner.builder()
                                                                       .credentialScope(CREDENTIAL_SCOPE)
                                                                       .chunkSize(CHUNK_SIZE)
+                                                                      .checksumAlgorithm(CRC32)
                                                                       .build();
 
-        assertThrows(IllegalArgumentException.class, () -> signer.sign(PAYLOAD, v4aContext));
+        requestBuilder.removeHeader(Header.CONTENT_LENGTH);
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
+        ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
+
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
+
+        byte[] tmp = new byte[2048];
+        int actualBytes = readAll(signedPayload.newStream(), tmp);
+        int expectedBytes = expectedByteCountUnsigned(DATA, CHUNK_SIZE);
+        // include trailer bytes in the count:
+        // (checksum-header + checksum-value + \r\n)
+        expectedBytes += 21 + 8 + 2;
+
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
+        assertEquals(expectedBytes, actualBytes);
     }
 
     @Test
@@ -283,9 +308,9 @@ public class AwsChunkedV4aPayloadSignerTest {
                                                                       .chunkSize(CHUNK_SIZE)
                                                                       .build();
 
+        signer.beforeSigning(requestBuilder, PAYLOAD, signingConfig.getSignedBodyValue());
         ContentStreamProvider signedPayload = signer.sign(PAYLOAD, v4aContext);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(DATA.length));
 
         byte[] tmp = new byte[2048];

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -29,6 +29,7 @@ import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSignin
 import static software.amazon.awssdk.http.auth.aws.TestUtils.AnonymousCredentialsIdentity;
 import static software.amazon.awssdk.http.auth.aws.crt.TestUtils.generateBasicRequest;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.toCredentials;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.readAll;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.AUTH_LOCATION;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.AuthLocation;
@@ -222,8 +223,11 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
                                .hasValue(STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD);
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("354");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
+
+        // Ensures that CRT runs correctly and without throwing an exception
+        readAll(signedRequest.payload().get().newStream());
     }
 
     @Test
@@ -241,9 +245,12 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
                                .hasValue(STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD_TRAILER);
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("555");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
+
+        // Ensures that CRT runs correctly and without throwing an exception
+        readAll(signedRequest.payload().get().newStream());
     }
 
     @Test
@@ -262,9 +269,12 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
                                .hasValue(STREAMING_UNSIGNED_PAYLOAD_TRAILER);
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("63");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
+
+        // Ensures that CRT runs correctly and without throwing an exception
+        readAll(signedRequest.payload().get().newStream());
     }
 
     @Test

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -223,7 +223,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
                                .hasValue(STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD);
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("354");
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("353");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
 
         // Ensures that CRT runs correctly and without throwing an exception
@@ -245,7 +245,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
                                .hasValue(STREAMING_AWS4_ECDSA_P256_SHA256_PAYLOAD_TRAILER);
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("555");
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("554");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
 
@@ -269,7 +269,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
                                .hasValue(STREAMING_UNSIGNED_PAYLOAD_TRAILER);
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("63");
+        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("62");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
 

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSignerTest.java
@@ -89,15 +89,15 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .chunkSize(chunkSize)
                                                                     .build();
 
-        signer.beforeSigning(requestBuilder);
+        signer.beforeSigning(requestBuilder, null);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
 
         byte[] tmp = new byte[1024];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedContent, new String(tmp, 0, actualBytes));
     }
 
@@ -132,16 +132,16 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(CRC32)
                                                                     .build();
 
-        signer.beforeSigning(requestBuilder);
+        signer.beforeSigning(requestBuilder, payload);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
 
         byte[] tmp = new byte[1024];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedContent, new String(tmp, 0, actualBytes));
     }
 
@@ -175,16 +175,16 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(SHA256)
                                                                     .build();
 
-        signer.beforeSigning(requestBuilder);
+        signer.beforeSigning(requestBuilder, payload);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
         assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-sha256");
 
         byte[] tmp = new byte[1024];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedContent, new String(tmp, 0, actualBytes));
     }
 
@@ -197,7 +197,7 @@ public class AwsChunkedV4PayloadSignerTest {
             "4\r\n: \"f\r\n" +
             "4\r\noo\"}\r\n" +
             "0\r\n" +
-            "PreExistingHeader1:someValue1, someValue2\r\n" +
+            "PreExistingHeader1:someValue1,someValue2\r\n" +
             "PreExistingHeader2:someValue3\r\n\r\n";
 
         requestBuilder
@@ -225,10 +225,9 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .chunkSize(chunkSize)
                                                                     .build();
 
-        signer.beforeSigning(requestBuilder);
+        signer.beforeSigning(requestBuilder, payload);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
         assertThat(requestBuilder.firstMatchingHeader("PreExistingHeader1")).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("PreExistingHeader2")).isNotPresent();
@@ -237,6 +236,7 @@ public class AwsChunkedV4PayloadSignerTest {
         byte[] tmp = new byte[1024];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedContent, new String(tmp, 0, actualBytes));
     }
 
@@ -249,7 +249,7 @@ public class AwsChunkedV4PayloadSignerTest {
             "4\r\n: \"f\r\n" +
             "4\r\noo\"}\r\n" +
             "0\r\n" +
-            "PreExistingHeader1:someValue1, someValue2\r\n" +
+            "PreExistingHeader1:someValue1,someValue2\r\n" +
             "PreExistingHeader2:someValue3\r\n" +
             "x-amz-checksum-crc32:a0bf9afe\r\n\r\n";
 
@@ -279,10 +279,9 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(CRC32)
                                                                     .build();
 
-        signer.beforeSigning(requestBuilder);
+        signer.beforeSigning(requestBuilder, payload);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
         assertThat(requestBuilder.firstMatchingHeader("PreExistingHeader1")).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("PreExistingHeader2")).isNotPresent();
@@ -293,6 +292,7 @@ public class AwsChunkedV4PayloadSignerTest {
         byte[] tmp = new byte[1024];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedContent, new String(tmp, 0, actualBytes));
     }
 
@@ -335,10 +335,9 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(CRC32)
                                                                     .build();
 
-        signer.beforeSigning(requestBuilder);
+        signer.beforeSigning(requestBuilder, payload);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
-        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
         assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
         assertThat(requestBuilder.firstMatchingHeader("PreExistingHeader1")).isNotPresent();
         assertThat(requestBuilder.matchingHeaders("x-amz-trailer")).contains("zzz", "PreExistingHeader1", "x-amz-checksum-crc32");
@@ -346,12 +345,23 @@ public class AwsChunkedV4PayloadSignerTest {
         byte[] tmp = new byte[1024];
         int actualBytes = readAll(signedPayload.newStream(), tmp);
 
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
         assertEquals(expectedContent, new String(tmp, 0, actualBytes));
     }
 
 
     @Test
-    public void sign_withoutContentLength_throws() {
+    public void sign_withoutContentLength_calculatesContentLengthFromPayload() throws IOException {
+        String expectedContent =
+            "4\r\n{\"Ta\r\n" +
+            "4\r\nbleN\r\n" +
+            "4\r\name\"\r\n" +
+            "4\r\n: \"f\r\n" +
+            "4\r\noo\"}\r\n" +
+            "0\r\n" +
+            "x-amz-checksum-sha256:a15c8292b1d12abbbbe4148605f7872fbdf645618fee5ab0e8072a7b34f155e2\r\n\r\n";
+
+        requestBuilder.putHeader("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER");
         V4CanonicalRequest canonicalRequest = new V4CanonicalRequest(
             requestBuilder.build(),
             "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
@@ -364,13 +374,24 @@ public class AwsChunkedV4PayloadSignerTest {
             canonicalRequest,
             requestBuilder
         );
-        v4Context.getSignedRequest().removeHeader(Header.CONTENT_LENGTH);
         AwsChunkedV4PayloadSigner signer = AwsChunkedV4PayloadSigner.builder()
                                                                     .credentialScope(credentialScope)
                                                                     .chunkSize(chunkSize)
+                                                                    .checksumAlgorithm(SHA256)
                                                                     .build();
 
-        assertThrows(IllegalArgumentException.class, () -> signer.sign(payload, v4Context));
+        v4Context.getSignedRequest().removeHeader(Header.CONTENT_LENGTH);
+        signer.beforeSigning(requestBuilder, payload);
+        ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
+
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-decoded-content-length")).hasValue(Integer.toString(data.length));
+        assertThat(requestBuilder.firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-sha256");
+
+        byte[] tmp = new byte[1024];
+        int actualBytes = readAll(signedPayload.newStream(), tmp);
+
+        assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue(Integer.toString(actualBytes));
+        assertEquals(expectedContent, new String(tmp, 0, actualBytes));
     }
 
     @Test
@@ -401,6 +422,7 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .chunkSize(chunkSize)
                                                                     .build();
 
+        signer.beforeSigning(requestBuilder, payload);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
         // successive calls to newStream() should return a stream with the same data every time - this makes sure that state

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSignerTest.java
@@ -89,6 +89,7 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .chunkSize(chunkSize)
                                                                     .build();
 
+        signer.beforeSigning(requestBuilder);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
@@ -131,6 +132,7 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(CRC32)
                                                                     .build();
 
+        signer.beforeSigning(requestBuilder);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
@@ -173,6 +175,7 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(SHA256)
                                                                     .build();
 
+        signer.beforeSigning(requestBuilder);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
@@ -222,6 +225,7 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .chunkSize(chunkSize)
                                                                     .build();
 
+        signer.beforeSigning(requestBuilder);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
@@ -275,6 +279,7 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(CRC32)
                                                                     .build();
 
+        signer.beforeSigning(requestBuilder);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
@@ -330,6 +335,7 @@ public class AwsChunkedV4PayloadSignerTest {
                                                                     .checksumAlgorithm(CRC32)
                                                                     .build();
 
+        signer.beforeSigning(requestBuilder);
         ContentStreamProvider signedPayload = signer.sign(payload, v4Context);
 
         assertThat(requestBuilder.firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -308,4 +308,19 @@ public class DefaultAwsV4HttpSignerTest {
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("a15c8292b1d12abbbbe4148605f7872fbdf645618fee5ab0e8072a7b34f155e2");
     }
+
+    @Test
+    public void sign_WithPayloadSigningNullAndHttp_FallsBackToPayloadSigning() {
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, null)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
+            .hasValue("a15c8292b1d12abbbbe4148605f7872fbdf645618fee5ab0e8072a7b34f155e2");
+    }
 }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -175,7 +175,7 @@ public class DefaultAwsV4HttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
-        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("194");
+        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("193");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
     }
 
@@ -194,7 +194,7 @@ public class DefaultAwsV4HttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER");
-        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("315");
+        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("314");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
     }
@@ -215,7 +215,7 @@ public class DefaultAwsV4HttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("STREAMING-UNSIGNED-PAYLOAD-TRAILER");
-        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("63");
+        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("62");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
     }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -28,6 +28,7 @@ import static software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner.PAYLOA
 
 import java.net.URI;
 import java.time.Duration;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -174,7 +175,7 @@ public class DefaultAwsV4HttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("194");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
     }
 
@@ -193,7 +194,7 @@ public class DefaultAwsV4HttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER");
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("315");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
     }
@@ -214,7 +215,7 @@ public class DefaultAwsV4HttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("STREAMING-UNSIGNED-PAYLOAD-TRAILER");
-        assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).isNotPresent();
+        Assertions.assertThat(signedRequest.request().firstMatchingHeader(Header.CONTENT_LENGTH)).hasValue("63");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-decoded-content-length")).hasValue("20");
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-trailer")).hasValue("x-amz-checksum-crc32");
     }


### PR DESCRIPTION
## Motivation and Context
- Content-Length should be pre-calculated for aws-chunked content-encoding and set, so that the http-client does not need to buffer the payload in memory to calculate it for us
- Updates to headers on the request by the payload signer must happen before request is signed, otherwise the canonical request that is signed will be incorrect
- Unsigned-payload with HTTP should fall back to signed-payload, just as the old signers do

## Testing
- Run new and existing tests, make sure pass


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
