### PR TITLE
Fix flakey MediaStoreData integ tests

### DIFF
--- a/services/mediastoredata/pom.xml
+++ b/services/mediastoredata/pom.xml
@@ -79,5 +79,11 @@
             <artifactId>http-auth-aws</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>2.21.15-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/mediastoredata/pom.xml
+++ b/services/mediastoredata/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
-            <version>2.21.15-SNAPSHOT</version>
+            <version>${awsjavasdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/RequestCompressionStreamingIntegrationTest.java
+++ b/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/RequestCompressionStreamingIntegrationTest.java
@@ -63,7 +63,7 @@ public class RequestCompressionStreamingIntegrationTest extends MediaStoreDataIn
 
     @BeforeAll
     public static void setup() {
-        uri = URI.create(createContainer(CONTAINER_NAME).endpoint());
+        uri = URI.create(createContainerIfNotExistAndGetEndpoint(CONTAINER_NAME));
 
         CompressionConfiguration compressionConfiguration =
             CompressionConfiguration.builder()

--- a/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/RequestCompressionStreamingIntegrationTest.java
+++ b/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/RequestCompressionStreamingIntegrationTest.java
@@ -18,10 +18,7 @@ package software.amazon.awssdk.services.mediastoredata;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.Instant;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -43,15 +40,12 @@ import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.services.mediastoredata.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.mediastoredata.model.GetObjectRequest;
 import software.amazon.awssdk.services.mediastoredata.model.GetObjectResponse;
-import software.amazon.awssdk.services.mediastoredata.model.ObjectNotFoundException;
 import software.amazon.awssdk.services.mediastoredata.model.PutObjectRequest;
-import software.amazon.awssdk.testutils.Waiter;
 
 /**
  * Integration test to verify Request Compression functionalities for streaming operations. Do not delete.
  */
 public class RequestCompressionStreamingIntegrationTest extends MediaStoreDataIntegrationTestBase {
-    protected static final String CONTAINER_NAME = "java-sdk-test-mediastoredata-compression" + Instant.now().toEpochMilli();
     private static final String UNCOMPRESSED_BODY =
         "RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest-RequestCompressionTest";
     private static String compressedBody;
@@ -63,8 +57,6 @@ public class RequestCompressionStreamingIntegrationTest extends MediaStoreDataIn
 
     @BeforeAll
     public static void setup() {
-        uri = URI.create(createContainerIfNotExistAndGetEndpoint(CONTAINER_NAME));
-
         CompressionConfiguration compressionConfiguration =
             CompressionConfiguration.builder()
                                     .minimumCompressionThresholdInBytes(1)
@@ -114,13 +106,8 @@ public class RequestCompressionStreamingIntegrationTest extends MediaStoreDataIn
     }
 
     @AfterAll
-    public static void tearDown() throws InterruptedException {
+    public static void tearDown() {
         syncClient.deleteObject(deleteObjectRequest);
-        Waiter.run(() -> syncClient.describeObject(r -> r.path("/foo")))
-              .untilException(ObjectNotFoundException.class)
-              .orFailAfter(Duration.ofMinutes(1));
-        Thread.sleep(1000);
-        mediaStoreClient.deleteContainer(r -> r.containerName(CONTAINER_NAME));
     }
 
     @AfterEach

--- a/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/TransferEncodingChunkedIntegrationTest.java
+++ b/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/TransferEncodingChunkedIntegrationTest.java
@@ -29,9 +29,6 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
-import software.amazon.awssdk.identity.spi.IdentityProvider;
-import software.amazon.awssdk.services.mediastore.model.Container;
 import software.amazon.awssdk.services.mediastoredata.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.mediastoredata.model.ObjectNotFoundException;
 import software.amazon.awssdk.services.mediastoredata.model.PutObjectRequest;
@@ -45,14 +42,12 @@ public class TransferEncodingChunkedIntegrationTest extends MediaStoreDataIntegr
     private static MediaStoreDataClient syncClientWithApache;
     private static MediaStoreDataClient syncClientWithUrlConnection;
     private static MediaStoreDataAsyncClient asyncClientWithNetty;
-    private static IdentityProvider<AwsCredentialsIdentity> credentialsProvider;
-    private static Container container;
     private static PutObjectRequest putObjectRequest;
     private static DeleteObjectRequest deleteObjectRequest;
 
     @BeforeAll
     public static void setup() {
-        uri = URI.create(createContainer(CONTAINER_NAME).endpoint());
+        uri = URI.create(createContainerIfNotExistAndGetEndpoint(CONTAINER_NAME));
         syncClientWithApache = MediaStoreDataClient.builder()
                                                    .endpointOverride(uri)
                                                    .credentialsProvider(credentialsProvider)

--- a/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/TransferEncodingChunkedIntegrationTest.java
+++ b/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/TransferEncodingChunkedIntegrationTest.java
@@ -17,10 +17,7 @@ package software.amazon.awssdk.services.mediastoredata;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.Instant;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,15 +27,12 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.mediastoredata.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.mediastoredata.model.ObjectNotFoundException;
 import software.amazon.awssdk.services.mediastoredata.model.PutObjectRequest;
-import software.amazon.awssdk.testutils.Waiter;
 
 /**
  * Integration test to verify Transfer-Encoding:chunked functionalities for all supported HTTP clients. Do not delete.
  */
 public class TransferEncodingChunkedIntegrationTest extends MediaStoreDataIntegrationTestBase {
-    protected static final String CONTAINER_NAME = "java-sdk-test-mediastoredata-transferencoding" + Instant.now().toEpochMilli();
     private static MediaStoreDataClient syncClientWithApache;
     private static MediaStoreDataClient syncClientWithUrlConnection;
     private static MediaStoreDataAsyncClient asyncClientWithNetty;
@@ -47,7 +41,6 @@ public class TransferEncodingChunkedIntegrationTest extends MediaStoreDataIntegr
 
     @BeforeAll
     public static void setup() {
-        uri = URI.create(createContainerIfNotExistAndGetEndpoint(CONTAINER_NAME));
         syncClientWithApache = MediaStoreDataClient.builder()
                                                    .endpointOverride(uri)
                                                    .credentialsProvider(credentialsProvider)
@@ -80,13 +73,8 @@ public class TransferEncodingChunkedIntegrationTest extends MediaStoreDataIntegr
     }
 
     @AfterAll
-    public static void tearDown() throws InterruptedException {
+    public static void tearDown() {
         syncClientWithApache.deleteObject(deleteObjectRequest);
-        Waiter.run(() -> syncClientWithApache.describeObject(r -> r.path("/foo")))
-              .untilException(ObjectNotFoundException.class)
-              .orFailAfter(Duration.ofMinutes(1));
-        Thread.sleep(1000);
-        mediaStoreClient.deleteContainer(r -> r.containerName(CONTAINER_NAME));
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When containers fail to delete and tests retry, `ContainerInUseException` is thrown, leading to integ test failure, causing release to fail

## Modifications
<!--- Describe your changes in detail -->
Keep one container always active per account, only create if it doesn't exist

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests with existing container successfully

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
