### PR TITLE
Change aws-sdk-java to an optional dependency

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2Bundle-7731e95.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2Bundle-7731e95.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 Bundle",
+    "contributor": "",
+    "description": "Fix an issue where external dependencies are also included unshaded in in the `bundle` JAR."
+}

--- a/bundle-sdk/pom.xml
+++ b/bundle-sdk/pom.xml
@@ -54,6 +54,7 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-sdk-java</artifactId>
             <version>${awsjavasdk.version}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Having it as a normal dependency causes third dependencies like SLF4J to also be included, unshaded in the JAR.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing

Build the `bundle` JAR using the `publishing` profile:

```
mvn clean install -P publishing  -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Dgpg.skip=true
```

Open the generated JAR and verify that there are no unshaded dependencies apart from `org.reactivestreams` which I believe is by design (this is also true for older versions of the Bundle).

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
