### PR TITLE
Add a default method to override credentialsProvider

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-bd91b46.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-bd91b46.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "sugmanue", 
+    "type": "bugfix", 
+    "description": "The Scala compiler gets confused when overriding a method with a more specific return type in the interface. To work around this we added a default implementation that fixes this issue with local testing."
+}

--- a/.changes/next-release/bugfix-AmazonPolly-2ee8af5.json
+++ b/.changes/next-release/bugfix-AmazonPolly-2ee8af5.json
@@ -1,5 +1,5 @@
 {
-    "category": "Amazon S3", 
+    "category": "Amazon Polly", 
     "contributor": "sugmanue", 
     "type": "bugfix", 
     "description": "The Scala compiler gets confused when overriding a method with a more specific return type in the interface. To work around this we added a default implementation that fixes this issue with local testing."

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
@@ -163,7 +163,9 @@ public interface PollyPresigner extends SdkPresigner {
         Builder region(Region region);
 
         @Override
-        Builder credentialsProvider(AwsCredentialsProvider credentialsProvider);
+        default Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            return credentialsProvider((IdentityProvider<? extends AwsCredentialsIdentity>) credentialsProvider);
+        }
 
         @Override
         Builder credentialsProvider(IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -586,7 +586,9 @@ public interface S3Presigner extends SdkPresigner {
         Builder region(Region region);
 
         @Override
-        Builder credentialsProvider(AwsCredentialsProvider credentialsProvider);
+        default Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            return credentialsProvider((IdentityProvider<? extends AwsCredentialsIdentity>) credentialsProvider);
+        }
 
         @Override
         Builder credentialsProvider(IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

A bug reported by a customer #4604 noticed that the Scala compiler is getting confused about an overridden method with a more specific type. In order to work around that this change defines a default method instead which makes the Scala compiler happy.

Fixes #4604.

## Modifications

Added a default method for the `SdkPresigner.Builder` class.

## Testing

Tested manually using an internal Scala based project.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
