### PR TITLE
Switch endpointdiscovery/endpointproviders back to useSraAuth=false

### DIFF
--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointdiscovery/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointdiscovery/customization.config
@@ -1,4 +1,3 @@
 {
-    "skipEndpointTestGeneration": true,
-    "useSraAuth": true
+    "skipEndpointTestGeneration": true
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
@@ -1,4 +1,3 @@
 {
-    "skipEndpointTestGeneration": true,
-    "useSraAuth": true
+    "skipEndpointTestGeneration": true
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
@@ -15,33 +15,20 @@
 
 package software.amazon.awssdk.services.endpointproviders;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
-import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
-import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
-import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
-import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.endpoints.Endpoint;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
-import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
-import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
 import software.amazon.awssdk.http.auth.spi.signer.BaseSignRequest;
@@ -52,7 +39,6 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.RegionScope;
 import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersAsyncClient;
 import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersAsyncClientBuilder;
 import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersClient;
@@ -201,6 +187,8 @@ public class EndpointInterceptorTests {
         assertThat(interceptor.context.httpRequest().matchingHeaders("TestHeader")).containsExactly("TestValue", "TestValue0");
     }
 
+    // TODO(sra-identity-auth): Enable for useSraAuth=true
+    /*
     @Test
     public void sync_endpointProviderReturnsSignerProperties_overridesV4AuthSchemeResolverProperties() {
         RestJsonEndpointProvidersEndpointProvider defaultEndpointProvider =
@@ -464,6 +452,7 @@ public class EndpointInterceptorTests {
         assertThat(interceptor.executionAttributes.getAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME)).isEqualTo("name-from-ep");
         assertThat(interceptor.executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE)).isEqualTo(true);
     }
+     */
 
     private static AuthScheme<?> authScheme(String schemeId, HttpSigner<AwsCredentialsIdentity> signer) {
         return new AuthScheme<AwsCredentialsIdentity>() {
@@ -524,8 +513,6 @@ public class EndpointInterceptorTests {
     }
 
     private RestJsonEndpointProvidersClientBuilder syncClientBuilder() {
-        // TODO(sra-identity-auth): The service is currently using useSraAuth=true.
-        //  Need to have tests for useSraAuth=false that work too - needs codegen changes I think.
         return RestJsonEndpointProvidersClient.builder()
                                               .region(Region.US_WEST_2)
                                               .credentialsProvider(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Was switched to useSraAuth=true in https://github.com/aws/aws-sdk-java-v2/pull/4491/commits/e0e6a422e5d5bdab613e567e352df7e18d56e5c5 as part of #4491. Switching it back to false, like the rest of the feature/master/sra-identity-auth branch. New tests that were added earlier for useSraAuth=true have been disabled here. They should be enabled when we switch useSraAuth=true.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
