### PR TITLE
Update signer payload-signing conditional to honor PAYLOAD_SIGNING_ENABLED when payload is null

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -53,6 +53,7 @@ import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Logger;
 
 /**
  * An implementation of a {@link AwsV4aHttpSigner} that uses properties to compose v4a-signers in order to delegate signing of a
@@ -62,6 +63,7 @@ import software.amazon.awssdk.utils.CompletableFutureUtils;
 public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
 
     private static final int DEFAULT_CHUNK_SIZE_IN_BYTES = 128 * 1024;
+    private static final Logger LOG = Logger.loggerFor(DefaultAwsCrtV4aHttpSigner.class);
 
     private static V4aProperties v4aProperties(BaseSignRequest<?, ? extends AwsCredentialsIdentity> request) {
         Clock signingClock = request.requireProperty(SIGNING_CLOCK, Clock.systemUTC());
@@ -174,11 +176,20 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
         boolean isPayloadSigningEnabled = request.requireProperty(PAYLOAD_SIGNING_ENABLED, true);
         boolean isEncrypted = "https".equals(request.request().protocol());
 
-        if (isPayloadSigningEnabled) {
-            return !isAnonymous;
+        if (isAnonymous) {
+            return false;
         }
 
-        return !isAnonymous && !isEncrypted;
+        // presigning requests should always have a null payload, and should always be unsigned-payload
+        if (!isEncrypted && request.payload().isPresent()) {
+            if (!isPayloadSigningEnabled) {
+                LOG.debug(() -> "Payload signing was disabled for an HTTP request with a payload. " +
+                                "Signing will be enabled. Use HTTPS for unsigned payloads.");
+            }
+            return true;
+        }
+
+        return isPayloadSigningEnabled;
     }
 
     private static void configureUnsignedPayload(AwsSigningConfig signingConfig, boolean isChunkEncoding,

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -174,7 +174,11 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
         boolean isPayloadSigningEnabled = request.requireProperty(PAYLOAD_SIGNING_ENABLED, true);
         boolean isEncrypted = "https".equals(request.request().protocol());
 
-        return !isAnonymous && (isPayloadSigningEnabled || !isEncrypted);
+        if (isPayloadSigningEnabled) {
+            return !isAnonymous;
+        }
+
+        return !isAnonymous && !isEncrypted;
     }
 
     private static void configureUnsignedPayload(AwsSigningConfig signingConfig, boolean isChunkEncoding,

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
@@ -44,6 +44,7 @@ import software.amazon.awssdk.http.auth.spi.signer.BaseSignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.utils.Logger;
 
 /**
  * An implementation of a {@link AwsV4HttpSigner} that uses properties to compose v4-signers in order to delegate signing of a
@@ -53,6 +54,7 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
 
     private static final int DEFAULT_CHUNK_SIZE_IN_BYTES = 128 * 1024;
+    private static final Logger LOG = Logger.loggerFor(DefaultAwsV4HttpSigner.class);
 
     @Override
     public SignedRequest sign(SignRequest<? extends AwsCredentialsIdentity> request) {
@@ -313,11 +315,20 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
         boolean isPayloadSigningEnabled = request.requireProperty(PAYLOAD_SIGNING_ENABLED, true);
         boolean isEncrypted = "https".equals(request.request().protocol());
 
-        if (isPayloadSigningEnabled) {
-            return !isAnonymous;
+        if (isAnonymous) {
+            return false;
         }
 
-        return !isAnonymous && !isEncrypted;
+        // presigning requests should always have a null payload, and should always be unsigned-payload
+        if (!isEncrypted && request.payload().isPresent()) {
+            if (!isPayloadSigningEnabled) {
+                LOG.debug(() -> "Payload signing was disabled for an HTTP request with a payload. " +
+                          "Signing will be enabled. Use HTTPS for unsigned payloads.");
+            }
+            return true;
+        }
+
+        return isPayloadSigningEnabled;
     }
 
     private static boolean isEventStreaming(SdkHttpRequest request) {

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
@@ -313,7 +313,11 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
         boolean isPayloadSigningEnabled = request.requireProperty(PAYLOAD_SIGNING_ENABLED, true);
         boolean isEncrypted = "https".equals(request.request().protocol());
 
-        return !isAnonymous && (isPayloadSigningEnabled || !isEncrypted);
+        if (isPayloadSigningEnabled) {
+            return !isAnonymous;
+        }
+
+        return !isAnonymous && !isEncrypted;
     }
 
     private static boolean isEventStreaming(SdkHttpRequest request) {

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -264,6 +264,38 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
+    public void sign_WithPayloadSigningFalseAndHttpAndNoPayload_DelegatesToUnsignedPayloadSigner() {
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest ->
+                httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
+                .payload(null)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue("UNSIGNED-PAYLOAD");
+    }
+
+    @Test
+    public void signAsync_WithPayloadSigningFalseAndHttpAndNoPayload_DelegatesToUnsignedPayloadSigner() {
+        AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest ->
+                httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
+                .payload(null)
+        );
+
+        AsyncSignedRequest signedRequest = signer.signAsync(request).join();
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue("UNSIGNED-PAYLOAD");
+    }
+
+    @Test
     public void sign_WithEventStreamContentTypeWithoutHttpAuthAwsEventStreamModule_throws() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),


### PR DESCRIPTION
## Motivation and Context
- Prior to SRA, certain signers (i.e. `Aws4UnsignedPayloadSigner`) enforce usage of payload-signing when HTTP (not HTTPS) is used
- SRA tries to keep this behavior, but there is no way to force the signer to do unsigned-payload with HTTP (this PR changes this)
- Presigned requests will not have a payload, so `UNSIGNED-PAYLOAD` should always be used in this case.
- Addresses #4697

## Modifications
- Updates the conditionals for checking whether to sign the payload or not
  - If `PAYLOAD_SIGNING_ENABLED` is set to false, we will honor that if the payload is not present (such as in the case of presigned requests), otherwise, we will still sign the payload (for security)

## Testing
- Ran local integration tests for s3, all passed
- Ran unit tests for all signers and s3

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
