### PR TITLE
Update codegen tests that assert checksumming behavior

### DIFF
--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AsyncRequestBodyFlexibleChecksumInTrailerTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AsyncRequestBodyFlexibleChecksumInTrailerTest.java
@@ -26,6 +26,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute.ENABLE_CHUNKED_ENCODING;
+import static software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING;
 import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
 import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
 
@@ -84,12 +86,24 @@ public class AsyncRequestBodyFlexibleChecksumInTrailerTest {
                                                            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                                            .region(Region.US_EAST_1)
                                                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                                           .overrideConfiguration(
+                                                               // TODO(sra-identity-and-auth): we should remove these
+                                                               //  overrides once we set up codegen to set chunk-encoding to true
+                                                               //  for requests that are streaming and checksum-enabled
+                                                               o -> o.putExecutionAttribute(ENABLE_CHUNKED_ENCODING, true)
+                                                                     .putExecutionAttribute(ENABLE_PAYLOAD_SIGNING, false))
                                                            .build();
 
         asyncClient = ProtocolRestJsonAsyncClient.builder()
                                                  .credentialsProvider(AnonymousCredentialsProvider.create())
                                                  .region(Region.US_EAST_1)
                                                  .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                                 .overrideConfiguration(
+                                                     // TODO(sra-identity-and-auth): we should remove these
+                                                     //  overrides once we set up codegen to set chunk-encoding to true
+                                                     //  for requests that are streaming and checksum-enabled
+                                                     o -> o.putExecutionAttribute(ENABLE_CHUNKED_ENCODING, true)
+                                                           .putExecutionAttribute(ENABLE_PAYLOAD_SIGNING, false))
                                                  .build();
     }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumInHeaderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumInHeaderTest.java
@@ -122,7 +122,8 @@ public class HttpChecksumInHeaderTest {
                                                           .checksumAlgorithm(software.amazon.awssdk.services.protocolrestxml.model.ChecksumAlgorithm.SHA1).build());
         assertThat(getSyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form "<?xml version="1.0" encoding="UTF-8"?><stringMember>Hello world</stringMember>"
-        assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("FB/utBbwFLbIIt5ul3Ojuy5dKgU=");
+        // TODO(sra-identity-and-auth): Uncomment once sra is set to true
+        // assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("FB/utBbwFLbIIt5ul3Ojuy5dKgU=");
     }
 
     @Test
@@ -132,7 +133,8 @@ public class HttpChecksumInHeaderTest {
 
         assertThat(getSyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form "<?xml version="1.0" encoding="UTF-8"?><stringMember>Hello world</stringMember>"
-        assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("2jmj7l5rSw0yVb/vlWAYkK/YBwk=");
+        // TODO(sra-identity-and-auth): Uncomment once sra is set to true
+        // assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("2jmj7l5rSw0yVb/vlWAYkK/YBwk=");
     }
 
     @Test
@@ -154,7 +156,8 @@ public class HttpChecksumInHeaderTest {
 
         assertThat(getAsyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form <?xml version="1.0" encoding="UTF-8"?><stringMember>Hello world</stringMember>"
-        assertThat(getAsyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("2jmj7l5rSw0yVb/vlWAYkK/YBwk=");
+        // TODO(sra-identity-and-auth): Uncomment once sra is set to true
+        // assertThat(getAsyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("2jmj7l5rSw0yVb/vlWAYkK/YBwk=");
     }
 
     private SdkHttpRequest getSyncRequest() {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumInHeaderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumInHeaderTest.java
@@ -21,9 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import io.reactivex.Flowable;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -106,8 +103,6 @@ public class HttpChecksumInHeaderTest {
         assertThat(getSyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form "{"stringMember":"Hello world"}"
         assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("M68rRwFal7o7B3KEMt3m0w39TaA=");
-        // Assertion to make sure signer was not executed
-        assertThat(getSyncRequest().firstMatchingHeader("x-amz-content-sha256")).isNotPresent();
     }
 
     @Test
@@ -118,8 +113,6 @@ public class HttpChecksumInHeaderTest {
         assertThat(getAsyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form "{"stringMember":"Hello world"}"
         assertThat(getAsyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("M68rRwFal7o7B3KEMt3m0w39TaA=");
-        // Assertion to make sure signer was not executed
-        assertThat(getAsyncRequest().firstMatchingHeader("x-amz-content-sha256")).isNotPresent();
     }
 
     @Test
@@ -130,26 +123,16 @@ public class HttpChecksumInHeaderTest {
         assertThat(getSyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form "<?xml version="1.0" encoding="UTF-8"?><stringMember>Hello world</stringMember>"
         assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("FB/utBbwFLbIIt5ul3Ojuy5dKgU=");
-        // Assertion to make sure signer was not executed
-        assertThat(getSyncRequest().firstMatchingHeader("x-amz-content-sha256")).isNotPresent();
     }
 
     @Test
     public void sync_xml_nonStreaming_unsignedEmptyPayload_with_Sha1_in_header() {
         //  jsonClient.flexibleCheckSumOperationWithShaChecksum(r -> r.stringMember("Hello world"));
         xmlClient.operationWithChecksumNonStreaming(r -> r.checksumAlgorithm(software.amazon.awssdk.services.protocolrestxml.model.ChecksumAlgorithm.SHA1).build());
+
         assertThat(getSyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form "<?xml version="1.0" encoding="UTF-8"?><stringMember>Hello world</stringMember>"
-        assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).isNotPresent();
-
-
-        Map<String, List<String>> requestHeaders = getSyncRequest().headers();
-
-        boolean disjoint = Collections.disjoint(VALID_CHECKSUM_HEADERS, requestHeaders.keySet());
-        assertThat(disjoint).isTrue();
-
-        // Assertion to make sure signer was not executed
-        assertThat(getSyncRequest().firstMatchingHeader("x-amz-content-sha256")).isNotPresent();
+        assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("2jmj7l5rSw0yVb/vlWAYkK/YBwk=");
     }
 
     @Test
@@ -161,8 +144,6 @@ public class HttpChecksumInHeaderTest {
         assertThat(getAsyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form <?xml version="1.0" encoding="UTF-8"?><stringMember>Hello world</stringMember>"
         assertThat(getAsyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("FB/utBbwFLbIIt5ul3Ojuy5dKgU=");
-        // Assertion to make sure signer was not executed
-        assertThat(getAsyncRequest().firstMatchingHeader("x-amz-content-sha256")).isNotPresent();
     }
 
     @Test
@@ -171,17 +152,9 @@ public class HttpChecksumInHeaderTest {
 
         xmlAsyncClient.operationWithChecksumNonStreaming(r -> r.checksumAlgorithm(software.amazon.awssdk.services.protocolrestxml.model.ChecksumAlgorithm.SHA1).build()).join();
 
-
-        Map<String, List<String>> requestHeaders = getAsyncRequest().headers();
-
-        boolean disjoint = Collections.disjoint(VALID_CHECKSUM_HEADERS, requestHeaders.keySet());
-        assertThat(disjoint).isTrue();
-
         assertThat(getAsyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
         //Note that content will be of form <?xml version="1.0" encoding="UTF-8"?><stringMember>Hello world</stringMember>"
-        assertThat(getAsyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).isNotPresent();
-        // Assertion to make sure signer was not executed
-        assertThat(getAsyncRequest().firstMatchingHeader("x-amz-content-sha256")).isNotPresent();
+        assertThat(getAsyncRequest().firstMatchingHeader("x-amz-checksum-sha1")).hasValue("2jmj7l5rSw0yVb/vlWAYkK/YBwk=");
     }
 
     private SdkHttpRequest getSyncRequest() {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumRequiredTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumRequiredTest.java
@@ -159,6 +159,7 @@ public class HttpChecksumRequiredTest {
     public void syncJsonSupportsOperationWithCustomRequestChecksum() {
         jsonClient.operationWithCustomRequestChecksum(r -> r.stringMember("foo").checksumAlgorithm(ChecksumAlgorithm.CRC32));
         assertThat(getSyncRequest().firstMatchingHeader("Content-MD5")).isNotPresent();
+        assertThat(getSyncRequest().firstMatchingHeader("x-amz-checksum-crc32")).hasValue("rzlTOg==");
     }
 
     private SdkHttpRequest getSyncRequest() {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumValidationTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumValidationTest.java
@@ -29,6 +29,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute.ENABLE_CHUNKED_ENCODING;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -73,7 +74,14 @@ public class HttpChecksumValidationTest {
                                        .credentialsProvider(AnonymousCredentialsProvider.create())
                                        .region(Region.US_EAST_1)
                                        .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                       .overrideConfiguration(o -> o.addExecutionInterceptor(new CaptureChecksumValidationInterceptor()))
+                                       .overrideConfiguration(
+                                           // TODO(sra-identity-and-auth): we should remove these
+                                           //  overrides once we set up codegen to set chunk-encoding to true
+                                           //  for requests that are streaming and checksum-enabled
+                                           o -> o.addExecutionInterceptor(new CaptureChecksumValidationInterceptor())
+                                                 .putExecutionAttribute(
+                                                     ENABLE_CHUNKED_ENCODING, true
+                                                 ))
                                        .build();
 
         asyncClient = ProtocolRestJsonAsyncClient.builder()
@@ -125,7 +133,13 @@ public class HttpChecksumValidationTest {
     public void syncClientValidateNonStreamingResponse() {
         String expectedChecksum = "lzlLIA==";
         stubWithCRC32AndSha256Checksum("{\"stringMember\":\"Hello world\"}", expectedChecksum, "crc32");
-        client.operationWithChecksumNonStreaming(r -> r.stringMember("Hello world").checksumAlgorithm(ChecksumAlgorithm.CRC32));
+        client.operationWithChecksumNonStreaming(
+            r -> r.stringMember("Hello world").checksumAlgorithm(ChecksumAlgorithm.CRC32)
+                  // TODO(sra-identity-and-auth): we should remove these
+                  //  overrides once we set up codegen to set chunk-encoding to true
+                  //  for requests that are streaming and checksum-enabled
+                  .overrideConfiguration(c -> c.putExecutionAttribute(ENABLE_CHUNKED_ENCODING, false))
+        );
         verify(postRequestedFor(urlEqualTo("/")).withHeader("x-amz-checksum-crc32", equalTo(expectedChecksum)));
         OperationWithChecksumNonStreamingResponse operationWithChecksumNonStreamingResponse =
             client.operationWithChecksumNonStreaming(o -> o.checksumMode(ChecksumMode.ENABLED));
@@ -138,7 +152,13 @@ public class HttpChecksumValidationTest {
     public void syncClientValidateNonStreamingResponseZeroByte() {
         String expectedChecksum = "o6a/Qw==";
         stubWithCRC32AndSha256Checksum("{}", expectedChecksum, "crc32");
-        client.operationWithChecksumNonStreaming(r -> r.checksumAlgorithm(ChecksumAlgorithm.CRC32));
+        client.operationWithChecksumNonStreaming(
+            r -> r.checksumAlgorithm(ChecksumAlgorithm.CRC32)
+                  // TODO(sra-identity-and-auth): we should remove these
+                  //  overrides once we set up codegen to set chunk-encoding to true
+                  //  for requests that are streaming and checksum-enabled
+                  .overrideConfiguration(c -> c.putExecutionAttribute(ENABLE_CHUNKED_ENCODING, false))
+        );
         verify(postRequestedFor(urlEqualTo("/")).withHeader("x-amz-checksum-crc32", equalTo(expectedChecksum)));
         OperationWithChecksumNonStreamingResponse operationWithChecksumNonStreamingResponse =
             client.operationWithChecksumNonStreaming(o -> o.checksumMode(ChecksumMode.ENABLED));
@@ -240,7 +260,12 @@ public class HttpChecksumValidationTest {
         String expectedChecksum = "lzlLIA==";
         stubWithCRC32AndSha256Checksum("{\"stringMember\":\"Hello world\"}", expectedChecksum, "crc32");
         OperationWithChecksumNonStreamingResponse response =
-            asyncClient.operationWithChecksumNonStreaming(o -> o.checksumMode(ChecksumMode.ENABLED)).join();
+            asyncClient.operationWithChecksumNonStreaming(
+                o -> o.checksumMode(ChecksumMode.ENABLED)
+                      // TODO(sra-identity-and-auth): we should remove these
+                      //  overrides once we set up codegen to set chunk-encoding to true
+                      //  for requests that are streaming and checksum-enabled
+                      .overrideConfiguration(c -> c.putExecutionAttribute(ENABLE_CHUNKED_ENCODING, false))).join();
         assertThat(response.stringMember()).isEqualTo("Hello world");
         assertThat(CaptureChecksumValidationInterceptor.checksumValidation).isEqualTo(ChecksumValidation.VALIDATED);
         assertThat(CaptureChecksumValidationInterceptor.expectedAlgorithm).isEqualTo(Algorithm.CRC32);
@@ -251,7 +276,12 @@ public class HttpChecksumValidationTest {
         String expectedChecksum = "o6a/Qw==";
         stubWithCRC32AndSha256Checksum("{}", expectedChecksum, "crc32");
         OperationWithChecksumNonStreamingResponse operationWithChecksumNonStreamingResponse =
-            asyncClient.operationWithChecksumNonStreaming(o -> o.checksumMode(ChecksumMode.ENABLED)).join();
+            asyncClient.operationWithChecksumNonStreaming(
+                o -> o.checksumMode(ChecksumMode.ENABLED)
+                      // TODO(sra-identity-and-auth): we should remove these
+                      //  overrides once we set up codegen to set chunk-encoding to true
+                      //  for requests that are streaming and checksum-enabled
+                      .overrideConfiguration(c -> c.putExecutionAttribute(ENABLE_CHUNKED_ENCODING, false))).join();
         assertThat(operationWithChecksumNonStreamingResponse.stringMember()).isNull();
         assertThat(CaptureChecksumValidationInterceptor.checksumValidation).isEqualTo(ChecksumValidation.VALIDATED);
         assertThat(CaptureChecksumValidationInterceptor.expectedAlgorithm).isEqualTo(Algorithm.CRC32);

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SyncHttpChecksumInTrailerTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/SyncHttpChecksumInTrailerTest.java
@@ -26,6 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute.ENABLE_CHUNKED_ENCODING;
 import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
 import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
 
@@ -64,8 +65,13 @@ public class SyncHttpChecksumInTrailerTest {
                                        .credentialsProvider(AnonymousCredentialsProvider.create())
                                        .region(Region.US_EAST_1)
                                        .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                       // TODO(sra-identity-and-auth): we should remove these
+                                       //  overrides once we set up codegen to set chunk-encoding to true
+                                       //  for requests that are streaming and checksum-enabled
+                                       .overrideConfiguration(c -> c.putExecutionAttribute(
+                                           ENABLE_CHUNKED_ENCODING, true
+                                       ))
                                        .build();
-
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
- Previously, several test suites in `codegen-generated-classes-test` asserted checksumming behavior of clients under the assumption that HttpChecksumStage would handle checksums and NOT the signer for unsigned-payload cases
- This assumption is untrue with SRA, as checksums are now majorly handled in the signers (the only exception being async-streaming w/ checksums)
- Temporarily, we have to override certain attributes to enable the right behavior, but long term, we should codegen the correct behavior (set chunk-encoding when the request is modeled as streaming and checksum-required)

## Modifications
- Update several tests to assert the correct behavior
- Adds TODOs for later when codegen is implemented to correctly set the right attributes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
