### PR TITLE
Remove derived attribute logic for PRESIGNER_EXPIRATION

### DIFF
--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
@@ -60,7 +60,6 @@ class AwsSignerExecutionAttributeTest {
     public void setup() {
         this.attributes = new ExecutionAttributes();
         this.testClock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
-        AwsSignerExecutionAttribute.presignerExpirationClock(testClock);
     }
 
     @Test

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.SHA256;
 
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Collections;
@@ -158,14 +157,6 @@ class AwsSignerExecutionAttributeTest {
         assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.SIGNING_CLOCK,
                                              HttpSigner.SIGNING_CLOCK,
                                              Mockito.mock(Clock.class));
-    }
-
-    @Test
-    public void signingExpiration_oldAndNewAttributeAreMirrored() {
-        assertOldAndNewAttributesAreMirrored(AwsSignerExecutionAttribute.PRESIGNER_EXPIRATION,
-                                             AwsV4FamilyHttpSigner.EXPIRATION_DURATION,
-                                             testClock.instant().plusSeconds(10),
-                                             Duration.ofSeconds(10));
     }
 
     @Test

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import org.assertj.core.data.Offset;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +33,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
 import software.amazon.awssdk.auth.signer.internal.AbstractAwsS3V4Signer;
 import software.amazon.awssdk.auth.signer.internal.SignerConstant;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
@@ -214,22 +212,14 @@ public class S3PresignerTest {
 
     @Test
     public void getObject_Sigv4PresignerHonorsSignatureDuration() {
-        AwsRequestOverrideConfiguration override =
-            AwsRequestOverrideConfiguration.builder()
-                                           // TODO(sra-identity-auth): This test shouldn't need signer configured.
-                                           .signer(AwsS3V4Signer.create())
-                                           .build();
-
         PresignedGetObjectRequest presigned =
             presigner.presignGetObject(r -> r.signatureDuration(Duration.ofSeconds(1234))
                                              .getObjectRequest(gor -> gor.bucket("a")
-                                                                         .key("b")
-                                                                         .overrideConfiguration(override)));
+                                                                         .key("b")));
 
         assertThat(presigned.httpRequest().rawQueryParameters().get("X-Amz-Expires").get(0)).satisfies(expires -> {
             assertThat(expires).containsOnlyDigits();
-            // TODO(sra-identity-auth): This should be isEqualTo(1234)?
-            assertThat(Integer.parseInt(expires)).isCloseTo(1234, Offset.offset(2));
+            assertThat(Integer.parseInt(expires)).isEqualTo(1234);
         });
     }
 
@@ -326,22 +316,14 @@ public class S3PresignerTest {
 
     @Test
     public void putObject_Sigv4PresignerHonorsSignatureDuration() {
-        AwsRequestOverrideConfiguration override =
-            AwsRequestOverrideConfiguration.builder()
-                                           // TODO(sra-identity-auth): This test shouldn't need signer configured.
-                                           .signer(AwsS3V4Signer.create())
-                                           .build();
-
         PresignedPutObjectRequest presigned =
             presigner.presignPutObject(r -> r.signatureDuration(Duration.ofSeconds(1234))
                                              .putObjectRequest(gor -> gor.bucket("a")
-                                                                         .key("b")
-                                                                         .overrideConfiguration(override)));
+                                                                         .key("b")));
 
         assertThat(presigned.httpRequest().rawQueryParameters().get("X-Amz-Expires").get(0)).satisfies(expires -> {
             assertThat(expires).containsOnlyDigits();
-            // TODO(sra-identity-auth): This should be isEqualTo(1234)?
-            assertThat(Integer.parseInt(expires)).isCloseTo(1234, Offset.offset(2));
+            assertThat(Integer.parseInt(expires)).isEqualTo(1234);
         });
     }
 
@@ -438,22 +420,14 @@ public class S3PresignerTest {
 
     @Test
     public void deleteObject_Sigv4PresignerHonorsSignatureDuration() {
-        AwsRequestOverrideConfiguration override =
-            AwsRequestOverrideConfiguration.builder()
-                                           // TODO(sra-identity-auth): This test shouldn't need signer configured.
-                                           .signer(AwsS3V4Signer.create())
-                                           .build();
-
         PresignedDeleteObjectRequest presigned =
             presigner.presignDeleteObject(r -> r.signatureDuration(Duration.ofSeconds(1234))
                                                 .deleteObjectRequest(delo -> delo.bucket("a")
-                                                                               .key("b")
-                                                                               .overrideConfiguration(override)));
+                                                                                 .key("b")));
 
         assertThat(presigned.httpRequest().rawQueryParameters().get("X-Amz-Expires").get(0)).satisfies(expires -> {
             assertThat(expires).containsOnlyDigits();
-            // TODO(sra-identity-auth): This should be isEqualTo(1234)?
-            assertThat(Integer.parseInt(expires)).isCloseTo(1234, Offset.offset(2));
+            assertThat(Integer.parseInt(expires)).isEqualTo(1234);
         });
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Because of the 2 instant() calls in the write/read mappings, a basic write this attribute and read it back, would give different values.

Since this attribute should only be set/read explicitly by our presigner code, we don't need this mapping logic at all.

## Modifications
<!--- Describe your changes in detail -->
*Remove derived attribute logic for PRESIGNER_EXPIRATION
*Also, update S3PresignerTest to assert isEqualTo instead of isCloseTo and remove unnecessary override

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
