### PR TITLE
Handle credentialScope for STS AssumeRole

### DIFF
--- a/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
+++ b/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
@@ -151,8 +151,7 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
         assertNotNull(assumeRoleResult.assumedRoleUser());
         assertNotNull(assumeRoleResult.assumedRoleUser().arn());
         assertNotNull(assumeRoleResult.assumedRoleUser().assumedRoleId());
-        // TODO - uncomment once STS model is updated
-        //assertNotNull(assumeRoleResult.credentials());
+        assertNotNull(assumeRoleResult.credentials());
     }
 
     @Test

--- a/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
+++ b/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
@@ -119,8 +119,12 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
         // Create new credentials for the user
         CreateAccessKeyResponse createAccessKeyResult = iam.createAccessKey(r -> r.userName(USER_NAME));
-        userCredentials = AwsBasicCredentials.create(createAccessKeyResult.accessKey().accessKeyId(),
-                                                     createAccessKeyResult.accessKey().secretAccessKey());
+        userCredentials = AwsBasicCredentials.builder()
+                                             .accessKeyId(createAccessKeyResult.accessKey().accessKeyId())
+                                             .secretAccessKey(createAccessKeyResult.accessKey().secretAccessKey())
+                                             // TODO - uncomment once IAM model is updated
+                                             //.credentialScope(createAccessKeyResult.credentialScope())
+                                             .build();
 
         // Try to assume the role to make sure we won't hit issues during testing.
         StsClient userCredentialSts = StsClient.builder()
@@ -135,7 +139,7 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
     /** Tests that we can call assumeRole successfully. */
     @Test
-    public void testAssumeRole() throws InterruptedException {
+    public void testAssumeRole() {
         AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
                                                                .durationSeconds(SESSION_DURATION)
                                                                .roleArn(ROLE_ARN)
@@ -147,11 +151,12 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
         assertNotNull(assumeRoleResult.assumedRoleUser());
         assertNotNull(assumeRoleResult.assumedRoleUser().arn());
         assertNotNull(assumeRoleResult.assumedRoleUser().assumedRoleId());
-        assertNotNull(assumeRoleResult.credentials());
+        // TODO - uncomment once STS model is updated
+        //assertNotNull(assumeRoleResult.credentials());
     }
 
     @Test
-    public void profileCredentialsProviderCanAssumeRoles() throws InterruptedException {
+    public void profileCredentialsProviderCanAssumeRoles() {
         String ASSUME_ROLE_PROFILE =
             "[source]\n"
             + "aws_access_key_id = " + userCredentials.accessKeyId() + "\n"
@@ -178,11 +183,13 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
         assertThat(awsCredentials.accessKeyId()).isNotBlank();
         assertThat(awsCredentials.secretAccessKey()).isNotBlank();
+        // TODO - uncomment once STS model is updated
+        //assertThat(awsCredentials.credentialScope()).isPresent();
         ((SdkAutoCloseable) awsCredentialsProvider).close();
     }
 
     @Test
-    public void profileCredentialProviderCanAssumeRolesWithEnvironmentCredentialSource() throws InterruptedException {
+    public void profileCredentialProviderCanAssumeRolesWithEnvironmentCredentialSource() {
         EnvironmentVariableHelper.run(helper -> {
             helper.set("AWS_ACCESS_KEY_ID", userCredentials.accessKeyId());
             helper.set("AWS_SECRET_ACCESS_KEY", userCredentials.secretAccessKey());
@@ -210,12 +217,14 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
             assertThat(awsCredentials.accessKeyId()).isNotBlank();
             assertThat(awsCredentials.secretAccessKey()).isNotBlank();
+            // TODO - uncomment once STS model is updated
+            //assertThat(awsCredentials.credentialScope()).isPresent();
             ((SdkAutoCloseable) awsCredentialsProvider).close();
         });
     }
 
     @Test
-    public void profileCredentialProviderWithEnvironmentCredentialSourceAndSystemProperties() throws InterruptedException {
+    public void profileCredentialProviderWithEnvironmentCredentialSourceAndSystemProperties() {
         System.setProperty("aws.accessKeyId", userCredentials.accessKeyId());
         System.setProperty("aws.secretAccessKey", userCredentials.secretAccessKey());
 
@@ -247,6 +256,8 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
                 assertThat(awsCredentials.accessKeyId()).isNotBlank();
                 assertThat(awsCredentials.secretAccessKey()).isNotBlank();
+                // TODO - uncomment once STS model is updated
+                //assertThat(awsCredentials.credentialScope()).isPresent();
                 ((SdkAutoCloseable) awsCredentialsProvider).close();
             });
         } finally {

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsAuthUtils.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsAuthUtils.java
@@ -30,6 +30,7 @@ public final class StsAuthUtils {
                                     .secretAccessKey(credentials.secretAccessKey())
                                     .sessionToken(credentials.sessionToken())
                                     .expirationTime(credentials.expiration())
+                                    .credentialScope(credentials.credentialScope())
                                     .build();
     }
 }

--- a/services/sts/src/main/resources/codegen-resources/service-2.json
+++ b/services/sts/src/main/resources/codegen-resources/service-2.json
@@ -423,6 +423,10 @@
         "Expiration":{
           "shape":"dateType",
           "documentation":"<p>The date on which the current credentials expire.</p>"
+        },
+        "CredentialScope":{
+          "shape":"awsRegion",
+          "documentation":"<p>The AWS region of a single-region account.</p>"
         }
       },
       "documentation":"<p>Amazon Web Services credentials for API authentication.</p>"
@@ -761,6 +765,9 @@
       "max":193,
       "min":2,
       "pattern":"[\\w+=,.@:-]*"
+    },
+    "awsRegion":{
+      "type": "string"
     },
     "clientTokenType":{
       "type":"string",

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -20,10 +20,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -99,7 +97,13 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
     protected abstract ResponseT callClient(StsClient client, RequestT request);
 
     public void callClientWithCredentialsProvider(Instant credentialsExpirationDate, int numTimesInvokeCredentialsProvider, boolean overrideStaleAndPrefetchTimes) {
-        Credentials credentials = Credentials.builder().accessKeyId("a").secretAccessKey("b").sessionToken("c").expiration(credentialsExpirationDate).build();
+        Credentials credentials = Credentials.builder()
+                                             .accessKeyId("a")
+                                             .secretAccessKey("b")
+                                             .sessionToken("c")
+                                             .expiration(credentialsExpirationDate)
+                                             .credentialScope("d")
+                                             .build();
         RequestT request = getRequest();
         ResponseT response = getResponse(credentials);
 
@@ -129,6 +133,7 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
                 assertThat(providedCredentials.accessKeyId()).isEqualTo("a");
                 assertThat(providedCredentials.secretAccessKey()).isEqualTo("b");
                 assertThat(providedCredentials.sessionToken()).isEqualTo("c");
+                assertThat(providedCredentials.credentialScope()).isPresent().hasValue("d");
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
`STS` `Credentials` shape returned by `AssumeRole` will be updated to include `CredentialScope`

## Modifications
<!--- Describe your changes in detail -->
Update `StsAuthUtils` to handle `credentialScope` when resolving credentials

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
