### PR TITLE
Support to Disable Ennvironment Variable Proxy option when using S3CrtClient HttpProxyConfig options

### DIFF
--- a/.changes/next-release/feature-AWSCRTbasedS3client-666199c.json
+++ b/.changes/next-release/feature-AWSCRTbasedS3client-666199c.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS CRT-based S3 client",
+    "contributor": "",
+    "description": "Added a boolean flag, 'useEnvironmentVariableValues,' to the S3CrtProxyConfiguration to enable the disabling of reading ProxyConfig from environment variables by the CRT client."
+}

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
@@ -123,6 +123,15 @@ public abstract class CrtProxyConfiguration {
         return password;
     }
 
+    /**
+     * Indicates whether environment variables are utilized for proxy configuration.
+     *
+     * @return {@code true} if environment variables are being used for proxy configuration, {@code false} otherwise.
+     */
+    public final Boolean isUseEnvironmentVariableValues() {
+        return useEnvironmentVariableValues;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtProxyConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtProxyConfiguration.java
@@ -88,6 +88,9 @@ public final class S3CrtProxyConfiguration extends CrtProxyConfiguration
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
         @Override
+        Builder useEnvironmentVariableValues(Boolean useEnvironmentVariableValues);
+
+        @Override
         S3CrtProxyConfiguration build();
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.crt.auth.signing.AwsSigningConfig;
 import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpProxyEnvironmentVariableSetting;
 import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.crt.s3.ChecksumConfig;
 import software.amazon.awssdk.crt.s3.ResumeToken;
@@ -88,6 +89,9 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
         if (s3NativeClientConfiguration.standardRetryOptions() != null) {
             this.s3ClientOptions.withStandardRetryOptions(s3NativeClientConfiguration.standardRetryOptions());
+        }
+        if (Boolean.FALSE.equals(s3NativeClientConfiguration.isUseEnvironmentVariableValues())) {
+            s3ClientOptions.withProxyEnvironmentVariableSetting(disabledHttpProxyEnvironmentVariableSetting());
         }
         Optional.ofNullable(s3NativeClientConfiguration.proxyOptions()).ifPresent(s3ClientOptions::withProxyOptions);
         Optional.ofNullable(s3NativeClientConfiguration.connectionTimeout())
@@ -281,5 +285,11 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         return SdkHttpUtils.isUsingStandardPort(request.protocol(), request.port())
                ? request.host()
                : request.host() + ":" + request.port();
+    }
+
+    private static HttpProxyEnvironmentVariableSetting disabledHttpProxyEnvironmentVariableSetting() {
+        HttpProxyEnvironmentVariableSetting proxyEnvSetting = new HttpProxyEnvironmentVariableSetting();
+        proxyEnvSetting.setEnvironmentVariableType(HttpProxyEnvironmentVariableSetting.HttpProxyEnvironmentVariableType.DISABLED);
+        return proxyEnvSetting;
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -64,6 +64,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final Duration connectionTimeout;
     private final HttpMonitoringOptions httpMonitoringOptions;
 
+    private final Boolean useEnvironmentVariableProxyOptionsValues;
+
     public S3NativeClientConfiguration(Builder builder) {
         this.signingRegion = builder.signingRegion == null ? DefaultAwsRegionProviderChain.builder().build().getRegion().id() :
                              builder.signingRegion;
@@ -113,6 +115,20 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
             this.httpMonitoringOptions = null;
         }
         this.standardRetryOptions = builder.standardRetryOptions;
+        this.useEnvironmentVariableProxyOptionsValues = resolveUseEnvironmentVariableValues(builder);
+    }
+
+    private static Boolean resolveUseEnvironmentVariableValues(Builder builder) {
+        if (builder != null && builder.httpConfiguration != null) {
+            if (builder.httpConfiguration.proxyConfiguration() != null) {
+                return builder.httpConfiguration.proxyConfiguration().isUseEnvironmentVariableValues();
+            }
+        }
+        return true;
+    }
+
+    public Boolean isUseEnvironmentVariableValues() {
+        return useEnvironmentVariableProxyOptionsValues;
     }
 
     public HttpMonitoringOptions httpMonitoringOptions() {

--- a/utils/src/main/java/software/amazon/awssdk/utils/ProxyConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ProxyConfigProvider.java
@@ -70,9 +70,9 @@ public interface ProxyConfigProvider {
                                                              Boolean useEnvironmentVariableValues,
                                                              String scheme) {
         ProxyConfigProvider resultProxyConfig = null;
-        if (useSystemPropertyValues) {
+        if (Boolean.TRUE.equals(useSystemPropertyValues)) {
             resultProxyConfig = fromSystemPropertySettings(scheme);
-        } else if (useEnvironmentVariableValues) {
+        } else if (Boolean.TRUE.equals(useEnvironmentVariableValues)) {
             return fromEnvironmentSettings(scheme);
         }
         boolean isProxyConfigurationNotSet = resultProxyConfig != null && resultProxyConfig.host() == null

--- a/utils/src/main/java/software/amazon/awssdk/utils/ProxyConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ProxyConfigProvider.java
@@ -81,7 +81,7 @@ public interface ProxyConfigProvider {
                                              && !resultProxyConfig.userName().isPresent()
                                              && CollectionUtils.isNullOrEmpty(resultProxyConfig.nonProxyHosts());
 
-        if (isProxyConfigurationNotSet && useEnvironmentVariableValues) {
+        if (isProxyConfigurationNotSet && Boolean.TRUE.equals(useEnvironmentVariableValues)) {
             return fromEnvironmentSettings(scheme);
 
         }


### PR DESCRIPTION
Support to Disable Ennvironment Variable Proxy option when using S3CrtClient HttpProxyConfig options
<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Crt Client picks up HTTP_PROXY environment proxy settings
- User needs a way to disable picking up of Proxy settings from env variable.

## Modifications
<!--- Describe your changes in detail -->
- Added  logic in S3CrtAsyncHttpClient to set HttpProxyEnvironmentVariableSetting.HttpProxyEnvironmentVariableType.DISABLED when useEnvironmentVariableValues is enabled

## API usage
```java
        S3AsyncClient.crtBuilder()
                     .httpConfiguration(h -> h
                         .proxyConfiguration(proxy -> proxy.useEnvironmentVariableValues(false)))
                     .build();
```
 
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits
- tested by creating a jar and running on terminal which had environment variables set.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
