### PR TITLE
Log selected credentials provider at INFO level

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7acbaf0.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7acbaf0.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "singhbaljit",
+    "description": "Logs the selected credentials provider at the INFO level so its easy to which credentials the default credentials provider ended up using."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
@@ -108,7 +108,7 @@ public final class AwsCredentialsProviderChain
             try {
                 AwsCredentialsIdentity credentials = CompletableFutureUtils.joinLikeSync(provider.resolveIdentity());
 
-                log.debug(() -> "Loading credentials from " + provider);
+                log.info(() -> "Loading credentials from " + provider);
 
                 lastUsedProvider = provider;
                 return CredentialUtils.toCredentials(credentials);


### PR DESCRIPTION
Logs the selected credentials provider at the INFO level so its easy to which credentials the default credentials provider ended up using.

## Motivation and Context
See #4583 

## Modifications
Logs the credential provider at the INFO level, instead of the DEBUG level.

## Testing
N/A, change in logging level

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
