### PR TITLE
Add credentialScope as credential metadata

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.auth.credentials;
 import static software.amazon.awssdk.utils.StringUtils.trimToNull;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -43,10 +44,22 @@ public final class AwsBasicCredentials implements AwsCredentials {
      * This should be accessed via {@link AnonymousCredentialsProvider#resolveCredentials()}.
      */
     @SdkInternalApi
-    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = new AwsBasicCredentials(null, null, false);
+    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().validateCredentials(false).build();
 
     private final String accessKeyId;
     private final String secretAccessKey;
+    private final String credentialScope;
+
+    private AwsBasicCredentials(Builder builder) {
+        this.accessKeyId = trimToNull(builder.accessKeyId);
+        this.secretAccessKey = trimToNull(builder.secretAccessKey);
+
+        if (builder.validateCredentials) {
+            Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
+            Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
+        }
+        this.credentialScope = builder.credentialScope;
+    }
 
     /**
      * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
@@ -55,27 +68,25 @@ public final class AwsBasicCredentials implements AwsCredentials {
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
      */
     protected AwsBasicCredentials(String accessKeyId, String secretAccessKey) {
-        this(accessKeyId, secretAccessKey, true);
+        this(builder().accessKeyId(accessKeyId)
+                      .secretAccessKey(secretAccessKey)
+                      .validateCredentials(true));
     }
 
-    private AwsBasicCredentials(String accessKeyId, String secretAccessKey, boolean validateCredentials) {
-        this.accessKeyId = trimToNull(accessKeyId);
-        this.secretAccessKey = trimToNull(secretAccessKey);
-
-        if (validateCredentials) {
-            Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
-            Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
-        }
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
      * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
      *
-     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
+     * @param accessKeyId     The AWS access key, used to identify the user interacting with AWS.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
-     * */
+     */
     public static AwsBasicCredentials create(String accessKeyId, String secretAccessKey) {
-        return new AwsBasicCredentials(accessKeyId, secretAccessKey);
+        return builder().accessKeyId(accessKeyId)
+                        .secretAccessKey(secretAccessKey)
+                        .build();
     }
 
     /**
@@ -95,9 +106,15 @@ public final class AwsBasicCredentials implements AwsCredentials {
     }
 
     @Override
+    public Optional<String> credentialScope() {
+        return Optional.ofNullable(credentialScope);
+    }
+
+    @Override
     public String toString() {
         return ToString.builder("AwsCredentials")
                        .add("accessKeyId", accessKeyId)
+                       .add("credentialScope", credentialScope)
                        .build();
     }
 
@@ -111,7 +128,8 @@ public final class AwsBasicCredentials implements AwsCredentials {
         }
         AwsBasicCredentials that = (AwsBasicCredentials) o;
         return Objects.equals(accessKeyId, that.accessKeyId) &&
-               Objects.equals(secretAccessKey, that.secretAccessKey);
+               Objects.equals(secretAccessKey, that.secretAccessKey) &&
+               Objects.equals(credentialScope, that.credentialScope().orElse(null));
     }
 
     @Override
@@ -119,6 +137,50 @@ public final class AwsBasicCredentials implements AwsCredentials {
         int hashCode = 1;
         hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
+        hashCode = 31 * hashCode + Objects.hashCode(credentialScope());
         return hashCode;
+    }
+
+    public static final class Builder {
+        private String accessKeyId;
+        private String secretAccessKey;
+        private String credentialScope;
+        private boolean validateCredentials = true;
+
+        /**
+         * The AWS access key, used to identify the user interacting with services.
+         */
+        public Builder accessKeyId(String accessKeyId) {
+            this.accessKeyId = accessKeyId;
+            return this;
+        }
+
+        /**
+         * The AWS secret access key, used to authenticate the user interacting with services.
+         */
+        public Builder secretAccessKey(String secretAccessKey) {
+            this.secretAccessKey = secretAccessKey;
+            return this;
+        }
+
+        /**
+         * The AWS region of the single-region account.
+         */
+        public Builder credentialScope(String credentialScope) {
+            this.credentialScope = credentialScope;
+            return this;
+        }
+
+        /**
+         * Whether this class should verify that accessKeyId and secretAccessKey are not null.
+         */
+        Builder validateCredentials(Boolean validateCredentials) {
+            this.validateCredentials = validateCredentials;
+            return this;
+        }
+
+        public AwsBasicCredentials build() {
+            return new AwsBasicCredentials(this);
+        }
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
@@ -36,6 +36,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
     private final String accessKeyId;
     private final String secretAccessKey;
     private final String sessionToken;
+    private final String credentialScope;
 
     private final Instant expirationTime;
 
@@ -44,6 +45,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         this.secretAccessKey = Validate.paramNotNull(builder.secretAccessKey, "secretKey");
         this.sessionToken = Validate.paramNotNull(builder.sessionToken, "sessionToken");
         this.expirationTime = builder.expirationTime;
+        this.credentialScope = builder.credentialScope;
     }
 
     /**
@@ -82,6 +84,14 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
     }
 
     /**
+     * Retrieve the AWS region of the single-region account, if it exists. Otherwise, returns empty {@link Optional}.
+     */
+    @Override
+    public Optional<String> credentialScope() {
+        return Optional.ofNullable(credentialScope);
+    }
+
+    /**
      * Retrieve the expiration time of these credentials, if it exists.
      */
     @Override
@@ -101,6 +111,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
     public String toString() {
         return ToString.builder("AwsSessionCredentials")
                        .add("accessKeyId", accessKeyId())
+                       .add("credentialScope", credentialScope)
                        .build();
     }
 
@@ -117,7 +128,8 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         return Objects.equals(accessKeyId, that.accessKeyId) &&
                Objects.equals(secretAccessKey, that.secretAccessKey) &&
                Objects.equals(sessionToken, that.sessionToken) &&
-               Objects.equals(expirationTime, that.expirationTime().orElse(null));
+               Objects.equals(expirationTime, that.expirationTime().orElse(null)) &&
+               Objects.equals(credentialScope, that.credentialScope().orElse(null));
     }
 
     @Override
@@ -127,6 +139,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
         hashCode = 31 * hashCode + Objects.hashCode(sessionToken());
         hashCode = 31 * hashCode + Objects.hashCode(expirationTime);
+        hashCode = 31 * hashCode + Objects.hashCode(credentialScope);
         return hashCode;
     }
 
@@ -139,6 +152,7 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         private String secretAccessKey;
         private String sessionToken;
         private Instant expirationTime;
+        private String credentialScope;
 
         /**
          * The AWS access key, used to identify the user interacting with services. Required.
@@ -172,6 +186,14 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
          */
         public Builder expirationTime(Instant expirationTime) {
             this.expirationTime = expirationTime;
+            return this;
+        }
+
+        /**
+         * The AWS region of the single-region account. Optional
+         */
+        public Builder credentialScope(String credentialScope) {
+            this.credentialScope = credentialScope;
             return this;
         }
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
@@ -71,15 +71,21 @@ public final class CredentialUtils {
         // identity-spi defines 2 known types - AwsCredentialsIdentity and a sub-type AwsSessionCredentialsIdentity
         if (awsCredentialsIdentity instanceof AwsSessionCredentialsIdentity) {
             AwsSessionCredentialsIdentity awsSessionCredentialsIdentity = (AwsSessionCredentialsIdentity) awsCredentialsIdentity;
-            return AwsSessionCredentials.create(awsSessionCredentialsIdentity.accessKeyId(),
-                                                awsSessionCredentialsIdentity.secretAccessKey(),
-                                                awsSessionCredentialsIdentity.sessionToken());
+            return AwsSessionCredentials.builder()
+                                        .accessKeyId(awsSessionCredentialsIdentity.accessKeyId())
+                                        .secretAccessKey(awsSessionCredentialsIdentity.secretAccessKey())
+                                        .sessionToken(awsSessionCredentialsIdentity.sessionToken())
+                                        .credentialScope(awsSessionCredentialsIdentity.credentialScope().orElse(null))
+                                        .build();
         }
         if (isAnonymous(awsCredentialsIdentity)) {
             return AwsBasicCredentials.ANONYMOUS_CREDENTIALS;
         }
-        return AwsBasicCredentials.create(awsCredentialsIdentity.accessKeyId(),
-                                          awsCredentialsIdentity.secretAccessKey());
+        return AwsBasicCredentials.builder()
+                                  .accessKeyId(awsCredentialsIdentity.accessKeyId())
+                                  .secretAccessKey(awsCredentialsIdentity.secretAccessKey())
+                                  .credentialScope(awsCredentialsIdentity.credentialScope().orElse(null))
+                                  .build();
     }
 
     /**
@@ -94,7 +100,7 @@ public final class CredentialUtils {
      * @return The corresponding {@link AwsCredentialsProvider}
      */
     public static AwsCredentialsProvider toCredentialsProvider(
-            IdentityProvider<? extends AwsCredentialsIdentity> identityProvider) {
+        IdentityProvider<? extends AwsCredentialsIdentity> identityProvider) {
         if (identityProvider == null) {
             return null;
         }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/CredentialUtilsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/CredentialUtilsTest.java
@@ -116,11 +116,37 @@ public class CredentialUtilsTest {
     }
 
     @Test
+    public void toCredentialsProvider_withCredentialScope_AwsCredentialsProvider_returnsAsIs() {
+        IdentityProvider<AwsCredentialsIdentity> input =
+            StaticCredentialsProvider.create(AwsBasicCredentials.builder()
+                                                                .accessKeyId("akid")
+                                                                .secretAccessKey("skid")
+                                                                .credentialScope("region")
+                                                                .build());
+        AwsCredentialsProvider output = CredentialUtils.toCredentialsProvider(input);
+        assertThat(output).isSameAs(input);
+    }
+
+    @Test
     public void toCredentialsProvider_IdentityProvider_converts() {
         AwsCredentialsProvider credentialsProvider = CredentialUtils.toCredentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")));
         AwsCredentials credentials = credentialsProvider.resolveCredentials();
         assertThat(credentials.accessKeyId()).isEqualTo("akid");
         assertThat(credentials.secretAccessKey()).isEqualTo("skid");
+    }
+
+    @Test
+    public void toCredentialsProvider_withCredentialScope_IdentityProvider_converts() {
+        AwsCredentialsProvider credentialsProvider = CredentialUtils.toCredentialsProvider(
+            StaticCredentialsProvider.create(AwsBasicCredentials.builder()
+                                                                .accessKeyId("akid")
+                                                                .secretAccessKey("skid")
+                                                                .credentialScope("region")
+                                                                .build()));
+        AwsCredentials credentials = credentialsProvider.resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("akid");
+        assertThat(credentials.secretAccessKey()).isEqualTo("skid");
+        assertThat(credentials.credentialScope()).contains("region");
     }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/AwsSessionCredentialsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/AwsSessionCredentialsTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.auth.credentials.internal;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -27,6 +28,7 @@ public class AwsSessionCredentialsTest {
     private static final String ACCESS_KEY_ID = "accessKeyId";
     private static final String SECRET_ACCESS_KEY = "secretAccessKey";
     private static final String SESSION_TOKEN = "sessionToken";
+    private static final String CREDENTIAL_SCOPE = "credentialScope";
 
     public void equalsHashcode() {
         EqualsVerifier.forClass(AwsSessionCredentials.class)
@@ -70,9 +72,12 @@ public class AwsSessionCredentialsTest {
                                                               .accessKeyId(ACCESS_KEY_ID)
                                                               .secretAccessKey(SECRET_ACCESS_KEY)
                                                               .sessionToken(SESSION_TOKEN)
+                                                              .credentialScope(CREDENTIAL_SCOPE)
                                                               .build();
         assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
         assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
         assertEquals(SESSION_TOKEN, identity.sessionToken());
+        assertThat(identity.credentialScope()).isPresent();
+        assertEquals(CREDENTIAL_SCOPE, identity.credentialScope().get());
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/CredentialUtils.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/CredentialUtils.java
@@ -40,12 +40,16 @@ public final class CredentialUtils {
     public static AwsCredentialsIdentity sanitizeCredentials(AwsCredentialsIdentity credentials) {
         String accessKeyId = StringUtils.trim(credentials.accessKeyId());
         String secretKey = StringUtils.trim(credentials.secretAccessKey());
+        String credentialScope = StringUtils.trim(credentials.credentialScope().orElse(null));
 
         if (credentials instanceof AwsSessionCredentialsIdentity) {
             AwsSessionCredentialsIdentity sessionCredentials = (AwsSessionCredentialsIdentity) credentials;
-            return AwsSessionCredentialsIdentity.create(accessKeyId,
-                                                        secretKey,
-                                                        StringUtils.trim(sessionCredentials.sessionToken()));
+            return AwsSessionCredentialsIdentity.builder()
+                                                .accessKeyId(accessKeyId)
+                                                .secretAccessKey(secretKey)
+                                                .sessionToken(StringUtils.trim(sessionCredentials.sessionToken()))
+                                                .credentialScope(credentialScope)
+                                                .build();
         }
 
         // given credentials are anonymous, so don't create new instance
@@ -53,6 +57,10 @@ public final class CredentialUtils {
             return credentials;
         }
 
-        return AwsCredentialsIdentity.create(accessKeyId, secretKey);
+        return AwsCredentialsIdentity.builder()
+                                     .accessKeyId(accessKeyId)
+                                     .secretAccessKey(secretKey)
+                                     .credentialScope(credentialScope)
+                                     .build();
     }
 }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentity.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.identity.spi;
 
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.identity.spi.internal.DefaultAwsCredentialsIdentity;
@@ -43,6 +44,13 @@ public interface AwsCredentialsIdentity extends Identity {
      */
     String secretAccessKey();
 
+    /**
+     * Retrieve the AWS region, if set, of the single-region account. Otherwise, returns empty {@link Optional}.
+     */
+    default Optional<String> credentialScope() {
+        return Optional.empty();
+    }
+
     static Builder builder() {
         return DefaultAwsCredentialsIdentity.builder();
     }
@@ -69,6 +77,11 @@ public interface AwsCredentialsIdentity extends Identity {
          * The AWS secret access key, used to authenticate the user interacting with services.
          */
         Builder secretAccessKey(String secretAccessKey);
+
+        /**
+         * The AWS region of the single-region account.
+         */
+        Builder credentialScope(String credentialScope);
 
         AwsCredentialsIdentity build();
     }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentity.java
@@ -60,6 +60,9 @@ public interface AwsSessionCredentialsIdentity extends AwsCredentialsIdentity {
         @Override
         Builder secretAccessKey(String secretAccessKey);
 
+        @Override
+        Builder credentialScope(String credentialScope);
+
         /**
          * The AWS session token, retrieved from an AWS token service, used for authenticating that this user has
          * received temporary permission to access some resource.

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsCredentialsIdentity.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.identity.spi.internal;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.utils.ToString;
@@ -26,10 +27,12 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
 
     private final String accessKeyId;
     private final String secretAccessKey;
+    private final String credentialScope;
 
     private DefaultAwsCredentialsIdentity(Builder builder) {
         this.accessKeyId = builder.accessKeyId;
         this.secretAccessKey = builder.secretAccessKey;
+        this.credentialScope = builder.credentialScope;
 
         Validate.paramNotNull(accessKeyId, "accessKeyId");
         Validate.paramNotNull(secretAccessKey, "secretAccessKey");
@@ -50,9 +53,15 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
     }
 
     @Override
+    public Optional<String> credentialScope() {
+        return Optional.ofNullable(credentialScope);
+    }
+
+    @Override
     public String toString() {
         return ToString.builder("AwsCredentialsIdentity")
                        .add("accessKeyId", accessKeyId)
+                       .add("credentialScope", credentialScope)
                        .build();
     }
 
@@ -66,7 +75,8 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
         }
         AwsCredentialsIdentity that = (AwsCredentialsIdentity) o;
         return Objects.equals(accessKeyId, that.accessKeyId()) &&
-               Objects.equals(secretAccessKey, that.secretAccessKey());
+               Objects.equals(secretAccessKey, that.secretAccessKey()) &&
+               Objects.equals(credentialScope, that.credentialScope().orElse(null));
     }
 
     @Override
@@ -74,12 +84,14 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
         int hashCode = 1;
         hashCode = 31 * hashCode + Objects.hashCode(accessKeyId);
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey);
+        hashCode = 31 * hashCode + Objects.hashCode(credentialScope);
         return hashCode;
     }
 
     private static final class Builder implements AwsCredentialsIdentity.Builder {
         private String accessKeyId;
         private String secretAccessKey;
+        private String credentialScope;
 
         private Builder() {
         }
@@ -93,6 +105,12 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
         @Override
         public Builder secretAccessKey(String secretAccessKey) {
             this.secretAccessKey = secretAccessKey;
+            return this;
+        }
+
+        @Override
+        public AwsCredentialsIdentity.Builder credentialScope(String credentialScope) {
+            this.credentialScope = credentialScope;
             return this;
         }
 

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsSessionCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsSessionCredentialsIdentity.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.identity.spi.internal;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.utils.ToString;
@@ -27,11 +28,13 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
     private final String accessKeyId;
     private final String secretAccessKey;
     private final String sessionToken;
+    private final String credentialScope;
 
     private DefaultAwsSessionCredentialsIdentity(Builder builder) {
         this.accessKeyId = builder.accessKeyId;
         this.secretAccessKey = builder.secretAccessKey;
         this.sessionToken = builder.sessionToken;
+        this.credentialScope = builder.credentialScope;
 
         Validate.paramNotNull(accessKeyId, "accessKeyId");
         Validate.paramNotNull(secretAccessKey, "secretAccessKey");
@@ -53,6 +56,11 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
     }
 
     @Override
+    public Optional<String> credentialScope() {
+        return Optional.ofNullable(credentialScope);
+    }
+
+    @Override
     public String sessionToken() {
         return sessionToken;
     }
@@ -61,6 +69,7 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
     public String toString() {
         return ToString.builder("AwsSessionCredentialsIdentity")
                        .add("accessKeyId", accessKeyId)
+                       .add("credentialScope", credentialScope)
                        .build();
     }
 
@@ -72,10 +81,11 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AwsSessionCredentialsIdentity that = (AwsSessionCredentialsIdentity) o;
+        DefaultAwsSessionCredentialsIdentity that = (DefaultAwsSessionCredentialsIdentity) o;
         return Objects.equals(accessKeyId, that.accessKeyId()) &&
                Objects.equals(secretAccessKey, that.secretAccessKey()) &&
-               Objects.equals(sessionToken, that.sessionToken());
+               Objects.equals(sessionToken, that.sessionToken()) &&
+               Objects.equals(credentialScope, that.credentialScope().orElse(null));
     }
 
     @Override
@@ -84,6 +94,7 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
         hashCode = 31 * hashCode + Objects.hashCode(accessKeyId);
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey);
         hashCode = 31 * hashCode + Objects.hashCode(sessionToken);
+        hashCode = 31 * hashCode + Objects.hashCode(credentialScope);
         return hashCode;
     }
 
@@ -91,6 +102,7 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
         private String accessKeyId;
         private String secretAccessKey;
         private String sessionToken;
+        private String credentialScope;
 
         private Builder() {
         }
@@ -104,6 +116,12 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
         @Override
         public Builder secretAccessKey(String secretAccessKey) {
             this.secretAccessKey = secretAccessKey;
+            return this;
+        }
+
+        @Override
+        public Builder credentialScope(String credentialScope) {
+            this.credentialScope = credentialScope;
             return this;
         }
 

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentityTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentityTest.java
@@ -15,17 +15,18 @@
 
 package software.amazon.awssdk.identity.spi;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.internal.DefaultAwsCredentialsIdentity;
 
 public class AwsCredentialsIdentityTest {
     private static final String ACCESS_KEY_ID = "accessKeyId";
     private static final String SECRET_ACCESS_KEY = "secretAccessKey";
+    private static final String CREDENTIAL_SCOPE = "credentialScope";
 
     @Test
     public void equalsHashcode() {
@@ -60,8 +61,11 @@ public class AwsCredentialsIdentityTest {
         AwsCredentialsIdentity identity = AwsCredentialsIdentity.builder()
                                                                 .accessKeyId(ACCESS_KEY_ID)
                                                                 .secretAccessKey(SECRET_ACCESS_KEY)
+                                                                .credentialScope(CREDENTIAL_SCOPE)
                                                                 .build();
         assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
         assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
+        assertThat(identity.credentialScope()).isPresent();
+        assertEquals(CREDENTIAL_SCOPE, identity.credentialScope().get());
     }
 }

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentityTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentityTest.java
@@ -16,17 +16,18 @@
 package software.amazon.awssdk.identity.spi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.internal.DefaultAwsSessionCredentialsIdentity;
 
 public class AwsSessionCredentialsIdentityTest {
     private static final String ACCESS_KEY_ID = "accessKeyId";
     private static final String SECRET_ACCESS_KEY = "secretAccessKey";
     private static final String SESSION_TOKEN = "sessionToken";
+    private static final String CREDENTIAL_SCOPE = "us-west-2";
 
     @Test
     public void equalsHashcode() {
@@ -75,5 +76,34 @@ public class AwsSessionCredentialsIdentityTest {
         assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
         assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
         assertEquals(SESSION_TOKEN, identity.sessionToken());
+    }
+
+    @Test
+    public void build_withCredentialScope_isSuccessful() {
+        AwsSessionCredentialsIdentity identity = AwsSessionCredentialsIdentity.builder()
+                                                                              .accessKeyId(ACCESS_KEY_ID)
+                                                                              .secretAccessKey(SECRET_ACCESS_KEY)
+                                                                              .sessionToken(SESSION_TOKEN)
+                                                                              .credentialScope(CREDENTIAL_SCOPE)
+                                                                              .build();
+        assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
+        assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
+        assertEquals(SESSION_TOKEN, identity.sessionToken());
+        assertEquals(SESSION_TOKEN, identity.sessionToken());
+    }
+
+    @Test
+    public void build_withNullCredentialScope_isSuccessful() {
+        AwsSessionCredentialsIdentity identity = AwsSessionCredentialsIdentity.builder()
+                                                                              .accessKeyId(ACCESS_KEY_ID)
+                                                                              .secretAccessKey(SECRET_ACCESS_KEY)
+                                                                              .sessionToken(SESSION_TOKEN)
+                                                                              .credentialScope(null)
+                                                                              .build();
+        assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
+        assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
+        assertEquals(SESSION_TOKEN, identity.sessionToken());
+        assertEquals(SESSION_TOKEN, identity.sessionToken());
+        assertFalse(identity.credentialScope().isPresent());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
To support single-region accounts, a new `credentialScope` field will be added to credential metadata, indicating the region of the single-region account

## Modifications
<!--- Describe your changes in detail -->
Adds `credentialScope` as an optional field to `AwsCredentialsIdentity` and its child interfaces/classes

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
