### PR TITLE
Uncomment some previously disabled tests

### DIFF
--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
@@ -642,7 +642,6 @@ public class S3PresignerTest {
     }
 
     @Test
-    // TODO(sra-identity-and-auth), this test fails with Expected :"AWS4-ECDSA-P256-SHA256", Actual :"AWS4-HMAC-SHA256"
     public void accessPointArn_multiRegion_useArnRegionTrue_correctEndpointAndSigner() {
         String customEndpoint = "https://mfzwi23gnjvgw.mrap.accesspoint.s3-global.amazonaws.com";
         String accessPointArn = "arn:aws:s3::12345678910:accesspoint:mfzwi23gnjvgw.mrap";

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/PutObjectWithChecksumTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/PutObjectWithChecksumTest.java
@@ -35,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -162,7 +161,6 @@ public class PutObjectWithChecksumTest {
 
     // Even with incorrect  Etag, exception is not thrown because default check is skipped when checksumAlgorithm is set
     @Test
-    @Disabled // TODO(sra-identity-and-auth): Flexible checksums don't work
     void sync_putObject_httpChecksumValidation_withIncorrectChecksum(WireMockRuntimeInfo wm) {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)
                                                     .withHeader("x-amz-checksum-crc32", "7ErD0A==")
@@ -182,10 +180,6 @@ public class PutObjectWithChecksumTest {
 
     // Even with incorrect  Etag, exception is not thrown because default check is skipped when checksumAlgorithm is set
     @Test
-    @Disabled
-    // TODO(sra-identity-and-auth): Hmm, async was working earlier, but sync wasn't?!
-    //  This test is now failing with changes to bring old Signer back.
-    //  Disabling this test too temporarily.
     void async_putObject_httpChecksumValidation_withIncorrectChecksum(WireMockRuntimeInfo wm) {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)
                                                     .withHeader("x-amz-checksum-crc32", "7ErD0A==")

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/MultiRegionAccessPointEndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/MultiRegionAccessPointEndpointResolutionTest.java
@@ -21,7 +21,6 @@ import static software.amazon.awssdk.services.s3.S3MockUtils.mockListObjectsResp
 
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -42,9 +41,12 @@ public class MultiRegionAccessPointEndpointResolutionTest {
 
     private final static String MULTI_REGION_ARN = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
     // TODO(sra-identity-and-auth): The forward slash of the URL below was added to account for the signer behavior that
-    // sanitizes the URI path, we need to double check that this behavior it's safe and that it won't break anything else.
+    //  sanitizes the URI path, we need to double check that this behavior it's safe and that it won't break anything else.
+    //  With useSraAuth=test, need to add the forward slash to the endpoint below to make related tests pass.
+    // private final static URI MULTI_REGION_ENDPOINT =
+    //     URI.create("https://mfzwi23gnjvgw.mrap.accesspoint.s3-global.amazonaws.com/");
     private final static URI MULTI_REGION_ENDPOINT =
-        URI.create("https://mfzwi23gnjvgw.mrap.accesspoint.s3-global.amazonaws.com/");
+        URI.create("https://mfzwi23gnjvgw.mrap.accesspoint.s3-global.amazonaws.com");
     private MockHttpClient mockHttpClient;
 
     @BeforeEach
@@ -53,7 +55,6 @@ public class MultiRegionAccessPointEndpointResolutionTest {
     }
 
     @Test
-    @Disabled // Related to the TODO above on MULTI_REGION_ENDPOINT
     public void multiRegionArn_correctlyRewritesEndpoint() throws Exception {
         mockHttpClient.stubNextResponse(mockListObjectsResponse());
         S3Client s3Client = clientBuilder().serviceConfiguration(S3Configuration.builder().build()).build();
@@ -62,7 +63,6 @@ public class MultiRegionAccessPointEndpointResolutionTest {
     }
 
     @Test
-    @Disabled // Related to the TODO above on MULTI_REGION_ENDPOINT
     public void multiRegionArn_useArnRegionEnabled_correctlyRewritesEndpoint() throws Exception {
         mockHttpClient.stubNextResponse(mockListObjectsResponse());
         S3Client s3Client = clientBuilder().serviceConfiguration(S3Configuration.builder()
@@ -139,7 +139,6 @@ public class MultiRegionAccessPointEndpointResolutionTest {
     }
 
     @Test
-    @Disabled // Related to the TODO above on MULTI_REGION_ENDPOINT
     public void multiRegionArn_differentRegion_useArnRegionTrue() throws Exception {
         mockHttpClient.stubNextResponse(mockListObjectsResponse());
         S3Client s3Client = clientBuilder().build();

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/eventstreams/EventMarshallingTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/eventstreams/EventMarshallingTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.eventstreams;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ import software.amazon.awssdk.services.eventstreamrestjson.model.InputEventStrea
 import software.amazon.eventstream.Message;
 import software.amazon.eventstream.MessageDecoder;
 
-//@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class EventMarshallingTest {
     @Mock
     public SdkAsyncHttpClient mockHttpClient;
@@ -75,9 +76,10 @@ public class EventMarshallingTest {
         eventDecoder = new MessageDecoder();
     }
 
+    // Still failing for useSraAuth=true
     // TODO(sra-identity-and-auth): This test no longer works, it's unclear as of why not but seems related to the changes in
     // the signing stage.
-    //@Test
+    @Test
     public void testMarshalling_setsCorrectEventType() {
         List<InputEventStream> inputEvents = Stream.of(
                 InputEventStream.inputEventBuilder().build(),

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.reactivex.Flowable;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,9 +31,14 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.EventStream;
+import software.amazon.awssdk.services.protocolrestjson.model.EventStreamOperationResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.EventStreamOperationResponseHandler;
+import software.amazon.awssdk.services.protocolrestjson.model.InputEventStream;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
 
@@ -86,32 +92,33 @@ public class AsyncOperationCancelTest {
         assertThat(executeFuture.isCancelled()).isTrue();
     }
 
+    // Still failing for useSraAuth=true
     // TODO(sra-identity-and-auth): This test is now failing after changes made to the event-stream signer module. We need to
     //  investigate and figure out the fix.
     @Test
     public void testEventStreamingOperation() throws InterruptedException {
-        // CompletableFuture<Void> responseFuture =
-        //     client.eventStreamOperation(r -> {},
-        //                                 Flowable.just(InputEventStream.inputEventBuilder().build()),
-        //         new EventStreamOperationResponseHandler() {
-        //             @Override
-        //             public void responseReceived(EventStreamOperationResponse response) {
-        //             }
-        //
-        //             @Override
-        //             public void onEventStream(SdkPublisher<EventStream> publisher) {
-        //             }
-        //
-        //             @Override
-        //             public void exceptionOccurred(Throwable throwable) {
-        //             }
-        //
-        //             @Override
-        //             public void complete() {
-        //             }
-        //         });
-        // responseFuture.cancel(true);
-        // assertThat(executeFuture.isCompletedExceptionally()).isTrue();
-        // assertThat(executeFuture.isCancelled()).isTrue();
+        CompletableFuture<Void> responseFuture =
+            client.eventStreamOperation(r -> {},
+                                        Flowable.just(InputEventStream.inputEventBuilder().build()),
+                new EventStreamOperationResponseHandler() {
+                    @Override
+                    public void responseReceived(EventStreamOperationResponse response) {
+                    }
+
+                    @Override
+                    public void onEventStream(SdkPublisher<EventStream> publisher) {
+                    }
+
+                    @Override
+                    public void exceptionOccurred(Throwable throwable) {
+                    }
+
+                    @Override
+                    public void complete() {
+                    }
+                });
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
     }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/clockskew/ClockSkewAdjustmentTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/clockskew/ClockSkewAdjustmentTest.java
@@ -68,9 +68,7 @@ public class ClockSkewAdjustmentTest {
         asyncClient = createAsyncClient(1);
     }
 
-    // TODO(sra-identity-and-auth): This test does not work anymore, we will need to fix the signing stage and then re-enable
-    //  this test
-    //@Test
+    @Test
     public void clockSkewAdjustsOnClockSkewErrors() {
         assertAdjusts(Instant.now().plus(5, MINUTES), 400, "RequestTimeTooSkewed");
         assertAdjusts(Instant.now().minus(5, MINUTES), 400, "RequestTimeTooSkewed");
@@ -82,9 +80,7 @@ public class ClockSkewAdjustmentTest {
         assertAdjusts(Instant.now().minus(6, HOURS), 403, "");
     }
 
-    // TODO(sra-identity-and-auth): This test does not work anymore, we will need to fix the signing stage and then re-enable
-    //  this test
-    //@Test
+    @Test
     public void clockSkewDoesNotAdjustOnNonClockSkewErrors() {
         // Force client clock forward 1 hour
         Instant clientTime = Instant.now().plus(1, HOURS);
@@ -101,9 +97,7 @@ public class ClockSkewAdjustmentTest {
         assertNoAdjust(clientTime, clientTime.minus(1, HOURS), 500, "PriorRequestNotComplete");
     }
 
-    // TODO(sra-identity-and-auth): This test does not work anymore, we will need to fix the signing stage and then re-enable
-    //  this test
-    //@Test
+    @Test
     public void clientClockSkewAdjustsWithoutRetries() {
         try (ProtocolJsonRpcClient client = createClient(0)) {
             clientClockSkewAdjustsWithoutRetries(client::allTypes);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Some tests were disabled earlier while we were working on the feature branch, as they used to fail on SRA codepath, i.e., what is now useSraAuth=true. Some of these are now fixed. Uncommenting those tests. But some still fail with useSraAuth=true. The feature branch is now defaulting to useSraAuth=false, so uncommenting even those tests, with a TODO to fix them in the useSraAuth=true testing branch (feature/master/sra-identity-auth-testing). At least, this way we've ensured these tests work for useSraAuth=false - the first stage of the release; when we merge the feature/master/sra-identity-auth branch to master, we won't be reducing the tests run.

With this, the known tests failing with useSraAuth=true are in:
1. EventMarshallingTest
1. protocolrestjson/AsyncOperationCancelTest
1. MultiRegionAccessPointEndpointResolutionTest
1. NoneAuthTypeRequestTest

## Modifications
<!--- Describe your changes in detail -->
Uncomment tests, with TODOs where needed to fix for useSraAuth=true.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
