### PR TITLE
If authType=none don't use the old signer, even if overridden 

### DIFF
--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilderTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilderTest.java
@@ -17,14 +17,16 @@ package software.amazon.awssdk.awscore.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,12 +34,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.checksums.ChecksumSpecs;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -51,6 +53,11 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.internal.util.HttpChecksumUtils;
 import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
@@ -66,15 +73,24 @@ public class AwsExecutionContextBuilderTest {
     ExecutionInterceptor interceptor;
 
     @Mock
+    IdentityProvider<AwsCredentialsIdentity> defaultCredentialsProvider;
+
+    @Mock
     Signer defaultSigner;
 
     @Mock
     Signer clientOverrideSigner;
 
+    @Mock
+    Map<String, AuthScheme<?>> defaultAuthSchemes;
+
     @Before
     public void setUp() throws Exception {
         when(sdkRequest.overrideConfiguration()).thenReturn(Optional.empty());
         when(interceptor.modifyRequest(any(), any())).thenReturn(sdkRequest);
+        when(defaultCredentialsProvider.resolveIdentity()).thenAnswer(
+            invocationOnMock -> CompletableFuture.completedFuture(AwsCredentialsIdentity.create("ak", "sk")));
+
     }
 
     @Test
@@ -109,17 +125,45 @@ public class AwsExecutionContextBuilderTest {
         assertThat(executionContext.executionAttributes().getAttribute(SdkExecutionAttribute.SERVICE_NAME)).isEqualTo("DoNotOverrideService");
     }
 
+    // pre SRA, AuthorizationStrategy would setup the signer and resolve identity.
     @Test
-    public void signing_ifNoOverrides_assignDefaultSigner() {
+    public void preSra_signing_ifNoOverrides_assignDefaultSigner_resolveIdentity() {
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   preSraClientConfiguration().build());
+
+        assertThat(executionContext.signer()).isEqualTo(defaultSigner);
+        verify(defaultCredentialsProvider, times(1)).resolveIdentity();
+    }
+
+    // This is post SRA case. This is asserting that AuthorizationStrategy is not used.
+    @Test
+    public void postSra_ifNoOverrides_doesNotResolveIdentity_doesNotAssignSigner() {
         ExecutionContext executionContext =
             AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
                                                                                    testClientConfiguration().build());
 
-        assertThat(executionContext.signer()).isEqualTo(defaultSigner);
+        assertThat(executionContext.signer()).isNull();
+        verify(defaultCredentialsProvider, times(0)).resolveIdentity();
     }
 
     @Test
-    public void signing_ifClientOverride_assignClientOverrideSigner() {
+    public void preSra_signing_ifClientOverride_assignClientOverrideSigner_resolveIdentity() {
+        Optional overrideConfiguration = Optional.of(AwsRequestOverrideConfiguration.builder()
+                                                                                    .signer(clientOverrideSigner)
+                                                                                    .build());
+        when(sdkRequest.overrideConfiguration()).thenReturn(overrideConfiguration);
+
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   preSraClientConfiguration().build());
+
+        assertThat(executionContext.signer()).isEqualTo(clientOverrideSigner);
+        verify(defaultCredentialsProvider, times(1)).resolveIdentity();
+    }
+
+    @Test
+    public void postSra_signing_ifClientOverride_assignClientOverrideSigner_resolveIdentity() {
         Optional overrideConfiguration = Optional.of(AwsRequestOverrideConfiguration.builder()
                                                                                     .signer(clientOverrideSigner)
                                                                                     .build());
@@ -130,6 +174,102 @@ public class AwsExecutionContextBuilderTest {
                                                                                    testClientConfiguration().build());
 
         assertThat(executionContext.signer()).isEqualTo(clientOverrideSigner);
+        verify(defaultCredentialsProvider, times(1)).resolveIdentity();
+    }
+
+    @Test
+    public void preSra_authTypeNone_doesNotAssignSigner_doesNotResolveIdentity() {
+        SdkClientConfiguration.Builder clientConfig = preSraClientConfiguration();
+        clientConfig.option(SdkClientOption.EXECUTION_ATTRIBUTES)
+                    // yes, our code would put false instead of true
+                    .putAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false);
+
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   clientConfig.build());
+
+        assertThat(executionContext.signer()).isNull();
+        verify(defaultCredentialsProvider, times(0)).resolveIdentity();
+    }
+
+    @Test
+    public void postSra_authTypeNone_doesNotAssignSigner_doesNotResolveIdentity() {
+        SdkClientConfiguration.Builder clientConfig = noAuthAuthSchemeClientConfiguration();
+
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   clientConfig.build());
+
+        assertThat(executionContext.signer()).isNull();
+        verify(defaultCredentialsProvider, times(0)).resolveIdentity();
+    }
+
+    @Test
+    public void preSra_authTypeNone_signerClientOverride_doesNotAssignSigner_doesNotResolveIdentity() {
+        SdkClientConfiguration.Builder clientConfig = preSraClientConfiguration();
+        clientConfig.option(SdkClientOption.EXECUTION_ATTRIBUTES)
+                    // yes, our code would put false instead of true
+                    .putAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false);
+        clientConfig.option(SdkAdvancedClientOption.SIGNER, this.clientOverrideSigner)
+                    .option(SdkClientOption.SIGNER_OVERRIDDEN, true);
+
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   clientConfig.build());
+
+        assertThat(executionContext.signer()).isNull();
+        verify(defaultCredentialsProvider, times(0)).resolveIdentity();
+    }
+
+    @Test
+    public void postSra_authTypeNone_signerClientOverride_doesNotAssignSigner_doesNotResolveIdentity() {
+        SdkClientConfiguration.Builder clientConfig = noAuthAuthSchemeClientConfiguration();
+        clientConfig.option(SdkAdvancedClientOption.SIGNER, this.clientOverrideSigner)
+                    .option(SdkClientOption.SIGNER_OVERRIDDEN, true);
+
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   clientConfig.build());
+
+        assertThat(executionContext.signer()).isNull();
+        verify(defaultCredentialsProvider, times(0)).resolveIdentity();
+    }
+
+    @Test
+    public void preSra_authTypeNone_signerRequestOverride_doesNotAssignSigner_doesNotResolveIdentity() {
+        SdkClientConfiguration.Builder clientConfig = preSraClientConfiguration();
+        clientConfig.option(SdkClientOption.EXECUTION_ATTRIBUTES)
+                    // yes, our code would put false instead of true
+                    .putAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false);
+
+        Optional overrideConfiguration = Optional.of(AwsRequestOverrideConfiguration.builder()
+                                                                                    .signer(clientOverrideSigner)
+                                                                                    .build());
+        when(sdkRequest.overrideConfiguration()).thenReturn(overrideConfiguration);
+
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   clientConfig.build());
+
+        assertThat(executionContext.signer()).isNull();
+        verify(defaultCredentialsProvider, times(0)).resolveIdentity();
+    }
+
+    @Test
+    public void postSra_authTypeNone_signerRequestOverride_doesNotAssignSigner_doesNotResolveIdentity() {
+        SdkClientConfiguration.Builder clientConfig = noAuthAuthSchemeClientConfiguration();
+
+        Optional overrideConfiguration = Optional.of(AwsRequestOverrideConfiguration.builder()
+                                                                                    .signer(clientOverrideSigner)
+                                                                                    .build());
+        when(sdkRequest.overrideConfiguration()).thenReturn(overrideConfiguration);
+
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   clientConfig.build());
+
+        assertThat(executionContext.signer()).isNull();
+        verify(defaultCredentialsProvider, times(0)).resolveIdentity();
     }
 
     @Test
@@ -255,11 +395,44 @@ public class AwsExecutionContextBuilderTest {
     }
 
     private SdkClientConfiguration.Builder testClientConfiguration() {
+        // In real SRA case, SelectedAuthScheme is setup as an executionAttribute by {Service}AuthSchemeInterceptor that is setup
+        // in EXECUTION_INTERCEPTORS. But, faking it here for unit test, by already setting SELECTED_AUTH_SCHEME into the
+        // executionAttributes.
+        SelectedAuthScheme<?> selectedAuthScheme = new SelectedAuthScheme<>(
+            CompletableFuture.completedFuture(AwsCredentialsIdentity.create("ak", "sk")),
+            mock(HttpSigner.class),
+            AuthSchemeOption.builder().schemeId(AwsV4AuthScheme.SCHEME_ID).build()
+        );
+        ExecutionAttributes executionAttributes =
+            ExecutionAttributes.builder()
+                               .put(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme)
+                               .build();
+
         List<ExecutionInterceptor> interceptorList = Collections.singletonList(interceptor);
         return SdkClientConfiguration.builder()
-                                     .option(SdkClientOption.EXECUTION_INTERCEPTORS, new ArrayList<>())
                                      .option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptorList)
-                                     .option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER, DefaultCredentialsProvider.create())
-                                     .option(SdkAdvancedClientOption.SIGNER, this.defaultSigner);
+                                     .option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER, defaultCredentialsProvider)
+                                     .option(SdkClientOption.AUTH_SCHEMES, defaultAuthSchemes)
+                                     .option(SdkClientOption.EXECUTION_ATTRIBUTES, executionAttributes);
+    }
+
+    private SdkClientConfiguration.Builder noAuthAuthSchemeClientConfiguration() {
+        SdkClientConfiguration.Builder clientConfig = testClientConfiguration();
+        SelectedAuthScheme<?> selectedNoAuthScheme = new SelectedAuthScheme<>(
+            CompletableFuture.completedFuture(AwsCredentialsIdentity.create("ak", "sk")),
+            mock(HttpSigner.class),
+            AuthSchemeOption.builder().schemeId(NoAuthAuthScheme.SCHEME_ID).build()
+        );
+        clientConfig.option(SdkClientOption.EXECUTION_ATTRIBUTES)
+                    .putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedNoAuthScheme);
+        return clientConfig;
+    }
+
+    private SdkClientConfiguration.Builder preSraClientConfiguration() {
+        SdkClientConfiguration.Builder clientConfiguration = testClientConfiguration();
+        clientConfiguration.option(SdkClientOption.EXECUTION_ATTRIBUTES)
+                           .putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, null);
+        return clientConfiguration.option(SdkClientOption.AUTH_SCHEMES, null)
+                                  .option(SdkAdvancedClientOption.SIGNER, this.defaultSigner);
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
@@ -64,18 +64,26 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
     @Override
     public CompletableFuture<SdkHttpFullRequest> execute(SdkHttpFullRequest request, RequestExecutionContext context)
             throws Exception {
-        SelectedAuthScheme<?> selectedAuthScheme =
-            context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
-        if (shouldDoSraSigning(context, selectedAuthScheme)) {
+
+        updateHttpRequestInInterceptorContext(request, context.executionContext());
+
+        // Whether pre / post SRA, if old Signer is setup in context, that's the one to use
+        if (context.signer() != null) {
+            return signRequest(request, context);
+        }
+        // else if AUTH_SCHEMES != null (implies SRA), use SelectedAuthScheme
+        if (context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES) != null) {
+            SelectedAuthScheme<?> selectedAuthScheme =
+                context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
             return sraSignRequest(request, context, selectedAuthScheme);
         }
-        return signRequest(request, context);
+        // else, this implies pre SRA client with authType=None, so don't need to do anything
+        return CompletableFuture.completedFuture(request);
     }
 
     private <T extends Identity> CompletableFuture<SdkHttpFullRequest> sraSignRequest(SdkHttpFullRequest request,
                                                                                       RequestExecutionContext context,
                                                                                       SelectedAuthScheme<T> selectedAuthScheme) {
-        updateHttpRequestInInterceptorContext(request, context.executionContext());
         adjustForClockSkew(context.executionAttributes());
         CompletableFuture<? extends T> identityFuture = selectedAuthScheme.identity();
         return identityFuture.thenCompose(identity -> {
@@ -179,14 +187,8 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
      */
     private CompletableFuture<SdkHttpFullRequest> signRequest(SdkHttpFullRequest request,
                                                               RequestExecutionContext context) {
-        updateHttpRequestInInterceptorContext(request, context.executionContext());
-
         Signer signer = context.signer();
         MetricCollector metricCollector = context.attemptMetricCollector();
-
-        if (!shouldSign(context.executionAttributes(), signer)) {
-            return CompletableFuture.completedFuture(request);
-        }
 
         adjustForClockSkew(context.executionAttributes());
 
@@ -210,22 +212,6 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
      */
     private void updateHttpRequestInInterceptorContext(SdkHttpFullRequest request, ExecutionContext executionContext) {
         executionContext.interceptorContext(executionContext.interceptorContext().copy(b -> b.httpRequest(request)));
-    }
-
-    /**
-     * We sign if it isn't auth=none. This attribute is no longer set in the SRA, so this exists only for old clients. In
-     * addition to this, old clients only set this to false, never true. So, we have to treat null as true.
-     */
-    private boolean shouldSign(ExecutionAttributes attributes, Signer signer) {
-        return signer != null &&
-               !Boolean.FALSE.equals(attributes.getAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST));
-    }
-
-    /**
-     * Returns true if we should use SRA signing logic.
-     */
-    private boolean shouldDoSraSigning(RequestExecutionContext context, SelectedAuthScheme<?> selectedAuthScheme) {
-        return context.signer() == null && selectedAuthScheme != null;
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -64,18 +64,25 @@ public class SigningStage implements RequestToRequestPipeline {
     public SdkHttpFullRequest execute(SdkHttpFullRequest request, RequestExecutionContext context) throws Exception {
         InterruptMonitor.checkInterrupted();
 
-        SelectedAuthScheme<?> selectedAuthScheme =
-            context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
-        if (shouldDoSraSigning(context, selectedAuthScheme)) {
+        updateHttpRequestInInterceptorContext(request, context.executionContext());
+
+        // Whether pre / post SRA, if old Signer is setup in context, that's the one to use
+        if (context.signer() != null) {
+            return signRequest(request, context);
+        }
+        // else if AUTH_SCHEMES != null (implies SRA), use SelectedAuthScheme
+        if (context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES) != null) {
+            SelectedAuthScheme<?> selectedAuthScheme =
+                context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
             return sraSignRequest(request, context, selectedAuthScheme);
         }
-        return signRequest(request, context);
+        // else, this implies pre SRA client, with authType=None, so don't need to do anything
+        return request;
     }
 
     private <T extends Identity> SdkHttpFullRequest sraSignRequest(SdkHttpFullRequest request,
                                                                    RequestExecutionContext context,
                                                                    SelectedAuthScheme<T> selectedAuthScheme) {
-        updateHttpRequestInInterceptorContext(request, context.executionContext());
         adjustForClockSkew(context.executionAttributes());
         CompletableFuture<? extends T> identityFuture = selectedAuthScheme.identity();
         T identity = CompletableFutureUtils.joinLikeSync(identityFuture);
@@ -126,14 +133,8 @@ public class SigningStage implements RequestToRequestPipeline {
      * Sign the request if the signer if provided and credentials are present.
      */
     private SdkHttpFullRequest signRequest(SdkHttpFullRequest request, RequestExecutionContext context) {
-        updateHttpRequestInInterceptorContext(request, context.executionContext());
-
         Signer signer = context.signer();
         MetricCollector metricCollector = context.attemptMetricCollector();
-
-        if (!shouldSign(context.executionAttributes(), signer)) {
-            return request;
-        }
 
         adjustForClockSkew(context.executionAttributes());
 
@@ -164,22 +165,6 @@ public class SigningStage implements RequestToRequestPipeline {
      */
     private void updateHttpRequestInInterceptorContext(SdkHttpFullRequest request, ExecutionContext executionContext) {
         executionContext.interceptorContext(executionContext.interceptorContext().copy(b -> b.httpRequest(request)));
-    }
-
-    /**
-     * We sign if it isn't auth=none. This attribute is no longer set in the SRA, so this exists only for old clients. In
-     * addition to this, old clients only set this to false, never true. So, we have to treat null as true.
-     */
-    private boolean shouldSign(ExecutionAttributes attributes, Signer signer) {
-        return signer != null &&
-               !Boolean.FALSE.equals(attributes.getAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST));
-    }
-
-    /**
-     * Returns true if we should use SRA signing logic.
-     */
-    private boolean shouldDoSraSigning(RequestExecutionContext context, SelectedAuthScheme<?> selectedAuthScheme) {
-        return context.signer() == null && selectedAuthScheme != null;
     }
 
     /**

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,6 +49,7 @@ import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.http.ExecutionContext;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.signer.AsyncRequestBodySigner;
@@ -539,12 +541,15 @@ public class AsyncSigningStageTest {
                               // .httpRequest(request)
                               .build();
 
-        ExecutionAttributes executionAttributes = ExecutionAttributes.builder()
-                                                                     .put(SELECTED_AUTH_SCHEME, selectedAuthScheme)
-                                                                     .build();
+        ExecutionAttributes.Builder executionAttributes = ExecutionAttributes.builder()
+                                                                             .put(SELECTED_AUTH_SCHEME, selectedAuthScheme);
+        if (selectedAuthScheme != null) {
+            // Doesn't matter that it is empty, just needs to non-null, which implies SRA path.
+            executionAttributes.put(SdkInternalExecutionAttribute.AUTH_SCHEMES, new HashMap<>());
+        }
 
         ExecutionContext executionContext = ExecutionContext.builder()
-                                                            .executionAttributes(executionAttributes)
+                                                            .executionAttributes(executionAttributes.build())
                                                             .interceptorContext(interceptorContext)
                                                             .signer(oldSigner)
                                                             .build();

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
@@ -30,6 +30,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +46,7 @@ import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.http.ExecutionContext;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.signer.Signer;
@@ -381,12 +382,15 @@ public class SigningStageTest {
                               // .httpRequest(request)
                               .build();
 
-        ExecutionAttributes executionAttributes = ExecutionAttributes.builder()
-                                                                     .put(SELECTED_AUTH_SCHEME, selectedAuthScheme)
-                                                                     .build();
+        ExecutionAttributes.Builder executionAttributes = ExecutionAttributes.builder()
+                                                                             .put(SELECTED_AUTH_SCHEME, selectedAuthScheme);
+        if (selectedAuthScheme != null) {
+            // Doesn't matter that it is empty, just needs to non-null, which implies SRA path.
+            executionAttributes.put(SdkInternalExecutionAttribute.AUTH_SCHEMES, new HashMap<>());
+        }
 
         ExecutionContext executionContext = ExecutionContext.builder()
-                                                            .executionAttributes(executionAttributes)
+                                                            .executionAttributes(executionAttributes.build())
                                                             .interceptorContext(interceptorContext)
                                                             .signer(oldSigner)
                                                             .build();

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
@@ -17,6 +17,10 @@ package software.amazon.awssdk.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.reactivex.Flowable;
 import java.io.IOException;
@@ -24,9 +28,8 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsAsyncClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
@@ -48,8 +51,10 @@ import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlClient;
 /**
  * Verify that the "authtype" C2J trait for request type is honored for each requests.
  */
+// TODO(sra-identity-auth): Verify these tests pass for useSraAuht=true
 public class NoneAuthTypeRequestTest {
 
+    private AwsCredentialsProvider credentialsProvider;
     private SdkHttpClient httpClient;
     private SdkAsyncHttpClient httpAsyncClient;
     private ProtocolRestJsonClient jsonClient;
@@ -57,11 +62,14 @@ public class NoneAuthTypeRequestTest {
     private ProtocolRestXmlClient xmlClient;
     private ProtocolRestXmlAsyncClient xmlAsyncClient;
 
-
     @Before
     public void setup() throws IOException {
-        httpClient = Mockito.mock(SdkHttpClient.class);
-        httpAsyncClient = Mockito.mock(SdkAsyncHttpClient.class);
+        credentialsProvider = mock(AwsCredentialsProvider.class);
+        when(credentialsProvider.resolveIdentity()).thenAnswer(
+            invocationOnMock -> CompletableFuture.completedFuture(AwsBasicCredentials.create("123", "12344")));
+
+        httpClient = mock(SdkHttpClient.class);
+        httpAsyncClient = mock(SdkAsyncHttpClient.class);
         jsonClient = initializeSync(ProtocolRestJsonClient.builder()).build();
         jsonAsyncClient = initializeAsync(ProtocolRestJsonAsyncClient.builder()).build();
         xmlClient = initializeSync(ProtocolRestXmlClient.builder()).build();
@@ -72,13 +80,13 @@ public class NoneAuthTypeRequestTest {
                                                                     .putHeader("Content-Length", "0")
                                                                     .build();
 
-        ExecutableHttpRequest request = Mockito.mock(ExecutableHttpRequest.class);
+        ExecutableHttpRequest request = mock(ExecutableHttpRequest.class);
 
-        Mockito.when(request.call()).thenReturn(HttpExecuteResponse.builder()
+        when(request.call()).thenReturn(HttpExecuteResponse.builder()
                                                                    .response(successfulHttpResponse)
                                                                    .build());
-        Mockito.when(httpClient.prepareRequest(any())).thenReturn(request);
-        Mockito.when(httpAsyncClient.execute(any())).thenAnswer(invocation -> {
+        when(httpClient.prepareRequest(any())).thenReturn(request);
+        when(httpAsyncClient.execute(any())).thenAnswer(invocation -> {
             AsyncExecuteRequest asyncExecuteRequest = invocation.getArgument(0, AsyncExecuteRequest.class);
             asyncExecuteRequest.responseHandler().onHeaders(successfulHttpResponse);
             asyncExecuteRequest.responseHandler().onStream(Flowable.empty());
@@ -90,68 +98,76 @@ public class NoneAuthTypeRequestTest {
     public void sync_json_authorization_is_absent_for_noneAuthType() {
         jsonClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+        verify(credentialsProvider, times(0)).resolveIdentity();
     }
 
     @Test
     public void sync_json_authorization_is_present_for_defaultAuth() {
         jsonClient.jsonValuesOperation();
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isPresent();
+        verify(credentialsProvider, times(1)).resolveIdentity();
     }
 
     @Test
     public void async_json_authorization_is_absent_for_noneAuthType() {
         jsonAsyncClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+        verify(credentialsProvider, times(0)).resolveIdentity();
     }
 
     @Test
     public void async_json_authorization_is_present_for_defaultAuth() {
         jsonAsyncClient.jsonValuesOperation();
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isPresent();
+        verify(credentialsProvider, times(1)).resolveIdentity();
     }
 
     @Test
     public void sync_xml_authorization_is_absent_for_noneAuthType() {
         xmlClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+        verify(credentialsProvider, times(0)).resolveIdentity();
     }
 
     @Test
     public void sync_xml_authorization_is_present_for_defaultAuth() {
         xmlClient.jsonValuesOperation(json -> json.jsonValueMember("one"));
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isPresent();
+        verify(credentialsProvider, times(1)).resolveIdentity();
     }
 
     @Test
     public void async_xml_authorization_is_absent_for_noneAuthType() {
         xmlAsyncClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+        verify(credentialsProvider, times(0)).resolveIdentity();
     }
 
     @Test
     public void async_xml_authorization_is_present_for_defaultAuth() {
         xmlAsyncClient.jsonValuesOperation(json -> json.jsonValueMember("one"));
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isPresent();
+        verify(credentialsProvider, times(1)).resolveIdentity();
     }
 
     private SdkHttpRequest getSyncRequest() {
         ArgumentCaptor<HttpExecuteRequest> captor = ArgumentCaptor.forClass(HttpExecuteRequest.class);
-        Mockito.verify(httpClient).prepareRequest(captor.capture());
+        verify(httpClient).prepareRequest(captor.capture());
         return captor.getValue().httpRequest();
     }
 
     private SdkHttpRequest getAsyncRequest() {
         ArgumentCaptor<AsyncExecuteRequest> captor = ArgumentCaptor.forClass(AsyncExecuteRequest.class);
-        Mockito.verify(httpAsyncClient).execute(captor.capture());
+        verify(httpAsyncClient).execute(captor.capture());
         return captor.getValue().request();
     }
 
     private <T extends AwsSyncClientBuilder<T, ?> & AwsClientBuilder<T, ?>> T initializeSync(T syncClientBuilder) {
-        return initialize(syncClientBuilder.httpClient(httpClient).credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("123", "12344"))));
+        return initialize(syncClientBuilder.httpClient(httpClient).credentialsProvider(credentialsProvider));
     }
 
     private <T extends AwsAsyncClientBuilder<T, ?> & AwsClientBuilder<T, ?>> T initializeAsync(T asyncClientBuilder) {
-        return initialize(asyncClientBuilder.httpClient(httpAsyncClient));
+        return initialize(asyncClientBuilder.httpClient(httpAsyncClient).credentialsProvider(credentialsProvider));
     }
 
     private <T extends AwsClientBuilder<T, ?>> T initialize(T clientBuilder) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This addresses https://github.com/aws/aws-sdk-java-v2/pull/4396#discussion_r1318175674. If authType=none, there is no need to do identity resolution. https://github.com/aws/aws-sdk-java-v2/pull/4519 shows that that was the behavior before SRA (since they pass in the PR). But this behavior was changing because of https://github.com/aws/aws-sdk-java-v2/pull/4396#discussion_r1318175674 and this PR fixes it.

## Modifications
<!--- Describe your changes in detail -->
First I added a commit that adds the same pre SRA tests from https://github.com/aws/aws-sdk-java-v2/pull/4519. Also, added some more tests for similar expected behavior for post SRA. Without making the change to AwsExecutionContextBuilder, these tests failed:
* preSra_authTypeNone_signerRequestOverride_doesNotAssignSigner_doesNotResolveIdentity
* preSra_authTypeNone_doesNotAssignSigner_doesNotResolveIdentity
* preSra_authTypeNone_signerClientOverride_doesNotAssignSigner_doesNotResolveIdentity
* postSra_authTypeNone_signerRequestOverride_doesNotAssignSigner_doesNotResolveIdentity
* postSra_authTypeNone_signerClientOverride_doesNotAssignSigner_doesNotResolveIdentity 

Then I added a 2nd commit to the source code that fixes all these tests. It kind reverts the change to loadSigner from https://github.com/aws/aws-sdk-java-v2/pull/4396.

I don't intend to merge https://github.com/aws/aws-sdk-java-v2/pull/4519 to master directly, but those tests will get added via this PR to the SRA feature branch, and then merged to master.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see notes above.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
