### PR TITLE
Add ability to provide STS session duration via enviroment variables.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-e8beb7e.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-e8beb7e.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "bacek",
+    "description": "Add ability to override session duration in STS sessions with WebIdentity"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -51,6 +51,11 @@ public enum SdkSystemSetting implements SystemSetting {
     AWS_WEB_IDENTITY_TOKEN_FILE("aws.webIdentityTokenFile", null),
 
     /**
+     * Configure the AWS session duration seconds.
+     */
+    AWS_SESSION_DURATION_SECONDS("aws.sessionDurationSeconds", null),
+
+    /**
      * Configure the AWS role arn.
      */
     AWS_ROLE_ARN("aws.roleArn", null),


### PR DESCRIPTION



## Motivation and Context
This provides ability to configure session duration when running on EKS with IRSA. At the moment all created sessions are limited to default 1 hour. And this causes problems with things like pre-signed S3 URL, which lifetime is tied to session duration.

## Modifications
Follow standard way of defaulting to environment  variables usage.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [x] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

There are no tests for StsWebIdentityTokenFileCredentialsProvider at all.
And I have some Netty test failures which shouldn't be related to my changes.

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
