### PR TITLE
Improved speed and reliability of CloudFrontUtilitiesIntegrationTest.

### DIFF
--- a/services/cloudfront/pom.xml
+++ b/services/cloudfront/pom.xml
@@ -63,6 +63,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <scope>test</scope>

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -21,17 +21,22 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Base64;
-import org.junit.jupiter.api.AfterAll;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;
@@ -41,89 +46,53 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCannedPolicy;
 import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCustomPolicy;
-import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
-import software.amazon.awssdk.services.cloudfront.model.Aliases;
+import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 import software.amazon.awssdk.services.cloudfront.model.CacheBehavior;
-import software.amazon.awssdk.services.cloudfront.model.CacheBehaviors;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
-import software.amazon.awssdk.services.cloudfront.model.CloudFrontOriginAccessIdentityConfig;
-import software.amazon.awssdk.services.cloudfront.model.CookiePreference;
-import software.amazon.awssdk.services.cloudfront.model.CreateCloudFrontOriginAccessIdentityRequest;
+import software.amazon.awssdk.services.cloudfront.model.CloudFrontOriginAccessIdentitySummary;
 import software.amazon.awssdk.services.cloudfront.model.CreateCloudFrontOriginAccessIdentityResponse;
-import software.amazon.awssdk.services.cloudfront.model.CreateDistributionRequest;
-import software.amazon.awssdk.services.cloudfront.model.CreateDistributionResponse;
-import software.amazon.awssdk.services.cloudfront.model.CreateKeyGroupRequest;
-import software.amazon.awssdk.services.cloudfront.model.CreatePublicKeyRequest;
 import software.amazon.awssdk.services.cloudfront.model.CreatePublicKeyResponse;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.DefaultCacheBehavior;
-import software.amazon.awssdk.services.cloudfront.model.DeleteCloudFrontOriginAccessIdentityRequest;
-import software.amazon.awssdk.services.cloudfront.model.DeleteDistributionRequest;
-import software.amazon.awssdk.services.cloudfront.model.DeleteKeyGroupRequest;
-import software.amazon.awssdk.services.cloudfront.model.DeletePublicKeyRequest;
+import software.amazon.awssdk.services.cloudfront.model.Distribution;
 import software.amazon.awssdk.services.cloudfront.model.DistributionConfig;
-import software.amazon.awssdk.services.cloudfront.model.ForwardedValues;
-import software.amazon.awssdk.services.cloudfront.model.GetCloudFrontOriginAccessIdentityRequest;
-import software.amazon.awssdk.services.cloudfront.model.GetDistributionConfigRequest;
-import software.amazon.awssdk.services.cloudfront.model.GetDistributionConfigResponse;
-import software.amazon.awssdk.services.cloudfront.model.GetKeyGroupRequest;
-import software.amazon.awssdk.services.cloudfront.model.GetPublicKeyRequest;
-import software.amazon.awssdk.services.cloudfront.model.Headers;
-import software.amazon.awssdk.services.cloudfront.model.KeyGroup;
-import software.amazon.awssdk.services.cloudfront.model.KeyGroupConfig;
-import software.amazon.awssdk.services.cloudfront.model.LoggingConfig;
+import software.amazon.awssdk.services.cloudfront.model.DistributionSummary;
+import software.amazon.awssdk.services.cloudfront.model.KeyGroupSummary;
 import software.amazon.awssdk.services.cloudfront.model.Origin;
-import software.amazon.awssdk.services.cloudfront.model.Origins;
 import software.amazon.awssdk.services.cloudfront.model.PriceClass;
-import software.amazon.awssdk.services.cloudfront.model.PublicKeyConfig;
-import software.amazon.awssdk.services.cloudfront.model.S3OriginConfig;
-import software.amazon.awssdk.services.cloudfront.model.TrustedKeyGroups;
-import software.amazon.awssdk.services.cloudfront.model.UpdateDistributionResponse;
+import software.amazon.awssdk.services.cloudfront.model.PublicKeySummary;
 import software.amazon.awssdk.services.cloudfront.model.ViewerProtocolPolicy;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutBucketPolicyRequest;
+import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
+import software.amazon.awssdk.services.s3.model.Bucket;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceExistsException;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
 import software.amazon.awssdk.testutils.RandomTempFile;
-import software.amazon.awssdk.testutils.service.S3BucketUtils;
+import software.amazon.awssdk.testutils.Waiter;
 
 public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
-    private static final Base64.Encoder encoder = Base64.getEncoder();
-    private static final String callerReference =
-        S3BucketUtils.temporaryBucketName(String.valueOf(Instant.now().getEpochSecond()));
-    private static final String s3ObjectKey = "s3ObjectKey";
+    private static final Base64.Encoder ENCODER = Base64.getEncoder();
+    private static final String RESOURCE_PREFIX = "cf-test-";
+    private static final String CALLER_REFERENCE = UUID.randomUUID().toString();
+    private static final String S3_OBJECT_KEY = "s3ObjectKey";
+
+    private static String bucket;
     private static String domainName;
     private static String resourceUrl;
     private static String keyPairId;
-    private static KeyPair keyPair;
+    private static PrivateKey privateKey;
     private static File keyFile;
     private static Path keyFilePath;
     private static String keyGroupId;
     private static String originAccessId;
     private static String distributionId;
-    private static String distributionETag;
 
     @BeforeAll
     public static void init() throws Exception {
         IntegrationTestBase.setUp();
-        initKeys();
-        setUpDistribution();
-    }
-
-    @AfterAll
-    public static void tearDown() throws Exception {
-        disableDistribution();
-        cloudFrontClient.deleteDistribution(DeleteDistributionRequest.builder().ifMatch(distributionETag).id(distributionId).build());
-        deleteBucketAndAllContents(callerReference);
-        String keyGroupETag = cloudFrontClient.getKeyGroup(GetKeyGroupRequest.builder().id(keyGroupId).build()).eTag();
-        cloudFrontClient.deleteKeyGroup(DeleteKeyGroupRequest.builder().ifMatch(keyGroupETag).id(keyGroupId).build());
-        String publicKeyETag = cloudFrontClient.getPublicKey(GetPublicKeyRequest.builder().id(keyPairId).build()).eTag();
-        cloudFrontClient.deletePublicKey(DeletePublicKeyRequest.builder().ifMatch(publicKeyETag).id(keyPairId).build());
-        String originAccessIdETag = cloudFrontClient.getCloudFrontOriginAccessIdentity(GetCloudFrontOriginAccessIdentityRequest
-                                                                                           .builder().id(originAccessId).build()).eTag();
-        cloudFrontClient.deleteCloudFrontOriginAccessIdentity(DeleteCloudFrontOriginAccessIdentityRequest
-                                                                  .builder().ifMatch(originAccessIdETag).id(originAccessId).build());
-        keyFile.deleteOnExit();
+        initStaticFields();
     }
 
     @Test
@@ -144,7 +113,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
     @Test
     void getSignedUrlWithCannedPolicy_producesValidUrl() throws Exception {
-        InputStream originalBucketContent = s3Client.getObject(GetObjectRequest.builder().bucket(callerReference).key(s3ObjectKey).build());
+        InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CannedSignerRequest request = CannedSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
@@ -167,7 +136,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     void getSignedUrlWithCannedPolicy_withExpiredDate_shouldReturn403Response() throws Exception {
         Instant expirationDate = LocalDate.of(2020, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                      .privateKey(keyPair.getPrivate())
+                                                                                      .privateKey(privateKey)
                                                                                       .keyPairId(keyPairId)
                                                                                       .expirationDate(expirationDate));
         SdkHttpClient client = ApacheHttpClient.create();
@@ -180,7 +149,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
     @Test
     void getSignedUrlWithCustomPolicy_producesValidUrl() throws Exception {
-        InputStream originalBucketContent = s3Client.getObject(GetObjectRequest.builder().bucket(callerReference).key(s3ObjectKey).build());
+        InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CustomSignerRequest request = CustomSignerRequest.builder()
@@ -206,7 +175,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         Instant activeDate = LocalDate.of(2040, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                      .privateKey(keyPair.getPrivate())
+                                                                                      .privateKey(privateKey)
                                                                                       .keyPairId(keyPairId)
                                                                                       .expirationDate(expirationDate)
                                                                                       .activeDate(activeDate));
@@ -220,10 +189,10 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
     @Test
     void getCookiesForCannedPolicy_producesValidCookies() throws Exception {
-        InputStream originalBucketContent = s3Client.getObject(GetObjectRequest.builder().bucket(callerReference).key(s3ObjectKey).build());
+        InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CookiesForCannedPolicy cookies = cloudFrontUtilities.getCookiesForCannedPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                             .privateKey(keyPair.getPrivate())
+                                                                                             .privateKey(privateKey)
                                                                                              .keyPairId(keyPairId)
                                                                                              .expirationDate(expirationDate));
 
@@ -258,11 +227,11 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
     @Test
     void getCookiesForCustomPolicy_producesValidCookies() throws Exception {
-        InputStream originalBucketContent = s3Client.getObject(GetObjectRequest.builder().bucket(callerReference).key(s3ObjectKey).build());
+        InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                             .privateKey(keyPair.getPrivate())
+                                                                                             .privateKey(privateKey)
                                                                                              .keyPairId(keyPairId)
                                                                                              .expirationDate(expirationDate)
                                                                                              .activeDate(activeDate));
@@ -298,77 +267,149 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
     }
 
-    static void setUpDistribution() throws IOException, InterruptedException {
-        CreateCloudFrontOriginAccessIdentityResponse response = cloudFrontClient.createCloudFrontOriginAccessIdentity(
-            CreateCloudFrontOriginAccessIdentityRequest.builder()
-                                                       .cloudFrontOriginAccessIdentityConfig(CloudFrontOriginAccessIdentityConfig.builder()
-                                                                                                                                 .callerReference(callerReference)
-                                                                                                                                 .comment("SignerTestAccessIdentity" + callerReference)
-                                                                                                                                 .build())
-                                                       .build());
-        originAccessId = response.cloudFrontOriginAccessIdentity().id();
+    private static void initStaticFields() throws Exception {
+        initializeKeyFileAndPair();
+        originAccessId = getOrCreateOriginAccessIdentity();
+        keyGroupId = getOrCreateKeyGroup();
+        bucket = getOrCreateBucket();
 
-        KeyGroup keyGroup =
-            cloudFrontClient.createKeyGroup(CreateKeyGroupRequest.builder().keyGroupConfig(KeyGroupConfig.builder()
-                                                                                                     .name("TestKeyGroup" + callerReference)
-                                                                                                     .items(keyPairId)
-                                                                                                     .build()).build()).keyGroup();
-        keyGroupId = keyGroup.id();
+        TestDistribution distribution = getOrCreateDistribution();
 
-        s3Client.createBucket(CreateBucketRequest.builder().bucket(callerReference).build());
+        domainName = distribution.domainName;
+        resourceUrl = "https://" + domainName + "/" + S3_OBJECT_KEY;
+        distributionId = distribution.id;
+    }
+
+    private static void initializeKeyFileAndPair() throws Exception {
+        keyFile = new RandomTempFile(UUID.randomUUID() + "-key.pem", 0);
+        keyFile.deleteOnExit();
+        keyFilePath = keyFile.toPath();
+
+        String privateKeyName = RESOURCE_PREFIX + "private-key";
+        String publicKeyName = RESOURCE_PREFIX + "public-key";
+        try {
+            GetSecretValueResponse getSecretResponse = secretsManagerClient.getSecretValue(r -> r.secretId(privateKeyName));
+            Files.write(keyFile.toPath(), getSecretResponse.secretBinary().asByteArray(), StandardOpenOption.TRUNCATE_EXISTING);
+
+            Optional<PublicKeySummary> key = cloudFrontClient.listPublicKeys()
+                                                             .publicKeyList()
+                                                             .items()
+                                                             .stream()
+                                                             .filter(k -> publicKeyName.equals(k.name()))
+                                                             .findAny();
+            if (key.isPresent()) {
+                privateKey = SigningUtils.loadPrivateKey(keyFilePath);
+                keyPairId = key.get().id();
+                return;
+            }
+        } catch (ResourceNotFoundException e) {
+            // No private key, don't bother checking for a public one.
+        }
+
+        System.out.println("Creating keys.");
+
+        // We were missing a private or public key. Initialize them both.
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        FileWriter writer = new FileWriter(keyFile);
+        writer.write("-----BEGIN PRIVATE KEY-----\n");
+        writer.write(ENCODER.encodeToString(keyPair.getPrivate().getEncoded()));
+        writer.write("\n-----END PRIVATE KEY-----\n");
+        writer.close();
+
+        SdkBytes keyFileBytes = SdkBytes.fromByteArray(Files.readAllBytes(keyFilePath));
+        try {
+            secretsManagerClient.createSecret(r -> r.name(privateKeyName)
+                                                    .secretBinary(keyFileBytes));
+        } catch (ResourceExistsException e) {
+            secretsManagerClient.putSecretValue(r -> r.secretId(privateKeyName)
+                                                      .secretBinary(keyFileBytes));
+        }
+
+        String encodedKey = "-----BEGIN PUBLIC KEY-----\n"
+                            + ENCODER.encodeToString(keyPair.getPublic().getEncoded())
+                            + "\n-----END PUBLIC KEY-----\n";
+
+
+        CreatePublicKeyResponse publicKeyResponse =
+            cloudFrontClient.createPublicKey(r -> r.publicKeyConfig(k -> k.callerReference(CALLER_REFERENCE)
+                                                                          .name(publicKeyName)
+                                                                          .encodedKey(encodedKey)));
+        privateKey = keyPair.getPrivate();
+        keyPairId = publicKeyResponse.publicKey().id();
+    }
+
+    private static String getOrCreateOriginAccessIdentity() {
+        String originAccessIdentityComment = RESOURCE_PREFIX + "origin-access-identity";
+        Optional<CloudFrontOriginAccessIdentitySummary> originAccessIdentity =
+            cloudFrontClient.listCloudFrontOriginAccessIdentities()
+                            .cloudFrontOriginAccessIdentityList()
+                            .items()
+                            .stream()
+                            .filter(i -> originAccessIdentityComment.equals(i.comment()))
+                            .findAny();
+
+        if (originAccessIdentity.isPresent()) {
+            return originAccessIdentity.get().id();
+        }
+
+        System.out.println("Creating origin access identity.");
+
+        CreateCloudFrontOriginAccessIdentityResponse response =
+            cloudFrontClient.createCloudFrontOriginAccessIdentity(r -> r
+                .cloudFrontOriginAccessIdentityConfig(c -> c.callerReference(CALLER_REFERENCE)
+                                                            .comment(originAccessIdentityComment)));
+        return response.cloudFrontOriginAccessIdentity().id();
+    }
+
+    private static String getOrCreateKeyGroup() {
+        String keyGroupName = RESOURCE_PREFIX + "key-group";
+
+        Optional<KeyGroupSummary> keyGroup =
+            cloudFrontClient.listKeyGroups(r -> {})
+                            .keyGroupList()
+                            .items()
+                            .stream()
+                            .filter(kg -> keyGroupName.equals(kg.keyGroup()
+                                                                .keyGroupConfig()
+                                                                .name()))
+                            .findAny();
+
+        if (keyGroup.isPresent()) {
+            return keyGroup.get().keyGroup().id();
+        }
+
+        System.out.println("Creating key group.");
+
+        return cloudFrontClient.createKeyGroup(r -> r.keyGroupConfig(c -> c.name(keyGroupName)
+                                                                           .items(keyPairId)))
+                               .keyGroup()
+                               .id();
+    }
+
+    private static String getOrCreateBucket() throws IOException {
+        String bucketNamePrefix = RESOURCE_PREFIX + "bucket";
+
+        Optional<Bucket> bucket = s3Client.listBuckets()
+                                          .buckets()
+                                          .stream()
+                                          .filter(b -> b.name().startsWith(bucketNamePrefix))
+                                          .findAny();
+
+        if (bucket.isPresent()) {
+            return bucket.get().name();
+        }
+
+        System.out.println("Creating bucket.");
+
+        String newBucketName = bucketNamePrefix + "-" + System.currentTimeMillis();
+        s3Client.createBucket(r -> r.bucket(newBucketName));
+        s3Client.waiter().waitUntilBucketExists(r -> r.bucket(newBucketName));
+
         File content = new RandomTempFile("testFile", 1000L);
-        s3Client.putObject(PutObjectRequest.builder().bucket(callerReference).key(s3ObjectKey).build(), RequestBody.fromFile(content));
-
-        DefaultCacheBehavior defaultCacheBehavior = DefaultCacheBehavior.builder()
-                                                                        .forwardedValues(ForwardedValues.builder()
-                                                                                                        .queryString(false).cookies(CookiePreference.builder().forward("none").build())
-                                                                                                        .headers(Headers.builder().quantity(0).build()).build()).minTTL(10000L).maxTTL(10000L).defaultTTL(10000L)
-                                                                        .targetOriginId("1")
-                                                                        .viewerProtocolPolicy(ViewerProtocolPolicy.ALLOW_ALL)
-                                                                        .trustedKeyGroups(TrustedKeyGroups.builder().enabled(true).quantity(1).items(keyGroup.id()).build()).build();
-
-        CacheBehavior cacheBehavior = CacheBehavior.builder()
-                                                   .forwardedValues(ForwardedValues.builder()
-                                                                                   .queryString(false).cookies(CookiePreference.builder().forward("none").build())
-                                                                                   .headers(Headers.builder().quantity(0).build()).build()).minTTL(10000L).maxTTL(10000L).defaultTTL(10000L)
-                                                   .targetOriginId("1")
-                                                   .viewerProtocolPolicy(ViewerProtocolPolicy.ALLOW_ALL)
-                                                   .trustedKeyGroups(TrustedKeyGroups.builder().enabled(true).quantity(1).items(keyGroup.id()).build()).pathPattern("*").build();
-
-        Origin origin = Origin.builder()
-                              .domainName(callerReference + ".s3.amazonaws.com")
-                              .id("1")
-                              .s3OriginConfig(S3OriginConfig.builder().originAccessIdentity("origin-access-identity/cloudfront/" + originAccessId).build()).build();
-
-        DistributionConfig distributionConfiguration = DistributionConfig.builder()
-                                                                         .priceClass(PriceClass.PRICE_CLASS_100)
-                                                                         .defaultCacheBehavior(defaultCacheBehavior)
-                                                                         .aliases(Aliases.builder().quantity(0).build())
-                                                                         .logging(LoggingConfig.builder()
-                                                                                               .includeCookies(false)
-                                                                                               .enabled(false)
-                                                                                               .bucket(callerReference)
-                                                                                               .prefix("").build())
-                                                                         .callerReference(callerReference)
-                                                                         .cacheBehaviors(CacheBehaviors.builder()
-                                                                                                       .quantity(1)
-                                                                                                       .items(cacheBehavior).build())
-                                                                         .comment("PresignerTestDistribution")
-                                                                         .defaultRootObject("")
-                                                                         .enabled(true)
-                                                                         .origins(Origins.builder()
-                                                                                         .quantity(1)
-                                                                                         .items(origin).build()).build();
-
-        CreateDistributionResponse createDistributionResponse =
-            cloudFrontClient.createDistribution(CreateDistributionRequest.builder().distributionConfig(distributionConfiguration).build());
-
-        domainName = createDistributionResponse.distribution().domainName();
-        resourceUrl = "https://" + domainName + "/" + s3ObjectKey;
-        distributionId = createDistributionResponse.distribution().id();
-        distributionETag = createDistributionResponse.eTag();
-
-        waitForDistributionToDeploy(distributionId);
+        s3Client.putObject(PutObjectRequest.builder().bucket(newBucketName).key(S3_OBJECT_KEY).build(), RequestBody.fromFile(content));
 
         String bucketPolicy = "{\n"
                               + "\"Version\":\"2012-10-17\",\n"
@@ -380,51 +421,109 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                               + "\"AWS\":\"arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity " + originAccessId + "\"\n"
                               + "},\n"
                               + "\"Action\":\"s3:GetObject\",\n"
-                              + "\"Resource\":\"arn:aws:s3:::" + callerReference + "/*\"\n"
+                              + "\"Resource\":\"arn:aws:s3:::" + newBucketName + "/*\"\n"
                               + "}\n"
                               + "]\n"
                               + "}";
 
-        s3Client.putBucketPolicy(PutBucketPolicyRequest.builder().bucket(callerReference).policy(bucketPolicy).build());
+        // The origin access identity might not be ready right away, if it was just created. Retry this until
+        // identity catches up.
+        Waiter.run(() -> s3Client.putBucketPolicy(r -> r.bucket(newBucketName).policy(bucketPolicy)))
+              .ignoringException(S3Exception.class)
+              .orFailAfter(Duration.ofMinutes(2));
+
+        return newBucketName;
     }
 
-    static void initKeys() throws NoSuchAlgorithmException, IOException {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(2048);
-        keyPair = kpg.generateKeyPair();
+    private static class TestDistribution {
+        private final String id;
+        private final String domainName;
 
-        keyFile = new File("src/test/key.pem");
-        FileWriter writer = new FileWriter(keyFile);
-        writer.write("-----BEGIN PRIVATE KEY-----\n");
-        writer.write(encoder.encodeToString(keyPair.getPrivate().getEncoded()));
-        writer.write("\n-----END PRIVATE KEY-----\n");
-        writer.close();
-        keyFilePath = keyFile.toPath();
-
-        String encodedKey = "-----BEGIN PUBLIC KEY-----\n"
-                            + encoder.encodeToString(keyPair.getPublic().getEncoded())
-                            + "\n-----END PUBLIC KEY-----\n";
-        CreatePublicKeyResponse publicKeyResponse =
-            cloudFrontClient.createPublicKey(CreatePublicKeyRequest.builder().publicKeyConfig(PublicKeyConfig.builder()
-                                                                                                             .callerReference(callerReference)
-                                                                                                             .name("testKey" + callerReference)
-                                                                                                             .encodedKey(encodedKey).build()).build());
-        keyPairId = publicKeyResponse.publicKey().id();
+        private TestDistribution(String id, String domainName) {
+            this.id = id;
+            this.domainName = domainName;
+        }
     }
 
-    static void disableDistribution() throws InterruptedException {
-        GetDistributionConfigResponse distributionConfigResponse =
-            cloudFrontClient.getDistributionConfig(GetDistributionConfigRequest.builder().id(distributionId).build());
-        distributionETag = distributionConfigResponse.eTag();
-        DistributionConfig originalConfig = distributionConfigResponse.distributionConfig();
-        UpdateDistributionResponse updateDistributionResponse =
-            cloudFrontClient.updateDistribution(r -> r.id(distributionId)
-                                                      .ifMatch(distributionETag)
-                                                      .distributionConfig(originalConfig.toBuilder()
-                                                                                        .enabled(false)
-                                                                                        .build()));
-        distributionETag = updateDistributionResponse.eTag();
-        waitForDistributionToDeploy(distributionId);
-    }
+    private static TestDistribution getOrCreateDistribution() throws InterruptedException {
+        String distributionComment = RESOURCE_PREFIX + "distribution";
 
+        Optional<DistributionSummary> distribution =
+            cloudFrontClient.listDistributions()
+                            .distributionList()
+                            .items()
+                            .stream()
+                            .filter(d -> distributionComment.equals(d.comment()))
+                            .findAny();
+
+        if (distribution.isPresent()) {
+            DistributionSummary d = distribution.get();
+            return new TestDistribution(d.id(), d.domainName());
+        }
+
+        System.out.println("Creating distribution.");
+
+        DefaultCacheBehavior defaultCacheBehavior =
+            DefaultCacheBehavior.builder()
+                                .forwardedValues(f -> f.queryString(false)
+                                                       .cookies(c -> c.forward("none"))
+                                                       .headers(h -> h.quantity(0)))
+                                .minTTL(10000L)
+                                .maxTTL(10000L)
+                                .defaultTTL(10000L)
+                                .targetOriginId("1")
+                                .viewerProtocolPolicy(ViewerProtocolPolicy.ALLOW_ALL)
+                                .trustedKeyGroups(g -> g.enabled(true)
+                                                        .quantity(1)
+                                                        .items(keyGroupId))
+                                .build();
+
+        CacheBehavior cacheBehavior =
+            CacheBehavior.builder()
+                         .forwardedValues(f -> f.queryString(false)
+                                                .cookies(c -> c.forward("none"))
+                                                .headers(h -> h.quantity(0)))
+                         .minTTL(10000L)
+                         .maxTTL(10000L)
+                         .defaultTTL(10000L)
+                         .targetOriginId("1")
+                         .viewerProtocolPolicy(ViewerProtocolPolicy.ALLOW_ALL)
+                         .trustedKeyGroups(g -> g.enabled(true)
+                                                 .quantity(1)
+                                                 .items(keyGroupId))
+                         .pathPattern("*")
+                         .build();
+
+        Origin origin = Origin.builder()
+                              .domainName(bucket + ".s3.amazonaws.com")
+                              .id("1")
+                              .s3OriginConfig(c -> c.originAccessIdentity("origin-access-identity/cloudfront/" + originAccessId))
+                              .build();
+
+        DistributionConfig distributionConfiguration =
+            DistributionConfig.builder()
+                              .priceClass(PriceClass.PRICE_CLASS_100)
+                              .defaultCacheBehavior(defaultCacheBehavior)
+                              .aliases(a -> a.quantity(0))
+                              .logging(l -> l.includeCookies(false)
+                                             .enabled(false)
+                                             .bucket(bucket)
+                                             .prefix(""))
+                              .callerReference(CALLER_REFERENCE)
+                              .cacheBehaviors(b -> b.quantity(1)
+                                                    .items(cacheBehavior))
+                              .comment(distributionComment)
+                              .defaultRootObject("")
+                              .enabled(true)
+                              .origins(o -> o.quantity(1)
+                                             .items(origin))
+                              .build();
+
+        Distribution d = cloudFrontClient.createDistribution(r -> r.distributionConfig(distributionConfiguration))
+                                         .distribution();
+        System.out.println("Waiting for distribution to be deployed. This takes a while, but will be reused for "
+                           + "the next test run on this account.");
+        cloudFrontClient.waiter().waitUntilDistributionDeployed(r -> r.id(d.id()));
+        return new TestDistribution(d.id(), d.domainName());
+    }
 }


### PR DESCRIPTION
Resources are now reused between runs of the integration test, so they should not build up on the account anymore and no longer need to be re-created each time the test is run.