### PR TITLE
Defer requirement of mappedTableResource until it is required

### DIFF
--- a/.changes/next-release/bugfix-DynamoDBEnhancedClient-88bd6d9.json
+++ b/.changes/next-release/bugfix-DynamoDBEnhancedClient-88bd6d9.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Fix an issue where the presence of a `MappedTableResource` was being unnecessarily asserted when building a `WriteBatch` or `ReadBatch`."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatch.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatch.java
@@ -167,6 +167,9 @@ public final class ReadBatch {
 
         Boolean firstRecordConsistentRead = validateAndGetConsistentRead(readRequests);
 
+        requireNonNull(mappedTableResource, "A mappedTableResource (table) is required when generating the read requests for "
+                                            + "ReadBatch");
+
         List<Map<String, AttributeValue>> keys =
             readRequests.stream()
                         .map(GetItemEnhancedRequest::key)
@@ -213,9 +216,6 @@ public final class ReadBatch {
 
     @NotThreadSafe
     private static final class BuilderImpl<T> implements Builder<T> {
-        private static final String MAPPED_TABLE_RESOURCE_NOT_NULL_MESSAGE = String.format("A mappedTableResource (table) is "
-                                                                                           + "required when building a %s",
-                                                                                           ReadBatch.class.getSimpleName());
         private MappedTableResource<T> mappedTableResource;
         private List<GetItemEnhancedRequest> requests = new ArrayList<>();
 
@@ -248,7 +248,7 @@ public final class ReadBatch {
 
         @Override
         public Builder<T> addGetItem(T keyItem) {
-            requireNonNull(mappedTableResource, MAPPED_TABLE_RESOURCE_NOT_NULL_MESSAGE);
+            requireNonNull(mappedTableResource, "A mappedTableResource is required to derive a key from the given keyItem");
             return addGetItem(this.mappedTableResource.keyFrom(keyItem));
         }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatchTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatchTest.java
@@ -15,11 +15,11 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThrows;
 import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem.createUniqueFakeItem;
 
 import java.util.Collections;
@@ -97,12 +97,22 @@ public class ReadBatchTest {
     }
 
     @Test
-    public void builder_missing_mapped_table_resource_error_message() {
+    public void builder_key_from_item_missing_mapped_table_resource_error_message() {
         FakeItem fakeItem = createUniqueFakeItem();
 
         ReadBatch.Builder<FakeItem> builder = ReadBatch.builder(FakeItem.class);
 
-        NullPointerException exception = assertThrows(NullPointerException.class, () -> builder.addGetItem(fakeItem));
-        assertThat(exception.getMessage(), is("A mappedTableResource (table) is required when building a ReadBatch"));
+        assertThatThrownBy(() -> builder.addGetItem(fakeItem))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("A mappedTableResource is required to derive a key from the given keyItem");
+    }
+
+    @Test
+    public void builder_missing_mapped_table_resource_error_message() {
+        ReadBatch.Builder<FakeItem> builder = ReadBatch.builder(FakeItem.class);
+
+        assertThatThrownBy(() -> builder.addGetItem(GetItemEnhancedRequest.builder().build()).build())
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("A mappedTableResource (table) is required when generating the read requests for ReadBatch");
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix an issue where we were previously enforcing the requirement for mappedTableResource to be present before it was actually required. Now, we defer the validation utnil we actually need to access it.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
