### PR TITLE
Various performance optimization for CRT sync HTTP client

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
@@ -67,7 +67,7 @@ final class ClasspathSdkHttpServiceProvider<T> implements SdkHttpServiceProvider
 
     @Override
     public Optional<T> loadService() {
-        Queue<T> impls = new PriorityQueue<>(Comparator.comparingInt(o -> httpServicesPriority.getOrDefault(o.getClass(),
+        Queue<T> impls = new PriorityQueue<>(Comparator.comparingInt(o -> httpServicesPriority.getOrDefault(o.getClass().getName(),
                                                                                                             Integer.MAX_VALUE)));
         Iterable<T> iterable = () -> serviceLoader.loadServices(serviceClass);
         iterable.forEach(impl -> impls.add(impl));

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
@@ -67,8 +67,9 @@ final class ClasspathSdkHttpServiceProvider<T> implements SdkHttpServiceProvider
 
     @Override
     public Optional<T> loadService() {
-        Queue<T> impls = new PriorityQueue<>(Comparator.comparingInt(o -> httpServicesPriority.getOrDefault(o.getClass().getName(),
-                                                                                                            Integer.MAX_VALUE)));
+        Queue<T> impls = new PriorityQueue<>(
+            Comparator.comparingInt(o -> httpServicesPriority.getOrDefault(o.getClass().getName(),
+                                                                           Integer.MAX_VALUE)));
         Iterable<T> iterable = () -> serviceLoader.loadServices(serviceClass);
         iterable.forEach(impl -> impls.add(impl));
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProviderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProviderTest.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import software.amazon.awssdk.core.SdkSystemSetting;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.SdkHttpService;
 import software.amazon.awssdk.http.apache.ApacheSdkHttpService;
 import software.amazon.awssdk.http.async.SdkAsyncHttpService;
@@ -77,7 +75,7 @@ public class ClasspathSdkHttpServiceProviderTest {
         SdkHttpService mock = mock(SdkHttpService.class);
 
         when(serviceLoader.loadServices(SdkHttpService.class))
-                .thenReturn(iteratorOf(apacheSdkHttpService, mock));
+                .thenReturn(iteratorOf(mock, apacheSdkHttpService));
         assertThat(provider.loadService()).contains(apacheSdkHttpService);
 
         SdkHttpService mock1 = mock(SdkHttpService.class);
@@ -93,7 +91,7 @@ public class ClasspathSdkHttpServiceProviderTest {
         SdkAsyncHttpService mock = mock(SdkAsyncHttpService.class);
 
         when(serviceLoader.loadServices(SdkAsyncHttpService.class))
-            .thenReturn(iteratorOf(netty, mock));
+            .thenReturn(iteratorOf(mock, netty));
         assertThat(asyncProvider.loadService()).contains(netty);
 
         SdkAsyncHttpService mock1 = mock(SdkAsyncHttpService.class);

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpExecuteResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpExecuteResponse.java
@@ -38,7 +38,7 @@ public class HttpExecuteResponse {
     }
 
     /**
-     * /** Get the {@link AbortableInputStream} associated with this response.
+     * Get the {@link AbortableInputStream} associated with this response.
      *
      * <p>Always close the "responseBody" input stream to release the underlying HTTP connection.
      * Even for error responses, the SDK creates an input stream for reading error data. It is essential to close the input stream

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -153,12 +153,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-            <version>${awsjavasdk.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
             <version>${awsjavasdk.version}</version>
             <scope>test</scope>

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
@@ -30,11 +30,14 @@ import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
 import software.amazon.awssdk.http.HttpStatusFamily;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.async.SimplePublisher;
 
 /**
+ * Response handler adaptor for {@link AwsCrtAsyncHttpClient}.
+ * <p>
  * Implements the CrtHttpStreamHandler API and converts CRT callbacks into calls to SDK AsyncExecuteRequest methods
  */
 @SdkInternalApi

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/InputStreamAdaptingHttpStreamResponseHandler.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/InputStreamAdaptingHttpStreamResponseHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal.response;
+
+import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapWithIoExceptionIfRetryable;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpException;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpHeaderBlock;
+import software.amazon.awssdk.crt.http.HttpStream;
+import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpStatusFamily;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.utils.async.InputStreamSubscriber;
+import software.amazon.awssdk.utils.async.SimplePublisher;
+
+/**
+ * Response handler adaptor for {@link AwsCrtHttpClient}.
+ */
+@SdkInternalApi
+public final class InputStreamAdaptingHttpStreamResponseHandler implements HttpStreamResponseHandler {
+    private final SdkHttpFullResponse.Builder responseBuilder = SdkHttpFullResponse.builder();
+    private volatile InputStreamSubscriber inputStreamSubscriber;
+    private final SimplePublisher<ByteBuffer> simplePublisher = new SimplePublisher<>();
+
+    private final CompletableFuture<SdkHttpFullResponse> requestCompletionFuture;
+    private final HttpClientConnection crtConn;
+
+    public InputStreamAdaptingHttpStreamResponseHandler(HttpClientConnection crtConn,
+                                                        CompletableFuture<SdkHttpFullResponse> requestCompletionFuture) {
+        this.crtConn = crtConn;
+        this.requestCompletionFuture = requestCompletionFuture;
+    }
+
+    @Override
+    public void onResponseHeaders(HttpStream stream, int responseStatusCode, int blockType,
+                                  HttpHeader[] nextHeaders) {
+        if (blockType == HttpHeaderBlock.MAIN.getValue()) {
+            for (HttpHeader h : nextHeaders) {
+                responseBuilder.appendHeader(h.getName(), h.getValue());
+            }
+        }
+
+        responseBuilder.statusCode(responseStatusCode);
+    }
+
+    @Override
+    public int onResponseBody(HttpStream stream, byte[] bodyBytesIn) {
+        if (inputStreamSubscriber == null) {
+            inputStreamSubscriber = new InputStreamSubscriber();
+            simplePublisher.subscribe(inputStreamSubscriber);
+            responseBuilder.content(AbortableInputStream.create(inputStreamSubscriber));
+        }
+
+        CompletableFuture<Void> writeFuture = simplePublisher.send(ByteBuffer.wrap(bodyBytesIn));
+
+        if (writeFuture.isDone() && !writeFuture.isCompletedExceptionally()) {
+            // Optimization: If write succeeded immediately, return non-zero to avoid the extra call back into the CRT.
+            return bodyBytesIn.length;
+        }
+
+        writeFuture.whenComplete((result, failure) -> {
+            if (failure != null) {
+                failFutureAndCloseConnection(stream, failure);
+                return;
+            }
+
+            // increment the window upon buffer consumption.
+            stream.incrementWindow(bodyBytesIn.length);
+        });
+
+        // the bodyBytesIn have not cleared the queues yet, so do let backpressure do its thing.
+        return 0;
+    }
+
+    @Override
+    public void onResponseComplete(HttpStream stream, int errorCode) {
+        if (errorCode == CRT.AWS_CRT_SUCCESS) {
+            onSuccessfulResponseComplete(stream);
+        } else {
+            onFailedResponseComplete(stream, errorCode);
+        }
+    }
+
+    private void failFutureAndCloseConnection(HttpStream stream, Throwable failure) {
+        requestCompletionFuture.completeExceptionally(failure);
+        crtConn.shutdown();
+        crtConn.close();
+        stream.close();
+    }
+
+    private void onFailedResponseComplete(HttpStream stream, int errorCode) {
+        Throwable toThrow =
+            wrapWithIoExceptionIfRetryable(new HttpException(errorCode));
+
+        simplePublisher.error(toThrow);
+        failFutureAndCloseConnection(stream, toThrow);
+    }
+
+    private void onSuccessfulResponseComplete(HttpStream stream) {
+        // always close the connection on a 5XX response code.
+        if (HttpStatusFamily.of(responseBuilder.statusCode()) == HttpStatusFamily.SERVER_ERROR) {
+            crtConn.shutdown();
+        }
+
+        requestCompletionFuture.complete(responseBuilder.build());
+        simplePublisher.complete();
+        crtConn.close();
+        stream.close();
+    }
+}

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -175,6 +175,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
             <scope>test</scope>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crthttpclient/S3WithCrtHttpClientsIntegrationTests.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crthttpclient/S3WithCrtHttpClientsIntegrationTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.crthttpclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.utils.ChecksumUtils;
+import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.utils.Md5Utils;
+
+public class S3WithCrtHttpClientsIntegrationTests extends S3IntegrationTestBase {
+    private static final String TEST_BUCKET = temporaryBucketName(S3WithCrtHttpClientsIntegrationTests.class);
+    private static final String TEST_KEY = "2mib_file.dat";
+    private static final int OBJ_SIZE = 2 * 1024 * 1024;
+
+    private static RandomTempFile testFile;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        S3IntegrationTestBase.setUp();
+        S3IntegrationTestBase.createBucket(TEST_BUCKET);
+        testFile = new RandomTempFile(TEST_KEY, OBJ_SIZE);
+        s3WithCrtHttpClient.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), RequestBody.fromFile(testFile.toPath()));
+    }
+
+    @AfterAll
+    public static void teardown() throws IOException {
+        S3IntegrationTestBase.deleteBucketAndAllContents(TEST_BUCKET);
+        Files.delete(testFile.toPath());
+        s3WithCrtHttpClient.close();
+        CrtResource.logNativeResources();
+        CrtResource.waitForNoResources();
+    }
+
+    @Test
+    void getObject_toResponseStream_objectSentCorrectly() throws Exception {
+        ResponseInputStream<GetObjectResponse> objContent =
+            s3WithCrtHttpClient.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY),
+                                          ResponseTransformer.toInputStream());
+
+        byte[] expectedSum = ChecksumUtils.computeCheckSum(Files.newInputStream(testFile.toPath()));
+
+        assertThat(ChecksumUtils.computeCheckSum(objContent)).isEqualTo(expectedSum);
+    }
+
+    @Test
+    void getObject_toFile_objectSentCorrectly() throws Exception {
+        Path destination = RandomTempFile.randomUncreatedFile().toPath();
+        GetObjectResponse response = s3WithCrtHttpClient.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY),
+                                                                 ResponseTransformer.toFile(destination));
+
+        assertThat(Md5Utils.md5AsBase64(destination.toFile())).isEqualTo(Md5Utils.md5AsBase64(testFile));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Various performance optimization for CRT sync HTTP client:
1. `InputStreamSubscriber`:  not throw exception when `close` is invoked if it has buffered all content to avoid exception creation.
2. `InputStreamAdaptingHttpStreamResponseHandler`: remove volatile for simplePublisher variable since it's unncesssary `private volatile SimplePublisher<ByteBuffer> simplePublisher;` 
3.  `InputStreamAdaptingHttpStreamResponseHandler`: complete future as soon as streaming starts. Previously, the future completes after streaming has finished, which means we'll buffer all data in memory first before user starts to read from the inputstream

