### PR TITLE
Fix ChecksumIntegrationTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.15</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.29.1</awscrt.version>
+        <awscrt.version>0.29.2</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.10.0</junit5.version>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/CrtChecksumIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/CrtChecksumIntegrationTest.java
@@ -22,30 +22,36 @@ import java.io.IOException;
 import java.nio.file.Files;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
-import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.core.checksums.Algorithm;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectTaggingResponse;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
+import software.amazon.awssdk.services.s3.utils.ChecksumUtils;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.testutils.service.AwsTestBase;
 
-public class ChecksumIntegrationTest extends S3IntegrationTestBase {
-    private static final String TEST_BUCKET = temporaryBucketName(ChecksumIntegrationTest.class);
+public class CrtChecksumIntegrationTest extends S3IntegrationTestBase {
+    private static final String TEST_BUCKET = temporaryBucketName(CrtChecksumIntegrationTest.class);
     private static final String TEST_KEY = "10mib_file.dat";
     private static final int OBJ_SIZE = 10 * 1024 * 1024;
 
     private static RandomTempFile testFile;
+
+    private static String testFileSha1;
+    private static String testFileCrc32;
+
     private static S3AsyncClient s3Crt;
 
     @BeforeAll
@@ -54,10 +60,15 @@ public class ChecksumIntegrationTest extends S3IntegrationTestBase {
         S3IntegrationTestBase.createBucket(TEST_BUCKET);
 
         testFile = new RandomTempFile(TEST_KEY, OBJ_SIZE);
+        testFileSha1 = ChecksumUtils.calculatedChecksum(testFile.toPath(), Algorithm.SHA1);
+        testFileCrc32 = ChecksumUtils.calculatedChecksum(testFile.toPath(), Algorithm.CRC32);
 
         s3Crt = S3CrtAsyncClient.builder()
                                 .credentialsProvider(AwsTestBase.CREDENTIALS_PROVIDER_CHAIN)
                                 .region(S3IntegrationTestBase.DEFAULT_REGION)
+                                // make sure we don't do a multipart upload, it will mess with validation against the precomputed
+                                // checksums above
+                                .thresholdInBytes(2L * OBJ_SIZE)
                                 .build();
     }
 
@@ -72,37 +83,35 @@ public class ChecksumIntegrationTest extends S3IntegrationTestBase {
     @Test
     void noChecksumCustomization_crc32ShouldBeUsed() {
         AsyncRequestBody body = AsyncRequestBody.fromFile(testFile.toPath());
-        PutObjectResponse putObjectResponse =
-            s3Crt.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), body).join();
-        assertThat(putObjectResponse).isNotNull();
+        s3Crt.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), body).join();
 
         ResponseBytes<GetObjectResponse> getObjectResponseResponseBytes =
-            s3Crt.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY).partNumber(1), AsyncResponseTransformer.toBytes()).join();
+            s3Crt.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), AsyncResponseTransformer.toBytes()).join();
         String getObjectChecksum = getObjectResponseResponseBytes.response().checksumCRC32();
-        assertThat(getObjectChecksum).isNotNull();
+        assertThat(getObjectChecksum).isEqualTo(testFileCrc32);
     }
 
     @Test
     void putObject_checksumProvidedInRequest_shouldTakePrecendence() {
         AsyncRequestBody body = AsyncRequestBody.fromFile(testFile.toPath());
-        PutObjectResponse putObjectResponse =
-            s3Crt.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY).checksumAlgorithm(ChecksumAlgorithm.SHA1), body).join();
-        assertThat(putObjectResponse).isNotNull();
+        s3Crt.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY).checksumAlgorithm(ChecksumAlgorithm.SHA1), body).join();
 
         ResponseBytes<GetObjectResponse> getObjectResponseResponseBytes =
-            s3Crt.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY).partNumber(1), AsyncResponseTransformer.toBytes()).join();
+            s3Crt.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), AsyncResponseTransformer.toBytes()).join();
         String getObjectChecksum = getObjectResponseResponseBytes.response().checksumSHA1();
-        assertThat(getObjectChecksum).isNotNull();
+        // TODO: We compare against the precomputed SHA-1, but this shouldn't be necessary since the PutObjectResponse should
+        //  have this info. This looks like an issue with CRT.
+        assertThat(getObjectChecksum).isEqualTo(testFileSha1);
     }
 
     @Test
     void checksumDisabled_shouldNotPerformChecksumValidationByDefault() {
 
         try (S3AsyncClient s3Crt = S3CrtAsyncClient.builder()
-                                                      .credentialsProvider(AwsTestBase.CREDENTIALS_PROVIDER_CHAIN)
-                                                      .region(S3IntegrationTestBase.DEFAULT_REGION)
-                                                      .checksumValidationEnabled(Boolean.FALSE)
-                                                      .build()) {
+                                                   .credentialsProvider(AwsTestBase.CREDENTIALS_PROVIDER_CHAIN)
+                                                   .region(S3IntegrationTestBase.DEFAULT_REGION)
+                                                   .checksumValidationEnabled(Boolean.FALSE)
+                                                   .build()) {
             AsyncRequestBody body = AsyncRequestBody.fromFile(testFile.toPath());
             PutObjectResponse putObjectResponse =
                 s3Crt.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), body).join();

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/CrtChecksumIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/CrtChecksumIntegrationTest.java
@@ -31,9 +31,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
-import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectTaggingResponse;
 import software.amazon.awssdk.services.s3.model.Tag;
@@ -99,8 +97,6 @@ public class CrtChecksumIntegrationTest extends S3IntegrationTestBase {
         ResponseBytes<GetObjectResponse> getObjectResponseResponseBytes =
             s3Crt.getObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), AsyncResponseTransformer.toBytes()).join();
         String getObjectChecksum = getObjectResponseResponseBytes.response().checksumSHA1();
-        // TODO: We compare against the precomputed SHA-1, but this shouldn't be necessary since the PutObjectResponse should
-        //  have this info. This looks like an issue with CRT.
         assertThat(getObjectChecksum).isEqualTo(testFileSha1);
     }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/crt/CrtDownloadErrorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/crt/CrtDownloadErrorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.crt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class CrtDownloadErrorTest {
+    private static final String BUCKET = "my-bucket";
+    private static final String KEY = "my-key";
+    private static final WireMockServer WM = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    private S3AsyncClient s3;
+
+    @BeforeAll
+    public static void setup() {
+        WM.start();
+        // Execute this statement before constructing the SDK service client.
+        Log.initLoggingToStdout(Log.LogLevel.Trace);
+    }
+
+    @AfterAll
+    public static void teardown() {
+        WM.stop();
+    }
+
+    @AfterEach
+    public void methodTeardown() {
+        if (s3 != null) {
+            s3.close();
+        }
+        s3 = null;
+    }
+
+    @Test
+    public void getObject_headObjectOk_getObjectThrows_operationThrows() {
+        s3 = S3AsyncClient.crtBuilder()
+                                        .endpointOverride(URI.create("http://localhost:" + WM.port()))
+                                        .forcePathStyle(true)
+                                        .region(Region.US_EAST_1)
+                                        .build();
+
+        String path = String.format("/%s/%s", BUCKET, KEY);
+
+        WM.stubFor(WireMock.head(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(200)
+                                               .withHeader("ETag", "etag")
+                                               .withHeader("Content-Length", "5")));
+
+        String errorContent = ""
+                              + "<Error>\n"
+                              + "  <Code>AccessDenied</Code>\n"
+                              + "  <Message>User does not have permission</Message>\n"
+                              + "  <RequestId>request-id</RequestId>\n"
+                              + "  <HostId>host-id</HostId>\n"
+                              + "</Error>";
+        WM.stubFor(WireMock.get(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(403)
+                                               .withBody(errorContent)));
+
+        assertThatThrownBy(s3.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes())::join)
+            .hasCauseInstanceOf(S3Exception.class)
+            .hasMessageContaining("User does not have permission")
+            .hasMessageContaining("Status Code: 403");
+    }
+
+    @Test
+    public void getObject_headObjectOk_getObjectOk_operationSucceeds() {
+        s3 = S3AsyncClient.crtBuilder()
+                          .endpointOverride(URI.create("http://localhost:" + WM.port()))
+                          .forcePathStyle(true)
+                          .region(Region.US_EAST_1)
+                          .build();
+
+        String path = String.format("/%s/%s", BUCKET, KEY);
+
+        byte[] content = "hello".getBytes(StandardCharsets.UTF_8);
+
+        WM.stubFor(WireMock.head(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(200)
+                                               .withHeader("ETag", "etag")
+                                               .withHeader("Content-Length", Integer.toString(content.length))));
+        WM.stubFor(WireMock.get(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(200)
+                                               .withHeader("Content-Type", "text/plain")
+                                               .withBody(content)));
+
+        String objectContent = s3.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes())
+                                 .join()
+                                 .asUtf8String();
+
+        assertThat(objectContent.getBytes(StandardCharsets.UTF_8)).isEqualTo(content);
+    }
+
+    @Test
+    public void getObject_headObjectThrows_operationThrows() {
+        s3 = S3AsyncClient.crtBuilder()
+                          .endpointOverride(URI.create("http://localhost:" + WM.port()))
+                          .forcePathStyle(true)
+                          .region(Region.US_EAST_1)
+                          .build();
+
+        String path = String.format("/%s/%s", BUCKET, KEY);
+
+
+        WM.stubFor(WireMock.head(WireMock.urlPathEqualTo(path))
+                           .willReturn(WireMock.aResponse()
+                                               .withStatus(403)));
+
+        assertThatThrownBy(s3.getObject(r -> r.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes())::join)
+            .hasCauseInstanceOf(S3Exception.class)
+            .hasMessageContaining("Status Code: 403");
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
@@ -19,6 +19,7 @@ package software.amazon.awssdk.services.s3.internal.crt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -59,7 +59,7 @@ public class S3CrtResponseHandlerAdapterTest {
     @Before
     public void setup() {
         future = new CompletableFuture<>();
-        sdkResponseHandler = new TestResponseHandler();
+        sdkResponseHandler = spy(new TestResponseHandler());
         responseHandlerAdapter = new S3CrtResponseHandlerAdapter(future,
                                                                  sdkResponseHandler,
                                                                  null);
@@ -75,17 +75,20 @@ public class S3CrtResponseHandlerAdapterTest {
         int statusCode = 200;
         responseHandlerAdapter.onResponseHeaders(statusCode, httpHeaders);
 
-        SdkHttpResponse actualSdkHttpResponse = sdkResponseHandler.sdkHttpResponse;
-        assertThat(actualSdkHttpResponse.statusCode()).isEqualTo(statusCode);
-        assertThat(actualSdkHttpResponse.firstMatchingHeader("foo")).contains("1");
-        assertThat(actualSdkHttpResponse.firstMatchingHeader("bar")).contains("2");
         stubOnResponseBody();
 
         responseHandlerAdapter.onFinished(stubResponseContext(0, 0, null));
         future.get(5, TimeUnit.SECONDS);
+
+        SdkHttpResponse actualSdkHttpResponse = sdkResponseHandler.sdkHttpResponse;
+        assertThat(actualSdkHttpResponse.statusCode()).isEqualTo(statusCode);
+        assertThat(actualSdkHttpResponse.firstMatchingHeader("foo")).contains("1");
+        assertThat(actualSdkHttpResponse.firstMatchingHeader("bar")).contains("2");
+
         assertThat(future).isCompleted();
         verify(s3MetaRequest, times(2)).incrementReadWindow(11L);
         verify(s3MetaRequest).close();
+        verify(sdkResponseHandler).onHeaders(any(SdkHttpResponse.class));
     }
 
     @Test
@@ -103,6 +106,7 @@ public class S3CrtResponseHandlerAdapterTest {
                                                                                                    + "null");
         assertThat(future).isCompletedExceptionally();
         verify(s3MetaRequest).close();
+        verify(sdkResponseHandler).onHeaders(any(SdkHttpResponse.class));
     }
 
     @Test
@@ -110,17 +114,17 @@ public class S3CrtResponseHandlerAdapterTest {
         int statusCode = 400;
         responseHandlerAdapter.onResponseHeaders(statusCode, new HttpHeader[0]);
 
+        byte[] errorPayload = "errorResponse".getBytes(StandardCharsets.UTF_8);
+        stubOnResponseBody();
+        responseHandlerAdapter.onFinished(stubResponseContext(1, statusCode, errorPayload));
+
         SdkHttpResponse actualSdkHttpResponse = sdkResponseHandler.sdkHttpResponse;
         assertThat(actualSdkHttpResponse.statusCode()).isEqualTo(400);
         assertThat(actualSdkHttpResponse.headers()).isEmpty();
 
-        byte[] errorPayload = "errorResponse".getBytes(StandardCharsets.UTF_8);
-        stubOnResponseBody();
-
-        responseHandlerAdapter.onFinished(stubResponseContext(1, statusCode, errorPayload));
-
         assertThat(future).isCompleted();
         verify(s3MetaRequest).close();
+        verify(sdkResponseHandler).onHeaders(any(SdkHttpResponse.class));
     }
 
     @Test
@@ -164,7 +168,7 @@ public class S3CrtResponseHandlerAdapterTest {
         responseHandlerAdapter.onResponseBody(ByteBuffer.wrap("helloworld2".getBytes()), 1, 2);
     }
 
-    private static final class TestResponseHandler implements SdkAsyncHttpResponseHandler {
+    private static class TestResponseHandler implements SdkAsyncHttpResponseHandler {
         private SdkHttpResponse sdkHttpResponse;
         private Throwable error;
         @Override

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/ChecksumUtils.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/ChecksumUtils.java
@@ -15,17 +15,15 @@
 
 package software.amazon.awssdk.services.s3.utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import software.amazon.awssdk.core.checksums.Algorithm;
@@ -86,6 +84,20 @@ public final class ChecksumUtils {
             sdkChecksum.update(character);
         }
         return BinaryUtils.toBase64(sdkChecksum.getChecksumBytes());
+    }
+
+    public static String calculatedChecksum(Path path, Algorithm algorithm) {
+        SdkChecksum sdkChecksum = SdkChecksum.forAlgorithm(algorithm);
+        try (InputStream is = Files.newInputStream(path)) {
+            byte[] buffer = new byte[4096];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                sdkChecksum.update(buffer, 0, read);
+            }
+            return BinaryUtils.toBase64(sdkChecksum.getChecksumBytes());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static String createDataOfSize(int dataSize, char contentCharacter) {


### PR DESCRIPTION
- Some tests specificy a part number, but CRT may do a range get under the hood. S3 will throw an error if both a range and part number are specified. This is an issue that needs to be fixed in CRT, but part number is not required in this test, so removing it.

 - Rename test file to CrtCheckIntegrationTest so it gets added to CRT test suite

- This PR also reverts https://github.com/aws/aws-sdk-java-v2/commit/045bcc4e7263b5f1452b2f7a335d3010483869ad, which itself reverted the change that uncovered this issue.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
