### PR TITLE
Revert deprecations until SRA release is complete

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -115,14 +115,9 @@ public class SdkExecutionAttribute {
     public static final ExecutionAttribute<String> PROFILE_NAME = new ExecutionAttribute<>("ProfileName");
 
     /**
-     * The checksums specs used to control checksum behavior in the signer.
-     *
-     * @deprecated This is a protected class that is internal to the SDK, so you shouldn't be using it. If you are using it
-     * from execution interceptors, you should instead be overriding the resolved-checksum-specs setting via the {@code
-     * AuthSchemeProvider} that is configured on the SDK client builder. If you're using it to call the SDK's signers, you
-     * should migrate to a subtype of {@code HttpSigner}.
+     * The checksum algorithm is resolved based on the Request member.
+     * The RESOLVED_CHECKSUM_SPECS holds the final checksum which will be used for checksum computation.
      */
-    @Deprecated
     public static final ExecutionAttribute<ChecksumSpecs> RESOLVED_CHECKSUM_SPECS =
         ExecutionAttribute.mappedBuilder("ResolvedChecksumSpecs",
                                          ChecksumSpecs.class,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The release plan is service-by-service, so we don't want to deprecate any public interfaces until the release is fully rolled out.

`git diff origin/master origin/feature/master/sra-identity-auth` - looking through the diff, the relevant @Deprecated changes are in:

AwsSignerExecutionAttribute
S3SignerExecutionAttribute
SdkTokenExecutionAttribute

AwsClientOption.CREDENTIALS_PROVIDER, TOKEN_PROVIDER

AuthorizationStrategy
AuthorizationStrategyFactory
AwsCredentialsAuthorizationStrategy
TokenAuthorizationStrategy

SignerOverrideUtils methods.

SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS

Of these, only SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS is SdkPublicApi, rest are all protected/internal. So reverting just that one. Note, javadoc content also reverted to what was earlier.

## Modifications
<!--- Describe your changes in detail -->
Revert deprecation of RESOLVED_CHECKSUM_SPECS

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
