### PR TITLE
Fail codegen for Query protocol operations with explicit String payload

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -183,7 +183,7 @@ final class AddOperations {
 
                 if (isQueryProtocolWithExplicitStringPayload(c2jShapes, c2jShapes.get(inputShape))) {
                     throw SdkClientException.create("Operations with explicit String payloads are not supported for Query "
-                                                    + "protocols.");
+                                                    + "protocols. Unsupported operation: " + operationName);
                 }
 
                 String documentation = input.getDocumentation() != null ? input.getDocumentation() :
@@ -205,7 +205,7 @@ final class AddOperations {
                         new ReturnTypeModel(responseClassName).withDocumentation(documentation));
                 if (isQueryProtocolWithExplicitStringPayload(c2jShapes, outputShape)) {
                     throw SdkClientException.create("Operations with explicit String payloads are not supported for Query "
-                                                    + "protocols. - " + operationName);
+                                                    + "protocols. Unsupported operation: " + operationName);
                 }
                 if (isBlobShape(getPayloadShape(c2jShapes, outputShape))) {
                     operationModel.setHasBlobMemberAsPayload(true);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -35,7 +35,6 @@ import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Shape;
 import software.amazon.awssdk.codegen.naming.NamingStrategy;
-import software.amazon.awssdk.core.exception.SdkClientException;
 
 /**
  * Constructs the operation model for every operation defined by the service.
@@ -74,7 +73,7 @@ final class AddOperations {
      * @return True if shape is a String type. False otherwise
      */
     private static boolean isStringShape(Shape shape) {
-        return shape != null && shape.getType().equalsIgnoreCase("String");
+        return shape != null && "String".equalsIgnoreCase(shape.getType());
     }
 
     /**
@@ -180,12 +179,6 @@ final class AddOperations {
             if (input != null) {
                 String originalShapeName = input.getShape();
                 String inputShape = namingStrategy.getRequestClassName(operationName);
-
-                if (isQueryProtocolWithExplicitStringPayload(c2jShapes, c2jShapes.get(inputShape))) {
-                    throw SdkClientException.create("Operations with explicit String payloads are not supported for Query "
-                                                    + "protocols. Unsupported operation: " + operationName);
-                }
-
                 String documentation = input.getDocumentation() != null ? input.getDocumentation() :
                                        c2jShapes.get(originalShapeName).getDocumentation();
 
@@ -203,10 +196,6 @@ final class AddOperations {
 
                 operationModel.setReturnType(
                         new ReturnTypeModel(responseClassName).withDocumentation(documentation));
-                if (isQueryProtocolWithExplicitStringPayload(c2jShapes, outputShape)) {
-                    throw SdkClientException.create("Operations with explicit String payloads are not supported for Query "
-                                                    + "protocols. Unsupported operation: " + operationName);
-                }
                 if (isBlobShape(getPayloadShape(c2jShapes, outputShape))) {
                     operationModel.setHasBlobMemberAsPayload(true);
                 }
@@ -237,12 +226,6 @@ final class AddOperations {
         }
 
         return javaOperationModels;
-    }
-
-    private boolean isQueryProtocolWithExplicitStringPayload(Map<String, Shape> c2jShapes, Shape shape) {
-        String protocol = serviceModel.getMetadata().getProtocol();
-        return (protocol.equals("ec2") || protocol.equals("query")) && shape != null
-               && isStringShape(getPayloadShape(c2jShapes, shape));
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
@@ -38,7 +38,8 @@ public final class DefaultCustomizationProcessor {
                 new UseLegacyEventGenerationSchemeProcessor(),
                 new NewAndLegacyEventStreamProcessor(),
                 new S3RemoveBucketFromUriProcessor(),
-                new S3ControlRemoveAccountIdHostPrefixProcessor()
+                new S3ControlRemoveAccountIdHostPrefixProcessor(),
+                new ExplicitStringPayloadQueryProtocolProcessor()
                 );
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ExplicitStringPayloadQueryProtocolProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ExplicitStringPayloadQueryProtocolProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.customization.processors;
+
+import java.util.Map;
+import software.amazon.awssdk.codegen.customization.CodegenCustomizationProcessor;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.service.Input;
+import software.amazon.awssdk.codegen.model.service.Member;
+import software.amazon.awssdk.codegen.model.service.Output;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+import software.amazon.awssdk.codegen.model.service.Shape;
+
+/**
+ * Operations with explicit String payloads are not supported for services with Query protocol. We fail the codegen if the
+ * httpPayload or eventPayload trait is set on a String.
+ */
+public class ExplicitStringPayloadQueryProtocolProcessor implements CodegenCustomizationProcessor {
+    @Override
+    public void preprocess(ServiceModel serviceModel) {
+        String protocol = serviceModel.getMetadata().getProtocol();
+        if (!"ec2".equals(protocol) && !"query".equals(protocol)) {
+            return;
+        }
+
+        Map<String, Shape> c2jShapes = serviceModel.getShapes();
+
+        serviceModel.getOperations().forEach((operationName, op) -> {
+
+            Input input = op.getInput();
+            if (input != null && isExplicitStringPayload(c2jShapes, c2jShapes.get(input.getShape()))) {
+                throw new RuntimeException("Operations with explicit String payloads are not supported for Query "
+                                           + "protocols. Unsupported operation: " + operationName);
+
+            }
+
+            Output output = op.getOutput();
+            if (output != null && isExplicitStringPayload(c2jShapes, c2jShapes.get(output.getShape()))) {
+                throw new RuntimeException("Operations with explicit String payloads are not supported for Query "
+                                           + "protocols. Unsupported operation: " + operationName);
+
+            }
+        });
+    }
+
+    @Override
+    public void postprocess(IntermediateModel intermediateModel) {
+        // no-op
+    }
+
+    private boolean isExplicitStringPayload(Map<String, Shape> c2jShapes, Shape shape) {
+        if (shape.getPayload() == null) {
+            return false;
+        }
+
+        Member payloadMember = shape.getMembers().get(shape.getPayload());
+        Shape payloadShape = c2jShapes.get(payloadMember.getShape());
+        return payloadShape != null && "String".equalsIgnoreCase(payloadShape.getType());
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
@@ -325,7 +325,7 @@
     "ChecksumStructure":{
       "type":"structure",
       "members":{
-        "stringMember":{"shape":"subMember"},
+        "Body":{"shape":"Body"},
         "ChecksumMode":{
           "shape":"ChecksumMode",
           "location":"header",
@@ -337,7 +337,7 @@
           "locationName":"x-amz-checksum-algorithm"
         }
       },
-      "payload":"stringMember"
+      "payload":"Body"
     },
     "String":{"type":"string"},
     "BearerAuthOperationRequest": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -612,7 +612,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "GetOperationWithChecksum");
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                                                                           .isPayloadJson(false).build();
 
             HttpResponseHandler<GetOperationWithChecksumResponse> responseHandler = protocolFactory.createResponseHandler(
                 operationMetadata, GetOperationWithChecksumResponse::builder);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -277,7 +277,7 @@ final class DefaultJsonClient implements JsonClient {
         GetOperationWithChecksumRequest getOperationWithChecksumRequest) throws AwsServiceException, SdkClientException,
                                                                                 JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                       .isPayloadJson(true).build();
+                                                                       .isPayloadJson(false).build();
 
         HttpResponseHandler<GetOperationWithChecksumResponse> responseHandler = protocolFactory.createResponseHandler(
             operationMetadata, GetOperationWithChecksumResponse::builder);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Explicit String payloads are not supported for Query protocols

## Modifications
<!--- Describe your changes in detail -->
Update codegen to fail if there is Query protocol operation with explicit String payload

Update Json codegen test classes which were missed in previous [PR](https://github.com/aws/aws-sdk-java-v2/pull/4450) - `string` can be lowercase when calling `shape.getType()`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
