### PR TITLE
Adds a client builder option to disable the default MD5 checksum vali…

### DIFF
--- a/.changes/next-release/feature-AmazonSQS-79a6b63.json
+++ b/.changes/next-release/feature-AmazonSQS-79a6b63.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon SQS",
+    "contributor": "",
+    "description": "Adds a client builder option to disable the default MD5 checksum validation for SendMessage, ReceiveMessage and SendMessageBatch"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/EndpointProviderTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/EndpointProviderTasks.java
@@ -128,7 +128,9 @@ public final class EndpointProviderTasks extends BaseGeneratorTasks {
 
     private boolean hasClientContextParams() {
         Map<String, ClientContextParam> clientContextParams = model.getClientContextParams();
-        return clientContextParams != null && !clientContextParams.isEmpty();
+        Map<String, ClientContextParam> customClientContextParams = model.getCustomizationConfig().getCustomClientContextParams();
+        return (clientContextParams != null && !clientContextParams.isEmpty()) ||
+               (customClientContextParams != null && !customClientContextParams.isEmpty());
     }
 
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/ClientContextParamsClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/ClientContextParamsClassSpec.java
@@ -50,9 +50,11 @@ public class ClientContextParamsClassSpec implements ClassSpec {
 
         b.addMethod(ctor());
 
-        model.getClientContextParams().forEach((n, m) -> {
-            b.addField(paramDeclaration(n, m));
-        });
+        if (model.getClientContextParams() != null) {
+            model.getClientContextParams().forEach((n, m) -> {
+                b.addField(paramDeclaration(n, m));
+            });
+        }
 
         if (model.getCustomizationConfig() != null && model.getCustomizationConfig().getCustomClientContextParams() != null) {
             model.getCustomizationConfig().getCustomClientContextParams().forEach((n, m) -> {

--- a/services/sqs/pom.xml
+++ b/services/sqs/pom.xml
@@ -85,5 +85,11 @@
             <artifactId>http-auth-aws</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>service-test-utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/MessageMD5ChecksumInterceptor.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/MessageMD5ChecksumInterceptor.java
@@ -101,8 +101,8 @@ public final class MessageMD5ChecksumInterceptor implements ExecutionInterceptor
 
     private static boolean validateMessageMD5Enabled(ExecutionAttributes executionAttributes) {
         AttributeMap clientContextParams = executionAttributes.getAttribute(SdkInternalExecutionAttribute.CLIENT_CONTEXT_PARAMS);
-        Boolean disableMd5Validation = clientContextParams.get(SqsClientContextParams.DISABLE_DEFAULT_CHECKSUM_VALIDATION);
-        return disableMd5Validation == null || !disableMd5Validation;
+        Boolean enableMd5Validation = clientContextParams.get(SqsClientContextParams.CHECKSUM_VALIDATION_ENABLED);
+        return enableMd5Validation == null || enableMd5Validation;
     }
 
     /**

--- a/services/sqs/src/main/resources/codegen-resources/customization.config
+++ b/services/sqs/src/main/resources/codegen-resources/customization.config
@@ -6,8 +6,8 @@
         "software.amazon.awssdk.services.sqs.internal.MessageMD5ChecksumInterceptor"
     ],
     "customClientContextParams":{
-       "disableDefaultChecksumValidation":{
-         "documentation":"Disable default Message MD5 checksum validation. Normally, checksum validation is recommended. Only turn it off if required, for instance if your cryptographic library does not support MD5.",
+       "checksumValidationEnabled":{
+         "documentation":"Enable message MD5 checksum validation.<p>Checksum validation for messages defaults to true. Only set to false if required, for instance if your cryptographic library does not support MD5.<p>Supported operations are SendMessage, ReceiveMessage and SendMessageBatch.",
          "type":"boolean"
        }
     }

--- a/services/sqs/src/main/resources/codegen-resources/customization.config
+++ b/services/sqs/src/main/resources/codegen-resources/customization.config
@@ -4,5 +4,11 @@
     ],
     "interceptors": [
         "software.amazon.awssdk.services.sqs.internal.MessageMD5ChecksumInterceptor"
-    ]
+    ],
+    "customClientContextParams":{
+       "disableDefaultChecksumValidation":{
+         "documentation":"Disable default Message MD5 checksum validation. Normally, checksum validation is recommended. Only turn it off if required, for instance if your cryptographic library does not support MD5.",
+         "type":"boolean"
+       }
+    }
 }

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptorTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptorTest.java
@@ -26,6 +26,8 @@ import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.services.sqs.endpoints.SqsClientContextParams;
 import software.amazon.awssdk.services.sqs.internal.MessageMD5ChecksumInterceptor;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
@@ -37,6 +39,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.AttributeMap;
 
 /**
  * Verifies the functionality of {@link MessageMD5ChecksumInterceptor}.
@@ -236,11 +239,13 @@ public class MessageMD5ChecksumInterceptorTest {
     }
 
     private void callInterceptor(SdkRequest request, SdkResponse response) {
+        ExecutionAttributes executionAttributes = new ExecutionAttributes();
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_CONTEXT_PARAMS, AttributeMap.builder().build());
         new MessageMD5ChecksumInterceptor().afterExecution(InterceptorContext.builder()
                                                                              .request(request)
                                                                              .response(response)
                                                                              .build(),
-                                                           new ExecutionAttributes());
+                                                           executionAttributes);
     }
 
     private String messageBody() {

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumValidationDisableTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumValidationDisableTest.java
@@ -94,7 +94,7 @@ public class MessageMD5ChecksumValidationDisableTest {
         SqsAsyncClient client = SqsAsyncClient.builder()
                                               .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
                                               .httpClient(asyncHttpClient)
-                                              .disableDefaultChecksumValidation(true)
+                                              .checksumValidationEnabled(false)
                                               .build();
 
         SendMessageResponse sendMessageResponse =
@@ -109,7 +109,7 @@ public class MessageMD5ChecksumValidationDisableTest {
         SqsAsyncClient client = SqsAsyncClient.builder()
                                               .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
                                               .httpClient(asyncHttpClient)
-                                              .disableDefaultChecksumValidation(true)
+                                              .checksumValidationEnabled(false)
                                               .build();
 
         SendMessageResponse sendMessageResponse =
@@ -124,7 +124,7 @@ public class MessageMD5ChecksumValidationDisableTest {
         SqsClient client = SqsClient.builder()
                                     .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
                                     .httpClient(syncHttpClient)
-                                    .disableDefaultChecksumValidation(true)
+                                    .checksumValidationEnabled(false)
                                     .build();
 
         SendMessageResponse sendMessageResponse =

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumValidationDisableTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumValidationDisableTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.sqs.internal.MessageMD5ChecksumInterceptor;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+import software.amazon.awssdk.utils.StringInputStream;
+
+/**
+ * Verifies that the logic in {@link MessageMD5ChecksumInterceptor} can be disabled, which is needed for use cases like
+ * FIPS cryptography libraries that don't have MD5 support. SendMessage is used as the test API, but the flow is the
+ * same for ReceiveMessage and SendMessageBatch.
+ */
+public class MessageMD5ChecksumValidationDisableTest {
+    private static final AwsBasicCredentials CLIENT_CREDENTIALS = AwsBasicCredentials.create("ca", "cs");
+    private static final String MESSAGE_ID = "0f433476-621e-4638-811a-112d2c2e41d7";
+
+    private MockAsyncHttpClient asyncHttpClient;
+    private MockSyncHttpClient syncHttpClient;
+
+    @BeforeEach
+    public void setupClient() {
+        asyncHttpClient = new MockAsyncHttpClient();
+        syncHttpClient = new MockSyncHttpClient();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        asyncHttpClient.reset();
+        syncHttpClient.reset();
+    }
+
+    @Test
+    public void md5ValidationEnabled_default_md5InResponse_Works() {
+        asyncHttpClient.stubResponses(responseWithMd5());
+        SqsAsyncClient client = SqsAsyncClient.builder()
+                                              .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
+                                              .httpClient(asyncHttpClient)
+                                              .build();
+
+        SendMessageResponse sendMessageResponse =
+            client.sendMessage(r -> r.messageBody(messageBody()).messageAttributes(createAttributeValues())).join();
+
+        assertThat(sendMessageResponse.messageId()).isEqualTo(MESSAGE_ID);
+    }
+
+    @Test
+    public void md5ValidationEnabled_default_noMd5InResponse_throwsException() {
+        asyncHttpClient.stubResponses(responseWithoutMd5());
+        SqsAsyncClient client = SqsAsyncClient.builder()
+                                              .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
+                                              .httpClient(asyncHttpClient)
+                                              .build();
+
+        assertThatThrownBy(() -> client.sendMessage(r -> r.messageBody(messageBody())
+                                                          .messageAttributes(createAttributeValues()))
+                                       .join())
+            .hasMessageContaining("MD5 returned by SQS does not match the calculation on the original request");
+    }
+
+    @Test
+    public void md5ValidationDisabled_md5InResponse_Works() {
+        asyncHttpClient.stubResponses(responseWithMd5());
+        SqsAsyncClient client = SqsAsyncClient.builder()
+                                              .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
+                                              .httpClient(asyncHttpClient)
+                                              .disableDefaultChecksumValidation(true)
+                                              .build();
+
+        SendMessageResponse sendMessageResponse =
+            client.sendMessage(r -> r.messageBody(messageBody()).messageAttributes(createAttributeValues())).join();
+
+        assertThat(sendMessageResponse.messageId()).isEqualTo(MESSAGE_ID);
+    }
+
+    @Test
+    public void md5ValidationDisabled_noMd5InResponse_Works() {
+        asyncHttpClient.stubResponses(responseWithoutMd5());
+        SqsAsyncClient client = SqsAsyncClient.builder()
+                                              .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
+                                              .httpClient(asyncHttpClient)
+                                              .disableDefaultChecksumValidation(true)
+                                              .build();
+
+        SendMessageResponse sendMessageResponse =
+            client.sendMessage(r -> r.messageBody(messageBody()).messageAttributes(createAttributeValues())).join();
+
+        assertThat(sendMessageResponse.messageId()).isEqualTo(MESSAGE_ID);
+    }
+
+    @Test
+    public void sync_md5ValidationDisabled_noMd5InResponse_Works() {
+        syncHttpClient.stubResponses(responseWithoutMd5());
+        SqsClient client = SqsClient.builder()
+                                    .credentialsProvider(StaticCredentialsProvider.create(CLIENT_CREDENTIALS))
+                                    .httpClient(syncHttpClient)
+                                    .disableDefaultChecksumValidation(true)
+                                    .build();
+
+        SendMessageResponse sendMessageResponse =
+            client.sendMessage(r -> r.messageBody(messageBody()).messageAttributes(createAttributeValues()));
+
+        assertThat(sendMessageResponse.messageId()).isEqualTo(MESSAGE_ID);
+    }
+
+    private static String messageBody() {
+        return "Body";
+    }
+
+    private static HttpExecuteResponse responseWithMd5() {
+        return HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(200).build()).responseBody(
+                                      AbortableInputStream.create(new StringInputStream(
+                                          "{\"MD5OfMessageAttributes\":\"43eeb333d10515533e317490584ea243\","
+                                          + "\"MD5OfMessageBody\":\"ac101b32dda4448cf13a93fe283dddd8\","
+                                          + "\"MessageId\":\"" + MESSAGE_ID + "\"} ")))
+                                  .build();
+    }
+
+    private static HttpExecuteResponse responseWithoutMd5() {
+        return HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(200).build())
+                                  .responseBody(AbortableInputStream
+                                                    .create(new StringInputStream("{\"MessageId\":\"" + MESSAGE_ID + "\"} ")))
+                                  .build();
+    }
+
+    protected static Map<String, MessageAttributeValue> createAttributeValues() {
+        Map<String, MessageAttributeValue> attrs = new HashMap();
+        attrs.put("attribute-1", MessageAttributeValue.builder().dataType("String").stringValue("tmp").build());
+        return Collections.unmodifiableMap(attrs);
+    }
+}


### PR DESCRIPTION
…dation

## Motivation and Context
The SDK automatically performs validation on the MD5 checksums that SQS returns for SendMessage, ReceiveMessage and SendMessageBatch. If the client application does not support MD5, the validation fails. 

Fixes #4717 

## Modifications
Added a new client parameter to disable checksum validation. There are several ways to add this to the client and I chose a customClientContextParam,  because most plumbing already exists

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Codegen
Results in 
~~~
@Generated("software.amazon.awssdk:codegen")
@SdkPublicApi
public interface SqsBaseClientBuilder<B extends SqsBaseClientBuilder<B, C>, C> extends AwsClientBuilder<B, C> {

    /**
     * Enable message MD5 checksum validation.
     * <p>
     * Checksum validation for messages defaults to true. Only set to false if required, for instance if your
     * cryptographic library does not support MD5.
     * <p>
     * Supported operations are SendMessage, ReceiveMessage and SendMessageBatch.
     */
    B checksumValidationEnabled(Boolean checksumValidationEnabled);
}

~~~

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [x] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
