### PR TITLE
Fix retrying multipart uploads for default S3

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-a7ec49e.json
+++ b/.changes/next-release/bugfix-S3TransferManager-a7ec49e.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Fix an issue where multipart uploads from a file are not retryable when using the default, non CRT S3 client."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/listener/AsyncRequestBodyListener.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/listener/AsyncRequestBodyListener.java
@@ -17,10 +17,13 @@ package software.amazon.awssdk.core.async.listener;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
@@ -61,6 +64,16 @@ public interface AsyncRequestBodyListener extends PublisherListener<ByteBuffer> 
         @Override
         public String contentType() {
             return delegate.contentType();
+        }
+
+        @Override
+        public SdkPublisher<AsyncRequestBody> split(AsyncRequestBodySplitConfiguration splitConfiguration) {
+            return delegate.split(splitConfiguration);
+        }
+
+        @Override
+        public SdkPublisher<AsyncRequestBody> split(Consumer<AsyncRequestBodySplitConfiguration.Builder> splitConfiguration) {
+            return delegate.split(splitConfiguration);
         }
 
         @Override

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/listener/NotifyingAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/listener/NotifyingAsyncRequestBodyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async.listener;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
+
+public class NotifyingAsyncRequestBodyTest {
+    private static AsyncRequestBody mockRequestBody;
+    private static AsyncRequestBodyListener mockListener;
+
+    @BeforeEach
+    public void setup() {
+        mockRequestBody = mock(AsyncRequestBody.class);
+        mockListener = mock(AsyncRequestBodyListener.class);
+    }
+
+    @Test
+    public void contentLength_delegatesCall() {
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(mockRequestBody, mockListener);
+
+        notifying.contentLength();
+        verify(mockRequestBody).contentLength();
+    }
+
+    @Test
+    public void contentType_delegatesCall() {
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(mockRequestBody, mockListener);
+
+        notifying.contentType();
+        verify(mockRequestBody).contentType();
+    }
+
+    @Test
+    public void subscribe_delegatesCall() {
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(mockRequestBody, mockListener);
+
+        notifying.subscribe(mock(Subscriber.class));
+        verify(mockRequestBody).subscribe(any(Subscriber.class));
+    }
+
+    @Test
+    public void split_configObject_delegatesCall() {
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(mockRequestBody, mockListener);
+
+        AsyncRequestBodySplitConfiguration config = AsyncRequestBodySplitConfiguration.builder().build();
+        notifying.split(config);
+        verify(mockRequestBody).split(eq(config));
+    }
+
+    @Test
+    public void split_consumer_delegatesCall() {
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(mockRequestBody, mockListener);
+
+        Consumer<AsyncRequestBodySplitConfiguration.Builder> consumer = c -> {};
+        notifying.split(consumer);
+        verify(mockRequestBody).split(eq(consumer));
+
+    }
+}

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DefaultFileUploadWireMockTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DefaultFileUploadWireMockTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.moreThanOrExactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+
+/**
+ * WireMock test for verifying the DefaultFileUpload codepath.
+ */
+public class DefaultFileUploadWireMockTest {
+    private static final WireMockServer wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+    private static final FileSystem testFs = Jimfs.newFileSystem(Configuration.unix());
+    private static Path testFile;
+    private static S3AsyncClient s3;
+
+    @BeforeAll
+    public static void setup() {
+        testFile = testFs.getPath("/32mib.dat");
+        writeTestFile(testFile, 32 * 1024 * 1024);
+        wireMock.start();
+    }
+
+    @AfterAll
+    public static void teardown() throws IOException {
+        testFs.close();
+        wireMock.stop();
+    }
+
+    @BeforeEach
+    public void methodSetup() {
+        s3 = S3AsyncClient.builder()
+                          .credentialsProvider(StaticCredentialsProvider.create(
+                              AwsBasicCredentials.create("akid", "skid")))
+                          .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                          .region(Region.US_EAST_1)
+                          .forcePathStyle(true)
+                          .multipartEnabled(true)
+                          .multipartConfiguration(c -> c.thresholdInBytes(16 * 1024 * 1024L))
+                          .overrideConfiguration(o -> o.retryPolicy(RetryPolicy.defaultRetryPolicy().toBuilder()
+                                                                               .numRetries(3)
+                                                                               .build()))
+                          .build();
+    }
+
+    @AfterEach
+    public void methodTeardown() {
+        s3.close();
+    }
+
+    @Test
+    void retryableErrorDuringUpload_shouldSupportRetries() {
+        S3TransferManager tm = S3TransferManager.builder().s3Client(s3).build();
+
+        String mpuInitBody = ""
+                             + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                             + "<InitiateMultipartUploadResult>\n"
+                             + "   <Bucket>bucket</Bucket>\n"
+                             + "   <Key>key</Key>\n"
+                             + "   <UploadId>uploadId</UploadId>\n"
+                             + "</InitiateMultipartUploadResult>";
+
+        wireMock.stubFor(post(urlEqualTo("/bucket/key?uploads"))
+                                 .willReturn(aResponse()
+                                                 .withStatus(200)
+                                                 .withBody(mpuInitBody)));
+
+        wireMock.stubFor(put(anyUrl())
+                             .willReturn(aResponse()
+                                             .withStatus(500)
+                                             .withBody("Internal Error")));
+
+        UploadFileRequest request = UploadFileRequest.builder()
+                                                     .source(testFile).
+                                                     putObjectRequest(put -> put.bucket("bucket").key("key"))
+                                                     .build();
+
+        assertThatThrownBy(() -> tm.uploadFile(request).completionFuture().join())
+            .hasCauseInstanceOf(S3Exception.class);
+
+        wireMock.verify(moreThanOrExactly(3),
+                        putRequestedFor(urlPathMatching("/bucket/key"))
+                            .withQueryParam("uploadId", matching("uploadId"))
+                            .withQueryParam("partNumber", matching("1")));
+    }
+
+    private static void writeTestFile(Path file, long size) {
+        try (OutputStream os = Files.newOutputStream(file, StandardOpenOption.CREATE_NEW)) {
+            byte[] buff = new byte[4096];
+            long remaining = size;
+            while (remaining != 0) {
+                int writeLen = (int) Math.min(remaining, buff.length);
+                os.write(buff, 0, writeLen);
+                remaining -= writeLen;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
When the TransferManager does a mutlipart upload using the AsyncFileRequestBody (i.e. not CRT), it wraps the request body in a notifying listner, but this listener does not delegate back to the AsyncFileRequestBody for split() operations, resulting in the default split implementation to be used which is incorrect.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
