### PR TITLE
Revert RESOLVED_CHECKSUM_SPECS mapping for SRA

### DIFF
--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/AwsSignerExecutionAttributeTest.java
@@ -17,24 +17,19 @@ package software.amazon.awssdk.auth.signer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.SHA256;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.core.SelectedAuthScheme;
-import software.amazon.awssdk.core.checksums.Algorithm;
-import software.amazon.awssdk.core.checksums.ChecksumSpecs;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
@@ -167,42 +162,6 @@ class AwsSignerExecutionAttributeTest {
                                              AwsV4FamilyHttpSigner.EXPIRATION_DURATION,
                                              testClock.instant().plusSeconds(10),
                                              Duration.ofSeconds(10));
-    }
-
-    @Test
-    public void checksum_AttributeWriteReflectedInProperty() {
-        assertOldAttributeWrite_canBeReadFromNewAttributeCases(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS,
-                                                               AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM,
-                                                               ChecksumSpecs.builder()
-                                                                            .isRequestChecksumRequired(true)
-                                                                            .headerName("beepboop")
-                                                                            .isRequestStreaming(true)
-                                                                            .isValidationEnabled(true)
-                                                                            .responseValidationAlgorithms(
-                                                                                Collections.singletonList(Algorithm.CRC32))
-                                                                            .algorithm(Algorithm.SHA256)
-                                                                            .build(),
-                                                               SHA256);
-    }
-
-    @Test
-    public void checksum_PropertyWriteReflectedInAttribute() {
-        // We need to set up the attribute first, so that ChecksumSpecs information is not lost
-        ChecksumSpecs valueToWrite = ChecksumSpecs.builder()
-                                                  .isRequestChecksumRequired(true)
-                                                  .headerName("beepboop")
-                                                  .isRequestStreaming(true)
-                                                  .isValidationEnabled(true)
-                                                  .responseValidationAlgorithms(
-                                                      Collections.singletonList(Algorithm.CRC32))
-                                                  .algorithm(Algorithm.SHA256)
-                                                  .build();
-        attributes.putAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS, valueToWrite);
-
-        assertNewPropertyWrite_canBeReadFromNewAttributeCases(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS,
-                                                              AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM,
-                                                              valueToWrite,
-                                                              SHA256);
     }
 
     private void assertOldAndNewBooleanAttributesAreMirrored(ExecutionAttribute<Boolean> attribute,

--- a/core/sdk-core/pom.xml
+++ b/core/sdk-core/pom.xml
@@ -58,21 +58,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>http-auth-aws</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>checksums-spi</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>checksums</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>identity-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -15,35 +15,17 @@
 
 package software.amazon.awssdk.core.interceptor;
 
-import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.CRC32;
-import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.CRC32C;
-import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.SHA1;
-import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.SHA256;
-
 import java.net.URI;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.core.ClientType;
-import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.core.checksums.Algorithm;
 import software.amazon.awssdk.core.checksums.ChecksumSpecs;
 import software.amazon.awssdk.core.checksums.ChecksumValidation;
 import software.amazon.awssdk.core.signer.Signer;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
-import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
-import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
-import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
-import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
-import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
-import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
-import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.profiles.ProfileFile;
-import software.amazon.awssdk.utils.CompletableFutureUtils;
-import software.amazon.awssdk.utils.ImmutableMap;
 
 /**
  * Contains attributes attached to the execution. This information is available to {@link ExecutionInterceptor}s and
@@ -119,12 +101,7 @@ public class SdkExecutionAttribute {
      * The RESOLVED_CHECKSUM_SPECS holds the final checksum which will be used for checksum computation.
      */
     public static final ExecutionAttribute<ChecksumSpecs> RESOLVED_CHECKSUM_SPECS =
-        ExecutionAttribute.mappedBuilder("ResolvedChecksumSpecs",
-                                         ChecksumSpecs.class,
-                                         () -> SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME)
-                          .readMapping(SdkExecutionAttribute::signerChecksumReadMapping)
-                          .writeMapping(SdkExecutionAttribute::signerChecksumWriteMapping)
-                          .build();
+        new ExecutionAttribute("ResolvedChecksumSpecs");
 
     /**
      * The Algorithm used for checksum validation of a response.
@@ -138,86 +115,6 @@ public class SdkExecutionAttribute {
     public static final ExecutionAttribute<ChecksumValidation> HTTP_RESPONSE_CHECKSUM_VALIDATION = new ExecutionAttribute<>(
         "HttpResponseChecksumValidation");
 
-    private static final ImmutableMap<Algorithm, ChecksumAlgorithm> CHECKSUM_ALGORITHM_MAP = ImmutableMap.of(
-        Algorithm.SHA256, SHA256,
-        Algorithm.SHA1, SHA1,
-        Algorithm.CRC32, CRC32,
-        Algorithm.CRC32C, CRC32C
-    );
-
-    private static final ImmutableMap<ChecksumAlgorithm, Algorithm> ALGORITHM_MAP = ImmutableMap.of(
-        SHA256, Algorithm.SHA256,
-        SHA1, Algorithm.SHA1,
-        CRC32, Algorithm.CRC32,
-        CRC32C, Algorithm.CRC32C
-    );
-
     protected SdkExecutionAttribute() {
-    }
-
-    private static <T extends Identity> ChecksumSpecs signerChecksumReadMapping(ChecksumSpecs checksumSpecs,
-                                                                                SelectedAuthScheme<T> authScheme) {
-        if (authScheme == null) {
-            return null;
-        }
-
-        ChecksumAlgorithm checksumAlgorithm =
-            authScheme.authSchemeOption().signerProperty(AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM);
-
-        if (checksumAlgorithm == null) {
-            return null;
-        }
-
-
-        return ChecksumSpecs.builder()
-                            .algorithm(ALGORITHM_MAP.getOrDefault(checksumAlgorithm, null))
-                            .isRequestStreaming(checksumSpecs != null && checksumSpecs.isRequestStreaming())
-                            .isRequestChecksumRequired(checksumSpecs != null && checksumSpecs.isRequestChecksumRequired())
-                            .isValidationEnabled(checksumSpecs != null && checksumSpecs.isValidationEnabled())
-                            .headerName(checksumSpecs != null ? checksumSpecs.headerName() : null)
-                            .responseValidationAlgorithms(checksumSpecs != null ? checksumSpecs.responseValidationAlgorithms()
-                                                                                : null)
-                            .build();
-    }
-
-    private static <T extends Identity> SelectedAuthScheme<?> signerChecksumWriteMapping(SelectedAuthScheme<T> authScheme,
-                                                                                         ChecksumSpecs checksumSpecs) {
-        ChecksumAlgorithm checksumAlgorithm =
-            checksumSpecs == null ? null
-                                  : CHECKSUM_ALGORITHM_MAP.getOrDefault(checksumSpecs.algorithm(), null);
-
-        if (authScheme == null) {
-            // This is an unusual use-case.
-            // Let's assume they're setting the checksum-algorithm so that they can call the signer directly. If that's true,
-            // then it doesn't really matter what we store other than the checksum-algorithm.
-            return new SelectedAuthScheme<>(CompletableFuture.completedFuture(new UnsetIdentity()),
-                                            new UnsetHttpSigner(),
-                                            AuthSchemeOption.builder()
-                                                            .schemeId("unset")
-                                                            .putSignerProperty(AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM,
-                                                                               checksumAlgorithm)
-                                                            .build());
-        }
-
-        return new SelectedAuthScheme<>(authScheme.identity(),
-                                        authScheme.signer(),
-                                        authScheme.authSchemeOption()
-                                                  .copy(o -> o.putSignerProperty(AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM,
-                                                                                 checksumAlgorithm)));
-    }
-
-    private static class UnsetIdentity implements Identity {
-    }
-
-    private static class UnsetHttpSigner implements HttpSigner<UnsetIdentity> {
-        @Override
-        public SignedRequest sign(SignRequest<? extends UnsetIdentity> request) {
-            throw new IllegalStateException("A signer was not configured.");
-        }
-
-        @Override
-        public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest<? extends UnsetIdentity> request) {
-            return CompletableFutureUtils.failedFuture(new IllegalStateException("A signer was not configured."));
-        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -101,7 +101,7 @@ public class SdkExecutionAttribute {
      * The RESOLVED_CHECKSUM_SPECS holds the final checksum which will be used for checksum computation.
      */
     public static final ExecutionAttribute<ChecksumSpecs> RESOLVED_CHECKSUM_SPECS =
-        new ExecutionAttribute("ResolvedChecksumSpecs");
+        new ExecutionAttribute<>("ResolvedChecksumSpecs");
 
     /**
      * The Algorithm used for checksum validation of a response.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix for https://github.com/aws/aws-sdk-java-v2/issues/4608.

## Modifications
<!--- Describe your changes in detail -->
This is reverting the read/write mapping logic for checksum related execution attribute (RESOLVED_CHECKSUM_SPECS) that was introduced in https://github.com/aws/aws-sdk-java-v2/pull/4452/files#diff-933c20d96318c11c8224fcd3904f17bad1614606bd1d934e17bb719d99b183be to support SRA SignerProperty for the same. With this revert, flexible checksums (used only by SRA) will to not work with useSraAuth=true, but this is a minimal fix to resolve the issue, and we can make a different fix with SRA support later.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran regular tests in CI, as well as integration/stability tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
