### PR TITLE
Implement get(Marker|Logger)FactoryClassStr

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2Bundle-d0cd612.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2Bundle-d0cd612.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 Bundle",
+    "contributor": "",
+    "description": "Fix an issue where `NoSuchMethodError` can be thrown an runtime if the SLF4J implementation detects multiple bindings when using the SDK bundle."
+}

--- a/bundle-logging-bridge/src/main/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticLoggerBinder.java
+++ b/bundle-logging-bridge/src/main/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticLoggerBinder.java
@@ -86,6 +86,11 @@ public class StaticLoggerBinder {
         }
     }
 
+    // SLF4J API
+    public String getLoggerFactoryClassStr() {
+        return ILoggerFactoryAdapter.class.getCanonicalName();
+    }
+
     @SdkTestInternalApi
     Object getActualStaticLoggerBinder() {
         return IMPL;

--- a/bundle-logging-bridge/src/main/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticMarkerBinder.java
+++ b/bundle-logging-bridge/src/main/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticMarkerBinder.java
@@ -99,6 +99,11 @@ public class StaticMarkerBinder {
         }
     }
 
+    // SLF4J API
+    public String getMarkerFactoryClassStr() {
+        return IMarkerFactoryAdapter.class.getCanonicalName();
+    }
+
     @SdkTestInternalApi
     Object getActualStaticMarkerBinder() {
         return IMPL;

--- a/test/bundle-logging-bridge-binding-test/src/test/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticLoggerBinderTest.java
+++ b/test/bundle-logging-bridge-binding-test/src/test/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticLoggerBinderTest.java
@@ -31,4 +31,10 @@ public class StaticLoggerBinderTest {
         assertThat(StaticLoggerBinder.getSingleton().getActualStaticLoggerBinder())
             .isInstanceOf(org.slf4j.impl.StaticLoggerBinder.class);
     }
+
+    @Test
+    public void getLoggerFactoryClassStr_returnsCorrectValue() {
+        assertThat(StaticLoggerBinder.getSingleton().getLoggerFactoryClassStr())
+            .isEqualTo("software.amazon.awssdk.thirdparty.org.slf4j.impl.internal.ILoggerFactoryAdapter");
+    }
 }

--- a/test/bundle-logging-bridge-binding-test/src/test/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticMarkerBinderTest.java
+++ b/test/bundle-logging-bridge-binding-test/src/test/java/software/amazon/awssdk/thirdparty/org/slf4j/impl/StaticMarkerBinderTest.java
@@ -30,4 +30,10 @@ public class StaticMarkerBinderTest {
         assertThat(StaticMarkerBinder.getSingleton().getActualStaticMarkerBinder())
             .isInstanceOf(org.slf4j.impl.StaticMarkerBinder.class);
     }
+
+    @Test
+    public void getMarkerFactoryClassStr_returnsCorrectValue() {
+        assertThat(StaticMarkerBinder.getSingleton().getMarkerFactoryClassStr())
+            .isEqualTo("software.amazon.awssdk.thirdparty.org.slf4j.impl.internal.IMarkerFactoryAdapter");
+    }
 }


### PR DESCRIPTION
SLF4J uses this to for reporting when there are multiple bindings.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
