### PR TITLE
Add stability test case to test issue #4608

### DIFF
--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockStabilityTestBase.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockStabilityTestBase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.stability.tests.s3;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.IntFunction;
+import org.apache.commons.lang3.RandomStringUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.stability.tests.exceptions.StabilityTestsRetryableException;
+import software.amazon.awssdk.stability.tests.utils.RetryableTest;
+import software.amazon.awssdk.stability.tests.utils.StabilityTestRunner;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.utils.Logger;
+
+public abstract class S3MockStabilityTestBase {
+
+    protected static final int CONCURRENCY = 100;
+    protected static final int TOTAL_RUNS = 50;
+    private static final Logger log = Logger.loggerFor(S3MockStabilityTestBase.class);
+    MockAsyncHttpClient mockAsyncHttpClient;
+    S3AsyncClient testClient;
+
+    protected static StaticCredentialsProvider getDummyCredentials() {
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", ":dummy"));
+    }
+
+    @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)
+    public void putObject_Checksum() {
+        putObjectChecksumVariations();
+    }
+
+    protected void putObjectChecksumVariations() {
+        mockAsyncHttpClient.stubNextResponse200();
+        byte[] bytes = RandomStringUtils.randomAlphanumeric(10_000).getBytes();
+
+        IntFunction<CompletableFuture<?>> future = i -> {
+            String keyName = computeKeyName(i);
+
+            return testClient.putObject(b -> b.bucket(getTestBucketName())
+                                              .key(keyName)
+                                              .checksumAlgorithm(ChecksumAlgorithm.CRC32_C), AsyncRequestBody.fromBytes(bytes))
+                             .thenRunAsync(
+                                 () -> testClient.putObject(b -> b.bucket(getTestBucketName())
+                                                                  .key(keyName), AsyncRequestBody.fromBytes(bytes)));
+        };
+
+        StabilityTestRunner.newRunner()
+                           .testName("S3MockStabilityTestBase.putObjectChecksumVariations")
+                           .futureFactory(future)
+                           .requestCountPerRun(CONCURRENCY)
+                           .totalRuns(TOTAL_RUNS)
+                           .delaysBetweenEachRun(Duration.ofMillis(100))
+                           .run();
+    }
+
+    protected String computeKeyName(int i) {
+        return "key_" + i;
+    }
+
+    protected abstract String getTestBucketName();
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockStabilityTestBase.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockStabilityTestBase.java
@@ -19,8 +19,6 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntFunction;
 import org.apache.commons.lang3.RandomStringUtils;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
@@ -37,11 +35,6 @@ public abstract class S3MockStabilityTestBase {
     private static final Logger log = Logger.loggerFor(S3MockStabilityTestBase.class);
     MockAsyncHttpClient mockAsyncHttpClient;
     S3AsyncClient testClient;
-
-    protected static StaticCredentialsProvider getDummyCredentials() {
-        return StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", ":dummy"));
-    }
-
     @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)
     public void putObject_Checksum() {
         putObjectChecksumVariations();

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockWithAsyncClientStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockWithAsyncClientStabilityTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.stability.tests.s3;
+
+import org.junit.jupiter.api.BeforeEach;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+
+public class S3MockWithAsyncClientStabilityTest extends S3MockStabilityTestBase {
+
+    private static String bucketName = "s3mockwithasyncclientstabilitytests" + System.currentTimeMillis();
+
+    @BeforeEach
+    void setup(){
+        mockAsyncHttpClient = new MockAsyncHttpClient();
+        testClient = S3AsyncClient.builder()
+                                  .credentialsProvider(getDummyCredentials())
+                                  .httpClient(mockAsyncHttpClient)
+                                  .build();
+    }
+
+    @Override
+    protected String getTestBucketName() {
+        return bucketName;
+    }
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockWithAsyncClientStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockWithAsyncClientStabilityTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.stability.tests.s3;
 
+import static software.amazon.awssdk.testutils.service.AwsTestBase.CREDENTIALS_PROVIDER_CHAIN;
+
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
@@ -27,7 +29,7 @@ public class S3MockWithAsyncClientStabilityTest extends S3MockStabilityTestBase 
     void setup(){
         mockAsyncHttpClient = new MockAsyncHttpClient();
         testClient = S3AsyncClient.builder()
-                                  .credentialsProvider(getDummyCredentials())
+                                  .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                   .httpClient(mockAsyncHttpClient)
                                   .build();
     }

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockWithAsyncClientStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MockWithAsyncClientStabilityTest.java
@@ -38,4 +38,5 @@ public class S3MockWithAsyncClientStabilityTest extends S3MockStabilityTestBase 
     protected String getTestBucketName() {
         return bucketName;
     }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Test [#4608](https://github.com/aws/aws-sdk-java-v2/issues/4608)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

### Root cause of #4608
The issue was fixed with revert  https://github.com/aws/aws-sdk-java-v2/pull/4621 and actual fix https://github.com/aws/aws-sdk-java-v2/pull/4620
Following was the root cause
 1. This issue is specific when we have S3 API calls with and without checksum back to back.
 2. The Race condition occurs in [This code](https://github.com/aws/aws-sdk-java-v2/blob/1c93c02108fc10f077f393e5f03dabb2b262783c/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HttpChecksumStage.java#L218-L225)
 ```
 
        return headerChecksumSpecs != null &&
               headerChecksumSpecs.algorithm() != null &&
               !HttpChecksumUtils.isHttpChecksumPresent(interceptorContext.httpRequest(), headerChecksumSpecs) &&
               HttpChecksumUtils.isUnsignedPayload(
                   context.executionAttributes().getAttribute(SIGNING_METHOD), interceptorContext.httpRequest().protocol(),
                   isContentStreaming) &&
               !headerChecksumSpecs.isRequestStreaming();
```            
 3. ChecksumThread Has a checksum because Its CHECKSUM_SPECS was updated with non null values [here](https://github.com/aws/aws-sdk-java-v2/blob/1c93c02108fc10f077f393e5f03dabb2b262783c/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/HttpChecksumResolver.java#L52) thus its `headerChecksumSpecs !=null`  passes and it goes to `HttpChecksumUtils.isHttpChecksumPresent(interceptorContext.httpRequest(), headerChecksumSpecs)`
 4. Now when a Non Checksum API in another NonChecksumThread acccess the RESOLVED_CHECKSUM_SPECS its header and other attributes are reset to null because no checksum for that API
 5. When the API in ChecksumThread resumes , its in call where it does `DefaultSdkHttpFullRequest.firstMatchingHeader` where it expects the string to be nonNull for a String compare to find the header in a Tree Map, thus  ends up with NPE
 

## Modifications
<!--- Describe your changes in detail -->
- Added a test case in stability test to send Request with and without checksum back to back

## Testing
- Made sure that test is valid by checking on release which had the issue
- git checkout d9cd9d342359ca2a6940b88b2a040d862f2684cf and tested issue is recreated with the stabilty test added
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
