### PR TITLE
Handling Anonymous, chunking decisions, and existing checksums

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/Checksummer.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/Checksummer.java
@@ -90,6 +90,10 @@ public interface Checksummer {
         throw new IllegalArgumentException("Checksum Algorithm cannot be null!");
     }
 
+    static Checksummer forNoOp() {
+        return new FlexibleChecksummer();
+    }
+
     /**
      * Given a payload, calculate a checksum and add it to the request.
      */

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.auth.aws.internal.signer;
 
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.checksumHeaderName;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.CredentialUtils.sanitizeCredentials;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.OptionalDependencyLoaderUtil.getEventStreamV4PayloadSigner;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.PRESIGN_URL_MAX_EXPIRATION_DURATION;
@@ -31,6 +32,7 @@ import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.Header;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -77,6 +79,11 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
 
         AuthLocation authLocation = request.requireProperty(AUTH_LOCATION, AuthLocation.HEADER);
         Duration expirationDuration = request.property(EXPIRATION_DURATION);
+        boolean isAnonymous = CredentialUtils.isAnonymous(request.identity());
+
+        if (isAnonymous) {
+            return V4RequestSigner.anonymous(v4Properties);
+        }
 
         Function<V4Properties, V4RequestSigner> requestSigner;
         switch (authLocation) {
@@ -99,12 +106,25 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
         return requestSigner.apply(v4Properties);
     }
 
+    private static boolean hasChecksumHeader(BaseSignRequest<?, ? extends AwsCredentialsIdentity> request) {
+        ChecksumAlgorithm checksumAlgorithm = request.property(CHECKSUM_ALGORITHM);
+
+        if (checksumAlgorithm != null) {
+            String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
+            return request.request().firstMatchingHeader(checksumHeaderName).isPresent();
+        }
+
+        return false;
+    }
+
     private static Checksummer checksummer(BaseSignRequest<?, ? extends AwsCredentialsIdentity> request) {
         boolean isPayloadSigning = isPayloadSigning(request);
         boolean isEventStreaming = isEventStreaming(request.request());
-        boolean isChunkEncoding = request.requireProperty(CHUNK_ENCODING_ENABLED, false);
+        boolean hasChecksumHeader = hasChecksumHeader(request);
+        boolean isChunkEncoding = request.requireProperty(CHUNK_ENCODING_ENABLED, false) && !hasChecksumHeader;
         boolean isTrailing = request.request().firstMatchingHeader(X_AMZ_TRAILER).isPresent();
         boolean isFlexible = request.hasProperty(CHECKSUM_ALGORITHM);
+        boolean isAnonymous = CredentialUtils.isAnonymous(request.identity());
 
         if (isEventStreaming) {
             return Checksummer.forPrecomputed256Checksum(STREAMING_EVENTS_PAYLOAD);
@@ -118,21 +138,24 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
                 return Checksummer.forPrecomputed256Checksum(STREAMING_SIGNED_PAYLOAD);
             }
 
-            if (request.hasProperty(CHECKSUM_ALGORITHM)) {
+            if (isFlexible) {
                 return Checksummer.forFlexibleChecksum(request.property(CHECKSUM_ALGORITHM));
             }
             return Checksummer.create();
         }
 
-        if (isChunkEncoding) {
-            if (isFlexible || isTrailing) {
+        if (isFlexible || isTrailing) {
+            if (isChunkEncoding) {
                 return Checksummer.forPrecomputed256Checksum(STREAMING_UNSIGNED_PAYLOAD_TRAILER);
             }
-            throw new UnsupportedOperationException("Chunk-Encoding without Payload-Signing must have a trailer!");
         }
 
-        if (isFlexible) {
+        if (isFlexible && !hasChecksumHeader) {
             return Checksummer.forFlexibleChecksum(UNSIGNED_PAYLOAD, request.property(CHECKSUM_ALGORITHM));
+        }
+
+        if (isAnonymous) {
+            return Checksummer.forNoOp();
         }
 
         return Checksummer.forPrecomputed256Checksum(UNSIGNED_PAYLOAD);
@@ -144,7 +167,9 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
 
         boolean isPayloadSigning = isPayloadSigning(request);
         boolean isEventStreaming = isEventStreaming(request.request());
-        boolean isChunkEncoding = request.requireProperty(CHUNK_ENCODING_ENABLED, false);
+        boolean isChunkEncoding = request.requireProperty(CHUNK_ENCODING_ENABLED, false) && !hasChecksumHeader(request);
+        boolean isTrailing = request.request().firstMatchingHeader(X_AMZ_TRAILER).isPresent();
+        boolean isFlexible = request.hasProperty(CHECKSUM_ALGORITHM);
 
         if (isEventStreaming) {
             if (isPayloadSigning) {
@@ -157,7 +182,7 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
             throw new UnsupportedOperationException("Unsigned payload is not supported with event-streaming.");
         }
 
-        if (isChunkEncoding) {
+        if ((isChunkEncoding && isPayloadSigning) || (isChunkEncoding && (isTrailing || isFlexible))) {
             return AwsChunkedV4PayloadSigner.builder()
                                             .credentialScope(properties.getCredentialScope())
                                             .chunkSize(DEFAULT_CHUNK_SIZE_IN_BYTES)
@@ -199,12 +224,6 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
                                         Checksummer checksummer,
                                         V4RequestSigner requestSigner,
                                         V4PayloadSigner payloadSigner) {
-        if (CredentialUtils.isAnonymous(request.identity())) {
-            return SignedRequest.builder()
-                                .request(request.request())
-                                .payload(request.payload().orElse(null))
-                                .build();
-        }
 
         SdkHttpRequest.Builder requestBuilder = request.request().toBuilder();
 
@@ -226,14 +245,6 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
                                                                 Checksummer checksummer,
                                                                 V4RequestSigner requestSigner,
                                                                 V4PayloadSigner payloadSigner) {
-        if (CredentialUtils.isAnonymous(request.identity())) {
-            return CompletableFuture.completedFuture(
-                AsyncSignedRequest.builder()
-                                  .request(request.request())
-                                  .payload(request.payload().orElse(null))
-                                  .build()
-            );
-        }
 
         SdkHttpRequest.Builder requestBuilder = request.request().toBuilder();
 
@@ -261,7 +272,11 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
     }
 
     private static boolean isPayloadSigning(BaseSignRequest<?, ? extends AwsCredentialsIdentity> request) {
-        return request.requireProperty(PAYLOAD_SIGNING_ENABLED, true) || !"https".equals(request.request().protocol());
+        boolean isAnonymous = CredentialUtils.isAnonymous(request.identity());
+        boolean isPayloadSigningEnabled = request.requireProperty(PAYLOAD_SIGNING_ENABLED, true);
+        boolean isEncrypted = "https".equals(request.request().protocol());
+
+        return !isAnonymous && (isPayloadSigningEnabled || !isEncrypted);
     }
 
     private static boolean isEventStreaming(SdkHttpRequest request) {

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4RequestSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4RequestSigner.java
@@ -109,6 +109,15 @@ public interface V4RequestSigner {
     }
 
     /**
+     * Retrieve an implementation of a V4RequestSigner, which signs the request and adds authentication through query parameters,
+     * which includes an expiration param, signalling how long a request signature is valid.
+     */
+    static V4RequestSigner anonymous(V4Properties properties) {
+        return requestBuilder ->
+            new V4Context("", new byte[] {}, null, null, requestBuilder);
+    }
+
+    /**
      * Given a request builder, sign a request and return a v4-context containing the signed request and its properties.
      */
     V4Context sign(SdkHttpRequest.Builder requestBuilder);

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4RequestSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4RequestSigner.java
@@ -109,8 +109,8 @@ public interface V4RequestSigner {
     }
 
     /**
-     * Retrieve an implementation of a V4RequestSigner, which signs the request and adds authentication through query parameters,
-     * which includes an expiration param, signalling how long a request signature is valid.
+     * Retrieve an implementation of a V4RequestSigner to handle the anonymous credentials case, where the request is not
+     * sigend at all.
      */
     static V4RequestSigner anonymous(V4Properties properties) {
         return requestBuilder ->


### PR DESCRIPTION
## Motivation and Context
- If a request has an anonymous identity, we should not sign it, but we should still optionally encode it and add flexible checksum information to it
- If a request is chunk-encoding enabled, we still must do some checks before we decide to chunk-encode the payload (i.e. if checksum is in headers and it's unsigned, we should NOT chunk-encode)
- If a checksum is already provided in the request headers, we should not re-compute it or override it

## Testing
- Run s3 integration tests
- Run unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
