### PR TITLE
Create a separate module to allow CRT Sync HTTP client to be discover…

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -10,6 +10,7 @@
         "aws-cbor-protocol": { "packageName": "AwsJavaSdk-Core-AwsCborProtocol" },
         "aws-core": { "packageName": "AwsJavaSdk-Core-AwsCore" },
         "aws-crt-client": { "packageName": "AwsJavaSdk-HttpClient-CrtClient" },
+        "aws-crt-sync-client": { "packageName": "AwsJavaSdk-HttpClient-SyncCrtClient" },
         "aws-ion-protocol": { "packageName": "AwsJavaSdk-Core-AwsIonProtocol" },
         "aws-json-protocol": { "packageName": "AwsJavaSdk-Core-AwsJsonProtocol" },
         "aws-query-protocol": { "packageName": "AwsJavaSdk-Core-AwsQueryProtocol" },

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -209,6 +209,11 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
+                <artifactId>aws-crt-sync-client</artifactId>
+                <version>${awsjavasdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
                 <artifactId>auth-crt</artifactId>
                 <version>${awsjavasdk.version}</version>
             </dependency>

--- a/http-clients/aws-crt-sync-client/pom.xml
+++ b/http-clients/aws-crt-sync-client/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>http-clients</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.21.40-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>aws-crt-sync-client</artifactId>
+    <name>AWS Java SDK :: HTTP Clients :: AWS Common Runtime Client</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <awsjavasdk.version>${project.parent.version}</awsjavasdk.version>
+        <jre.version>1.8</jre.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom-internal</artifactId>
+                <version>${awsjavasdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!--SDK dependencies-->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.http.crtsync</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/http-clients/aws-crt-sync-client/src/main/java/software/amazon/awssdk/http/crtsync/AwsCrtSdkSyncHttpService.java
+++ b/http-clients/aws-crt-sync-client/src/main/java/software/amazon/awssdk/http/crtsync/AwsCrtSdkSyncHttpService.java
@@ -13,10 +13,11 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.crt;
+package software.amazon.awssdk.http.crtsync;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.http.async.SdkAsyncHttpService;
+import software.amazon.awssdk.http.SdkHttpService;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 
 /**
  * Service binding for the AWS common runtime HTTP client implementation. Allows SDK to pick this up automatically from the
@@ -24,9 +25,9 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpService;
  *
  */
 @SdkPublicApi
-public class AwsCrtSdkHttpService implements SdkAsyncHttpService {
+public class AwsCrtSdkSyncHttpService implements SdkHttpService {
     @Override
-    public AwsCrtAsyncHttpClient.Builder createAsyncHttpClientFactory() {
-        return AwsCrtAsyncHttpClient.builder();
+    public AwsCrtHttpClient.Builder createHttpClientBuilder() {
+        return AwsCrtHttpClient.builder();
     }
 }

--- a/http-clients/aws-crt-sync-client/src/main/resources/META-INF/services/software.amazon.awssdk.http.SdkHttpService
+++ b/http-clients/aws-crt-sync-client/src/main/resources/META-INF/services/software.amazon.awssdk.http.SdkHttpService
@@ -13,4 +13,4 @@
 # permissions and limitations under the License.
 #
 
-software.amazon.awssdk.http.crt.AwsCrtSdkHttpService
+software.amazon.awssdk.http.crtsync.AwsCrtSdkSyncHttpService

--- a/http-clients/pom.xml
+++ b/http-clients/pom.xml
@@ -32,6 +32,7 @@
     <modules>
         <module>apache-client</module>
         <module>aws-crt-client</module>
+        <module>aws-crt-sync-client</module>
         <module>netty-nio-client</module>
         <module>url-connection-client</module>
     </modules>


### PR DESCRIPTION
…able on classpath

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
If we keep everything in `aws-crt-client` module, it will break customers who depend on `aws-crt-client` AND create sync SDK client without specifying an http client or http client builder. They will get "Multiple HTTP implementations were found on the classpath" error since there will be two sync implementations (apache and crt)

## Modifications
This change moves `AwsCrtSdkSyncHttpService` that allows the sync HTTP client to be discoverable at runtime to a separate module `aws-crt-sync-client`. 

## Testing
Tested it locally

