### PR TITLE
Uncomment disabled S3PresignerTest for sigv4a

### DIFF
--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
@@ -641,7 +641,6 @@ public class S3PresignerTest {
             .hasMessageContaining("Invalid configuration: region from ARN `us-east-1` does not match client region `us-west-2` and UseArnRegion is `false`");
     }
 
-    /*
     @Test
     // TODO(sra-identity-and-auth), this test fails with Expected :"AWS4-ECDSA-P256-SHA256", Actual :"AWS4-HMAC-SHA256"
     public void accessPointArn_multiRegion_useArnRegionTrue_correctEndpointAndSigner() {
@@ -662,7 +661,6 @@ public class S3PresignerTest {
             .isEqualTo("AWS4-ECDSA-P256-SHA256");
         assertThat(presignedRequest.url().toString()).startsWith(customEndpoint);
     }
-     */
 
     @Test
     public void outpostArn_usWest_calculatesCorrectSignature() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This test was disabled earlier as sigv4a signer wasn't wired up properly.

## Modifications
<!--- Describe your changes in detail -->
Uncomment the test.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
the test passes

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
