### PR TITLE
Disable useEnvironmentVariableValues by default because of regression issue #4728

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-34a2686.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-34a2686.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2\"",
+    "contributor": "",
+    "description": "Disabling the useEnvironmentVariableValues by default for all Http clients since it caused regression issues as Issue [#4728](https://github.com/aws/aws-sdk-java-v2/issues/4728)"
+}

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
@@ -20,6 +20,7 @@ import static software.amazon.awssdk.utils.ProxyConfigProvider.fromSystemEnviron
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.ProxyConfigProvider;
+import software.amazon.awssdk.utils.ProxyEnvironmentSetting;
 import software.amazon.awssdk.utils.ProxySystemSetting;
 import software.amazon.awssdk.utils.StringUtils;
 
@@ -240,10 +241,11 @@ public abstract class CrtProxyConfiguration {
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
         /**
-         * The option whether to use environment variable values from {@link ProxySystemSetting} if any of the config options are
-         * missing. The value is set to "true" by default which means SDK will automatically use environment variable values if
-         * options are not provided during building the {@link CrtProxyConfiguration} object. To disable this behavior, set this
-         * value to false.It is important to note that when this property is set to "true," all proxy settings will exclusively
+         * The option whether to use environment variable values from {@link ProxyEnvironmentSetting} if any of the config options
+         * are missing.
+         * The value is set to "false" by default which means SDK will not automatically use environment variable values if
+         * options are not provided during building the {@link CrtProxyConfiguration} object. To enable this behavior, set this
+         * value to true. It is important to note that when this property is set to "true," all proxy settings will exclusively
          * originate from environment variableValues, and no partial settings will be obtained from SystemPropertyValues.
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values
@@ -263,7 +265,7 @@ public abstract class CrtProxyConfiguration {
         private String username;
         private String password;
         private Boolean useSystemPropertyValues = Boolean.TRUE;
-        private Boolean useEnvironmentVariableValues = Boolean.TRUE;
+        private Boolean useEnvironmentVariableValues = Boolean.FALSE;
 
         protected DefaultBuilder() {
         }

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.ProxyConfigProvider;
+import software.amazon.awssdk.utils.ProxyEnvironmentSetting;
 import software.amazon.awssdk.utils.ProxySystemSetting;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
@@ -285,13 +286,12 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
         /**
-         * Option whether to use environment variable values for proxy configuration if any of the config options are missing.
-         * <p>
-         * This value is set to "true" by default, which means the SDK will automatically use environment variable values for
-         * proxy configuration options that are not provided during the building of the {@link ProxyConfiguration} object. To
-         * disable this behavior, set this value to "false". It is important to note that when this property is set to "true," all
-         * proxy settings will exclusively originate from environment variableValues, and no partial settings will be obtained
-         * from SystemPropertyValues.
+         * Option whether to use environment variable values from {@link ProxyEnvironmentSetting} if any of the config options are
+         * missing. This value is set to "false" by default, which means SDK will not automatically use environment variable
+         * values for options that are not provided during building of  {@link ProxyConfiguration} object. To enable this
+         * behavior, set this value to "true".It is important to note that when this property is set to "true," all proxy
+         * settings will exclusively originate from environment variableValues, and no partial settings will be obtained from
+         * SystemPropertyValues.
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values.
          * @return This object for method chaining.
@@ -323,7 +323,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         private Set<String> nonProxyHosts;
         private Boolean preemptiveBasicAuthenticationEnabled;
         private Boolean useSystemPropertyValues = Boolean.TRUE;
-        private Boolean useEnvironmentVariableValues = Boolean.TRUE;
+        private Boolean useEnvironmentVariableValues = Boolean.FALSE;
         private String scheme = "http";
 
         @Override

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
@@ -273,12 +273,12 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
 
         /**
-         * Set the option whether to use environment variable values for {@link ProxyEnvironmentSetting} if any of the config
-         * options are missing. The value is set to "true" by default, enabling the SDK to automatically use environment variable
-         * values for proxy configuration options that are not provided during building the {@link ProxyConfiguration} object. To
-         * disable this behavior, set this value to "false".It is important to note that when this property is set to "true," all
-         * proxy settings will exclusively originate from Environment Variable Values, and no partial settings will be obtained
-         * from System Property Values.
+         * Option whether to use environment variable values from {@link ProxyEnvironmentSetting} if any of the config options are
+         * missing. This value is set to "false" by default, which means SDK will not automatically use environment variable
+         * values for options that are not provided during building of  {@link ProxyConfiguration} object. To enable this
+         * behavior, set this value to "true".It is important to note that when this property is set to "true," all proxy
+         * settings will exclusively originate from environment variableValues, and no partial settings will be obtained from
+         * SystemPropertyValues.
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values
          * @return This object for method chaining.
@@ -295,7 +295,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         private String password;
         private Set<String> nonProxyHosts;
         private Boolean useSystemPropertyValues = Boolean.TRUE;
-        private Boolean useEnvironmentVariablesValues = Boolean.TRUE;
+        private Boolean useEnvironmentVariablesValues = Boolean.FALSE;
 
         private BuilderImpl() {
         }

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
@@ -241,10 +241,11 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
         /**
          * Option whether to use environment variable values from {@link ProxyEnvironmentSetting} if any of the config options are
-         * missing. This value is set to "true" by default, which means SDK will automatically use environment variable values for
-         * options that are not provided during building the {@link ProxyConfiguration} object. To disable this behavior, set this
-         * value to "false".It is important to note that when this property is set to "true," all proxy settings will exclusively
-         * originate from environment variableValues, and no partial settings will be obtained from SystemPropertyValues.
+         * missing. This value is set to "false" by default, which means SDK will not automatically use environment variable
+         * values for options that are not provided during building of  {@link ProxyConfiguration} object. To enable this
+         * behavior, set this value to "true".It is important to note that when this property is set to "true," all proxy
+         * settings will exclusively originate from environment variableValues, and no partial settings will be obtained from
+         * SystemPropertyValues.
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values
          * @return This object for method chaining.
@@ -273,7 +274,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         private String password;
         private Set<String> nonProxyHosts;
         private Boolean useSystemPropertyValues = Boolean.TRUE;
-        private Boolean useEnvironmentVariablesValues = Boolean.TRUE;
+        private Boolean useEnvironmentVariablesValues = Boolean.FALSE;
 
         @Override
         public Builder endpoint(URI endpoint) {

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/proxy/ProxyConfigCommonTestData.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/proxy/ProxyConfigCommonTestData.java
@@ -90,7 +90,7 @@ public final class ProxyConfigCommonTestData {
                 + "when using the default proxy builder, the proxy configuration is resolved to use environment variables.",
                 Collections.singletonList(Pair.of("", "")),
                 environmentSettings(),
-                new TestProxySetting(), null, null, getEnvironmentVariableProxySettings()),
+                new TestProxySetting(), null, null, new TestProxySetting()),
 
             Arguments.of(
                 "Provided with no system property and valid environment variables, when using the host,"
@@ -119,7 +119,7 @@ public final class ProxyConfigCommonTestData {
                 + "then proxy resolved to environment",
                 Collections.singletonList(Pair.of("", "")),
                 environmentSettings(),
-                null, true, null, getEnvironmentVariableProxySettings()),
+                null, true, null, new TestProxySetting()),
 
             Arguments.of(
                 "Provided only environment variable when useEnvironmentVariable set to false then proxy resolved "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Disable useEnvironmentVariableValues by default because of regression issue #4728

## Modifications
<!--- Describe your changes in detail -->


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
