### PR TITLE
Load HTTP implementation from classpath based on priority order

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-0090bf8.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-0090bf8.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "If an HTTP client or HTTP client builder is not specified explicitly on the SDK client AND there are multiple HTTP client implementations on the classpath, the SDK will choose the one that has the highest priority instead of throwing exception. ApacheHttpClient and NettyNioAsyncHttpClient have the highest priority in sync and async SDK client respectively for now."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
@@ -15,66 +15,89 @@
 
 package software.amazon.awssdk.core.internal.http.loader;
 
-import java.util.List;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+import java.util.StringJoiner;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
-import software.amazon.awssdk.core.SdkSystemSetting;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.SdkHttpService;
 import software.amazon.awssdk.http.async.SdkAsyncHttpService;
-import software.amazon.awssdk.utils.SystemSetting;
+import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.awssdk.utils.Logger;
 
 /**
  * {@link SdkHttpServiceProvider} implementation that uses {@link ServiceLoader} to find HTTP implementations on the
- * classpath. If more than one implementation is found on the classpath then an exception is thrown.
+ * classpath. If more than one implementation is found on the classpath, then the SDK will choose based on priority order.
  */
 @SdkInternalApi
 final class ClasspathSdkHttpServiceProvider<T> implements SdkHttpServiceProvider<T> {
 
+    static final Map<String, Integer> SYNC_HTTP_SERVICES_PRIORITY =
+        ImmutableMap.<String, Integer>builder()
+                    .put("software.amazon.awssdk.http.apache.ApacheSdkHttpService", 1)
+                    .put("software.amazon.awssdk.http.crt.AwsCrtSdkHttpService", 2)
+                    .put("software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService", 3)
+                    .build();
+
+    static final Map<String, Integer> ASYNC_HTTP_SERVICES_PRIORITY =
+        ImmutableMap.<String, Integer>builder()
+                    .put("software.amazon.awssdk.http.nio.netty.NettySdkAsyncHttpService", 1)
+                    .put("software.amazon.awssdk.http.crt.AwsCrtSdkHttpService", 2)
+                    .build();
+
+    private static final Logger log = Logger.loggerFor(ClasspathSdkHttpServiceProvider.class);
+
+    private final Map<String, Integer> httpServicesPriority;
+
     private final SdkServiceLoader serviceLoader;
-    private final SystemSetting implSystemProperty;
     private final Class<T> serviceClass;
 
     @SdkTestInternalApi
-    ClasspathSdkHttpServiceProvider(SdkServiceLoader serviceLoader, SystemSetting implSystemProperty, Class<T> serviceClass) {
+    ClasspathSdkHttpServiceProvider(SdkServiceLoader serviceLoader,
+                                    Class<T> serviceClass,
+                                    Map<String, Integer> httpServicesPriority) {
         this.serviceLoader = serviceLoader;
-        this.implSystemProperty = implSystemProperty;
         this.serviceClass = serviceClass;
+        this.httpServicesPriority = httpServicesPriority;
     }
 
     @Override
     public Optional<T> loadService() {
+        Queue<T> impls = new PriorityQueue<>(Comparator.comparingInt(o -> httpServicesPriority.getOrDefault(o.getClass(),
+                                                                                                            Integer.MAX_VALUE)));
         Iterable<T> iterable = () -> serviceLoader.loadServices(serviceClass);
-        List<T> impls = StreamSupport
-            .stream(iterable.spliterator(), false)
-            .collect(Collectors.toList());
+        iterable.forEach(impl -> impls.add(impl));
 
         if (impls.isEmpty()) {
             return Optional.empty();
         }
 
-        if (impls.size() > 1) {
+        log.debug(() -> logServices(impls));
+        return Optional.of(impls.poll());
+    }
 
-            String implText =
-                impls.stream()
-                     .map(clazz -> clazz.getClass().getName())
-                     .collect(Collectors.joining(",", "[", "]"));
-
-            throw SdkClientException.builder().message(
-                    String.format(
-                            "Multiple HTTP implementations were found on the classpath. To avoid non-deterministic loading " +
-                            "implementations, please explicitly provide an HTTP client via the client builders, set the %s " +
-                            "system property with the FQCN of the HTTP service to use as the default, or remove all but one " +
-                            "HTTP implementation from the classpath.  The multiple implementations found were: %s",
-                            implSystemProperty.property(), implText))
-                    .build();
+    private String logServices(Queue<T> impls) {
+        StringJoiner joiner = new StringJoiner(",", "[", "]");
+        int count = 0;
+        for (T clazz : impls) {
+            String name = clazz.getClass().getName();
+            joiner.add(name);
+            count++;
         }
+        String implText = joiner.toString();
+        T impl = impls.peek();
+        String message = count == 1 ? "The HTTP implementation loaded is " + impl :
+                         String.format(
+                             "Multiple HTTP implementations were found on the classpath. The SDK will use %s since it has the "
+                             + "highest. The multiple implementations found were: %s",
+                             impl,
+                             implText);
 
-        return impls.stream().findFirst();
+        return message;
     }
 
     /**
@@ -82,8 +105,8 @@ final class ClasspathSdkHttpServiceProvider<T> implements SdkHttpServiceProvider
      */
     static SdkHttpServiceProvider<SdkHttpService> syncProvider() {
         return new ClasspathSdkHttpServiceProvider<>(SdkServiceLoader.INSTANCE,
-                                                     SdkSystemSetting.SYNC_HTTP_SERVICE_IMPL,
-                                                     SdkHttpService.class);
+                                                     SdkHttpService.class,
+                                                     SYNC_HTTP_SERVICES_PRIORITY);
     }
 
     /**
@@ -91,8 +114,7 @@ final class ClasspathSdkHttpServiceProvider<T> implements SdkHttpServiceProvider
      */
     static SdkHttpServiceProvider<SdkAsyncHttpService> asyncProvider() {
         return new ClasspathSdkHttpServiceProvider<>(SdkServiceLoader.INSTANCE,
-                                                     SdkSystemSetting.ASYNC_HTTP_SERVICE_IMPL,
-                                                     SdkAsyncHttpService.class);
+                                                     SdkAsyncHttpService.class,
+                                                     ASYNC_HTTP_SERVICES_PRIORITY);
     }
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This change allows multiple HTTP implementations to be present on the classpath. Previously, exception will be thrown in this case, and with this change, the SDK will pick an HTTP implementation based on priority order.

Context: we found that if we release CRT sync HTTP client in the same `aws-crt-client` module, it will break customers who depend on `aws-crt-client` and use sync SDK client without specifying http client builder because there will be two sync HTTP implementations, Apache HTTP client and CRT Sync HTTP client. In order to fix this, we need to either change classpath loading logic to allow multiple HTTP implementations or create a separate module for CRT sync HTTP client service. After discussing with the team, we decided to go with the first approach because 1) we'll need the logic if we ever decide to change the default HTTP implementation anyway 2) creating a separate module for CRT sync HTTP client may be and has extra maintenance cost 3) this will make our integ tests easier to write because we no longer need to specify HTTP implementation.

This change should not break any customers because the current behavior is failure.

## Modifications
Load HTTP implementation from classpath based on priority order

## Testing
Added unit tests and tested it locally by verifying that no error was thrown when adding aws-crt-client dependency

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
