### PR TITLE
FullJitterBackoffStrategy zero check

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-daafab1.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-daafab1.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix IllegalArgumentException in FullJitterBackoffStrategy when base delay and max backoff time are zero."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FullJitterBackoffStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FullJitterBackoffStrategy.java
@@ -61,8 +61,7 @@ public final class FullJitterBackoffStrategy implements BackoffStrategy,
     @Override
     public Duration computeDelayBeforeNextRetry(RetryPolicyContext context) {
         int ceil = calculateExponentialDelay(context.retriesAttempted(), baseDelay, maxBackoffTime);
-        // Minimum of 1 ms (consistent with BackoffStrategy.none()'s behavior)
-        return ceil == 0 ? Duration.ofMillis(1L) : Duration.ofMillis(random.nextInt(ceil) + 1L);
+        return ceil == 0 ? Duration.ofMillis(0L) : Duration.ofMillis(random.nextInt(ceil) + 1L);
     }
 
     @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FullJitterBackoffStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FullJitterBackoffStrategy.java
@@ -62,7 +62,7 @@ public final class FullJitterBackoffStrategy implements BackoffStrategy,
     public Duration computeDelayBeforeNextRetry(RetryPolicyContext context) {
         int ceil = calculateExponentialDelay(context.retriesAttempted(), baseDelay, maxBackoffTime);
         // Minimum of 1 ms (consistent with BackoffStrategy.none()'s behavior)
-        return Duration.ofMillis(random.nextInt(ceil) + 1L);
+        return ceil == 0 ? Duration.ofMillis(1L) : Duration.ofMillis(random.nextInt(ceil) + 1L);
     }
 
     @Override

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
@@ -184,5 +185,17 @@ public class RetryPolicyTest {
     @Test
     public void hashCodeDoesNotThrow() {
         RetryPolicy.defaultRetryPolicy().hashCode();
+    }
+
+    @Test
+    public void fullJitter_zeroBackoffTimeZeroDelayZeroRetries_shouldNotThrowIllegalArgumentException() {
+        RetryPolicyContext context = RetryPolicyContext.builder()
+                                                       .retriesAttempted(0)
+                                                       .build();
+        FullJitterBackoffStrategy strategy = FullJitterBackoffStrategy.builder()
+                                                            .baseDelay(Duration.ZERO)
+                                                            .maxBackoffTime(Duration.ZERO)
+                                                            .build();
+        assertDoesNotThrow(() -> strategy.computeDelayBeforeNextRetry(context));
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyTest.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.core.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
@@ -188,7 +187,7 @@ public class RetryPolicyTest {
     }
 
     @Test
-    public void fullJitter_zeroBackoffTimeZeroDelayZeroRetries_shouldNotThrowIllegalArgumentException() {
+    public void fullJitter_zeroBackoffTimeZeroDelayZeroRetries_delayShouldBeZero() {
         RetryPolicyContext context = RetryPolicyContext.builder()
                                                        .retriesAttempted(0)
                                                        .build();
@@ -196,6 +195,6 @@ public class RetryPolicyTest {
                                                             .baseDelay(Duration.ZERO)
                                                             .maxBackoffTime(Duration.ZERO)
                                                             .build();
-        assertDoesNotThrow(() -> strategy.computeDelayBeforeNextRetry(context));
+        assertThat(strategy.computeDelayBeforeNextRetry(context)).isEqualTo(Duration.ofMillis(0L));
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/Validate.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/Validate.java
@@ -757,11 +757,11 @@ public final class Validate {
     }
 
     /**
-     * Asserts that the given duration is positive (non-negative and non-zero).
+     * Asserts that the given duration is positive, including zero.
      *
      * @param duration Number to validate
      * @param fieldName Field name to display in exception message if not positive.
-     * @return Duration if positive.
+     * @return Duration if positive or zero.
      */
     public static Duration isNotNegative(Duration duration, String fieldName) {
         if (duration == null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When providing zero base delay and zero max backoff time to FullJitterBackoffStrategy, the SDK throws an IllegalArgumentException:

```
java.lang.IllegalArgumentException: bound must be positive
	at java.base/java.util.Random.nextInt(Random.java:388)
	at software.amazon.awssdk.core.retry.backoff.FullJitterBackoffStrategy.computeDelayBeforeNextRetry(FullJitterBackoffStrategy.java:65)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.getBackoffDelay(RetryableStageHelper.java:146)
	...
```

That's because bound in `Random#nextInt(bound)` must be positive, and in the first retry attempt the calculated bound was zero.

After this change, the calculated delay will be ~~1ms~~ 0ms in this case.

Repro code:
```java
        S3Client client = S3Client.builder()
                .overrideConfiguration(c->c.retryPolicy(r->r.backoffStrategy(
                        FullJitterBackoffStrategy.builder().baseDelay(Duration.ZERO).maxBackoffTime(Duration.ZERO).build())))
                .endpointOverride(URI.create("https://myendpoint.com"))
                .build();
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes https://github.com/aws/aws-sdk-java-v2/issues/4724.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
