### PR TITLE
Add EKS container host in ContainerCredentialsProvider , also validate the resolved endpoint for RelativeURI

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-341feda.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-341feda.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Add the EKS container host to the allowed loopback addresses for ContainerCredentialsProvider. Validate the loopback addresses even for RelativeURI after they have been resolved."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -15,16 +15,23 @@
 
 package software.amazon.awssdk.auth.credentials;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.internal.ContainerCredentialsRetryPolicy;
@@ -68,6 +75,12 @@ public final class ContainerCredentialsProvider
     private static final Predicate<InetAddress> IS_LOOPBACK_ADDRESS = InetAddress::isLoopbackAddress;
     private static final Predicate<InetAddress> ALLOWED_HOSTS_RULES = IS_LOOPBACK_ADDRESS;
     private static final String HTTPS = "https";
+
+    private static final String ECS_CONTAINER_HOST = "169.254.170.2";
+    private static final String EKS_CONTAINER_HOST_IPV6 = "[fd00:ec2::23]";
+    private static final String EKS_CONTAINER_HOST_IPV4 = "169.254.170.23";
+    private static final List<String> VALID_LOOP_BACK_IPV4 = Arrays.asList(ECS_CONTAINER_HOST, EKS_CONTAINER_HOST_IPV4);
+    private static final List<String> VALID_LOOP_BACK_IPV6 = Arrays.asList(EKS_CONTAINER_HOST_IPV6);
 
     private final String endpoint;
     private final HttpCredentialsLoader httpCredentialsLoader;
@@ -177,9 +190,12 @@ public final class ContainerCredentialsProvider
             }
 
             try {
-                return SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI.getStringValue()
-                                                                              .map(this::createUri)
-                                                                              .orElseGet(this::createGenericContainerUrl);
+                URI resolvedURI = SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+                    .getStringValue()
+                    .map(this::createUri)
+                    .orElseGet(() -> URI.create(SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI.getStringValueOrThrow()));
+                validateURI(resolvedURI);
+                return resolvedURI;
             } catch (SdkClientException e) {
                 throw e;
             } catch (Exception e) {
@@ -199,10 +215,37 @@ public final class ContainerCredentialsProvider
         public Map<String, String> headers() {
             Map<String, String> requestHeaders = new HashMap<>();
             requestHeaders.put("User-Agent", SdkUserAgent.create().userAgent());
-            SdkSystemSetting.AWS_CONTAINER_AUTHORIZATION_TOKEN.getStringValue()
+            getTokenValue()
                                                               .filter(StringUtils::isNotBlank)
                                                               .ifPresent(t -> requestHeaders.put("Authorization", t));
             return requestHeaders;
+        }
+
+        private Optional<String> getTokenValue() {
+            if (SdkSystemSetting
+                .AWS_CONTAINER_AUTHORIZATION_TOKEN.getStringValue().isPresent()) {
+                return SdkSystemSetting
+                    .AWS_CONTAINER_AUTHORIZATION_TOKEN
+                    .getStringValue();
+            }
+
+
+            return SdkSystemSetting.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE.getStringValue()
+                                                                          .map(this::readToken);
+
+        }
+
+        private String readToken(String filePath) {
+            Path path = Paths.get(filePath);
+            if (!Files.exists(path)) {
+                throw SdkClientException.create(
+                    String.format("Failed to read authorization token from '%s': no such file or directory", filePath));
+            }
+            try {
+                return new String(Files.readAllBytes(path), UTF_8);
+            } catch (IOException e) {
+                throw SdkClientException.create(String.format("Failed to read %s.", path.toAbsolutePath()), e);
+            }
         }
 
         private URI createUri(String relativeUri) {
@@ -210,8 +253,7 @@ public final class ContainerCredentialsProvider
             return URI.create(host + relativeUri);
         }
 
-        private URI createGenericContainerUrl() {
-            URI uri = URI.create(SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI.getStringValueOrThrow());
+        private URI validateURI(URI uri) {
             if (!isHttps(uri) && !isAllowedHost(uri.getHost())) {
                 String envVarName = SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable();
                 throw SdkClientException.builder()
@@ -240,10 +282,9 @@ public final class ContainerCredentialsProvider
         private boolean isAllowedHost(String host) {
             try {
                 InetAddress[] addresses = InetAddress.getAllByName(host);
-
-                return addresses.length > 0 && Arrays.stream(addresses)
-                                                     .allMatch(this::matchesAllowedHostRules);
-
+                return addresses.length > 0 && (
+                    Arrays.stream(addresses).allMatch(this::matchesAllowedHostRules)
+                       || isMetadataServiceEndpoint(host));
             } catch (UnknownHostException e) {
                 throw SdkClientException.builder()
                                         .cause(e)
@@ -253,7 +294,15 @@ public final class ContainerCredentialsProvider
         }
 
         private boolean matchesAllowedHostRules(InetAddress inetAddress) {
-            return ALLOWED_HOSTS_RULES.test(inetAddress);
+            return ALLOWED_HOSTS_RULES.test(inetAddress) ;
+        }
+
+        public boolean isMetadataServiceEndpoint(String host) {
+            String mode = SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE.getStringValueOrThrow();
+            if ("IPV6".equalsIgnoreCase(mode)) {
+                return VALID_LOOP_BACK_IPV6.contains(host);
+            }
+            return VALID_LOOP_BACK_IPV4.contains(host);
         }
     }
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -237,10 +237,6 @@ public final class ContainerCredentialsProvider
 
         private String readToken(String filePath) {
             Path path = Paths.get(filePath);
-            if (!Files.exists(path)) {
-                throw SdkClientException.create(
-                    String.format("Failed to read authorization token from '%s': no such file or directory", filePath));
-            }
             try {
                 return new String(Files.readAllBytes(path), UTF_8);
             } catch (IOException e) {

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsEndpointProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsEndpointProviderTest.java
@@ -15,114 +15,352 @@
 
 package software.amazon.awssdk.auth.credentials;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_CONTAINER_AUTHORIZATION_TOKEN;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_CONTAINER_SERVICE_ENDPOINT;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.util.SdkUserAgent;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.Pair;
 
 public class ContainerCredentialsEndpointProviderTest {
 
     private static final EnvironmentVariableHelper helper = new EnvironmentVariableHelper();
+    public static final String HTTPS_VALID_URI = "https://awscredentials.amazonaws.com/credentials";
+    public static final String V4_LOOPBACK_URI = "http://127.0.0.2/credentials";
+    public static final String V6_LOOPBACK_URI = "http://[::1]/credentials";
+    public static final String COMPLEX_URI = "http://127.0.0.1:8080/credentials?foo=bar%20baz";
+    public static final String AUTHORIZATION_HEADER_VALUE = "Basic static%20token2";
+
+    private static final String EKS_CONTAINER_HOST_IPV6 = "http://[fd00:ec2::23]";
+    public static final String ECS_CONTAINER_HOST = "http://169.254.170.2";
+    public static final String EKS_CONTAINER_HOST_IPV4 = "http://169.254.170.23";
+    public static final String RELATIVE_URI_ENV = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+    public static final String TOKEN_FILE_ENV = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+    public static final String FULL_URI_ENV = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+
+    public static File testFile  ;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        testFile = File.createTempFile("testFile", UUID.randomUUID().toString());
+        Files.write(testFile.toPath(), AUTHORIZATION_HEADER_VALUE.getBytes(StandardCharsets.UTF_8));
+        testFile.deleteOnExit();
+    }
+
+    private static Stream<Arguments> requestConstruction() {
+
+        return Stream.of(
+            Arguments.of("should reject forbidden host in full URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, "http://192.168.1.1/endpoint")),
+                         "http://192.168.1.1/endpoint",
+                         new Result().type("error").reason("Host should resolve to a loopback address or have the full URI be HTTPS.")),
+
+            Arguments.of("should reject forbidden link-local host in full URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, "http://169.254.170.3/endpoint")),
+                         "http://192.168.1.1/endpoint",
+                         new Result().type("error").reason("Host should resolve to a loopback address or have the full URI be HTTPS.")),
+
+            Arguments.of("should reject invalid token file path",
+                         Arrays.asList(
+                             Pair.of(RELATIVE_URI_ENV, "/endpoint"),
+                             Pair.of(TOKEN_FILE_ENV, "/full/path/to/token/file")
+                         ),
+                         AWS_CONTAINER_SERVICE_ENDPOINT.defaultValue(),
+                         new Result().type("headerError").reason("Failed to read authorization token from '/full/path/to/token/file':"
+                                                           + " no such file or directory")),
+
+            Arguments.of("https URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, HTTPS_VALID_URI)),
+                         HTTPS_VALID_URI,
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(HTTPS_VALID_URI))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
+            Arguments.of("http loopback(v4) URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, V4_LOOPBACK_URI)),
+                         V4_LOOPBACK_URI,
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(V4_LOOPBACK_URI))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
+            Arguments.of("http loopback(v6) URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, V6_LOOPBACK_URI)),
+                         V6_LOOPBACK_URI,
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(V6_LOOPBACK_URI))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
+            Arguments.of("http link-local ECS URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, ECS_CONTAINER_HOST + "/credentials")),
+                         ECS_CONTAINER_HOST + "/credentials",
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(ECS_CONTAINER_HOST + "/credentials"))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
+            Arguments.of("http link-local EKS URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, EKS_CONTAINER_HOST_IPV4 + "/credentials")),
+                         EKS_CONTAINER_HOST_IPV4 + "/credentials",
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(EKS_CONTAINER_HOST_IPV4 + "/credentials"))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
+            Arguments.of("http link-local EKS URI with IPv6",
+                         Arrays.asList(
+                             Pair.of(FULL_URI_ENV, EKS_CONTAINER_HOST_IPV6 + "/credentials"),
+                             Pair.of("AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE", "IPv6")
+
+                         ),
+                         EKS_CONTAINER_HOST_IPV6 + "/credentials",
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(EKS_CONTAINER_HOST_IPV6 + "/credentials"))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
+            Arguments.of("complex full URI",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, COMPLEX_URI)),
+                         COMPLEX_URI,
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(COMPLEX_URI))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
+            Arguments.of("auth token from file",
+                         Arrays.asList(
+                             Pair.of(RELATIVE_URI_ENV, "/credentials-relative"),
+                             Pair.of(TOKEN_FILE_ENV, testFile.toPath().toString())
+                         ),
+                         AWS_CONTAINER_SERVICE_ENDPOINT.defaultValue(),
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(AWS_CONTAINER_SERVICE_ENDPOINT.defaultValue()+"/credentials-relative"))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(addHeaders(Pair.of("Authorization", AUTHORIZATION_HEADER_VALUE)))
+                                               .build())),
+
+            Arguments.of("auth token from env",
+                         Arrays.asList(
+                             Pair.of(RELATIVE_URI_ENV, "/credentials-relative"),
+                             Pair.of("AWS_CONTAINER_AUTHORIZATION_TOKEN", "Basic static%20token2")
+                             ),
+                         AWS_CONTAINER_SERVICE_ENDPOINT.defaultValue(),
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(AWS_CONTAINER_SERVICE_ENDPOINT.defaultValue()+"/credentials-relative"))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(addHeaders(Pair.of("Authorization", "Basic static%20token2")))
+                                               .build()))
+        );
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("requestConstruction")
+    void standardTestCases(String testCase, List<Pair<String, String>> envKeyValues, String hostname, Result expected) throws IOException {
+        assertThat(expected).isNotNull();
+        envKeyValues.forEach(pair -> {
+            helper.set(pair.left(), pair.right());
+        });
+
+        boolean relativeURIPresent = envKeyValues.stream().anyMatch(p -> RELATIVE_URI_ENV.equals(p.left()));
+        ContainerCredentialsProvider.ContainerCredentialsEndpointProvider provider = relativeURIPresent ?
+            new ContainerCredentialsProvider.ContainerCredentialsEndpointProvider(hostname) : sut;
+        if("success".equals(expected.type) ){
+            assertThat(provider.endpoint()).hasToString(expected.sdkRequest.getUri().toString());
+            expected.sdkRequest.firstMatchingHeader("Authorization")
+                               .ifPresent(header -> assertThat(header).isEqualTo(provider.headers().get("Authorization")));
+        }else if ("error".equals(expected.type)){
+            Assertions.assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> provider.endpoint())
+                      .withMessageContaining(expected.reason);
+        }
+        else if ("headerError".equals(expected.type)){
+            Assertions.assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> provider.headers())
+                      .withMessageContaining(expected.reason);
+        }else {
+            throw new IllegalStateException("Unknown expected.type " +expected.type);
+        }
+    }
+
+
     private static final ContainerCredentialsProvider.ContainerCredentialsEndpointProvider sut =
         new ContainerCredentialsProvider.ContainerCredentialsEndpointProvider(null);
 
-    @Before
-    public void clearContainerVariablesIncaseWereRunningTestsOnEC2() {
+    @BeforeEach
+    void clearContainerVariablesIncaseWereRunningTestsOnEC2() {
         helper.remove(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
+        helper.remove(AWS_CONTAINER_AUTHORIZATION_TOKEN);
+        helper.remove(AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE);
     }
 
-    @After
+    @AfterEach
     public void restoreOriginal() {
         helper.reset();
     }
 
     @Test
-    public void takesUriFromOverride() throws IOException {
+    void takesUriFromOverride() throws IOException {
         String hostname = "http://localhost:8080";
         String path = "/endpoint";
         helper.set(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, path);
-        assertThat(new ContainerCredentialsProvider.ContainerCredentialsEndpointProvider(hostname).endpoint().toString(),
-                   equalTo(hostname + path));
+        assertThat(new ContainerCredentialsProvider.ContainerCredentialsEndpointProvider(hostname).endpoint())
+            .hasToString(hostname + path);
     }
 
     @Test
-    public void takesUriFromTheEnvironmentVariable() throws IOException {
+    void takesUriFromTheEnvironmentVariable() throws IOException {
         String fullUri = "http://localhost:8080/endpoint";
         helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
-        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+        assertThat(sut.endpoint()).hasToString(fullUri);
     }
 
     @Test
-    public void theLoopbackAddressIsAlsoAcceptable() throws IOException {
+    void theLoopbackAddressIsAlsoAcceptable() throws IOException {
         String fullUri = "http://127.0.0.1:9851/endpoint";
         helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
 
-        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+        assertThat(sut.endpoint()).hasToString(fullUri);
     }
 
     @Test
-    public void theLoopbackIpv6AddressIsAlsoAcceptable() throws IOException {
+    void theLoopbackIpv6AddressIsAlsoAcceptable() throws IOException {
         String fullUri = "http://[::1]:9851/endpoint";
         helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
 
-        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+        assertThat(sut.endpoint()).hasToString(fullUri);
     }
 
     @Test
-    public void anyHttpsAddressIsAlsoAcceptable() throws IOException {
+    void anyHttpsAddressIsAlsoAcceptable() throws IOException {
         String fullUri = "https://192.168.10.120:9851/endpoint";
         helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
 
-        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+        assertThat(sut.endpoint()).hasToString(fullUri);
     }
 
     @Test
-    public void anyHttpsIpv6AddressIsAlsoAcceptable() throws IOException {
+    void anyHttpsIpv6AddressIsAlsoAcceptable() throws IOException {
         String fullUri = "https://[::FFFF:152.16.24.123]/endpoint";
         helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
 
-        assertThat(sut.endpoint().toString(), equalTo(fullUri));
-    }
-
-    @Test(expected = SdkClientException.class)
-    public void nonLoopbackAddressIsNotAcceptable() throws IOException {
-        String fullUri = "http://192.168.10.120:9851/endpoint";
-        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
-
-        assertThat(sut.endpoint().toString(), equalTo(fullUri));
-    }
-
-    @Test(expected = SdkClientException.class)
-    public void nonLoopbackIpv6AddressIsNotAcceptable() throws IOException {
-        String fullUri = "http://[::FFFF:152.16.24.123]/endpoint";
-        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
-
-        assertThat(sut.endpoint().toString(), equalTo(fullUri));
-    }
-
-    @Test(expected = SdkClientException.class)
-    public void onlyLocalHostAddressesAreValid() throws IOException {
-        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), "http://google.com/endpoint");
-        sut.endpoint();
+        assertThat(sut.endpoint()).hasToString(fullUri);
     }
 
     @Test
-    public void authorizationHeaderIsPresentIfEnvironmentVariableSet() {
+    void nonLoopbackAddressIsNotAcceptable() throws IOException {
+        String fullUri = "http://192.168.10.120:9851/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+
+        Assertions.assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> sut.endpoint());
+    }
+
+    @Test
+    void nonLoopbackIpv6AddressIsNotAcceptable() throws IOException {
+        String fullUri = "http://[::FFFF:152.16.24.123]/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+
+        Assertions.assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> sut.endpoint());
+    }
+
+    @Test
+    void onlyLocalHostAddressesAreValid()  {
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), "http://google.com/endpoint");
+        Assertions.assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> sut.endpoint());
+    }
+
+    @Test
+    void authorizationHeaderIsPresentIfEnvironmentVariableSet() {
         helper.set(AWS_CONTAINER_AUTHORIZATION_TOKEN.environmentVariable(), "hello authorized world!");
         Map<String, String> headers = sut.headers();
-        assertThat(headers.size(), equalTo(2));
-        assertThat(headers, hasEntry("Authorization", "hello authorized world!"));
-        assertThat(headers, hasEntry("User-Agent", SdkUserAgent.create().userAgent()));
+        assertThat(headers).hasSize(2);
+        assertThat(headers).containsEntry("Authorization", "hello authorized world!");
+        assertThat(headers).containsEntry("User-Agent", SdkUserAgent.create().userAgent());
+    }
+
+    @Test
+    void failureWhileReadingTokenFile(){
+
+        File tokenDir = new File(UUID.randomUUID().toString());
+        tokenDir.mkdir();
+        String fullUri = "https://192.168.10.120:9851/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+        helper.set(AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE.environmentVariable(), tokenDir.getAbsolutePath());
+        Assertions.assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> sut.headers())
+                  .withMessage(String.format("Failed to read %s.",tokenDir.getAbsolutePath()));
+        tokenDir.delete();
+    }
+
+    private static Map<String, List<String>> addHeaders(Pair<String, String>... authorization) {
+        return Arrays.stream(authorization)
+                     .collect(Collectors.groupingBy(
+                         Pair::left,
+                         LinkedHashMap::new,
+                         Collectors.mapping(Pair::right, Collectors.toList())
+                     ));
+    }
+
+    static class Result{
+        private String type;
+        SdkHttpFullRequest sdkRequest;
+        String reason;
+
+
+        Result type(String type){
+            this.type = type;
+            return this;
+        }
+        Result sdkRequest(SdkHttpFullRequest sdkRequest){
+            this.sdkRequest = sdkRequest;
+            return this;
+        }
+        Result reason(String reason){
+            this.reason = reason;
+            return this;
+        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -114,6 +114,13 @@ public enum SdkSystemSetting implements SystemSetting {
     AWS_CONTAINER_AUTHORIZATION_TOKEN("aws.containerAuthorizationToken", null),
 
     /**
+     * The absolute file path containing the authorization token in plain text to pass to a container metadata
+     * service, only used when {@link #AWS_CONTAINER_CREDENTIALS_FULL_URI} is specified.
+     * @see #AWS_CONTAINER_CREDENTIALS_FULL_URI
+     */
+    AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE("aws.containerAuthorizationTokenFile", null),
+
+    /**
      * Explicitly identify the default synchronous HTTP implementation the SDK will use. Useful
      * when there are multiple implementations on the classpath or as a performance optimization
      * since implementation discovery requires classpath scanning.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

- Add support for EKS host and auth token file, EKS: IRSAv2 auth
- Also validation is updated to validate the loopBacks even for Relative URI

## Modifications
<!--- Describe your changes in detail -->
- EKS hosts IPV4 and IPV6 added in the allow hosts
- Validation of Endpoint is done as soon as final endpoint is resolved

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added new Test cases from specifications

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
