### PR TITLE
Fix checksum encoding, content-encoding header

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
@@ -17,6 +17,8 @@ package software.amazon.awssdk.http.auth.aws.internal.signer;
 
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.checksumHeaderName;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.fromChecksumAlgorithm;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.AWS_CHUNKED;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.CONTENT_ENCODING;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.STREAMING_SIGNED_PAYLOAD;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.STREAMING_SIGNED_PAYLOAD_TRAILER;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.STREAMING_UNSIGNED_PAYLOAD_TRAILER;
@@ -43,6 +45,7 @@ import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.SigV
 import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.TrailerProvider;
 import software.amazon.awssdk.http.auth.aws.internal.signer.io.ChecksumInputStream;
 import software.amazon.awssdk.http.auth.aws.internal.signer.io.ResettableContentStreamProvider;
+import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.Pair;
 import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.awssdk.utils.Validate;
@@ -161,6 +164,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
             request.appendHeader(X_AMZ_TRAILER, checksumHeaderName);
         }
         request.putHeader(Header.CONTENT_LENGTH, Long.toString(encodedContentLength));
+        request.appendHeader(CONTENT_ENCODING, AWS_CHUNKED);
     }
 
     /**
@@ -237,8 +241,8 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
 
         // get the base checksum for the algorithm
         SdkChecksum sdkChecksum = fromChecksumAlgorithm(checksumAlgorithm);
-        // size of checksum value as hex-string
-        lengthInBytes += sdkChecksum.getChecksum().length();
+        // size of checksum value as encoded-string
+        lengthInBytes += BinaryUtils.toBase64(sdkChecksum.getChecksumBytes()).length();
 
         // terminating \r\n
         return lengthInBytes + 2;

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
@@ -214,7 +214,7 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
 
         V4Context v4Context = requestSigner.sign(requestBuilder);
 
-        ContentStreamProvider payload = payloadSigner.sign(request.payload().orElse(null), v4Context);
+        ContentStreamProvider payload = request.payload().map(p -> payloadSigner.sign(p, v4Context)).orElse(null);
 
         return SignedRequest.builder()
                             .request(v4Context.getSignedRequest().build())

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/ConstantChecksum.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/ConstantChecksum.java
@@ -55,9 +55,4 @@ public class ConstantChecksum implements SdkChecksum {
     @Override
     public void mark(int readLimit) {
     }
-
-    @Override
-    public String getChecksum() {
-        return value;
-    }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/SdkChecksum.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/SdkChecksum.java
@@ -15,8 +15,6 @@
 
 package software.amazon.awssdk.http.auth.aws.internal.signer.checksums;
 
-import static software.amazon.awssdk.utils.BinaryUtils.toHex;
-
 import java.nio.ByteBuffer;
 import java.util.zip.Checksum;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -96,13 +94,5 @@ public interface SdkChecksum extends Checksum {
             }
         }
         buffer.position(limit);
-    }
-
-    /**
-     * Return an encoded-string representation of the checksum. By default, this returns a String that is the lowercase, base16
-     * (hex) representation of the checksum.
-     */
-    default String getChecksum() {
-        return toHex(getChecksumBytes());
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProvider.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.SdkChecksum;
+import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.Pair;
 
 @SdkInternalApi
@@ -41,7 +42,7 @@ public class ChecksumTrailerProvider implements TrailerProvider {
     public Pair<String, List<String>> get() {
         return Pair.of(
             checksumName,
-            Collections.singletonList(checksum.getChecksum())
+            Collections.singletonList(BinaryUtils.toBase64(checksum.getChecksumBytes()))
         );
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerConstant.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerConstant.java
@@ -49,6 +49,8 @@ public final class SignerConstant {
 
     public static final String X_AMZ_TRAILER = "x-amz-trailer";
 
+    public static final String AWS_CHUNKED = "aws-chunked";
+
     public static final String HOST = "Host";
 
     public static final String LINE_SEPARATOR = "\n";

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSignerTest.java
@@ -110,8 +110,8 @@ public class AwsChunkedV4PayloadSignerTest {
             "4;chunk-signature=aff22ddad9d4388233fe9bc47e9c552a6e9ba9285af79555d2ce7fdaab726320\r\n: \"f\r\n" +
             "4;chunk-signature=30e55f4e1c1fd444c06e9be42d9594b8fd7ead436bc67a58b5350ffd58b6aaa5\r\noo\"}\r\n" +
             "0;chunk-signature=825ad80195cae47f54984835543ff2179c2c5a53c324059cd632e50259384ee3\r\n" +
-            "x-amz-checksum-crc32:a0bf9afe\r\n" +
-            "x-amz-trailer-signature:6a0343202e883c7a91c5bfeeb18a564a0bc8f294089530b443dfb4a16a3cdc92\r\n\r\n";
+            "x-amz-checksum-crc32:oL+a/g==\r\n" +
+            "x-amz-trailer-signature:23457d04f4a8e279780cb91e28d4fbd1c6a2dd678d419705461a80514cea206c\r\n\r\n";
 
         requestBuilder.putHeader("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER");
         V4CanonicalRequest canonicalRequest = new V4CanonicalRequest(
@@ -154,7 +154,7 @@ public class AwsChunkedV4PayloadSignerTest {
             "4\r\n: \"f\r\n" +
             "4\r\noo\"}\r\n" +
             "0\r\n" +
-            "x-amz-checksum-sha256:a15c8292b1d12abbbbe4148605f7872fbdf645618fee5ab0e8072a7b34f155e2\r\n\r\n";
+            "x-amz-checksum-sha256:oVyCkrHRKru75BSGBfeHL732RWGP7lqw6AcqezTxVeI=\r\n\r\n";
 
         requestBuilder.putHeader("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER");
         V4CanonicalRequest canonicalRequest = new V4CanonicalRequest(
@@ -251,7 +251,7 @@ public class AwsChunkedV4PayloadSignerTest {
             "0\r\n" +
             "PreExistingHeader1:someValue1,someValue2\r\n" +
             "PreExistingHeader2:someValue3\r\n" +
-            "x-amz-checksum-crc32:a0bf9afe\r\n\r\n";
+            "x-amz-checksum-crc32:oL+a/g==\r\n\r\n";
 
         requestBuilder
             .putHeader("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
@@ -307,8 +307,8 @@ public class AwsChunkedV4PayloadSignerTest {
             "0;chunk-signature=825ad80195cae47f54984835543ff2179c2c5a53c324059cd632e50259384ee3\r\n" +
             "zzz:123\r\n" +
             "PreExistingHeader1:someValue1\r\n" +
-            "x-amz-checksum-crc32:a0bf9afe\r\n" +
-            "x-amz-trailer-signature:6df1f5fff22281fd2e64ed859b0242a2651d06ec3f772a9f36c6bc6a1e006a3d\r\n\r\n";
+            "x-amz-checksum-crc32:oL+a/g==\r\n" +
+            "x-amz-trailer-signature:3f65ab57ede6a5fb7c77b14b35faf2d9dd2c6d89828bdae189a04f3677bc16f2\r\n\r\n";
 
         requestBuilder
             .putHeader("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER")
@@ -359,7 +359,7 @@ public class AwsChunkedV4PayloadSignerTest {
             "4\r\n: \"f\r\n" +
             "4\r\noo\"}\r\n" +
             "0\r\n" +
-            "x-amz-checksum-sha256:a15c8292b1d12abbbbe4148605f7872fbdf645618fee5ab0e8072a7b34f155e2\r\n\r\n";
+            "x-amz-checksum-sha256:oVyCkrHRKru75BSGBfeHL732RWGP7lqw6AcqezTxVeI=\r\n\r\n";
 
         requestBuilder.putHeader("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER");
         V4CanonicalRequest canonicalRequest = new V4CanonicalRequest(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Flexible checksums are supposed to be **base64**-encoded, not hex

## Modifications
- Updates encoding of checksums to be configurable
- Updates FlexibleChecksummer to be more configurable through options

## Testing
- Ran with a few s3 integ tests, and chunk-encoded payloads now return 200's 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
