### PR TITLE
Wait until response body or error body received to process request

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-dacab37.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-dacab37.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix an issue where the S3 CRT client can incorrectly treat the body of an error response for `GetObject` as the object's content. For example, if a role has permissions for `HeadObject` but not a `GetObject`, the S3 CRT client would download the `403` response as the object's contents."
+}

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.15</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.29.1</awscrt.version>
+        <awscrt.version>0.29.2</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.10.0</junit5.version>

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/crt/CrtDownloadErrorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/crt/CrtDownloadErrorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.crt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class CrtDownloadErrorTest {
+    private static final String BUCKET = "my-bucket";
+    private static final String KEY = "my-key";
+    private static final WireMockServer WM = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    private S3AsyncClient s3;
+
+    @BeforeAll
+    public static void setup() {
+        WM.start();
+        // Execute this statement before constructing the SDK service client.
+        Log.initLoggingToStdout(Log.LogLevel.Trace);
+    }
+
+    @AfterAll
+    public static void teardown() {
+        WM.stop();
+    }
+
+    @AfterEach
+    public void methodTeardown() {
+        if (s3 != null) {
+            s3.close();
+        }
+        s3 = null;
+    }
+
+    @Test
+    public void getObject_headObjectOk_getObjectThrows_operationThrows() {
+        s3 = S3AsyncClient.crtBuilder()
+                                        .endpointOverride(URI.create("http://localhost:" + WM.port()))
+                                        .forcePathStyle(true)
+                                        .region(Region.US_EAST_1)
+                                        .build();
+
+        String path = String.format("/%s/%s", BUCKET, KEY);
+
+        WM.stubFor(WireMock.head(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(200)
+                                               .withHeader("ETag", "etag")
+                                               .withHeader("Content-Length", "5")));
+
+        String errorContent = ""
+                              + "<Error>\n"
+                              + "  <Code>AccessDenied</Code>\n"
+                              + "  <Message>User does not have permission</Message>\n"
+                              + "  <RequestId>request-id</RequestId>\n"
+                              + "  <HostId>host-id</HostId>\n"
+                              + "</Error>";
+        WM.stubFor(WireMock.get(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(403)
+                                               .withBody(errorContent)));
+
+        assertThatThrownBy(s3.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes())::join)
+            .hasCauseInstanceOf(S3Exception.class)
+            .hasMessageContaining("User does not have permission")
+            .hasMessageContaining("Status Code: 403");
+    }
+
+    @Test
+    public void getObject_headObjectOk_getObjectOk_operationSucceeds() {
+        s3 = S3AsyncClient.crtBuilder()
+                          .endpointOverride(URI.create("http://localhost:" + WM.port()))
+                          .forcePathStyle(true)
+                          .region(Region.US_EAST_1)
+                          .build();
+
+        String path = String.format("/%s/%s", BUCKET, KEY);
+
+        byte[] content = "hello".getBytes(StandardCharsets.UTF_8);
+
+        WM.stubFor(WireMock.head(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(200)
+                                               .withHeader("ETag", "etag")
+                                               .withHeader("Content-Length", Integer.toString(content.length))));
+        WM.stubFor(WireMock.get(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(200)
+                                               .withHeader("Content-Type", "text/plain")
+                                               .withBody(content)));
+
+        String objectContent = s3.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes())
+                                 .join()
+                                 .asUtf8String();
+
+        assertThat(objectContent.getBytes(StandardCharsets.UTF_8)).isEqualTo(content);
+    }
+
+    @Test
+    public void getObject_headObjectThrows_operationThrows() {
+        s3 = S3AsyncClient.crtBuilder()
+                          .endpointOverride(URI.create("http://localhost:" + WM.port()))
+                          .forcePathStyle(true)
+                          .region(Region.US_EAST_1)
+                          .build();
+
+        String path = String.format("/%s/%s", BUCKET, KEY);
+
+
+        WM.stubFor(WireMock.head(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(403)));
+
+        assertThatThrownBy(s3.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes())::join)
+            .hasCauseInstanceOf(S3Exception.class)
+            .hasMessageContaining("Status Code: 403");
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
@@ -19,6 +19,7 @@ package software.amazon.awssdk.services.s3.internal.crt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -59,7 +59,7 @@ public class S3CrtResponseHandlerAdapterTest {
     @Before
     public void setup() {
         future = new CompletableFuture<>();
-        sdkResponseHandler = new TestResponseHandler();
+        sdkResponseHandler = spy(new TestResponseHandler());
         responseHandlerAdapter = new S3CrtResponseHandlerAdapter(future,
                                                                  sdkResponseHandler,
                                                                  null);
@@ -75,17 +75,20 @@ public class S3CrtResponseHandlerAdapterTest {
         int statusCode = 200;
         responseHandlerAdapter.onResponseHeaders(statusCode, httpHeaders);
 
-        SdkHttpResponse actualSdkHttpResponse = sdkResponseHandler.sdkHttpResponse;
-        assertThat(actualSdkHttpResponse.statusCode()).isEqualTo(statusCode);
-        assertThat(actualSdkHttpResponse.firstMatchingHeader("foo")).contains("1");
-        assertThat(actualSdkHttpResponse.firstMatchingHeader("bar")).contains("2");
         stubOnResponseBody();
 
         responseHandlerAdapter.onFinished(stubResponseContext(0, 0, null));
         future.get(5, TimeUnit.SECONDS);
+
+        SdkHttpResponse actualSdkHttpResponse = sdkResponseHandler.sdkHttpResponse;
+        assertThat(actualSdkHttpResponse.statusCode()).isEqualTo(statusCode);
+        assertThat(actualSdkHttpResponse.firstMatchingHeader("foo")).contains("1");
+        assertThat(actualSdkHttpResponse.firstMatchingHeader("bar")).contains("2");
+
         assertThat(future).isCompleted();
         verify(s3MetaRequest, times(2)).incrementReadWindow(11L);
         verify(s3MetaRequest).close();
+        verify(sdkResponseHandler).onHeaders(any(SdkHttpResponse.class));
     }
 
     @Test
@@ -103,6 +106,7 @@ public class S3CrtResponseHandlerAdapterTest {
                                                                                                    + "null");
         assertThat(future).isCompletedExceptionally();
         verify(s3MetaRequest).close();
+        verify(sdkResponseHandler).onHeaders(any(SdkHttpResponse.class));
     }
 
     @Test
@@ -110,17 +114,17 @@ public class S3CrtResponseHandlerAdapterTest {
         int statusCode = 400;
         responseHandlerAdapter.onResponseHeaders(statusCode, new HttpHeader[0]);
 
+        byte[] errorPayload = "errorResponse".getBytes(StandardCharsets.UTF_8);
+        stubOnResponseBody();
+        responseHandlerAdapter.onFinished(stubResponseContext(1, statusCode, errorPayload));
+
         SdkHttpResponse actualSdkHttpResponse = sdkResponseHandler.sdkHttpResponse;
         assertThat(actualSdkHttpResponse.statusCode()).isEqualTo(400);
         assertThat(actualSdkHttpResponse.headers()).isEmpty();
 
-        byte[] errorPayload = "errorResponse".getBytes(StandardCharsets.UTF_8);
-        stubOnResponseBody();
-
-        responseHandlerAdapter.onFinished(stubResponseContext(1, statusCode, errorPayload));
-
         assertThat(future).isCompleted();
         verify(s3MetaRequest).close();
+        verify(sdkResponseHandler).onHeaders(any(SdkHttpResponse.class));
     }
 
     @Test
@@ -164,7 +168,7 @@ public class S3CrtResponseHandlerAdapterTest {
         responseHandlerAdapter.onResponseBody(ByteBuffer.wrap("helloworld2".getBytes()), 1, 2);
     }
 
-    private static final class TestResponseHandler implements SdkAsyncHttpResponseHandler {
+    private static class TestResponseHandler implements SdkAsyncHttpResponseHandler {
         private SdkHttpResponse sdkHttpResponse;
         private Throwable error;
         @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This fixes issue reported in #4684. Basically, in situations where the identity used to call `s3.getObject()` has permissions to successfully perform a `HeadObject` but not a `GetObject` (i.e. this results in an error response), the S3 client thinks the the call was actually successful (because `HeadObject` was successful) and returns the error response content as the object content.

## Modifications
- Don't rely on `onResponseHeaders` because these are not indicative if whether the request succeeded. Move calls to `responseHandler.onHeanders()` to `onResponseBody` and `onFinished`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
