### PR TITLE
Add dependency on http-auth-aws-crt from auth-crt.

### DIFF
--- a/core/auth-crt/pom.xml
+++ b/core/auth-crt/pom.xml
@@ -68,6 +68,13 @@
             <version>${awscrt.version}</version>
         </dependency>
 
+        <!-- Ensure that users that depend on auth-crt also get a dependency on the new signers -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws-crt</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
Customers currently depend on auth-crt to get Sigv4a support. In the future, customers should depend on http-auth-aws-crt for Sigv4a support. In order to ensure existing customers still work after SRA, we want users who depend on auth-crt today to automatically depend on http-auth-aws-crt.