### PR TITLE
Invoke plugins at client build time

### DIFF
--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SraIdentityResolutionUsingPluginsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SraIdentityResolutionUsingPluginsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.SdkServiceClientConfiguration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
+import software.amazon.awssdk.services.protocolquery.ProtocolQueryClient;
+import software.amazon.awssdk.services.protocolquery.ProtocolQueryServiceClientConfiguration;
+import software.amazon.awssdk.utils.Validate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SraIdentityResolutionUsingPluginsTest {
+
+    @Mock
+    private AwsCredentialsProvider credentialsProvider;
+
+    @Test
+    public void testIdentityBasedPluginsResolutionIsUsedAndNotAnotherIdentityResolution() {
+        when(credentialsProvider.identityType()).thenReturn(AwsCredentialsIdentity.class);
+        when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(AwsBasicCredentials.create("akid1", "skid2")));
+
+        ProtocolQueryClient syncClient = ProtocolQueryClient
+            .builder()
+            .addPlugin(new TestPlugin(credentialsProvider))
+            // Below is necessary to create the test case where, addCredentialsToExecutionAttributes was getting called before
+            .overrideConfiguration(ClientOverrideConfiguration.builder().build())
+            .build();
+
+        try {
+            syncClient.allTypes(builder -> {
+            });
+        } catch (Exception expected) {
+            expected.printStackTrace(System.out);
+        }
+
+        verify(credentialsProvider, times(2)).identityType();
+
+        // This asserts that the identity used is the one from resolveIdentity() called by SRA AuthSchemeInterceptor and not
+        // from another call like from AwsCredentialsAuthorizationStrategy.addCredentialsToExecutionAttributes, asserted by
+        // combination of times(1) and verifyNoMoreInteractions.
+        verify(credentialsProvider, times(1)).resolveIdentity(any(ResolveIdentityRequest.class));
+        verifyNoMoreInteractions(credentialsProvider);
+    }
+
+    static class TestPlugin implements SdkPlugin {
+        private final AwsCredentialsProvider credentialsProvider;
+
+        TestPlugin(AwsCredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+        }
+
+        @Override
+        public void configureClient(SdkServiceClientConfiguration.Builder config) {
+            ProtocolQueryServiceClientConfiguration.Builder builder =
+                Validate.isInstanceOf(ProtocolQueryServiceClientConfiguration.Builder.class,
+                                      config,
+                                      "Expecting an instance of " +
+                                      ProtocolQueryServiceClientConfiguration.class);
+            builder.credentialsProvider(credentialsProvider);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Adds the wiring to run the plugins at client build time. 

The plugins will be invoked **after** building the configuration and **before** the finalizing hooks, 

The final configuration used for the sync client is [built here](https://github.com/aws/aws-sdk-java-v2/blob/349a0e6918b90478d5704006ef348e5c0bb9f006/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java#L169) for the sync configuration and [built here](https://github.com/aws/aws-sdk-java-v2/blob/349a0e6918b90478d5704006ef348e5c0bb9f006/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java#L197) for the async configuration. 

During the first phase (as demarcated by the comments) the override configuration and defaults creates the initial revision of the configuration.

```
        // Apply overrides
        configuration = setOverrides(configuration);

        // Apply defaults
        configuration = mergeChildDefaults(configuration);
        configuration = mergeGlobalDefaults(configuration);
```

The next part, the finalizers, create additional configuration values from the default applied-configuration.

```
        // Create additional configuration from the default-applied configuration
        configuration = finalizeChildConfiguration(configuration);
        configuration = finalizeSyncConfiguration(configuration);
        configuration = finalizeConfiguration(configuration);
```

For AWS clients we have logic to use the configured values to derive new configuration values, for instance [this is how we create](https://github.com/aws/aws-sdk-java-v2/blob/fa9dbcce47637486e3f7d4d366ab6509b535342a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java#L207C1-L219C1) a default `IdentityProviders` class out of a single `IdentityProvider` of `AwsCredentialsProvider`.

```
        // Add the identityProvider to the IdentityProviders configured for the client.
        // Currently, it is not possible for identityProvider to be null as default provider is used while building the client if
        // the clientConfig is null. However, we do want to support ability to unset a identity provider later.
        // Moreover, putIdentityProvider will throw NPE on null, so adding the null check here. Also, validateClientOptions
        // currently asserts it is not null, which will have to change when we allow unsetting default identity provider.
        if (identityProvider != null) {
            configBuilder.option(SdkClientOption.IDENTITY_PROVIDERS,
                                 configuration.option(SdkClientOption.IDENTITY_PROVIDERS)
                                              .toBuilder()
                                              .putIdentityProvider(identityProvider)
                                              .build());
        }

```

This means that the plugins have to be able to update the configuration before the finalizers phase make decisions on it or somehow captures it, otherwise those changes won't be reflected on the changes made by the finalizers.

After this change the configuration will be built like the code below, invoking the plugins after defaults and before the finalizers.

```
        // Apply overrides
        configuration = setOverrides(configuration);
        // Apply defaults
        configuration = mergeChildDefaults(configuration);
        configuration = mergeGlobalDefaults(configuration);

        // Invoke the plugins after defaults and before finalizing the configuration.
        configuration = invokePluginsIfNeeded(configuration);

        // Create additional configuration from the default-applied configuration
        configuration = finalizeChildConfiguration(configuration);
        configuration = finalizeAsyncConfiguration(configuration);
```

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
