### PR TITLE
Revert Presigners to pre SRA Identity & Auth

### DIFF
--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -48,16 +48,12 @@ import software.amazon.awssdk.core.signer.Presigner;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
-import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
-import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
-import software.amazon.awssdk.services.polly.auth.scheme.PollyAuthSchemeProvider;
 import software.amazon.awssdk.services.polly.internal.presigner.model.transform.SynthesizeSpeechRequestMarshaller;
 import software.amazon.awssdk.services.polly.model.PollyRequest;
 import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
@@ -67,6 +63,9 @@ import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Validate;
 
+// TODO(sra-identity-auth): Move to SRA I&A. Note, until we expose ability configuration for the SRA interfaces, like
+//  AuthSchemeProvider (directly or via Plugins), there isn't any real customer benefit to moving to SRA, other than just getting
+//  off the old deprecated Signer interface.
 /**
  * Default implementation of {@link PollyPresigner}.
  */
@@ -186,6 +185,7 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     private SdkHttpFullRequest presignRequest(PollyRequest requestToPresign,
                                               SdkHttpFullRequest marshalledRequest,
                                               ExecutionAttributes executionAttributes) {
+        // TODO(sra-identity-auth): Move to SRA HttpSigner
         Presigner presigner = resolvePresigner(requestToPresign);
         SdkHttpFullRequest presigned = presigner.presign(marshalledRequest, executionAttributes);
         List<String> signedHeadersQueryParam = presigned.firstMatchingRawQueryParameters("X-Amz-SignedHeaders");
@@ -208,19 +208,25 @@ public final class DefaultPollyPresigner implements PollyPresigner {
                 .putAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX, false)
                 .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, ClientType.SYNC)
                 .putAttribute(SdkExecutionAttribute.SERVICE_NAME, SERVICE_NAME)
-                .putAttribute(PRESIGNER_EXPIRATION, signatureExpiration)
+                .putAttribute(PRESIGNER_EXPIRATION, signatureExpiration);
+        // TODO(sra-identity-auth): Uncomment when switching to useSraAuth=true
+        /*
                 .putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER, PollyAuthSchemeProvider.defaultProvider())
                 .putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES, authSchemes())
                 .putAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDERS,
                               IdentityProviders.builder()
                                                .putIdentityProvider(credentialsProvider())
                                                .build());
+         */
     }
 
+    // TODO(sra-identity-auth): Uncomment when switching to useSraAuth=true
+    /*
     private Map<String, AuthScheme<?>> authSchemes() {
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
         return Collections.singletonMap(awsV4AuthScheme.schemeId(), awsV4AuthScheme);
     }
+     */
 
     private IdentityProvider<? extends AwsCredentialsIdentity> resolveCredentialsProvider(PollyRequest request) {
         return request.overrideConfiguration().flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Since the release will be service by service, will start with S3/Polly on preSRA, making the Presigners be not dependent on new interfaces.

## Modifications
<!--- Describe your changes in detail -->
 So reverting SRA changes for Presigners from https://github.com/aws/aws-sdk-java-v2/pull/4311. That change was necessary in the scope of #4311, but now is not necessary because of derived attributes change from https://github.com/aws/aws-sdk-java-v2/pull/4396.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
` ./mvnw clean install -pl :polly,:s3`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
