### PR TITLE
Do not re-use sanitized request when forming signed request

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -228,7 +228,7 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
 
         HttpRequest crtRequest = toRequest(sanitizedRequest, request.payload().orElse(null));
 
-        V4aContext v4aContext = sign(sanitizedRequest, crtRequest, signingConfig);
+        V4aContext v4aContext = sign(requestBuilder.build(), crtRequest, signingConfig);
 
         ContentStreamProvider payload = payloadSigner.sign(request.payload().orElse(null), v4aContext);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/MultiRegionAccessPointEndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/MultiRegionAccessPointEndpointResolutionTest.java
@@ -40,11 +40,6 @@ import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
 public class MultiRegionAccessPointEndpointResolutionTest {
 
     private final static String MULTI_REGION_ARN = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
-    // TODO(sra-identity-and-auth): The forward slash of the URL below was added to account for the signer behavior that
-    //  sanitizes the URI path, we need to double check that this behavior it's safe and that it won't break anything else.
-    //  With useSraAuth=test, need to add the forward slash to the endpoint below to make related tests pass.
-    // private final static URI MULTI_REGION_ENDPOINT =
-    //     URI.create("https://mfzwi23gnjvgw.mrap.accesspoint.s3-global.amazonaws.com/");
     private final static URI MULTI_REGION_ENDPOINT =
         URI.create("https://mfzwi23gnjvgw.mrap.accesspoint.s3-global.amazonaws.com");
     private MockHttpClient mockHttpClient;


### PR DESCRIPTION
## Motivation and Context
- Before signing a request with CRT, a request is sanitized (forbidden headers/params are removed, encoded-path is set to `/` if path is empty, etc)
- After signing, we should use the original request when forming the signed request, instead of the sanitized one, such that original metadata is not lost (headers, params, path, etc.)

## Modifications
- Update signer to use original request when converting to signed request
- Remove TODOs in tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
