### PR TITLE
Add integ test with old Signer override for sigv4a

### DIFF
--- a/services/acm/pom.xml
+++ b/services/acm/pom.xml
@@ -61,5 +61,11 @@
             <artifactId>http-auth-aws</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth-crt</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/acm/src/it/java/software/amazon/awssdk/services/acm/AwsCertficateManagerIntegrationTest.java
+++ b/services/acm/src/it/java/software/amazon/awssdk/services/acm/AwsCertficateManagerIntegrationTest.java
@@ -19,6 +19,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.authcrt.signer.AwsCrtV4aSigner;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.acm.model.AcmException;
 import software.amazon.awssdk.services.acm.model.GetCertificateRequest;
 import software.amazon.awssdk.services.acm.model.ListCertificatesRequest;
@@ -36,6 +38,17 @@ public class AwsCertficateManagerIntegrationTest extends AwsIntegrationTestBase 
 
     @Test
     public void list_certificates() {
+        ListCertificatesResponse result = client.listCertificates(ListCertificatesRequest.builder().build());
+        Assert.assertTrue(result.certificateSummaryList().size() >= 0);
+    }
+
+    @Test
+    public void list_certificates_using_oldSigv4aSigner() {
+        AcmClient client = AcmClient.builder()
+                                    .credentialsProvider(StaticCredentialsProvider.create(getCredentials()))
+                                    .overrideConfiguration(c -> c.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
+                                                                                    AwsCrtV4aSigner.create()))
+                                    .build();
         ListCertificatesResponse result = client.listCertificates(ListCertificatesRequest.builder().build());
         Assert.assertTrue(result.certificateSummaryList().size() >= 0);
     }

--- a/services/acm/src/it/resources/log4j2.properties
+++ b/services/acm/src/it/resources/log4j2.properties
@@ -1,0 +1,38 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+status = warn
+
+appender.console.type = Console
+appender.console.name = ConsoleAppender
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n%throwable
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = ConsoleAppender
+
+# Uncomment below to enable more specific logging
+#
+#logger.sdk.name = software.amazon.awssdk
+#logger.sdk.level = debug
+#
+#logger.request.name = software.amazon.awssdk.request
+#logger.request.level = debug
+#
+#logger.apache.name = org.apache.http.wire
+#logger.apache.level = debug
+#
+#logger.netty.name = io.netty.handler.logging
+#logger.netty.level = debug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Adding an integration test to make sure overriding client to use Sigv4a signer works and continues to work with useSraAuth=true.

## Modifications
<!--- Describe your changes in detail -->
Add integ test

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran integ test locally, with both useSraAuth=false/true

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
