### PR TITLE
Fix incorrect variable usage in S3PresignerIntegrationTest

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3PresignerIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3PresignerIntegrationTest.java
@@ -211,7 +211,7 @@ public class S3PresignerIntegrationTest {
         PresignedDeleteObjectRequest presigned =
             presigner.presignDeleteObject(r -> r.signatureDuration(Duration.ofMinutes(5))
                                              .deleteObjectRequest(delo -> delo.bucket(testBucket)
-                                                                         .key(testGetObjectKey)
+                                                                         .key(objectKey)
                                                                          .requestPayer(RequestPayer.REQUESTER)));
 
         assertThat(presigned.isBrowserExecutable()).isFalse();


### PR DESCRIPTION
## Motivation and Context
- Bug in code where the test object gets deleted before tests run that depend on the object being present

## Modifications
- Fix reference to object key, delete test should use the object that was meant to be deleted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
