### PR TITLE
Proxy Port system properties: changed log level from error to warning

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1054797.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1054797.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "When parsing proxy port from system properties, exceptions will be ignored and logged as warning."
+}

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1054797.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1054797.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "When parsing proxy port from system properties, exceptions will be ignored and logged as warning."
+    "description": "Changed the log level from error to warning when exceptions are found in parsing proxy configuration from system properties/environment variables, as we ignore those exceptions and proceed."
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyEnvironmentVariableConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyEnvironmentVariableConfigProvider.java
@@ -57,7 +57,7 @@ public class ProxyEnvironmentVariableConfigProvider implements ProxyConfigProvid
             try {
                 return Optional.of(new URL(stringUrl));
             } catch (MalformedURLException e) {
-                log.error(() -> "Malformed proxy config environment variable " + stringUrl, e);
+                log.warn(() -> "Malformed proxy config environment variable.", e);
             }
         }
         return Optional.empty();

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxySystemPropertyConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxySystemPropertyConfigProvider.java
@@ -46,7 +46,7 @@ public class ProxySystemPropertyConfigProvider implements ProxyConfigProvider {
         try {
             return Integer.parseInt(string);
         } catch (Exception e) {
-            log.warn(() -> "Failed to parse string. The failure will be ignored." + string, e);
+            log.warn(() -> "Failed to parse string.", e);
         }
         return null;
     }

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxySystemPropertyConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxySystemPropertyConfigProvider.java
@@ -46,7 +46,7 @@ public class ProxySystemPropertyConfigProvider implements ProxyConfigProvider {
         try {
             return Integer.parseInt(string);
         } catch (Exception e) {
-            log.error(() -> "Failed to parse string" + string, e);
+            log.warn(() -> "Failed to parse string. The failure will be ignored." + string, e);
         }
         return null;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently, the exception is already ignored but logged as `error`, which can be confusing.

This changes the log level to `warning`.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
