### PR TITLE
Support non-XML String payloads

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-78a6c88.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-78a6c88.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Adds support for non-XML String payloads"
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/MarshallerUtil.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/MarshallerUtil.java
@@ -26,7 +26,7 @@ public final class MarshallerUtil {
     /**
      * @return true if the location is in the URI, false otherwise.
      */
-    public static boolean locationInUri(MarshallLocation location) {
+    public static boolean isInUri(MarshallLocation location) {
         switch (location) {
             case PATH:
             case QUERY_PARAM:

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -194,7 +194,8 @@ public final class JsonProtocolUnmarshaller {
     private boolean hasJsonPayload(SdkPojo sdkPojo, SdkHttpFullResponse response) {
         return sdkPojo.sdkFields()
                       .stream()
-                      .anyMatch(f -> isPayloadMemberOnUnmarshall(f) && !isExplicitBlobPayloadMember(f) && !isExplicitStringPayloadMember(f))
+                      .anyMatch(f -> isPayloadMemberOnUnmarshall(f) && !isExplicitBlobPayloadMember(f)
+                                     && !isExplicitStringPayloadMember(f))
                && response.content().isPresent();
     }
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -187,38 +187,31 @@ public final class JsonProtocolUnmarshaller {
 
     public <TypeT extends SdkPojo> TypeT unmarshall(SdkPojo sdkPojo,
                             SdkHttpFullResponse response) throws IOException {
-        if (hasPayloadMembersOnUnmarshall(sdkPojo)
-            && !hasExplicitBlobPayloadMember(sdkPojo)
-            && !hasExplicitStringPayloadMember(sdkPojo)
-            && response.content().isPresent()) {
-            JsonNode jsonNode = parser.parse(response.content().get());
-            return unmarshall(sdkPojo, response, jsonNode);
-        } else {
-            return unmarshall(sdkPojo, response, null);
-        }
+        JsonNode jsonNode = hasJsonPayload(sdkPojo, response) ? parser.parse(response.content().get()) : null;
+        return unmarshall(sdkPojo, response, jsonNode);
     }
 
-    private boolean hasExplicitBlobPayloadMember(SdkPojo sdkPojo) {
+    private boolean hasJsonPayload(SdkPojo sdkPojo, SdkHttpFullResponse response) {
         return sdkPojo.sdkFields()
                       .stream()
-                      .anyMatch(f -> isExplicitPayloadMember(f) && f.marshallingType() == MarshallingType.SDK_BYTES);
+                      .anyMatch(f -> isPayloadMemberOnUnmarshall(f) && !isExplicitBlobPayloadMember(f) && !isExplicitStringPayloadMember(f))
+               && response.content().isPresent();
     }
 
-    private boolean hasExplicitStringPayloadMember(SdkPojo sdkPojo) {
-        return sdkPojo.sdkFields()
-                      .stream()
-                      .anyMatch(f -> isExplicitPayloadMember(f) && f.marshallingType() == MarshallingType.STRING);
+    private boolean isExplicitBlobPayloadMember(SdkField<?> f) {
+        return isExplicitPayloadMember(f) && f.marshallingType() == MarshallingType.SDK_BYTES;
+    }
+
+    private boolean isExplicitStringPayloadMember(SdkField<?> f) {
+        return isExplicitPayloadMember(f) && f.marshallingType() == MarshallingType.STRING;
     }
 
     private static boolean isExplicitPayloadMember(SdkField<?> f) {
         return f.containsTrait(PayloadTrait.class);
     }
 
-    private boolean hasPayloadMembersOnUnmarshall(SdkPojo sdkPojo) {
-        return sdkPojo.sdkFields()
-                .stream()
-                .anyMatch(f -> f.location() == MarshallLocation.PAYLOAD
-                        || MarshallerUtil.locationInUri(f.location()));
+    private boolean isPayloadMemberOnUnmarshall(SdkField<?> f) {
+        return f.location() == MarshallLocation.PAYLOAD || MarshallerUtil.isInUri(f.location());
     }
 
     public <TypeT extends SdkPojo> TypeT unmarshall(SdkPojo sdkPojo,

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallerContext.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallerContext.java
@@ -54,7 +54,7 @@ public final class JsonUnmarshallerContext {
     public JsonUnmarshaller<Object> getUnmarshaller(MarshallLocation location, MarshallingType<?> marshallingType) {
         // A member being in the URI on a response is nonsensical; when a member is declared to be somewhere in the URI,
         // it should be found in the payload on response
-        if (MarshallerUtil.locationInUri(location)) {
+        if (MarshallerUtil.isInUri(location)) {
             location = MarshallLocation.PAYLOAD;
         }
         return unmarshallerRegistry.getUnmarshaller(location, marshallingType);

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
@@ -111,6 +111,15 @@
       "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
       "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
     },
+    "OperationWithExplicitPayloadString":{
+      "name":"OperationWithExplicitPayloadString",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
+      },
+      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
+      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
+    },
     "OperationWithExplicitPayloadStructure":{
       "name":"OperationWithExplicitPayloadStructure",
       "http":{
@@ -566,6 +575,13 @@
       "type":"structure",
       "members":{
         "PayloadMember":{"shape":"BlobType"}
+      },
+      "payload":"PayloadMember"
+    },
+    "OperationWithExplicitPayloadStringInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"String"}
       },
       "payload":"PayloadMember"
     },

--- a/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
@@ -91,6 +91,15 @@
       "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
       "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
     },
+    "OperationWithExplicitPayloadString":{
+      "name":"OperationWithExplicitPayloadString",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
+      },
+      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
+      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
+    },
     "OperationWithGreedyLabel":{
       "name":"OperationWithGreedyLabel",
       "http":{
@@ -436,6 +445,13 @@
       "type":"structure",
       "members":{
         "PayloadMember":{"shape":"BlobType"}
+      },
+      "payload":"PayloadMember"
+    },
+    "OperationWithExplicitPayloadStringInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"String"}
       },
       "payload":"PayloadMember"
     },

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/RestXmlEventStreamProtocolTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/RestXmlEventStreamProtocolTest.java
@@ -114,7 +114,7 @@ public class RestXmlEventStreamProtocolTest {
         TestHandler testHandler = new TestHandler();
         client.eventStreamOperation(r -> {}, testHandler).join();
 
-        assertThat(testHandler.receivedEvents).containsExactly(EventStream.eventPayloadEventBuilder().foo("bar").build());
+        assertThat(testHandler.receivedEvents).containsExactly(EventStream.eventPayloadEventBuilder().foo("<Foo>bar</Foo>").build());
         assertThat(testHandler.receivedEvents.get(0).sdkEventType()).isEqualTo(EventStream.EventType.EVENT_PAYLOAD_EVENT);
     }
 
@@ -130,7 +130,7 @@ public class RestXmlEventStreamProtocolTest {
         TestHandler testHandler = new TestHandler();
         client.eventStreamOperation(r -> {}, testHandler).join();
 
-        assertThat(testHandler.receivedEvents).containsExactly(EventStream.secondEventPayloadEventBuilder().foo("bar").build());
+        assertThat(testHandler.receivedEvents).containsExactly(EventStream.secondEventPayloadEventBuilder().foo("<Foo>bar</Foo>").build());
         assertThat(testHandler.receivedEvents.get(0).sdkEventType()).isEqualTo(EventStream.EventType.SECOND_EVENT_PAYLOAD_EVENT);
     }
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/XmlPayloadStringTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/XmlPayloadStringTest.java
@@ -74,8 +74,7 @@ public class XmlPayloadStringTest {
         String loggedRequestBody = new String(SdkBytes.fromInputStream(loggedRequestStream).asByteArray());
 
         assertThat(loggedRequestBody).isEqualTo(PAYLOAD_STRING_XML);
-        // Explicit XML String payload should be unmarshalled to raw value without tags in response POJO
-        assertThat(response.payloadMember()).isEqualTo(PAYLOAD_STRING_NON_XML);
+        assertThat(response.payloadMember()).isEqualTo(PAYLOAD_STRING_XML);
     }
 
     @Test

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/XmlPayloadStringTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/XmlPayloadStringTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlClient;
+import software.amazon.awssdk.services.protocolrestxml.model.OperationWithExplicitPayloadBlobRequest;
+import software.amazon.awssdk.services.protocolrestxml.model.OperationWithExplicitPayloadBlobResponse;
+import software.amazon.awssdk.services.protocolrestxml.model.OperationWithExplicitPayloadStringRequest;
+import software.amazon.awssdk.services.protocolrestxml.model.OperationWithExplicitPayloadStringResponse;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+
+public class XmlPayloadStringTest {
+    private final String PAYLOAD_STRING_XML = "<Field>StringPayload</Field>";
+    private final String PAYLOAD_STRING_NON_XML = "StringPayload";
+    private final SdkBytes PAYLOAD_BYTES_XML = SdkBytes.fromUtf8String(PAYLOAD_STRING_XML);
+    private final SdkBytes PAYLOAD_BYTES_NON_XML = SdkBytes.fromUtf8String(PAYLOAD_STRING_NON_XML);
+    private ProtocolRestXmlClient syncClient;
+    private MockSyncHttpClient mockHttpClient;
+
+    @BeforeEach
+    public void setUp() {
+        mockHttpClient = new MockSyncHttpClient();
+        syncClient = ProtocolRestXmlClient.builder()
+                                           .credentialsProvider(AnonymousCredentialsProvider.create())
+                                           .region(Region.US_EAST_1)
+                                           .httpClient(mockHttpClient)
+                                           .build();
+    }
+
+    @AfterEach
+    public void reset() {
+        mockHttpClient.reset();
+    }
+
+    @Test
+    public void operationWithExplicitPayloadString_xml_marshallsAndUnmarshallsCorrectly() {
+        mockHttpClient.stubNextResponse(mockResponse(PAYLOAD_BYTES_XML), Duration.ofMillis(500));
+
+        OperationWithExplicitPayloadStringRequest request = OperationWithExplicitPayloadStringRequest.builder()
+                                                                                                     .payloadMember(PAYLOAD_STRING_XML)
+                                                                                                     .build();
+        OperationWithExplicitPayloadStringResponse response = syncClient.operationWithExplicitPayloadString(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockHttpClient.getLastRequest();
+        InputStream loggedRequestStream = loggedRequest.contentStreamProvider().get().newStream();
+        String loggedRequestBody = new String(SdkBytes.fromInputStream(loggedRequestStream).asByteArray());
+
+        assertThat(loggedRequestBody).isEqualTo(PAYLOAD_STRING_XML);
+        // Explicit XML String payload should be unmarshalled to raw value without tags in response POJO
+        assertThat(response.payloadMember()).isEqualTo(PAYLOAD_STRING_NON_XML);
+    }
+
+    @Test
+    public void operationWithExplicitPayloadString_nonXml_marshallsAndUnmarshallsCorrectly() {
+        mockHttpClient.stubNextResponse(mockResponse(PAYLOAD_BYTES_NON_XML), Duration.ofMillis(500));
+
+        OperationWithExplicitPayloadStringRequest request = OperationWithExplicitPayloadStringRequest.builder()
+                                                                                                     .payloadMember(PAYLOAD_STRING_NON_XML)
+                                                                                                     .build();
+        OperationWithExplicitPayloadStringResponse response = syncClient.operationWithExplicitPayloadString(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockHttpClient.getLastRequest();
+        InputStream loggedRequestStream = loggedRequest.contentStreamProvider().get().newStream();
+        String loggedRequestBody = new String(SdkBytes.fromInputStream(loggedRequestStream).asByteArray());
+
+        assertThat(loggedRequestBody).isEqualTo(PAYLOAD_STRING_NON_XML);
+        assertThat(response.payloadMember()).isEqualTo(PAYLOAD_STRING_NON_XML);
+    }
+
+    @Test
+    public void operationWithExplicitPayloadBlob_xml_marshallsAndUnmarshallsCorrectly() {
+        mockHttpClient.stubNextResponse(mockResponse(PAYLOAD_BYTES_XML), Duration.ofMillis(500));
+
+        OperationWithExplicitPayloadBlobRequest request = OperationWithExplicitPayloadBlobRequest.builder()
+                                                                                                 .payloadMember(PAYLOAD_BYTES_XML)
+                                                                                                 .build();
+        OperationWithExplicitPayloadBlobResponse response = syncClient.operationWithExplicitPayloadBlob(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockHttpClient.getLastRequest();
+        InputStream loggedRequestStream = loggedRequest.contentStreamProvider().get().newStream();
+        SdkBytes loggedRequestBody = SdkBytes.fromInputStream(loggedRequestStream);
+
+        assertThat(loggedRequestBody).isEqualTo(PAYLOAD_BYTES_XML);
+        assertThat(response.payloadMember()).isEqualTo(PAYLOAD_BYTES_XML);
+    }
+
+    @Test
+    public void operationWithExplicitPayloadBlob_nonXml_marshallsAndUnmarshallsCorrectly() {
+        mockHttpClient.stubNextResponse(mockResponse(PAYLOAD_BYTES_NON_XML), Duration.ofMillis(500));
+
+        OperationWithExplicitPayloadBlobRequest request = OperationWithExplicitPayloadBlobRequest.builder()
+                                                                                                 .payloadMember(PAYLOAD_BYTES_NON_XML)
+                                                                                                 .build();
+        OperationWithExplicitPayloadBlobResponse response = syncClient.operationWithExplicitPayloadBlob(request);
+
+        SdkHttpFullRequest loggedRequest = (SdkHttpFullRequest) mockHttpClient.getLastRequest();
+        InputStream loggedRequestStream = loggedRequest.contentStreamProvider().get().newStream();
+        SdkBytes loggedRequestBody = SdkBytes.fromInputStream(loggedRequestStream);
+
+        assertThat(loggedRequestBody).isEqualTo(PAYLOAD_BYTES_NON_XML);
+        assertThat(response.payloadMember()).isEqualTo(PAYLOAD_BYTES_NON_XML);
+    }
+
+    private HttpExecuteResponse mockResponse(SdkBytes sdkBytes) {
+        InputStream inputStream = new ByteArrayInputStream(sdkBytes.asByteArray());
+
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder()
+                                                           .statusCode(200)
+                                                           .build())
+                                  .responseBody(AbortableInputStream.create(inputStream))
+                                  .build();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
To support non-XML String payloads

## Modifications
<!--- Describe your changes in detail -->
Update XML marshaller/unmarshaller to support explicit String payloads, including non-XML Strings

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
