### PR TITLE
Add AsyncRequestBody#fromInputStream(AsyncRequestBodyFromInputStreamC…

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-db840ec.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-db840ec.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Introduce `AsyncRequestBody#fromInputStream(AsyncRequestBodyFromInputStreamConfiguration)` that allows users to specify the max read limit on the provided InputStream."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
@@ -358,7 +358,27 @@ public interface AsyncRequestBody extends SdkPublisher<ByteBuffer> {
      * non-blocking event loop threads owned by the SDK.
      */
     static AsyncRequestBody fromInputStream(InputStream inputStream, Long contentLength, ExecutorService executor) {
-        return new InputStreamWithExecutorAsyncRequestBody(inputStream, contentLength, executor);
+        return fromInputStream(b -> b.inputStream(inputStream).contentLength(contentLength).executor(executor));
+    }
+
+    /**
+     * Creates an {@link AsyncRequestBody} from an {@link InputStream} with the provided
+     * {@link AsyncRequestBodySplitConfiguration}.
+     */
+    static AsyncRequestBody fromInputStream(AsyncRequestBodyFromInputStreamConfiguration configuration) {
+        Validate.notNull(configuration, "configuration");
+        return new InputStreamWithExecutorAsyncRequestBody(configuration);
+    }
+
+    /**
+     * This is a convenience method that passes an instance of the {@link AsyncRequestBodyFromInputStreamConfiguration} builder,
+     * avoiding the need to create one manually via {@link AsyncRequestBodyFromInputStreamConfiguration#builder()}.
+     *
+     * @see #fromInputStream(AsyncRequestBodyFromInputStreamConfiguration)
+     */
+    static AsyncRequestBody fromInputStream(Consumer<AsyncRequestBodyFromInputStreamConfiguration.Builder> configuration) {
+        Validate.notNull(configuration, "configuration");
+        return fromInputStream(AsyncRequestBodyFromInputStreamConfiguration.builder().applyMutation(configuration).build());
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBodyFromInputStreamConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBodyFromInputStreamConfiguration.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * Configuration options for {@link AsyncRequestBody#fromInputStream(AsyncRequestBodyFromInputStreamConfiguration)}
+ * to configure how the SDK should create an {@link AsyncRequestBody} from an {@link InputStream}.
+ */
+@SdkPublicApi
+public final class AsyncRequestBodyFromInputStreamConfiguration
+    implements ToCopyableBuilder<AsyncRequestBodyFromInputStreamConfiguration.Builder,
+    AsyncRequestBodyFromInputStreamConfiguration> {
+    private final InputStream inputStream;
+    private final Long contentLength;
+    private final ExecutorService executor;
+    private final Integer maxReadLimit;
+
+    private AsyncRequestBodyFromInputStreamConfiguration(DefaultBuilder builder) {
+        this.inputStream = Validate.paramNotNull(builder.inputStream, "inputStream");
+        this.contentLength = Validate.isNotNegativeOrNull(builder.contentLength, "contentLength");
+        this.maxReadLimit = Validate.isPositiveOrNull(builder.maxReadLimit, "maxReadLimit");
+        this.executor = Validate.paramNotNull(builder.executor, "executor");
+    }
+
+    /**
+     * @return the provided {@link InputStream}.
+     */
+    public InputStream inputStream() {
+        return inputStream;
+    }
+
+    /**
+     * @return the provided content length.
+     */
+    public Long contentLength() {
+        return contentLength;
+    }
+
+    /**
+     * @return the provided {@link ExecutorService}.
+     */
+    public ExecutorService executor() {
+        return executor;
+    }
+
+    /**
+     * @return the provided max read limit used to mark and reset the {@link InputStream}).
+     */
+    public Integer maxReadLimit() {
+        return maxReadLimit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AsyncRequestBodyFromInputStreamConfiguration that = (AsyncRequestBodyFromInputStreamConfiguration) o;
+
+        if (!Objects.equals(inputStream, that.inputStream)) {
+            return false;
+        }
+        if (!Objects.equals(contentLength, that.contentLength)) {
+            return false;
+        }
+        if (!Objects.equals(executor, that.executor)) {
+            return false;
+        }
+        return Objects.equals(maxReadLimit, that.maxReadLimit);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = inputStream != null ? inputStream.hashCode() : 0;
+        result = 31 * result + (contentLength != null ? contentLength.hashCode() : 0);
+        result = 31 * result + (executor != null ? executor.hashCode() : 0);
+        result = 31 * result + (maxReadLimit != null ? maxReadLimit.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * Create a {@link Builder}, used to create a {@link AsyncRequestBodyFromInputStreamConfiguration}.
+     */
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+
+    @Override
+    public AsyncRequestBodyFromInputStreamConfiguration.Builder toBuilder() {
+        return new DefaultBuilder(this);
+    }
+
+    public interface Builder extends CopyableBuilder<AsyncRequestBodyFromInputStreamConfiguration.Builder,
+        AsyncRequestBodyFromInputStreamConfiguration>  {
+
+        /**
+         * Configures the InputStream.
+         *
+         * @param inputStream the InputStream
+         * @return This object for method chaining.
+         */
+        Builder inputStream(InputStream inputStream);
+
+        /**
+         * Configures the length of the provided {@link InputStream}
+         * @param contentLength the content length
+         * @return This object for method chaining.
+         */
+        Builder contentLength(Long contentLength);
+
+        /**
+         * Configures the {@link ExecutorService} to perform the blocking data reads.
+         *
+         * @param executor the executor
+         * @return This object for method chaining.
+         */
+        Builder executor(ExecutorService executor);
+
+        /**
+         * Configures max read limit used to mark and reset the {@link InputStream}. This will have no
+         * effect if the stream doesn't support mark and reset.
+         *
+         * <p>
+         * By default, it is 128 KiB.
+         *
+         * @param maxReadLimit the max read limit
+         * @return This object for method chaining.
+         * @see InputStream#mark(int)
+         */
+        Builder maxReadLimit(Integer maxReadLimit);
+    }
+
+    private static final class DefaultBuilder implements Builder {
+        private InputStream inputStream;
+        private Long contentLength;
+        private ExecutorService executor;
+        private Integer maxReadLimit;
+
+        private DefaultBuilder(AsyncRequestBodyFromInputStreamConfiguration asyncRequestBodyFromInputStreamConfiguration) {
+            this.inputStream = asyncRequestBodyFromInputStreamConfiguration.inputStream;
+            this.contentLength = asyncRequestBodyFromInputStreamConfiguration.contentLength;
+            this.executor = asyncRequestBodyFromInputStreamConfiguration.executor;
+            this.maxReadLimit = asyncRequestBodyFromInputStreamConfiguration.maxReadLimit;
+        }
+
+        private DefaultBuilder() {
+
+        }
+
+        public Builder inputStream(InputStream inputStream) {
+            this.inputStream = inputStream;
+            return this;
+        }
+
+        public Builder contentLength(Long contentLength) {
+            this.contentLength = contentLength;
+            return this;
+        }
+
+        public Builder executor(ExecutorService executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        public Builder maxReadLimit(Integer maxReadLimit) {
+            this.maxReadLimit = maxReadLimit;
+            return this;
+        }
+
+        @Override
+        public AsyncRequestBodyFromInputStreamConfiguration build() {
+            return new AsyncRequestBodyFromInputStreamConfiguration(this);
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBody.java
@@ -29,6 +29,7 @@ import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBodyFromInputStreamConfiguration;
 import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
 import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.internal.util.NoopSubscription;
@@ -52,13 +53,11 @@ public class InputStreamWithExecutorAsyncRequestBody implements AsyncRequestBody
 
     private Future<?> writeFuture;
 
-    public InputStreamWithExecutorAsyncRequestBody(InputStream inputStream,
-                                                   Long contentLength,
-                                                   ExecutorService executor) {
-        this.inputStream = inputStream;
-        this.contentLength = contentLength;
-        this.executor = executor;
-        IoUtils.markStreamWithMaxReadLimit(inputStream);
+    public InputStreamWithExecutorAsyncRequestBody(AsyncRequestBodyFromInputStreamConfiguration configuration) {
+        this.inputStream = configuration.inputStream();
+        this.contentLength = configuration.contentLength();
+        this.executor = configuration.executor();
+        IoUtils.markStreamWithMaxReadLimit(inputStream, configuration.maxReadLimit());
     }
 
     @Override

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyFromInputStreamConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyFromInputStreamConfigurationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.io.InputStream;
+import java.util.concurrent.ExecutorService;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class AsyncRequestBodyFromInputStreamConfigurationTest {
+
+    @Test
+    void equalsHashcode() {
+        EqualsVerifier.forClass(AsyncRequestBodyFromInputStreamConfiguration.class)
+                      .verify();
+    }
+
+    @Test
+    void toBuilder_shouldCopyProperties() {
+        InputStream inputStream = mock(InputStream.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        AsyncRequestBodyFromInputStreamConfiguration configuration = AsyncRequestBodyFromInputStreamConfiguration.builder()
+                                                                                                                 .inputStream(inputStream)
+                                                                                                                 .contentLength(10L)
+                                                                                                                 .executor(executorService)
+                                                                                                                 .maxReadLimit(10)
+                                                                                                                 .build();
+        assertThat(configuration.toBuilder().build()).isEqualTo(configuration);
+
+    }
+
+    @Test
+    void inputStreamIsNull_shouldThrowException() {
+        assertThatThrownBy(() ->
+                               AsyncRequestBodyFromInputStreamConfiguration.builder()
+                                                                           .executor(mock(ExecutorService.class))
+                                                                           .build())
+            .isInstanceOf(NullPointerException.class).hasMessageContaining("inputStream");
+    }
+
+
+    @Test
+    void executorIsNull_shouldThrowException() {
+        assertThatThrownBy(() ->
+                               AsyncRequestBodyFromInputStreamConfiguration.builder()
+                                                                           .inputStream(mock(InputStream.class))
+                                                                           .build())
+            .isInstanceOf(NullPointerException.class).hasMessageContaining("executor");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void readLimitNotPositive_shouldThrowException(int value) {
+        assertThatThrownBy(() ->
+                               AsyncRequestBodyFromInputStreamConfiguration.builder()
+                                                                           .inputStream(mock(InputStream.class))
+                                                                           .executor(mock(ExecutorService.class))
+                                                                           .maxReadLimit(value)
+                                                                           .build())
+            .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("maxReadLimit");
+    }
+
+    @Test
+    void contentLengthNegative_shouldThrowException() {
+        assertThatThrownBy(() ->
+                               AsyncRequestBodyFromInputStreamConfiguration.builder()
+                                                                           .inputStream(mock(InputStream.class))
+                                                                           .executor(mock(ExecutorService.class))
+                                                                           .contentLength(-1L)
+                                                                           .build())
+            .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("contentLength");
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBodyTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber;
 import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult;
 
@@ -39,7 +40,7 @@ class InputStreamWithExecutorAsyncRequestBodyTest {
             PipedInputStream is = new PipedInputStream(os);
 
             InputStreamWithExecutorAsyncRequestBody asyncRequestBody =
-                new InputStreamWithExecutorAsyncRequestBody(is, 4L, executor);
+                (InputStreamWithExecutorAsyncRequestBody) AsyncRequestBody.fromInputStream(b -> b.inputStream(is).executor(executor).contentLength(4L));
 
             ByteBufferStoringSubscriber subscriber = new ByteBufferStoringSubscriber(8);
             asyncRequestBody.subscribe(subscriber);
@@ -75,8 +76,10 @@ class InputStreamWithExecutorAsyncRequestBodyTest {
             PipedInputStream is = new PipedInputStream(os);
 
             is.close();
+
             InputStreamWithExecutorAsyncRequestBody asyncRequestBody =
-                new InputStreamWithExecutorAsyncRequestBody(is, 4L, executor);
+                (InputStreamWithExecutorAsyncRequestBody) AsyncRequestBody.fromInputStream(b -> b.inputStream(is).executor(executor).contentLength(4L));
+
 
             ByteBufferStoringSubscriber subscriber = new ByteBufferStoringSubscriber(8);
             asyncRequestBody.subscribe(subscriber);

--- a/test/codegen-generated-classes-test/pom.xml
+++ b/test/codegen-generated-classes-test/pom.xml
@@ -163,6 +163,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <scope>test</scope>

--- a/utils/src/main/java/software/amazon/awssdk/utils/IoUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/IoUtils.java
@@ -145,4 +145,19 @@ public final class IoUtils {
             s.mark(1 << 17);
         }
     }
+
+    /**
+     * If the stream supports marking, marks the stream at the current position with a read limit specified in {@code
+     * maxReadLimit}.
+     *
+     * @param maxReadLimit the maxReadLimit, if it's null, 128 KiB will be used.
+     * @param s The stream.
+     */
+    public static void markStreamWithMaxReadLimit(InputStream s, Integer maxReadLimit) {
+        Validate.isPositiveOrNull(maxReadLimit, "maxReadLimit");
+        if (s.markSupported()) {
+            int maxLimit = maxReadLimit == null ? 1 << 17 : maxReadLimit;
+            s.mark(maxLimit);
+        }
+    }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/IoUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/IoUtilsTest.java
@@ -15,8 +15,11 @@
 
 package software.amazon.awssdk.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -66,8 +69,28 @@ public class IoUtilsTest {
         assertEquals(-1, inputStream.read());
     }
 
+    @Test
+    public void applyMaxReadLimit_shouldHonor() throws IOException {
+        int length = 1 << 18;
+        InputStream inputStream = randomInputStream(length);
+        InputStream bufferedInputStream = new BufferedInputStream(inputStream);
+
+        IoUtils.markStreamWithMaxReadLimit(bufferedInputStream, length + 1);
+        IoUtils.drainInputStream(bufferedInputStream);
+        assertThat(bufferedInputStream.available()).isEqualTo(0);
+        bufferedInputStream.reset();
+
+        assertThat(bufferedInputStream.available()).isEqualTo(length);
+    }
+
     private InputStream randomInputStream() {
         byte[] data = new byte[100];
+        random.nextBytes(data);
+        return new ByteArrayInputStream(data);
+    }
+
+    private InputStream randomInputStream(int length) {
+        byte[] data = new byte[length];
         random.nextBytes(data);
         return new ByteArrayInputStream(data);
     }


### PR DESCRIPTION
…onfiguration) to allow users to specify the max read limit on the InputStream

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Transient network error is not uncommon when customers upload objects of a larger size to S3 and those failed requests would normally succeed upon retry. However, if users use `AsyncRequestBodyFromInputStream` as the `AsyncRequestBody` and the stream is larger than the default mark value, the SDK may not be able to retry the request in the event of network issue. This is because the default read limit of the provided inputStream used for mark and reset is 128KB.

```
java.io.IOException: Resetting to invalid mark

	at java.base/java.io.BufferedInputStream.reset(BufferedInputStream.java:454)
```

Related to https://github.com/aws/aws-sdk-java/issues/427 

### Notes:

- This option is exposed in v1 via [RequestClientOptions#setReadLimit](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/RequestClientOptions.html#setReadLimit-int-). I did not include this in the ReqeustOverrideConfiguration because this only applies to `InputStream` only.

- This is technically possible to do in `RequestBody`, (`RequestBody#fromContentProvider`), that's why I didn't make the change in RequestBody

## Modifications
Add `AsyncRequestBody#fromInputStream(AsyncRequestBodyFromInputStreamConfiguration)` that allow users to configure max read limit.

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
