### PR TITLE
Use a backing attribute for ResolvedChecksumSpecs

### DIFF
--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
@@ -188,8 +188,7 @@ class AwsSignerExecutionAttributeTest {
 
     @Test
     public void checksum_PropertyWriteReflectedInAttribute() {
-        // We need to set up the attribute first, so that ChecksumSpecs information is not lost
-        ChecksumSpecs valueToWrite = ChecksumSpecs.builder()
+        ChecksumSpecs initialValue = ChecksumSpecs.builder()
                                                   .isRequestChecksumRequired(true)
                                                   .headerName("x-amz-checksum-sha256")
                                                   .isRequestStreaming(true)
@@ -198,12 +197,35 @@ class AwsSignerExecutionAttributeTest {
                                                       Collections.singletonList(Algorithm.CRC32))
                                                   .algorithm(Algorithm.SHA256)
                                                   .build();
-        attributes.putAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS, valueToWrite);
+        attributes.putAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS, initialValue);
 
-        assertNewPropertyWrite_canBeReadFromNewAttributeCases(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS,
-                                                              AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM,
-                                                              valueToWrite,
-                                                              SHA256);
+        assertNewPropertyWrite_canBeReadFromNewAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS,
+                                                         AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM, initialValue, SHA256);
+    }
+
+    @Test
+    public void checksum_NullPropertyWriteReflectedInAttribute() {
+        ChecksumSpecs initialValue = ChecksumSpecs.builder()
+                                                  .isRequestChecksumRequired(true)
+                                                  .headerName("x-amz-checksum-sha256")
+                                                  .isRequestStreaming(true)
+                                                  .isValidationEnabled(true)
+                                                  .responseValidationAlgorithms(
+                                                      Collections.singletonList(Algorithm.CRC32))
+                                                  .algorithm(Algorithm.SHA256)
+                                                  .build();
+        attributes.putAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS, initialValue);
+
+        ChecksumSpecs expectedValue = ChecksumSpecs.builder()
+                                                   .isRequestChecksumRequired(true)
+                                                   .isRequestStreaming(true)
+                                                   .isValidationEnabled(true)
+                                                   .responseValidationAlgorithms(
+                                                       Collections.singletonList(Algorithm.CRC32))
+                                                   .build();
+
+        assertNewPropertyWrite_canBeReadFromNewAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS,
+                                                         AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM, expectedValue, null);
     }
 
     @Test
@@ -231,10 +253,9 @@ class AwsSignerExecutionAttributeTest {
                                                   .algorithm(Algorithm.CRC32)
                                                   .build();
 
-        assertNewPropertyWrite_canBeReadFromNewAttributeCases(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS,
-                                                              AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM,
-                                                              expectedValue,
-                                                              CRC32);
+        assertNewPropertyWrite_canBeReadFromNewAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS,
+                                                         AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM, expectedValue, CRC32);
+
     }
 
     private void assertOldAndNewBooleanAttributesAreMirrored(ExecutionAttribute<Boolean> attribute,

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/checksum/AwsSignerWithChecksumTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/checksum/AwsSignerWithChecksumTest.java
@@ -34,8 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AwsSignerWithChecksumTest {
 
-    final ChecksumSpecs SHA_256_HEADER = getCheckSum(Algorithm.SHA256, false, "header-sha256");
-    final ChecksumSpecs SHA_256_TRAILER = getCheckSum(Algorithm.SHA256, true, "trailer-sha256");
+    final String headerName = "x-amz-checksum-sha256";
+    final ChecksumSpecs SHA_256_HEADER = getCheckSum(Algorithm.SHA256, false, headerName);
     private final Aws4Signer signer = Aws4Signer.create();
     private final AwsBasicCredentials credentials = AwsBasicCredentials.create("access", "secret");
 
@@ -44,7 +44,7 @@ public class AwsSignerWithChecksumTest {
         SdkHttpFullRequest.Builder request = generateBasicRequest("abc");
         ExecutionAttributes executionAttributes = getExecutionAttributes(SHA_256_HEADER);
         SdkHttpFullRequest signed = signer.sign(request.build(), executionAttributes);
-        final Optional<String> checksumHeader = signed.firstMatchingHeader("header-sha256");
+        final Optional<String> checksumHeader = signed.firstMatchingHeader(headerName);
         assertThat(checksumHeader).hasValue("ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=");
     }
 
@@ -53,8 +53,7 @@ public class AwsSignerWithChecksumTest {
         SdkHttpFullRequest.Builder request = generateBasicRequest("abc");
         ExecutionAttributes executionAttributes = getExecutionAttributes(null);
         SdkHttpFullRequest signed = signer.sign(request.build(), executionAttributes);
-        assertThat(signed.firstMatchingHeader("header-sha256")).isNotPresent();
-        assertThat(signed.firstMatchingHeader("trailer-sha256")).isNotPresent();
+        assertThat(signed.firstMatchingHeader(headerName)).isNotPresent();
     }
 
     @Test
@@ -62,8 +61,7 @@ public class AwsSignerWithChecksumTest {
         SdkHttpFullRequest.Builder request = generateBasicRequest("abc");
         ExecutionAttributes executionAttributes = getExecutionAttributes(null);
         SdkHttpFullRequest signed = signer.sign(request.build(), executionAttributes);
-        assertThat(signed.firstMatchingHeader("header-sha256")).isNotPresent();
-        assertThat(signed.firstMatchingHeader("trailer-sha25")).isNotPresent();
+        assertThat(signed.firstMatchingHeader(headerName)).isNotPresent();
     }
 
     private ExecutionAttributes getExecutionAttributes(ChecksumSpecs checksumSpecs) {

--- a/core/sdk-core/pom.xml
+++ b/core/sdk-core/pom.xml
@@ -58,6 +58,21 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>checksums-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>checksums</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>identity-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/core/sdk-core/pom.xml
+++ b/core/sdk-core/pom.xml
@@ -56,6 +56,7 @@
             <artifactId>http-auth-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <!-- TODO: remove http-auth-aws once we deprecated RESOLVED_CHECKSUM_SPECS -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>http-auth-aws</artifactId>

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
@@ -304,7 +304,7 @@ public final class ExecutionAttribute<T> {
         @SuppressWarnings("unchecked") // Safe because of the implementation of set
         @Override
         public void set(Map<ExecutionAttribute<?>, Object> attributes, T value) {
-            attributes.compute(backingAttributeSupplier.get(), (k, attr) -> value);
+            attributes.put(backingAttributeSupplier.get(), value);
             attributes.compute(attributeSupplier.get(), (k, attr) -> writeMapping.apply((U) attr, value));
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
@@ -102,9 +102,9 @@ public final class ExecutionAttribute<T> {
      * @param backingAttributeSupplier The supplier for the backing attribute, which this attribute is backed by
      * @param attributeSupplier The supplier for the attribute which is mapped from the backing attribute
      */
-    protected static <T, U> MappedAttributeBuilder<T, U> mappedBuilder(String name,
-                                                                       Supplier<ExecutionAttribute<T>> backingAttributeSupplier,
-                                                                       Supplier<ExecutionAttribute<U>> attributeSupplier) {
+    static <T, U> MappedAttributeBuilder<T, U> mappedBuilder(String name,
+                                                             Supplier<ExecutionAttribute<T>> backingAttributeSupplier,
+                                                             Supplier<ExecutionAttribute<U>> attributeSupplier) {
         return new MappedAttributeBuilder<>(name, backingAttributeSupplier, attributeSupplier);
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -114,22 +114,13 @@ public class SdkExecutionAttribute {
 
     public static final ExecutionAttribute<String> PROFILE_NAME = new ExecutionAttribute<>("ProfileName");
 
-
-    /**
-     * The backing attribute for RESOLVED_CHECKSUM_SPECS.
-     * This holds the real ChecksumSpecs value, and is used to map to the ChecksumAlgorithm signer property
-     * in the SELECTED_AUTH_SCHEME execution attribute.
-     */
-    private static final ExecutionAttribute<ChecksumSpecs> INTERNAL_RESOLVED_CHECKSUM_SPECS =
-        new ExecutionAttribute<>("InternalResolvedChecksumSpecs");
-
     /**
      * The checksum algorithm is resolved based on the Request member.
      * The RESOLVED_CHECKSUM_SPECS holds the final checksum which will be used for checksum computation.
      */
     public static final ExecutionAttribute<ChecksumSpecs> RESOLVED_CHECKSUM_SPECS =
         ExecutionAttribute.mappedBuilder("ResolvedChecksumSpecs",
-                                         () -> INTERNAL_RESOLVED_CHECKSUM_SPECS,
+                                         () -> SdkExecutionAttribute.INTERNAL_RESOLVED_CHECKSUM_SPECS,
                                          () -> SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
                           .readMapping(SdkExecutionAttribute::signerChecksumReadMapping)
                           .writeMapping(SdkExecutionAttribute::signerChecksumWriteMapping)
@@ -146,6 +137,14 @@ public class SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<ChecksumValidation> HTTP_RESPONSE_CHECKSUM_VALIDATION = new ExecutionAttribute<>(
         "HttpResponseChecksumValidation");
+
+    /**
+     * The backing attribute for RESOLVED_CHECKSUM_SPECS.
+     * This holds the real ChecksumSpecs value, and is used to map to the ChecksumAlgorithm signer property
+     * in the SELECTED_AUTH_SCHEME execution attribute.
+     */
+    private static final ExecutionAttribute<ChecksumSpecs> INTERNAL_RESOLVED_CHECKSUM_SPECS =
+        new ExecutionAttribute<>("InternalResolvedChecksumSpecs");
 
     private static final ImmutableMap<Algorithm, ChecksumAlgorithm> CHECKSUM_ALGORITHM_MAP = ImmutableMap.of(
         Algorithm.SHA256, SHA256,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -169,7 +169,7 @@ public class SdkExecutionAttribute {
      */
     private static <T extends Identity> ChecksumSpecs signerChecksumReadMapping(ChecksumSpecs checksumSpecs,
                                                                                 SelectedAuthScheme<T> authScheme) {
-        if (checksumSpecs == null || authScheme == null || authScheme.signer() instanceof UnsetHttpSigner) {
+        if (checksumSpecs == null || authScheme == null) {
             return checksumSpecs;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -169,7 +169,7 @@ public class SdkExecutionAttribute {
      */
     private static <T extends Identity> ChecksumSpecs signerChecksumReadMapping(ChecksumSpecs checksumSpecs,
                                                                                 SelectedAuthScheme<T> authScheme) {
-        if (authScheme == null) {
+        if (authScheme == null || authScheme.signer() instanceof UnsetHttpSigner) {
             return checksumSpecs;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -176,18 +176,12 @@ public class SdkExecutionAttribute {
         ChecksumAlgorithm checksumAlgorithm =
             authScheme.authSchemeOption().signerProperty(AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM);
 
-        if (checksumAlgorithm == null) {
-            return null;
-        }
-
-        String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
-
         return ChecksumSpecs.builder()
-                            .algorithm(ALGORITHM_MAP.get(checksumAlgorithm))
+                            .algorithm(checksumAlgorithm != null ? ALGORITHM_MAP.get(checksumAlgorithm) : null)
                             .isRequestStreaming(checksumSpecs != null && checksumSpecs.isRequestStreaming())
                             .isRequestChecksumRequired(checksumSpecs != null && checksumSpecs.isRequestChecksumRequired())
                             .isValidationEnabled(checksumSpecs != null && checksumSpecs.isValidationEnabled())
-                            .headerName(checksumHeaderName)
+                            .headerName(checksumAlgorithm != null ? checksumHeaderName(checksumAlgorithm) : null)
                             .responseValidationAlgorithms(checksumSpecs != null ? checksumSpecs.responseValidationAlgorithms()
                                                                                 : null)
                             .build();

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -121,7 +121,7 @@ public class SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<ChecksumSpecs> RESOLVED_CHECKSUM_SPECS =
         ExecutionAttribute.mappedBuilder("ResolvedChecksumSpecs",
-                                         () -> SdkExecutionAttribute.INTERNAL_RESOLVED_CHECKSUM_SPECS,
+                                         () -> SdkInternalExecutionAttribute.INTERNAL_RESOLVED_CHECKSUM_SPECS,
                                          () -> SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
                           .readMapping(SdkExecutionAttribute::signerChecksumReadMapping)
                           .writeMapping(SdkExecutionAttribute::signerChecksumWriteMapping)
@@ -138,14 +138,6 @@ public class SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<ChecksumValidation> HTTP_RESPONSE_CHECKSUM_VALIDATION = new ExecutionAttribute<>(
         "HttpResponseChecksumValidation");
-
-    /**
-     * The backing attribute for RESOLVED_CHECKSUM_SPECS.
-     * This holds the real ChecksumSpecs value, and is used to map to the ChecksumAlgorithm signer property
-     * in the SELECTED_AUTH_SCHEME execution attribute.
-     */
-    private static final ExecutionAttribute<ChecksumSpecs> INTERNAL_RESOLVED_CHECKSUM_SPECS =
-        new ExecutionAttribute<>("InternalResolvedChecksumSpecs");
 
     private static final ImmutableMap<ChecksumAlgorithm, Algorithm> ALGORITHM_MAP = ImmutableMap.of(
         SHA256, Algorithm.SHA256,
@@ -191,9 +183,8 @@ public class SdkExecutionAttribute {
      */
     private static <T extends Identity> SelectedAuthScheme<?> signerChecksumWriteMapping(SelectedAuthScheme<T> authScheme,
                                                                                          ChecksumSpecs checksumSpecs) {
-        ChecksumAlgorithm checksumAlgorithm =
-            checksumSpecs == null ? null
-                                  : CHECKSUM_ALGORITHM_MAP.getOrDefault(checksumSpecs.algorithm(), null);
+        ChecksumAlgorithm checksumAlgorithm = checksumSpecs == null ? null :
+                                              CHECKSUM_ALGORITHM_MAP.get(checksumSpecs.algorithm());
 
         if (authScheme == null) {
             // This is an unusual use-case.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -169,7 +169,7 @@ public class SdkExecutionAttribute {
      */
     private static <T extends Identity> ChecksumSpecs signerChecksumReadMapping(ChecksumSpecs checksumSpecs,
                                                                                 SelectedAuthScheme<T> authScheme) {
-        if (authScheme == null || authScheme.signer() instanceof UnsetHttpSigner) {
+        if (checksumSpecs == null || authScheme == null || authScheme.signer() instanceof UnsetHttpSigner) {
             return checksumSpecs;
         }
 
@@ -178,12 +178,11 @@ public class SdkExecutionAttribute {
 
         return ChecksumSpecs.builder()
                             .algorithm(checksumAlgorithm != null ? ALGORITHM_MAP.get(checksumAlgorithm) : null)
-                            .isRequestStreaming(checksumSpecs != null && checksumSpecs.isRequestStreaming())
-                            .isRequestChecksumRequired(checksumSpecs != null && checksumSpecs.isRequestChecksumRequired())
-                            .isValidationEnabled(checksumSpecs != null && checksumSpecs.isValidationEnabled())
+                            .isRequestStreaming(checksumSpecs.isRequestStreaming())
+                            .isRequestChecksumRequired(checksumSpecs.isRequestChecksumRequired())
+                            .isValidationEnabled(checksumSpecs.isValidationEnabled())
                             .headerName(checksumAlgorithm != null ? checksumHeaderName(checksumAlgorithm) : null)
-                            .responseValidationAlgorithms(checksumSpecs != null ? checksumSpecs.responseValidationAlgorithms()
-                                                                                : null)
+                            .responseValidationAlgorithms(checksumSpecs.responseValidationAlgorithms())
                             .build();
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -170,7 +170,7 @@ public class SdkExecutionAttribute {
     private static <T extends Identity> ChecksumSpecs signerChecksumReadMapping(ChecksumSpecs checksumSpecs,
                                                                                 SelectedAuthScheme<T> authScheme) {
         if (authScheme == null) {
-            return null;
+            return checksumSpecs;
         }
 
         ChecksumAlgorithm checksumAlgorithm =

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -19,6 +19,7 @@ import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.CRC32;
 import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.CRC32C;
 import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.SHA1;
 import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.SHA256;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.checksumHeaderName;
 
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
@@ -179,12 +180,14 @@ public class SdkExecutionAttribute {
             return null;
         }
 
+        String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
+
         return ChecksumSpecs.builder()
                             .algorithm(ALGORITHM_MAP.get(checksumAlgorithm))
                             .isRequestStreaming(checksumSpecs != null && checksumSpecs.isRequestStreaming())
                             .isRequestChecksumRequired(checksumSpecs != null && checksumSpecs.isRequestChecksumRequired())
                             .isValidationEnabled(checksumSpecs != null && checksumSpecs.isValidationEnabled())
-                            .headerName(checksumSpecs != null ? checksumSpecs.headerName() : null)
+                            .headerName(checksumHeaderName)
                             .responseValidationAlgorithms(checksumSpecs != null ? checksumSpecs.responseValidationAlgorithms()
                                                                                 : null)
                             .build();

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkProtocolMetadata;
 import software.amazon.awssdk.core.SelectedAuthScheme;
+import software.amazon.awssdk.core.checksums.ChecksumSpecs;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
 import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
@@ -132,6 +133,14 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<SdkProtocolMetadata> PROTOCOL_METADATA =
         new ExecutionAttribute<>("ProtocolMetadata");
+
+    /**
+     * The backing attribute for RESOLVED_CHECKSUM_SPECS.
+     * This holds the real ChecksumSpecs value, and is used to map to the ChecksumAlgorithm signer property
+     * in the SELECTED_AUTH_SCHEME execution attribute.
+     */
+    static final ExecutionAttribute<ChecksumSpecs> INTERNAL_RESOLVED_CHECKSUM_SPECS =
+        new ExecutionAttribute<>("InternalResolvedChecksumSpecs");
 
     private SdkInternalExecutionAttribute() {
     }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HttpChecksumStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HttpChecksumStageTest.java
@@ -44,7 +44,7 @@ import utils.ValidSdkObjects;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpChecksumStageTest {
-    private static final String CHECKSUM_SPECS_HEADER = "ChecksumHeader";
+    private static final String CHECKSUM_SPECS_HEADER = "x-amz-checksum-sha256";
     private static final RequestBody REQUEST_BODY = RequestBody.fromString("TestBody");
     private static final AsyncRequestBody ASYNC_REQUEST_BODY = AsyncRequestBody.fromString("TestBody");
     private final HttpChecksumStage syncStage = new HttpChecksumStage(ClientType.SYNC);
@@ -112,7 +112,7 @@ public class HttpChecksumStageTest {
         assertThat(requestBuilder.headers().get("Content-encoding")).containsExactly("aws-chunked");
         assertThat(requestBuilder.headers().get("x-amz-content-sha256")).containsExactly("STREAMING-UNSIGNED-PAYLOAD-TRAILER");
         assertThat(requestBuilder.headers().get("x-amz-decoded-content-length")).containsExactly("8");
-        assertThat(requestBuilder.headers().get(CONTENT_LENGTH)).containsExactly("79");
+        assertThat(requestBuilder.headers().get(CONTENT_LENGTH)).containsExactly("86");
 
         assertThat(requestBuilder.firstMatchingHeader(CONTENT_MD5)).isEmpty();
         assertThat(requestBuilder.firstMatchingHeader(CHECKSUM_SPECS_HEADER)).isEmpty();
@@ -130,7 +130,7 @@ public class HttpChecksumStageTest {
         assertThat(requestBuilder.headers().get("Content-encoding")).containsExactly("aws-chunked");
         assertThat(requestBuilder.headers().get("x-amz-content-sha256")).containsExactly("STREAMING-UNSIGNED-PAYLOAD-TRAILER");
         assertThat(requestBuilder.headers().get("x-amz-decoded-content-length")).containsExactly("8");
-        assertThat(requestBuilder.headers().get(CONTENT_LENGTH)).containsExactly("79");
+        assertThat(requestBuilder.headers().get(CONTENT_LENGTH)).containsExactly("86");
 
         assertThat(requestBuilder.firstMatchingHeader(CONTENT_MD5)).isEmpty();
         assertThat(requestBuilder.firstMatchingHeader(CHECKSUM_SPECS_HEADER)).isEmpty();

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,8 @@
                             <exclude>software.amazon.awssdk.auth.token.credentials.SdkToken</exclude>
                             <!-- exclude ObjectPart size change TODO: re-enable -->
                             <exclude>software.amazon.awssdk.services.s3.model.ObjectPart</exclude>
+                            <!-- exclude mappedBuilder change, TODO: remove after merged -->
+                            <exclude>software.amazon.awssdk.core.interceptor.ExecutionAttribute</exclude>
                         </excludes>
 
                         <ignoreMissingOldVersion>true</ignoreMissingOldVersion>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Modifications
- Update `RESOLVED_CHECKSUM_SPECS` execution-attribute to be backed by an internal execution attribute, so that it doesn't need to rely on lossless conversion
- Remove bugged code that relies on `AtomicReference`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
