### PR TITLE
Cleanup some SRA identity auth TODOs

### DIFF
--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
@@ -51,7 +51,8 @@ import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlClient;
 /**
  * Verify that the "authtype" C2J trait for request type is honored for each requests.
  */
-// TODO(sra-identity-auth): Verify these tests pass for useSraAuht=true
+// TODO(sra-identity-auth): These tests need the updates from https://github.com/aws/aws-sdk-java-v2/pull/4548/files (to the mock
+//  setup and verify) when switching to useSraAuth=true.
 public class NoneAuthTypeRequestTest {
 
     private AwsCredentialsProvider credentialsProvider;

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/eventstreams/EventMarshallingTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/eventstreams/EventMarshallingTest.java
@@ -76,9 +76,6 @@ public class EventMarshallingTest {
         eventDecoder = new MessageDecoder();
     }
 
-    // Still failing for useSraAuth=true
-    // TODO(sra-identity-and-auth): This test no longer works, it's unclear as of why not but seems related to the changes in
-    // the signing stage.
     @Test
     public void testMarshalling_setsCorrectEventType() {
         List<InputEventStream> inputEvents = Stream.of(

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
@@ -92,9 +92,6 @@ public class AsyncOperationCancelTest {
         assertThat(executeFuture.isCancelled()).isTrue();
     }
 
-    // Still failing for useSraAuth=true
-    // TODO(sra-identity-and-auth): This test is now failing after changes made to the event-stream signer module. We need to
-    //  investigate and figure out the fix.
     @Test
     public void testEventStreamingOperation() throws InterruptedException {
         CompletableFuture<Void> responseFuture =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Cleanup some SRA identity auth TODOs.
* EventMarshallingTest passes with useSraAuth=true
* AsyncOperationCancelTest passes with useSraAuth=true
*  NoneAuthTypeRequestTest - the test needs some updates to the assertion in the test for useSraAuth=true. These have been made in https://github.com/aws/aws-sdk-java-v2/pull/4548/files#diff-4eea6ae550c8f98cf083d8cb756b42da8c010b31d3b3dfc2352f111acd4740f6 in the sra-identity-auth-testing branch, so updating this TODO - we will need to make those changes in master when we default useSraAuth=true in `master` branch.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
