### PR TITLE
Do not short-circuit toSdkHttpFullRequest

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStage.java
@@ -159,10 +159,6 @@ public class AsyncSigningStage implements RequestPipeline<SdkHttpFullRequest,
     }
 
     private SdkHttpFullRequest toSdkHttpFullRequest(SignedRequest signedRequest) {
-        SdkHttpRequest request = signedRequest.request();
-        if (request instanceof SdkHttpFullRequest) {
-            return (SdkHttpFullRequest) request;
-        }
         return toSdkHttpFullRequestBuilder(signedRequest).contentStreamProvider(signedRequest.payload().orElse(null)).build();
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncSigningStageTest.java
@@ -128,7 +128,7 @@ public class AsyncSigningStageTest {
         assertThat(context.executionAttributes().getAttribute(TIME_OFFSET))
             .isEqualTo(httpClientDependencies.timeOffset());
 
-        assertThat(result).isSameAs(signedRequest);
+        assertThat(result).usingRecursiveComparison().isEqualTo(signedRequest);
         // assert that interceptor context is updated with result
         assertThat(context.executionContext().interceptorContext().httpRequest()).isSameAs(result);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
With the short-circuit it is possible that the signedRequest.payload() isn't set on the resulting SdkHttpFullRequest. In cases where the payload doesn't actually change during HttpSigner.sign(), this is ok. But the payload *can* change, e.g., for chunk-encoding, so need to extract the resulting payload from signedRequest.payload().

This change was already made to SigningStage in https://github.com/aws/aws-sdk-java-v2/pull/4507/files#r1341852647.

## Modifications
<!--- Describe your changes in detail -->
Making the same change here.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
