### PR TITLE
Bugfix to support comma separated values in no_proxy environment settings

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-02e443d.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-02e443d.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Comma separated multiple hosts specified in no_proxy environment settings were not treated as multiple hosts"
+    "description": "Comma separated multiple hosts specified in `NO_PROXY` environment variable are now treated as multiple hosts."
 }

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-02e443d.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-02e443d.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Comma separated multiple hosts specified in no_proxy environment settings were not treated as multiple hosts"
+}

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
@@ -245,6 +245,8 @@ public abstract class CrtProxyConfiguration {
          * options are not provided during building the {@link CrtProxyConfiguration} object. To disable this behavior, set this
          * value to false.It is important to note that when this property is set to "true," all proxy settings will exclusively
          * originate from environment variableValues, and no partial settings will be obtained from SystemPropertyValues.
+         * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
+         * proxy settings.
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
@@ -292,6 +292,8 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * disable this behavior, set this value to "false". It is important to note that when this property is set to "true," all
          * proxy settings will exclusively originate from environment variableValues, and no partial settings will be obtained
          * from SystemPropertyValues.
+         * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
+         * proxy settings.
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values.
          * @return This object for method chaining.

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
@@ -279,6 +279,8 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * disable this behavior, set this value to "false".It is important to note that when this property is set to "true," all
          * proxy settings will exclusively originate from Environment Variable Values, and no partial settings will be obtained
          * from System Property Values.
+         * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
+         * proxy settings.
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
@@ -245,6 +245,8 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * options that are not provided during building the {@link ProxyConfiguration} object. To disable this behavior, set this
          * value to "false".It is important to note that when this property is set to "true," all proxy settings will exclusively
          * originate from environment variableValues, and no partial settings will be obtained from SystemPropertyValues.
+         * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
+         * proxy settings.
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
@@ -444,9 +444,9 @@ public final class SdkHttpUtils {
         return Collections.emptySet();
     }
 
-    private static Set<String> extractNonProxyHostsFromEnvironmentVariable(String systemNonProxyHosts) {
-        if (systemNonProxyHosts != null && !isEmpty(systemNonProxyHosts)) {
-            return Arrays.stream(systemNonProxyHosts.split(","))
+    private static Set<String> extractNonProxyHostsFromEnvironmentVariable(String environmentNonProxyHosts) {
+        if (environmentNonProxyHosts != null && !isEmpty(environmentNonProxyHosts)) {
+            return Arrays.stream(environmentNonProxyHosts.split(","))
                          .map(String::toLowerCase)
                          .map(String::trim)
                          .collect(Collectors.toSet());
@@ -455,7 +455,7 @@ public final class SdkHttpUtils {
     }
 
     public static Set<String> parseNonProxyHostsEnvironmentVariable() {
-        String systemNonProxyHosts = ProxyEnvironmentSetting.NO_PROXY.getStringValue().orElse(null);
-        return extractNonProxyHostsFromEnvironmentVariable(systemNonProxyHosts);
+        String environmentNonProxyHosts = ProxyEnvironmentSetting.NO_PROXY.getStringValue().orElse(null);
+        return extractNonProxyHostsFromEnvironmentVariable(environmentNonProxyHosts);
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
@@ -431,10 +431,10 @@ public final class SdkHttpUtils {
      */
     public static Set<String> parseNonProxyHostsProperty() {
         String systemNonProxyHosts = ProxySystemSetting.NON_PROXY_HOSTS.getStringValue().orElse(null);
-        return extractNonProxyHosts(systemNonProxyHosts);
+        return extractNonProxyHostsFromSystemProperty(systemNonProxyHosts);
     }
 
-    private static Set<String> extractNonProxyHosts(String systemNonProxyHosts) {
+    private static Set<String> extractNonProxyHostsFromSystemProperty(String systemNonProxyHosts) {
         if (systemNonProxyHosts != null && !isEmpty(systemNonProxyHosts)) {
             return Arrays.stream(systemNonProxyHosts.split("\\|"))
                          .map(String::toLowerCase)
@@ -444,8 +444,18 @@ public final class SdkHttpUtils {
         return Collections.emptySet();
     }
 
+    private static Set<String> extractNonProxyHostsFromEnvironmentVariable(String systemNonProxyHosts) {
+        if (systemNonProxyHosts != null && !isEmpty(systemNonProxyHosts)) {
+            return Arrays.stream(systemNonProxyHosts.split(","))
+                         .map(String::toLowerCase)
+                         .map(String::trim)
+                         .collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
+    }
+
     public static Set<String> parseNonProxyHostsEnvironmentVariable() {
         String systemNonProxyHosts = ProxyEnvironmentSetting.NO_PROXY.getStringValue().orElse(null);
-        return extractNonProxyHosts(systemNonProxyHosts);
+        return extractNonProxyHostsFromEnvironmentVariable(systemNonProxyHosts);
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
@@ -431,12 +431,12 @@ public final class SdkHttpUtils {
      */
     public static Set<String> parseNonProxyHostsProperty() {
         String systemNonProxyHosts = ProxySystemSetting.NON_PROXY_HOSTS.getStringValue().orElse(null);
-        return extractNonProxyHostsFromSystemProperty(systemNonProxyHosts);
+        return extractNonProxyHosts(systemNonProxyHosts);
     }
 
-    private static Set<String> extractNonProxyHostsFromSystemProperty(String systemNonProxyHosts) {
-        if (systemNonProxyHosts != null && !isEmpty(systemNonProxyHosts)) {
-            return Arrays.stream(systemNonProxyHosts.split("\\|"))
+    private static Set<String> extractNonProxyHosts(String nonProxyHosts) {
+        if (nonProxyHosts != null && !isEmpty(nonProxyHosts)) {
+            return Arrays.stream(nonProxyHosts.split("\\|"))
                          .map(String::toLowerCase)
                          .map(s -> StringUtils.replace(s, "*", ".*?"))
                          .collect(Collectors.toSet());
@@ -444,18 +444,10 @@ public final class SdkHttpUtils {
         return Collections.emptySet();
     }
 
-    private static Set<String> extractNonProxyHostsFromEnvironmentVariable(String environmentNonProxyHosts) {
-        if (environmentNonProxyHosts != null && !isEmpty(environmentNonProxyHosts)) {
-            return Arrays.stream(environmentNonProxyHosts.split(","))
-                         .map(String::toLowerCase)
-                         .map(String::trim)
-                         .collect(Collectors.toSet());
-        }
-        return Collections.emptySet();
-    }
-
     public static Set<String> parseNonProxyHostsEnvironmentVariable() {
-        String environmentNonProxyHosts = ProxyEnvironmentSetting.NO_PROXY.getStringValue().orElse(null);
-        return extractNonProxyHostsFromEnvironmentVariable(environmentNonProxyHosts);
+        String hosts = ProxyEnvironmentSetting.NO_PROXY.getStringValue()
+                                                       .map(noProxyHost -> noProxyHost.replace(",", "|"))
+                                                       .orElse(null);
+        return extractNonProxyHosts(hosts);
     }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
@@ -19,6 +19,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.net.URI;
@@ -29,10 +30,25 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 public class SdkHttpUtilsTest {
+
+
+
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    @BeforeEach
+    public void setup() {
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+    }
+
     @Test
     public void urlValuesEncodeCorrectly() {
         String nonEncodedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
@@ -217,6 +233,56 @@ public class SdkHttpUtilsTest {
                                        entry("oParam", Collections.singletonList("3456")),
                                        entry("noval", Arrays.asList((String)null)),
                                        entry("decoded&Part", Arrays.asList("equals=val")));
+    }
+
+    @Test
+    void parseSingleNonProxyHost(){
+        String singleHostName = "singleHost" ;
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", singleHostName);
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEqualTo(Stream.of(singleHostName.toLowerCase()).collect(Collectors.toSet()));
+    }
+    
+    @Test
+    void parseNullNonProxyHost(){
+        ENVIRONMENT_VARIABLE_HELPER.remove("no_proxy");
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEmpty();
+    }
+
+    @Test
+    void parseEmptyStringNonProxyHost(){
+        String emptyHostname = "" ;
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", emptyHostname);
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEmpty();
+    }
+
+    @Test
+    void parseListOfNonProxyHostWithCommas(){
+        String multipleHostNames =  "test1.com,test2.com,test3.com" ;
+
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEqualTo(Stream.of("test1.com","test2.com","test3.com").collect(Collectors.toSet()));
+    }
+
+    @Test
+    void parseListOfNonProxyHostWithCommasAndWildCard(){
+        String multipleHostNames = "example.com,*?.nongreedy.org,*.greedy.org,192.168.1.1";
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEqualTo(Stream.of("example.com","*?.nongreedy.org", "*.greedy.org", "192.168.1.1")
+                                                       .collect(Collectors.toSet()));
+    }
+
+    @Test
+    void parseListOfNonProxyHostWithCommasAndWildCardAndSpaced(){
+        String multipleHostNames = "example.com, *?.nongreedy.org, *.greedy.org,192.168.1.1 ";
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEqualTo(Stream.of("example.com","*?.nongreedy.org", "*.greedy.org", "192.168.1.1")
+                                           .collect(Collectors.toSet()));
     }
 
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
@@ -272,20 +272,21 @@ public class SdkHttpUtilsTest {
 
     @Test
     void parseListOfNonProxyHostWithCommasAndWildCard(){
-        String multipleHostNames = "example.com,*?.nongreedy.org,*.greedy.org,192.168.1.1";
+        String multipleHostNames = "example.com,*greedy.org,192.168.1.1";
         ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
         Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
-        assertThat(strings).isEqualTo(Stream.of("example.com","*?.nongreedy.org", "*.greedy.org", "192.168.1.1")
+        assertThat(strings).isEqualTo(Stream.of("example.com", ".*?greedy.org", "192.168.1.1")
                                                        .collect(Collectors.toSet()));
     }
 
     @Test
-    void parseListOfNonProxyHostWithCommasAndWildCardAndSpaced(){
-        String multipleHostNames = "example.com, *?.nongreedy.org, *.greedy.org,192.168.1.1 ";
+    void parseListOfNonProxyHostWithPipesAndWildCard(){
+        String multipleHostNames = "example.com|*greedy.org|192.168.1.1";
         ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
         Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
-        assertThat(strings).isEqualTo(Stream.of("example.com","*?.nongreedy.org", "*.greedy.org", "192.168.1.1")
-                                           .collect(Collectors.toSet()));
+        assertThat(strings).isEqualTo(Stream.of("example.com", ".*?greedy.org", "192.168.1.1")
+                                            .collect(Collectors.toSet()));
     }
+
 
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.net.URI;
@@ -33,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
@@ -40,12 +40,15 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 public class SdkHttpUtilsTest {
 
-
-
     private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
 
     @BeforeEach
     public void setup() {
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+    }
+
+    @AfterEach
+    public void clear() {
         ENVIRONMENT_VARIABLE_HELPER.reset();
     }
 

--- a/utils/src/test/java/software/amazon/awssdk/utils/proxy/ProxyConfigurationTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/proxy/ProxyConfigurationTest.java
@@ -80,6 +80,14 @@ public class ProxyConfigurationTest {
                          new ExpectedProxySetting().port(0).nonProxyHost("one", "two", "three"),
                          "Only Non Proxy Hosts are set with multiple value"),
 
+            Arguments.of(Collections.singletonList(
+                             Pair.of("http.nonProxyHosts", "one|two|three")),
+                         Collections.singletonList(
+                             Pair.of("no_proxy", "one|two|three")
+                         ),
+                         new ExpectedProxySetting().port(0).nonProxyHost("one", "two", "three"),
+                         "Only Non Proxy Hosts are set with multiple value where environment variables are Pipe separated"),
+
             Arguments.of(Arrays.asList(
                              Pair.of("%s.proxyVaildHost", "foo.com"),
                              Pair.of("%s.proxyPorts", "555")),

--- a/utils/src/test/java/software/amazon/awssdk/utils/proxy/ProxyConfigurationTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/proxy/ProxyConfigurationTest.java
@@ -73,11 +73,11 @@ public class ProxyConfigurationTest {
                          "All parameters are Blank"),
 
             Arguments.of(Collections.singletonList(
-                             Pair.of("http.nonProxyHosts", "one,two,three")),
+                             Pair.of("http.nonProxyHosts", "one|two|three")),
                          Collections.singletonList(
                              Pair.of("no_proxy", "one,two,three")
                          ),
-                         new ExpectedProxySetting().port(0).nonProxyHost("one,two,three"),
+                         new ExpectedProxySetting().port(0).nonProxyHost("one", "two", "three"),
                          "Only Non Proxy Hosts are set with multiple value"),
 
             Arguments.of(Arrays.asList(
@@ -199,7 +199,6 @@ public class ProxyConfigurationTest {
         setEnvironmentProperties(envSystemSetting, "https");
         assertProxyEquals(ProxyConfigProvider.fromSystemPropertySettings("https"), expectedProxySetting);
         assertProxyEquals(ProxyConfigProvider.fromEnvironmentSettings("https"), expectedProxySetting);
-
     }
 
     private static class ExpectedProxySetting {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
[4703](https://github.com/aws/aws-sdk-java-v2/issues/4703)


## Root Cause

- The logic to parse no_proxy environment variables for multiple host used logic same as that of System property NO_PROXY setting which treated "|" as separator

- Why was this missed in testing ?
  - [ProxyConfigurationTest](https://github.com/aws/aws-sdk-java-v2/blob/0e3b14d013a698b9cf4d6a1bc208542509fbe2bb/utils/src/test/java/software/amazon/awssdk/utils/proxy/ProxyConfigurationTest.java#L75-L82) had added a test case to test multiple hosts scenario. Unfortunately the test had a typo error where hosts names were added in double quotes instead of separate string.





## Modifications
<!--- Describe your changes in detail -->
- Added logic to split string based on  "," instead of "|".
- Added logic to trim extra spaces
- We are not adding greedy to non-greedy since it can cause issues if user already sends a non-greedy string. Wild cards are passed as it is.


## New revision
After offline Discussion with @zoewangg  updated this to be consistent as [V1-here](https://github.com/aws/aws-sdk-java/blob/c69beeca1e263c67f68e1d1a1f5d7f3dd9bf805a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java#L1109C20-L1116) and [V1-Here](https://github.com/aws/aws-sdk-java/blob/a186eadd5376908b472993353dfc1b115e61dc1b/aws-java-sdk-core/src/main/java/com/amazonaws/http/apache/SdkProxyRoutePlanner.java#L47-L55) supporting both commas and pipes.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Junits added


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
