### PR TITLE
Fix for Signing Error when ampersand character included in HttpQuery when using DefaultAwsCrtV4aSigner

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-aada2c3.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-aada2c3.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix for Signing Error when ampersand character included in HttpQuery when using DefaultAwsCrtV4aSigner."
+}

--- a/core/auth-crt/src/main/java/software/amazon/awssdk/authcrt/signer/internal/CrtHttpRequestConverter.java
+++ b/core/auth-crt/src/main/java/software/amazon/awssdk/authcrt/signer/internal/CrtHttpRequestConverter.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.authcrt.signer.internal;
 
 import static java.lang.Math.min;
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.urlDecode;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -82,7 +83,7 @@ public final class CrtHttpRequestConverter {
         }
 
         builder.encodedPath(fullUri.getRawPath());
-        String remainingQuery = fullUri.getQuery();
+        String remainingQuery = fullUri.getRawQuery();
 
         builder.clearQueryParameters();
         while (remainingQuery != null && remainingQuery.length() > 0) {
@@ -95,14 +96,14 @@ public final class CrtHttpRequestConverter {
                     queryValue = remainingQuery.substring(nextAssign + 1, nextQuery);
                 }
 
-                builder.appendRawQueryParameter(queryName, queryValue);
+                builder.appendRawQueryParameter(urlDecode(queryName), urlDecode(queryValue));
             } else {
                 String queryName = remainingQuery;
                 if (nextQuery >= 0) {
                     queryName = remainingQuery.substring(0, nextQuery);
                 }
 
-                builder.appendRawQueryParameter(queryName, null);
+                builder.appendRawQueryParameter(urlDecode(queryName), null);
             }
 
             if (nextQuery >= 0) {

--- a/core/auth-crt/src/test/java/software/amazon/awssdk/authcrt/signer/internal/CrtHttpRequestConverterTest.java
+++ b/core/auth-crt/src/test/java/software/amazon/awssdk/authcrt/signer/internal/CrtHttpRequestConverterTest.java
@@ -87,6 +87,55 @@ public class CrtHttpRequestConverterTest {
         assertHttpRequestSame(request, crtHttpRequest);
     }
 
+
+    @Test
+    public void request_withQueryParams_WithAmpersandAndEqualsInKeyAndValue_isConvertedToCrtFormat() {
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                                                       .method(SdkHttpMethod.GET)
+                                                       .putRawQueryParameter("ampersand&", "one & two")
+                                                       .putRawQueryParameter("equals=", "three = three")
+                                                       .putHeader("Host", "demo.us-east-1.amazonaws.com")
+                                                       .encodedPath("/path")
+                                                       .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
+                                                       .build();
+        HttpRequest crtHttpRequest = converter.requestToCrt(request);
+        assertThat(crtHttpRequest.getMethod()).isEqualTo("GET");
+        assertThat(crtHttpRequest.getEncodedPath()).isEqualTo("/path?ampersand%26=one%20%26%20two&equals%3D=three%20%3D%20three");
+        assertHttpRequestSame(request, crtHttpRequest);
+    }
+
+    @Test
+    public void request_withQueryParams_ApersandAndEqualsInValue_isConvertedToCrtFormat() {
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                                                       .method(SdkHttpMethod.GET)
+                                                       .putRawQueryParameter("ampersand", "one & two")
+                                                       .putRawQueryParameter("equals", "three = three")
+                                                       .putHeader("Host", "demo.us-east-1.amazonaws.com")
+                                                       .encodedPath("/path")
+                                                       .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
+                                                       .build();
+        HttpRequest crtHttpRequest = converter.requestToCrt(request);
+        assertThat(crtHttpRequest.getMethod()).isEqualTo("GET");
+        assertThat(crtHttpRequest.getEncodedPath()).isEqualTo("/path?ampersand=one%20%26%20two&equals=three%20%3D%20three");
+        assertHttpRequestSame(request, crtHttpRequest);
+    }
+
+    @Test
+    public void request_withQueryParams_EmptyApersandAndEqualsInValue_isConvertedToCrtFormat() {
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                                                       .method(SdkHttpMethod.GET)
+                                                       .putRawQueryParameter("&ampersand&", "")
+                                                       .putRawQueryParameter("=equals=", "")
+                                                       .putHeader("Host", "demo.us-east-1.amazonaws.com")
+                                                       .encodedPath("/path")
+                                                       .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
+                                                       .build();
+        HttpRequest crtHttpRequest = converter.requestToCrt(request);
+        assertThat(crtHttpRequest.getMethod()).isEqualTo("GET");
+        assertThat(crtHttpRequest.getEncodedPath()).isEqualTo("/path?%26ampersand%26=&%3Dequals%3D=");
+        assertHttpRequestSame(request, crtHttpRequest);
+    }
+
     @Test
     public void request_withEmptyPath_isConvertedToCrtFormat() {
         SdkHttpFullRequest request = SdkHttpFullRequest.builder()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
-  Signing Error when ampersand character included in HttpQuery when using DefaultAwsCrtV4aSigner
- If the Query parameters had `&` in its value then Signing for those request used to always fail.


## Modifications
<!--- Describe your changes in detail -->
- The `crtRequestToHttp` loops through query returned by fullUri using "&" and "=" for finding Key and Value.
- When the value has "&" or "=" it assumes it as separate parameters thus we need to use Raw non-decoded parameters,
- The looping is done on `getRawQuery` and then its Decoded while doing a `appendRawQueryParameter`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junit test case.
- tested with a service where the issue was seen.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
