### PR TITLE
Add useSraAuth=true for SraIdentityResolutionTest

### DIFF
--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/query/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/query/customization.config
@@ -1,3 +1,4 @@
 {
-    "skipEndpointTestGeneration": true
+    "skipEndpointTestGeneration": true,
+    "useSraAuth": true
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SraIdentityResolutionTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SraIdentityResolutionTest.java
@@ -31,7 +31,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
-import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolquery.ProtocolQueryClient;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SraIdentityResolutionTest {
@@ -44,7 +44,7 @@ public class SraIdentityResolutionTest {
         when(credsProvider.identityType()).thenReturn(AwsCredentialsIdentity.class);
         when(credsProvider.resolveIdentity(any(ResolveIdentityRequest.class)))
             .thenReturn(CompletableFuture.completedFuture(AwsBasicCredentials.create("akid1", "skid2")));
-        ProtocolRestJsonClient syncClient = ProtocolRestJsonClient
+        ProtocolQueryClient syncClient = ProtocolQueryClient
             .builder()
             .credentialsProvider(credsProvider)
             // Below is necessary to create the test case where, addCredentialsToExecutionAttributes was getting called before
@@ -52,7 +52,7 @@ public class SraIdentityResolutionTest {
             .build();
 
         try {
-            syncClient.allTypes();
+            syncClient.allTypes(builder -> {});
         } catch (Exception expected) {
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This test broke after #4491 , since now the client was defaulting to useSraAuth=false.

## Modifications
<!--- Describe your changes in detail -->
* Add useSraAuth=true
* Using the query service, as the restjson service was from codegen-resources/customresponsemetadata which seemed odd to use for this test. It doesn't really matter, but just switched to query, to use a vanilla service with no other customization.config.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`./mvnw clean install -pl :codegen-generated-classes-test`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
