### PR TITLE
Revert "Revert Presigners to pre SRA Identity & Auth (#4515)"

### DIFF
--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -48,12 +48,16 @@ import software.amazon.awssdk.core.signer.Presigner;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.polly.auth.scheme.PollyAuthSchemeProvider;
 import software.amazon.awssdk.services.polly.internal.presigner.model.transform.SynthesizeSpeechRequestMarshaller;
 import software.amazon.awssdk.services.polly.model.PollyRequest;
 import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
@@ -63,9 +67,6 @@ import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Validate;
 
-// TODO(sra-identity-auth): Move to SRA I&A. Note, until we expose ability configuration for the SRA interfaces, like
-//  AuthSchemeProvider (directly or via Plugins), there isn't any real customer benefit to moving to SRA, other than just getting
-//  off the old deprecated Signer interface.
 /**
  * Default implementation of {@link PollyPresigner}.
  */
@@ -185,7 +186,6 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     private SdkHttpFullRequest presignRequest(PollyRequest requestToPresign,
                                               SdkHttpFullRequest marshalledRequest,
                                               ExecutionAttributes executionAttributes) {
-        // TODO(sra-identity-auth): Move to SRA HttpSigner
         Presigner presigner = resolvePresigner(requestToPresign);
         SdkHttpFullRequest presigned = presigner.presign(marshalledRequest, executionAttributes);
         List<String> signedHeadersQueryParam = presigned.firstMatchingRawQueryParameters("X-Amz-SignedHeaders");
@@ -208,25 +208,19 @@ public final class DefaultPollyPresigner implements PollyPresigner {
                 .putAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX, false)
                 .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, ClientType.SYNC)
                 .putAttribute(SdkExecutionAttribute.SERVICE_NAME, SERVICE_NAME)
-                .putAttribute(PRESIGNER_EXPIRATION, signatureExpiration);
-        // TODO(sra-identity-auth): Uncomment when switching to useSraAuth=true
-        /*
+                .putAttribute(PRESIGNER_EXPIRATION, signatureExpiration)
                 .putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER, PollyAuthSchemeProvider.defaultProvider())
                 .putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES, authSchemes())
                 .putAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDERS,
                               IdentityProviders.builder()
                                                .putIdentityProvider(credentialsProvider())
                                                .build());
-         */
     }
 
-    // TODO(sra-identity-auth): Uncomment when switching to useSraAuth=true
-    /*
     private Map<String, AuthScheme<?>> authSchemes() {
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
         return Collections.singletonMap(awsV4AuthScheme.schemeId(), awsV4AuthScheme);
     }
-     */
 
     private IdentityProvider<? extends AwsCredentialsIdentity> resolveCredentialsProvider(PollyRequest request) {
         return request.overrideConfiguration().flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,10 +62,16 @@ import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
 import software.amazon.awssdk.protocols.xml.AwsS3ProtocolFactory;
 import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeProvider;
+import software.amazon.awssdk.services.s3.auth.scheme.internal.S3AuthSchemeInterceptor;
 import software.amazon.awssdk.services.s3.endpoints.S3ClientContextParams;
 import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.endpoints.internal.S3RequestSetEndpointInterceptor;
@@ -104,9 +111,6 @@ import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
-// TODO(sra-identity-auth): Move to SRA I&A. Note, until we expose ability configuration for the SRA interfaces, like
-//  AuthSchemeProvider (directly or via Plugins), there isn't any real customer benefit to moving to SRA, other than just getting
-//  off the old deprecated Signer interface.
 /**
  * The default implementation of the {@link S3Presigner} interface.
  */
@@ -205,8 +209,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
         List<ExecutionInterceptor> s3Interceptors =
             interceptorFactory.getInterceptors("software/amazon/awssdk/services/s3/execution.interceptors");
         List<ExecutionInterceptor> additionalInterceptors = new ArrayList<>();
-        // TODO(sra-identity-auth): Uncomment when S3 swithces to useSraAuth=true
-        // additionalInterceptors.add(new S3AuthSchemeInterceptor());
+        additionalInterceptors.add(new S3AuthSchemeInterceptor());
         additionalInterceptors.add(new S3ResolveEndpointInterceptor());
         additionalInterceptors.add(new S3RequestSetEndpointInterceptor());
         s3Interceptors = mergeLists(s3Interceptors, additionalInterceptors);
@@ -367,16 +370,13 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
             .putAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED, serviceConfiguration.dualstackEnabled())
             .putAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER, S3EndpointProvider.defaultProvider())
             .putAttribute(AwsExecutionAttribute.USE_GLOBAL_ENDPOINT, useGlobalEndpointResolver.resolve(region()))
-            .putAttribute(SdkInternalExecutionAttribute.CLIENT_CONTEXT_PARAMS, clientContextParams);
-        // TODO(sra-identity-auth): Uncomment when switching to useSraAuth=true
-        /*
+            .putAttribute(SdkInternalExecutionAttribute.CLIENT_CONTEXT_PARAMS, clientContextParams)
             .putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER, S3AuthSchemeProvider.defaultProvider())
             .putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES, authSchemes())
             .putAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDERS,
                           IdentityProviders.builder()
                                            .putIdentityProvider(credentialsProvider())
                                            .build());
-         */
 
         ExecutionInterceptorChain executionInterceptorChain = new ExecutionInterceptorChain(clientInterceptors);
 
@@ -386,9 +386,6 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
         interceptorContext = AwsExecutionContextBuilder.runInitialInterceptors(interceptorContext,
                                                                                executionAttributes,
                                                                                executionInterceptorChain);
-
-
-        // TODO(sra-identity-auth): To move to SRA, use HttpSigner and Identity from SelectedAuthScheme
         AwsCredentialsAuthorizationStrategy authorizationContext =
             AwsCredentialsAuthorizationStrategy.builder()
                                                .request(interceptorContext.request())
@@ -407,8 +404,6 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                                .build();
     }
 
-    // TODO(sra-identity-auth): Uncomment when S3 swithces to useSraAuth=true
-    /*
     private Map<String, AuthScheme<?>> authSchemes() {
         Map<String, AuthScheme<?>> schemes = new HashMap<>(2);
         AwsV4AuthScheme awsV4AuthScheme = AwsV4AuthScheme.create();
@@ -417,7 +412,6 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
         schemes.put(awsV4aAuthScheme.schemeId(), awsV4aAuthScheme);
         return Collections.unmodifiableMap(schemes);
     }
-     */
 
     /**
      * Call the before-marshalling interceptor hooks.
@@ -518,7 +512,6 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
     /**
      * Presign the provided HTTP request.
      */
-    // TODO(sra-identity-auth): Move to SRA HttpSigner
     private SdkHttpFullRequest presignRequest(ExecutionContext execCtx, SdkHttpFullRequest request) {
         Presigner presigner = Validate.isInstanceOf(Presigner.class, execCtx.signer(),
                                                     "Configured signer (%s) does not support presigning (must implement %s).",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws/aws-sdk-java-v2/pull/4515 caused S3PresignerIntegrationTest.keysWithScaryCharactersWorks to fail when useSraAuth=true. 

In master, the DefaultS3Presigner would include S3EndpointAuthSchemeInterceptor as seen [here](https://github.com/aws/aws-sdk-java-v2/blob/3fbf13cbed80c3e8ce355963be8f7bcffc2a49ab/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java#L207). With SRA codegen changes, there is no longer S3EndpointAuthSchemeInterceptor but it's functionality is part of S3ResolveEndpointInterceptor. However, because of https://github.com/aws/aws-sdk-java-v2/pull/4505 S3ResolveEndpointInterceptor behaves differently for useSraAuth=false v/s true. The integ test is fine with useSraAuth=false, but with useSraAuth=true, 
```
            if (!endpointAuthScheme.schemeId().equals(selectedAuthScheme.authSchemeOption().schemeId())) {
                continue;
            }
```
check added and that causes the test to fail. So DefaultS3Presigner using S3ResolveEndpointInterceptor generated with useSraAuth=true doesn't work unless DefaultS3Presigner also sets up the rest of SRA things like authSchemes, authSchemeProvider. This part was reverted in #4515 not realizing this issue that it matters to the presigner - the integ test wasn't run earlier with useSraAuth=true.

So to fix the issue, undoing the revert from #4515. Have ensured locally that S3PresignerIntegrationTest passes both with useSraAuth=false/true.


## Modifications
<!--- Describe your changes in detail -->
This reverts commit cadb6abe57eca7da8cc985c77942dacd743e9566 from https://github.com/aws/aws-sdk-java-v2/pull/4515.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Have ensured locally that S3PresignerIntegrationTest passes both with useSraAuth=false/true.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
