### PR TITLE
Update codegen-generated-classes-test for SRA

### DIFF
--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
@@ -42,6 +42,8 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
@@ -65,7 +67,8 @@ public class NoneAuthTypeRequestTest {
     @Before
     public void setup() throws IOException {
         credentialsProvider = mock(AwsCredentialsProvider.class);
-        when(credentialsProvider.resolveIdentity()).thenAnswer(
+        when(credentialsProvider.identityType()).thenReturn(AwsCredentialsIdentity.class);
+        when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenAnswer(
             invocationOnMock -> CompletableFuture.completedFuture(AwsBasicCredentials.create("123", "12344")));
 
         httpClient = mock(SdkHttpClient.class);
@@ -98,56 +101,56 @@ public class NoneAuthTypeRequestTest {
     public void sync_json_authorization_is_absent_for_noneAuthType() {
         jsonClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
-        verify(credentialsProvider, times(0)).resolveIdentity();
+        verify(credentialsProvider, times(0)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     @Test
     public void sync_json_authorization_is_present_for_defaultAuth() {
         jsonClient.jsonValuesOperation();
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isPresent();
-        verify(credentialsProvider, times(1)).resolveIdentity();
+        verify(credentialsProvider, times(1)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     @Test
     public void async_json_authorization_is_absent_for_noneAuthType() {
         jsonAsyncClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
-        verify(credentialsProvider, times(0)).resolveIdentity();
+        verify(credentialsProvider, times(0)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     @Test
     public void async_json_authorization_is_present_for_defaultAuth() {
         jsonAsyncClient.jsonValuesOperation();
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isPresent();
-        verify(credentialsProvider, times(1)).resolveIdentity();
+        verify(credentialsProvider, times(1)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     @Test
     public void sync_xml_authorization_is_absent_for_noneAuthType() {
         xmlClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
-        verify(credentialsProvider, times(0)).resolveIdentity();
+        verify(credentialsProvider, times(0)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     @Test
     public void sync_xml_authorization_is_present_for_defaultAuth() {
         xmlClient.jsonValuesOperation(json -> json.jsonValueMember("one"));
         assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isPresent();
-        verify(credentialsProvider, times(1)).resolveIdentity();
+        verify(credentialsProvider, times(1)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     @Test
     public void async_xml_authorization_is_absent_for_noneAuthType() {
         xmlAsyncClient.operationWithNoneAuthType(o -> o.booleanMember(true));
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
-        verify(credentialsProvider, times(0)).resolveIdentity();
+        verify(credentialsProvider, times(0)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     @Test
     public void async_xml_authorization_is_present_for_defaultAuth() {
         xmlAsyncClient.jsonValuesOperation(json -> json.jsonValueMember("one"));
         assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isPresent();
-        verify(credentialsProvider, times(1)).resolveIdentity();
+        verify(credentialsProvider, times(1)).resolveIdentity(any(ResolveIdentityRequest.class));
     }
 
     private SdkHttpRequest getSyncRequest() {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/bearerauth/ClientBuilderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/bearerauth/ClientBuilderTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider;
-import software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
@@ -34,6 +33,8 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.regions.Region;
 
+// TODO(sra-identity-auth): assert client is configured with SRA types like AUTH_SCHEMES, AUTH_SCHEME_PROVIDER,
+//  IDENTITY_PROVIDERS.
 public class ClientBuilderTest {
     @Test
     public void syncClient_includesDefaultProvider_includesDefaultSigner() {
@@ -42,8 +43,7 @@ public class ClientBuilderTest {
 
         assertThat(config.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER))
             .isInstanceOf(DefaultAwsTokenProvider.class);
-        assertThat(config.option(SdkAdvancedClientOption.TOKEN_SIGNER))
-            .isInstanceOf(BearerTokenSigner.class);
+        assertThat(config.option(SdkAdvancedClientOption.TOKEN_SIGNER)).isNull();;
     }
 
     @Test
@@ -90,8 +90,7 @@ public class ClientBuilderTest {
 
         assertThat(config.option(AwsClientOption.TOKEN_IDENTITY_PROVIDER))
             .isInstanceOf(DefaultAwsTokenProvider.class);
-        assertThat(config.option(SdkAdvancedClientOption.TOKEN_SIGNER))
-            .isInstanceOf(BearerTokenSigner.class);
+        assertThat(config.option(SdkAdvancedClientOption.TOKEN_SIGNER)).isNull();
     }
 
     @Test

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/mixedauth/ClientBuilderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/mixedauth/ClientBuilderTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
-
+// TODO(sra-identity-auth): assert client is configured with SRA types like AUTH_SCHEMES, AUTH_SCHEME_PROVIDER,
+//  IDENTITY_PROVIDERS. For mixed auth, assert AUTH_SCHEMES has all expected.
 public class ClientBuilderTest {
     @Test
     public void syncClient_buildWithDefaults_validationsSucceed() {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/ClientBuilderTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/ClientBuilderTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
+// TODO(sra-identity-auth): assert client is configured with SRA types like AUTH_SCHEMES, AUTH_SCHEME_PROVIDER,
+//  IDENTITY_PROVIDERS.
 public class ClientBuilderTest {
     @Test
     public void syncClient_buildWithDefaults_validationsSucceed() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
These are the 2 failing tests for codegen-generated-classes-test with useSraAuth=true (in the feature/master/sra-identity-auth-testing branch). Updating the tests for SRA. We would merge this to master, towards the end of the release, once useSraAuth=true in master.

The ClientBuilder tests actually should be updated to assert for SRA types, but just made it a TODO for now, to get the branch to green first.

## Modifications
<!--- Describe your changes in detail -->
Update tests.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
