### PR TITLE
Add additional backwards-compatibility testing for legacy clients.

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
@@ -269,7 +269,10 @@ public final class ExecutionAttribute<T> {
 
         @Override
         public void setIfAbsent(Map<ExecutionAttribute<?>, Object> attributes, T value) {
-            attributes.computeIfAbsent(realAttribute, k -> writeMapping.apply(null, value));
+            T currentValue = get(attributes);
+            if (currentValue == null) {
+                set(attributes, value);
+            }
         }
     }
 

--- a/test/old-client-version-compatibility-test/src/test/java/InterceptorSignerAttributeTest.java
+++ b/test/old-client-version-compatibility-test/src/test/java/InterceptorSignerAttributeTest.java
@@ -62,7 +62,8 @@ import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
 import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
 
 /**
- * Ensure that attributes set in execution interceptors are passed to custom signers.
+ * Ensure that attributes set in execution interceptors are passed to custom signers. These are protected APIs, but code
+ * searches show that customers are using them as if they aren't. We should push customers onto supported paths.
  */
 public class InterceptorSignerAttributeTest {
     private static final AwsCredentials CREDS = AwsBasicCredentials.create("akid", "skid");

--- a/test/old-client-version-compatibility-test/src/test/java/InterceptorSignerAttributeTest.java
+++ b/test/old-client-version-compatibility-test/src/test/java/InterceptorSignerAttributeTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+
+/**
+ * Ensure that attributes set in execution interceptors are passed to custom signers.
+ */
+public class InterceptorSignerAttributeTest {
+    private static final AwsCredentials CREDS = AwsBasicCredentials.create("akid", "skid");
+
+    @Test
+    public void canSetSignerExecutionAttributes_beforeExecution() {
+        test(attributeModifications -> new ExecutionInterceptor() {
+            @Override
+            public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
+                attributeModifications.accept(executionAttributes);
+            }
+        },
+             AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, // Endpoint rules override signing name
+             AwsSignerExecutionAttribute.SIGNING_REGION, // Endpoint rules override signing region
+             AwsSignerExecutionAttribute.AWS_CREDENTIALS, // Legacy auth strategy overrides credentials
+             AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE); // Endpoint rules override double-url-encode
+    }
+
+    @Test
+    public void canSetSignerExecutionAttributes_modifyRequest() {
+        test(attributeModifications -> new ExecutionInterceptor() {
+            @Override
+            public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
+                attributeModifications.accept(executionAttributes);
+                return context.request();
+            }
+        },
+             AwsSignerExecutionAttribute.AWS_CREDENTIALS); // Legacy auth strategy overrides credentials
+    }
+
+    @Test
+    public void canSetSignerExecutionAttributes_beforeMarshalling() {
+        test(attributeModifications -> new ExecutionInterceptor() {
+            @Override
+            public void beforeMarshalling(Context.BeforeMarshalling context, ExecutionAttributes executionAttributes) {
+                attributeModifications.accept(executionAttributes);
+            }
+        });
+    }
+
+    @Test
+    public void canSetSignerExecutionAttributes_afterMarshalling() {
+        test(attributeModifications -> new ExecutionInterceptor() {
+            @Override
+            public void afterMarshalling(Context.AfterMarshalling context, ExecutionAttributes executionAttributes) {
+                attributeModifications.accept(executionAttributes);
+            }
+        });
+    }
+
+    @Test
+    public void canSetSignerExecutionAttributes_modifyHttpRequest() {
+        test(attributeModifications -> new ExecutionInterceptor() {
+            @Override
+            public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+                attributeModifications.accept(executionAttributes);
+                return context.httpRequest();
+            }
+        });
+    }
+
+    private void test(Function<Consumer<ExecutionAttributes>, ExecutionInterceptor> interceptorFactory,
+                      ExecutionAttribute<?>... attributesToExcludeFromTest) {
+        Set<ExecutionAttribute<?>> attributesToExclude = new HashSet<>(Arrays.asList(attributesToExcludeFromTest));
+
+        ExecutionInterceptor interceptor = interceptorFactory.apply(executionAttributes -> {
+            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, "signing-name");
+            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, Region.of("signing-region"));
+            executionAttributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, CREDS);
+            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE, true);
+            executionAttributes.putAttribute(AwsSignerExecutionAttribute.SIGNER_NORMALIZE_PATH, true);
+        });
+
+        ClientOverrideConfiguration.Builder configBuilder =
+            ClientOverrideConfiguration.builder()
+                                       .addExecutionInterceptor(interceptor);
+
+        try (MockSyncHttpClient httpClient = new MockSyncHttpClient();
+             MockAsyncHttpClient asyncHttpClient = new MockAsyncHttpClient()) {
+            stub200Responses(httpClient, asyncHttpClient);
+
+            S3ClientBuilder s3Builder = createS3Builder(configBuilder, httpClient);
+            S3AsyncClientBuilder s3AsyncBuilder = createS3AsyncBuilder(configBuilder, asyncHttpClient);
+
+            CapturingSigner signer1 = new CapturingSigner();
+            try (S3Client s3 = s3Builder.overrideConfiguration(configBuilder.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
+                                                                                               signer1)
+                                                                            .build())
+                                        .build()) {
+                callS3(s3);
+                validateLegacySignRequest(attributesToExclude, signer1);
+            }
+
+            CapturingSigner signer2 = new CapturingSigner();
+            try (S3AsyncClient s3 =
+                     s3AsyncBuilder.overrideConfiguration(configBuilder.putAdvancedOption(SdkAdvancedClientOption.SIGNER, signer2)
+                                                                       .build())
+                                   .build()) {
+                callS3(s3);
+                validateLegacySignRequest(attributesToExclude, signer2);
+            }
+        }
+    }
+
+    private static void stub200Responses(MockSyncHttpClient httpClient, MockAsyncHttpClient asyncHttpClient) {
+        HttpExecuteResponse response =
+            HttpExecuteResponse.builder()
+                               .response(SdkHttpResponse.builder()
+                                                        .statusCode(200)
+                                                        .build())
+                               .build();
+        httpClient.stubResponses(response);
+        asyncHttpClient.stubResponses(response);
+    }
+
+    private static S3ClientBuilder createS3Builder(ClientOverrideConfiguration.Builder configBuilder, MockSyncHttpClient httpClient) {
+        return S3Client.builder()
+                       .region(Region.US_WEST_2)
+                       .credentialsProvider(AnonymousCredentialsProvider.create())
+                       .httpClient(httpClient)
+                       .overrideConfiguration(configBuilder.build());
+    }
+
+    private static S3AsyncClientBuilder createS3AsyncBuilder(ClientOverrideConfiguration.Builder configBuilder, MockAsyncHttpClient asyncHttpClient) {
+        return S3AsyncClient.builder()
+                            .region(Region.US_WEST_2)
+                            .credentialsProvider(AnonymousCredentialsProvider.create())
+                            .httpClient(asyncHttpClient)
+                            .overrideConfiguration(configBuilder.build());
+    }
+
+    private static void callS3(S3Client s3) {
+        s3.putObject(r -> r.bucket("foo")
+                           .key("bar")
+                           .checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                     RequestBody.fromString("text"));
+    }
+
+    private void callS3(S3AsyncClient s3) {
+        s3.putObject(r -> r.bucket("foo")
+                           .key("bar")
+                           .checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                     AsyncRequestBody.fromString("text"))
+          .join();
+    }
+
+    private void validateLegacySignRequest(Set<ExecutionAttribute<?>> attributesToExclude, CapturingSigner signer) {
+        if (!attributesToExclude.contains(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME)) {
+            assertThat(signer.executionAttributes.getAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME))
+                .isEqualTo("signing-name");
+        }
+        if (!attributesToExclude.contains(AwsSignerExecutionAttribute.SIGNING_REGION)) {
+            assertThat(signer.executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION))
+                .isEqualTo(Region.of("signing-region"));
+        }
+        if (!attributesToExclude.contains(AwsSignerExecutionAttribute.AWS_CREDENTIALS)) {
+            assertThat(signer.executionAttributes.getAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS))
+                .isEqualTo(CREDS);
+        }
+        if (!attributesToExclude.contains(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE)) {
+            assertThat(signer.executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE))
+                .isEqualTo(true);
+        }
+        if (!attributesToExclude.contains(AwsSignerExecutionAttribute.SIGNER_NORMALIZE_PATH)) {
+            assertThat(signer.executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNER_NORMALIZE_PATH))
+                .isEqualTo(true);
+        }
+    }
+
+    private static class CapturingSigner implements Signer {
+        private ExecutionAttributes executionAttributes;
+
+        @Override
+        public SdkHttpFullRequest sign(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {
+            this.executionAttributes = executionAttributes.copy();
+            return request;
+        }
+    }
+}

--- a/test/old-client-version-compatibility-test/src/test/java/S3AnonymousTest.java
+++ b/test/old-client-version-compatibility-test/src/test/java/S3AnonymousTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+
+/**
+ * Ensure that we can make anonymous requests using S3.
+ */
+public class S3AnonymousTest {
+    private MockSyncHttpClient httpClient;
+    private MockAsyncHttpClient asyncHttpClient;
+    private S3Client s3;
+    private S3AsyncClient s3Async;
+
+    @BeforeEach
+    public void setup() {
+        this.httpClient = new MockSyncHttpClient();
+        this.httpClient.stubNextResponse200();
+
+        this.asyncHttpClient = new MockAsyncHttpClient();
+        this.asyncHttpClient.stubNextResponse200();
+
+        this.s3 = S3Client.builder()
+                          .region(Region.US_WEST_2)
+                          .credentialsProvider(AnonymousCredentialsProvider.create())
+                          .httpClient(httpClient)
+                          .build();
+
+        this.s3Async = S3AsyncClient.builder()
+                                    .region(Region.US_WEST_2)
+                                    .credentialsProvider(AnonymousCredentialsProvider.create())
+                                    .httpClient(asyncHttpClient)
+                                    .build();
+    }
+
+    @AfterEach
+    public void teardown() {
+        httpClient.close();
+        asyncHttpClient.close();
+        s3.close();
+        s3Async.close();
+    }
+
+    @Test
+    public void nonStreamingOperations_canBeAnonymous() {
+        s3.listBuckets();
+        assertThat(httpClient.getLastRequest().firstMatchingHeader("Authorization")).isEmpty();
+    }
+
+    @Test
+    public void nonStreamingOperations_async_canBeAnonymous() {
+        s3Async.listBuckets().join();
+        assertThat(asyncHttpClient.getLastRequest().firstMatchingHeader("Authorization")).isEmpty();
+    }
+
+    @Test
+    public void streamingWriteOperations_canBeAnonymous() {
+        s3.putObject(r -> r.bucket("bucket").key("key"), RequestBody.fromString("foo"));
+        assertThat(httpClient.getLastRequest().firstMatchingHeader("Authorization")).isEmpty();
+    }
+
+    @Test
+    public void streamingWriteOperations_async_canBeAnonymous() {
+        s3Async.putObject(r -> r.bucket("bucket").key("key"), AsyncRequestBody.fromString("foo")).join();
+        assertThat(asyncHttpClient.getLastRequest().firstMatchingHeader("Authorization")).isEmpty();
+    }
+
+    @Test
+    public void streamingReadOperations_canBeAnonymous() {
+        s3.getObject(r -> r.bucket("bucket").key("key"), ResponseTransformer.toBytes());
+        assertThat(httpClient.getLastRequest().firstMatchingHeader("Authorization")).isEmpty();
+    }
+
+    @Test
+    public void streamingReadOperations_async_canBeAnonymous() {
+        s3Async.getObject(r -> r.bucket("bucket").key("key"), AsyncResponseTransformer.toBytes()).join();
+        assertThat(asyncHttpClient.getLastRequest().firstMatchingHeader("Authorization")).isEmpty();
+    }
+}

--- a/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/http/MockHttpClient.java
+++ b/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/http/MockHttpClient.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.List;
 import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.utils.Pair;
 
 public interface MockHttpClient {
@@ -31,6 +32,15 @@ public interface MockHttpClient {
      * Sets up the next HTTP response that will be returned by the mock. Removes responses previously added to the mock.
      */
     void stubNextResponse(HttpExecuteResponse nextResponse);
+
+    default void stubNextResponse200() {
+        stubNextResponse(HttpExecuteResponse.builder()
+                                            .response(SdkHttpResponse.builder()
+                                                                     .statusCode(200)
+                                                                     .putHeader("Content-Length", "0")
+                                                                     .build())
+                                            .build());
+    }
 
     /**
      * Sets up the next HTTP response that will be returned by the mock with a delay. Removes responses previously added to the


### PR DESCRIPTION
1. Ensure anonymous credentials function correctly
2. Ensure attributes set in custom execution interceptors make it to the legacy signer