### PR TITLE
Add disabled bearer integ test

### DIFF
--- a/services/codecatalyst/src/test/java/software/amazon/awssdk/services/codecatalyst/BearerCredentialTest.java
+++ b/services/codecatalyst/src/test/java/software/amazon/awssdk/services/codecatalyst/BearerCredentialTest.java
@@ -18,13 +18,29 @@ package software.amazon.awssdk.services.codecatalyst;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+import software.amazon.awssdk.auth.token.credentials.ProfileTokenProvider;
 import software.amazon.awssdk.auth.token.credentials.StaticTokenProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.codecatalyst.model.ListSpacesResponse;
 import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
 import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
 import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
 
 public class BearerCredentialTest extends AwsIntegrationTestBase {
+
+    /*
+    The test is disabled because it requires a codecatalyst profile that requires a human to run:
+    `aws sso login --profile codecatalyst` before running this test. But leaving the test code here, so one can manually run it
+     locally if needed.
+     */
+    // @Test
+    public void realClientSucceeds() {
+        CodeCatalystClient client = CodeCatalystClient.builder()
+                                   .tokenProvider(ProfileTokenProvider.create("codecatalyst"))
+                                   .build();
+        ListSpacesResponse result = client.listSpaces(r -> {});
+        assertThat(result.items()).isNotNull();
+    }
     @Test
     public void syncClientSendsBearerToken() {
         try (MockSyncHttpClient httpClient = new MockSyncHttpClient();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
We removed the code catalyst integration test in https://github.com/aws/aws-sdk-java-v2/pull/4502. But I was running it manually as part of the release checklist. Thought, might be useful to have it checked into the codebase, but `@Disabled`, so it is easy for someone to run it in the future again.

## Modifications
<!--- Describe your changes in detail -->
Add the test as `@Disabled`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
