### PR TITLE
Fixed the issue where closed connection exception thrown from AWS CRT…

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTHTTPClient-051bb93.json
+++ b/.changes/next-release/bugfix-AWSCRTHTTPClient-051bb93.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT HTTP Client",
+    "contributor": "",
+    "description": "Fixed the issue where `AWS_ERROR_HTTP_CONNECTION_CLOSED` was not retried by the SDK."
+}

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -169,6 +169,11 @@
             <version>${commons-codec.verion}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.internal.AwsCrtClientBuilderBase;
 import software.amazon.awssdk.http.crt.internal.CrtAsyncRequestContext;
-import software.amazon.awssdk.http.crt.internal.CrtRequestExecutor;
+import software.amazon.awssdk.http.crt.internal.CrtAsyncRequestExecutor;
 import software.amazon.awssdk.utils.AttributeMap;
 
 /**
@@ -98,7 +98,7 @@ public final class AwsCrtAsyncHttpClient extends AwsCrtHttpClientBase implements
                                                                    .request(asyncRequest)
                                                                    .build();
 
-            return new CrtRequestExecutor().execute(context);
+            return new CrtAsyncRequestExecutor().execute(context);
         }
     }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import static software.amazon.awssdk.http.crt.internal.CrtUtils.reportMetrics;
+import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapConnectionFailureException;
+import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapWithIoExceptionIfRetryable;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpException;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
+import software.amazon.awssdk.http.SdkCancellationException;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.crt.internal.request.CrtRequestAdapter;
+import software.amazon.awssdk.http.crt.internal.response.CrtResponseAdapter;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+import software.amazon.awssdk.utils.Logger;
+
+@SdkInternalApi
+public final class CrtAsyncRequestExecutor {
+
+    private static final Logger log = Logger.loggerFor(CrtAsyncRequestExecutor.class);
+
+    public CompletableFuture<Void> execute(CrtAsyncRequestContext executionContext) {
+        // go ahead and get a reference to the metricCollector since multiple futures will
+        // need it regardless.
+        MetricCollector metricCollector = executionContext.metricCollector();
+        boolean shouldPublishMetrics = metricCollector != null && !(metricCollector instanceof NoOpMetricCollector);
+
+        long acquireStartTime = 0;
+
+        if (shouldPublishMetrics) {
+            // go ahead and get acquireStartTime for the concurrency timer as early as possible,
+            // so it's as accurate as possible, but only do it in a branch since clock_gettime()
+            // results in a full sys call barrier (multiple mutexes and a hw interrupt).
+            acquireStartTime = System.nanoTime();
+        }
+
+        CompletableFuture<Void> requestFuture = createAsyncExecutionFuture(executionContext.sdkRequest());
+
+        // When a Connection is ready from the Connection Pool, schedule the Request on the connection
+        CompletableFuture<HttpClientConnection> httpClientConnectionCompletableFuture =
+            executionContext.crtConnPool().acquireConnection();
+
+        long finalAcquireStartTime = acquireStartTime;
+
+        httpClientConnectionCompletableFuture.whenComplete((crtConn, throwable) -> {
+            AsyncExecuteRequest asyncRequest = executionContext.sdkRequest();
+
+            if (shouldPublishMetrics) {
+                reportMetrics(executionContext.crtConnPool(), metricCollector, finalAcquireStartTime);
+            }
+
+            // If we didn't get a connection for some reason, fail the request
+            if (throwable != null) {
+                Throwable toThrow = wrapConnectionFailureException(throwable);
+                reportAsyncFailure(crtConn, toThrow, requestFuture, asyncRequest.responseHandler());
+                return;
+            }
+
+            executeRequest(executionContext, requestFuture, crtConn, asyncRequest);
+        });
+
+        return requestFuture;
+    }
+
+    private void executeRequest(CrtAsyncRequestContext executionContext,
+                                CompletableFuture<Void> requestFuture,
+                                HttpClientConnection crtConn,
+                                AsyncExecuteRequest asyncRequest) {
+        HttpRequest crtRequest = CrtRequestAdapter.toAsyncCrtRequest(executionContext);
+        HttpStreamResponseHandler crtResponseHandler =
+            CrtResponseAdapter.toCrtResponseHandler(crtConn, requestFuture, asyncRequest.responseHandler());
+
+        // Submit the request on the connection
+        try {
+            crtConn.makeRequest(crtRequest, crtResponseHandler).activate();
+        } catch (HttpException e) {
+            Throwable toThrow = wrapWithIoExceptionIfRetryable(e);
+            reportAsyncFailure(crtConn,
+                          toThrow,
+                          requestFuture,
+                          asyncRequest.responseHandler());
+        } catch (IllegalStateException | CrtRuntimeException e) {
+            // CRT throws IllegalStateException if the connection is closed
+            reportAsyncFailure(crtConn, new IOException("An exception occurred when making the request", e),
+                          requestFuture,
+                          asyncRequest.responseHandler());
+        } catch (Throwable throwable) {
+            reportAsyncFailure(crtConn, throwable,
+                               requestFuture,
+                               asyncRequest.responseHandler());
+        }
+    }
+
+    /**
+     * Create the execution future and set up the cancellation logic.
+     * @return The created execution future.
+     */
+    private CompletableFuture<Void> createAsyncExecutionFuture(AsyncExecuteRequest request) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        future.whenComplete((r, t) -> {
+            if (t == null) {
+                return;
+            }
+
+            // TODO: Aborting request once it's supported in CRT
+            if (future.isCancelled()) {
+                request.responseHandler().onError(new SdkCancellationException("The request was cancelled"));
+            }
+        });
+
+        return future;
+    }
+
+    /**
+     * Notify the provided response handler and future of the failure.
+     */
+    private void reportAsyncFailure(HttpClientConnection crtConn,
+                               Throwable cause,
+                               CompletableFuture<Void> executeFuture,
+                               SdkAsyncHttpResponseHandler responseHandler) {
+        if (crtConn != null) {
+            crtConn.close();
+        }
+
+        try {
+            responseHandler.onError(cause);
+        } catch (Exception e) {
+            log.error(() -> "SdkAsyncHttpResponseHandler " + responseHandler + " threw an exception in onError. It will be "
+                            + "ignored.", e);
+        }
+        executeFuture.completeExceptionally(cause);
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
@@ -15,32 +15,20 @@
 
 package software.amazon.awssdk.http.crt.internal;
 
-import static software.amazon.awssdk.http.HttpMetric.AVAILABLE_CONCURRENCY;
-import static software.amazon.awssdk.http.HttpMetric.CONCURRENCY_ACQUIRE_DURATION;
-import static software.amazon.awssdk.http.HttpMetric.LEASED_CONCURRENCY;
-import static software.amazon.awssdk.http.HttpMetric.MAX_CONCURRENCY;
-import static software.amazon.awssdk.http.HttpMetric.PENDING_CONCURRENCY_ACQUIRES;
+import static software.amazon.awssdk.http.crt.internal.CrtUtils.reportMetrics;
+import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapConnectionFailureException;
 import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapWithIoExceptionIfRetryable;
-import static software.amazon.awssdk.utils.NumericUtils.saturatedCast;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import javax.net.ssl.SSLHandshakeException;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
-import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
 import software.amazon.awssdk.crt.http.HttpException;
-import software.amazon.awssdk.crt.http.HttpManagerMetrics;
 import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
-import software.amazon.awssdk.http.SdkCancellationException;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
-import software.amazon.awssdk.http.async.AsyncExecuteRequest;
-import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 import software.amazon.awssdk.http.crt.internal.request.CrtRequestAdapter;
-import software.amazon.awssdk.http.crt.internal.response.CrtResponseAdapter;
 import software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -48,7 +36,6 @@ import software.amazon.awssdk.utils.Logger;
 
 @SdkInternalApi
 public final class CrtRequestExecutor {
-    public static final int CRT_TLS_NEGOTIATION_ERROR_CODE = 1029;
 
     private static final Logger log = Logger.loggerFor(CrtRequestExecutor.class);
 
@@ -82,18 +69,7 @@ public final class CrtRequestExecutor {
 
             // If we didn't get a connection for some reason, fail the request
             if (throwable != null) {
-                Throwable toThrow;
-                if (throwable instanceof HttpException) {
-                    HttpException httpException = (HttpException) throwable;
-
-                    if (httpException.getErrorCode() == CRT_TLS_NEGOTIATION_ERROR_CODE) {
-                        toThrow = new SSLHandshakeException(httpException.getMessage());
-                    } else {
-                        toThrow = new IOException(httpException.getMessage(), httpException);
-                    }
-                } else {
-                    toThrow = new IOException("An exception occurred when acquiring a connection", throwable);
-                }
+                Throwable toThrow = wrapConnectionFailureException(throwable);
                 requestFuture.completeExceptionally(toThrow);
                 return;
             }
@@ -102,96 +78,6 @@ public final class CrtRequestExecutor {
         });
 
         return requestFuture;
-    }
-
-    public CompletableFuture<Void> execute(CrtAsyncRequestContext executionContext) {
-        // go ahead and get a reference to the metricCollector since multiple futures will
-        // need it regardless.
-        MetricCollector metricCollector = executionContext.metricCollector();
-        boolean shouldPublishMetrics = metricCollector != null && !(metricCollector instanceof NoOpMetricCollector);
-
-        long acquireStartTime = 0;
-
-        if (shouldPublishMetrics) {
-            // go ahead and get acquireStartTime for the concurrency timer as early as possible,
-            // so it's as accurate as possible, but only do it in a branch since clock_gettime()
-            // results in a full sys call barrier (multiple mutexes and a hw interrupt).
-            acquireStartTime = System.nanoTime();
-        }
-
-        CompletableFuture<Void> requestFuture = createAsyncExecutionFuture(executionContext.sdkRequest());
-
-        // When a Connection is ready from the Connection Pool, schedule the Request on the connection
-        CompletableFuture<HttpClientConnection> httpClientConnectionCompletableFuture =
-            executionContext.crtConnPool().acquireConnection();
-
-        long finalAcquireStartTime = acquireStartTime;
-
-        httpClientConnectionCompletableFuture.whenComplete((crtConn, throwable) -> {
-            AsyncExecuteRequest asyncRequest = executionContext.sdkRequest();
-
-            if (shouldPublishMetrics) {
-                reportMetrics(executionContext.crtConnPool(), metricCollector, finalAcquireStartTime);
-            }
-
-            // If we didn't get a connection for some reason, fail the request
-            if (throwable != null) {
-                Throwable toThrow = new IOException("An exception occurred when acquiring a connection", throwable);
-                if (throwable instanceof HttpException) {
-                    HttpException httpException = (HttpException) throwable;
-
-                    if (httpException.getErrorCode() == CRT_TLS_NEGOTIATION_ERROR_CODE) {
-                        toThrow = new SSLHandshakeException(httpException.getMessage());
-                    }
-                }
-
-                reportAsyncFailure(crtConn, toThrow, requestFuture, asyncRequest.responseHandler());
-                return;
-            }
-
-            executeRequest(executionContext, requestFuture, crtConn, asyncRequest);
-        });
-
-        return requestFuture;
-    }
-
-    private static void reportMetrics(HttpClientConnectionManager connManager, MetricCollector metricCollector,
-                                      long acquireStartTime) {
-        long acquireCompletionTime = System.nanoTime();
-        Duration acquireTimeTaken = Duration.ofNanos(acquireCompletionTime - acquireStartTime);
-        metricCollector.reportMetric(CONCURRENCY_ACQUIRE_DURATION, acquireTimeTaken);
-        HttpManagerMetrics managerMetrics = connManager.getManagerMetrics();
-        // currently this executor only handles HTTP 1.1. Until H2 is added, the max concurrency settings are 1:1 with TCP
-        // connections. When H2 is added, this code needs to be updated to handle stream multiplexing
-        metricCollector.reportMetric(MAX_CONCURRENCY, connManager.getMaxConnections());
-        metricCollector.reportMetric(AVAILABLE_CONCURRENCY, saturatedCast(managerMetrics.getAvailableConcurrency()));
-        metricCollector.reportMetric(LEASED_CONCURRENCY, saturatedCast(managerMetrics.getLeasedConcurrency()));
-        metricCollector.reportMetric(PENDING_CONCURRENCY_ACQUIRES, saturatedCast(managerMetrics.getPendingConcurrencyAcquires()));
-    }
-
-    private void executeRequest(CrtAsyncRequestContext executionContext,
-                                CompletableFuture<Void> requestFuture,
-                                HttpClientConnection crtConn,
-                                AsyncExecuteRequest asyncRequest) {
-        HttpRequest crtRequest = CrtRequestAdapter.toAsyncCrtRequest(executionContext);
-        HttpStreamResponseHandler crtResponseHandler =
-            CrtResponseAdapter.toCrtResponseHandler(crtConn, requestFuture, asyncRequest.responseHandler());
-
-        // Submit the request on the connection
-        try {
-            crtConn.makeRequest(crtRequest, crtResponseHandler).activate();
-        } catch (HttpException e) {
-            Throwable toThrow = wrapWithIoExceptionIfRetryable(e);
-            reportAsyncFailure(crtConn,
-                          toThrow,
-                          requestFuture,
-                          asyncRequest.responseHandler());
-        } catch (IllegalStateException | CrtRuntimeException e) {
-            // CRT throws IllegalStateException if the connection is closed
-            reportAsyncFailure(crtConn, new IOException("An exception occurred when making the request", e),
-                          requestFuture,
-                          asyncRequest.responseHandler());
-        }
     }
 
     private void executeRequest(CrtRequestContext executionContext,
@@ -205,55 +91,28 @@ public final class CrtRequestExecutor {
 
             // Submit the request on the connection
             crtConn.makeRequest(crtRequest, crtResponseHandler).activate();
-        } catch (HttpException e) {
-            crtConn.close();
+        } catch (Throwable throwable) {
+            handleException(requestFuture, crtConn, throwable);
+        }
+    }
 
-            Throwable toThrow = wrapWithIoExceptionIfRetryable(e);
+    private static void handleException(CompletableFuture<SdkHttpFullResponse> requestFuture, HttpClientConnection crtConn,
+                          Throwable throwable) {
+
+        crtConn.close();
+
+        if (throwable instanceof HttpException) {
+            Throwable toThrow = wrapWithIoExceptionIfRetryable((HttpException) throwable);
             requestFuture.completeExceptionally(toThrow);
-        } catch (IllegalStateException | CrtRuntimeException e) {
-            crtConn.close();
-            requestFuture.completeExceptionally(e);
-        }
-    }
-
-    /**
-     * Create the execution future and set up the cancellation logic.
-     * @return The created execution future.
-     */
-    private CompletableFuture<Void> createAsyncExecutionFuture(AsyncExecuteRequest request) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-
-        future.whenComplete((r, t) -> {
-            if (t == null) {
-                return;
-            }
-
-            // TODO: Aborting request once it's supported in CRT
-            if (future.isCancelled()) {
-                request.responseHandler().onError(new SdkCancellationException("The request was cancelled"));
-            }
-        });
-
-        return future;
-    }
-
-    /**
-     * Notify the provided response handler and future of the failure.
-     */
-    private void reportAsyncFailure(HttpClientConnection crtConn,
-                               Throwable cause,
-                               CompletableFuture<Void> executeFuture,
-                               SdkAsyncHttpResponseHandler responseHandler) {
-        if (crtConn != null) {
-            crtConn.close();
+            return;
         }
 
-        try {
-            responseHandler.onError(cause);
-        } catch (Exception e) {
-            log.error(() -> "SdkAsyncHttpResponseHandler " + responseHandler + " threw an exception in onError. It will be "
-                            + "ignored.", e);
+        if (throwable instanceof CrtRuntimeException || throwable instanceof IllegalStateException) {
+            // CRT throws IllegalStateException if the connection is closed
+            requestFuture.completeExceptionally(new IOException(throwable));
+            return;
         }
-        executeFuture.completeExceptionally(cause);
+
+        requestFuture.completeExceptionally(throwable);
     }
 }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtUtils.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtUtils.java
@@ -15,19 +15,33 @@
 
 package software.amazon.awssdk.http.crt.internal;
 
+import static software.amazon.awssdk.http.HttpMetric.AVAILABLE_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.CONCURRENCY_ACQUIRE_DURATION;
+import static software.amazon.awssdk.http.HttpMetric.LEASED_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.MAX_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.PENDING_CONCURRENCY_ACQUIRES;
+import static software.amazon.awssdk.utils.NumericUtils.saturatedCast;
+
 import java.io.IOException;
+import java.time.Duration;
+import javax.net.ssl.SSLHandshakeException;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
 import software.amazon.awssdk.crt.http.HttpException;
+import software.amazon.awssdk.crt.http.HttpManagerMetrics;
+import software.amazon.awssdk.metrics.MetricCollector;
 
 @SdkInternalApi
 public final class CrtUtils {
+    public static final int CRT_TLS_NEGOTIATION_ERROR_CODE = 1029;
 
     private CrtUtils() {
     }
 
     public static Throwable wrapWithIoExceptionIfRetryable(HttpException httpException) {
         Throwable toThrow = httpException;
+
         if (HttpClientConnection.isErrorRetryable(httpException)) {
             // IOExceptions get retried, and if the CRT says this error is retryable,
             // it's semantically an IOException anyway.
@@ -35,4 +49,32 @@ public final class CrtUtils {
         }
         return toThrow;
     }
+
+    public static Throwable wrapConnectionFailureException(Throwable throwable) {
+        Throwable toThrow = new IOException("An exception occurred when acquiring a connection", throwable);
+        if (throwable instanceof HttpException) {
+            HttpException httpException = (HttpException) throwable;
+
+            if (httpException.getErrorCode() == CRT_TLS_NEGOTIATION_ERROR_CODE) {
+                toThrow = new SSLHandshakeException(httpException.getMessage());
+            }
+        }
+
+        return toThrow;
+    }
+
+    public static void reportMetrics(HttpClientConnectionManager connManager, MetricCollector metricCollector,
+                                      long acquireStartTime) {
+        long acquireCompletionTime = System.nanoTime();
+        Duration acquireTimeTaken = Duration.ofNanos(acquireCompletionTime - acquireStartTime);
+        metricCollector.reportMetric(CONCURRENCY_ACQUIRE_DURATION, acquireTimeTaken);
+        HttpManagerMetrics managerMetrics = connManager.getManagerMetrics();
+        // currently this executor only handles HTTP 1.1. Until H2 is added, the max concurrency settings are 1:1 with TCP
+        // connections. When H2 is added, this code needs to be updated to handle stream multiplexing
+        metricCollector.reportMetric(MAX_CONCURRENCY, connManager.getMaxConnections());
+        metricCollector.reportMetric(AVAILABLE_CONCURRENCY, saturatedCast(managerMetrics.getAvailableConcurrency()));
+        metricCollector.reportMetric(LEASED_CONCURRENCY, saturatedCast(managerMetrics.getLeasedConcurrency()));
+        metricCollector.reportMetric(PENDING_CONCURRENCY_ACQUIRES, saturatedCast(managerMetrics.getPendingConcurrencyAcquires()));
+    }
+
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
@@ -35,6 +35,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpException;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
@@ -35,8 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.Log;
-import software.amazon.awssdk.crt.http.HttpClientConnection;
-import software.amazon.awssdk.crt.http.HttpException;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutorTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutorTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.http.HttpTestUtils.createProvider;
+import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
+import software.amazon.awssdk.crt.http.HttpException;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.http.SdkCancellationException;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.crt.internal.response.CrtResponseAdapter;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class CrtAsyncRequestExecutorTest {
+
+    private CrtAsyncRequestExecutor requestExecutor;
+    @Mock
+    private HttpClientConnectionManager connectionManager;
+
+    @Mock
+    private SdkAsyncHttpResponseHandler responseHandler;
+
+    @Mock
+    private HttpClientConnection httpClientConnection;
+
+    @BeforeEach
+    public void setup() {
+        requestExecutor = new CrtAsyncRequestExecutor();
+    }
+
+    @AfterEach
+    public void teardown() {
+        Mockito.reset(connectionManager, responseHandler, httpClientConnection);
+    }
+
+    @Test
+    public void acquireConnectionThrowException_shouldInvokeOnError() {
+        RuntimeException exception = new RuntimeException("error");
+        CrtAsyncRequestContext context = CrtAsyncRequestContext.builder()
+                                                               .crtConnPool(connectionManager)
+                                                               .request(AsyncExecuteRequest.builder()
+                                                                                 .responseHandler(responseHandler)
+                                                                                 .build())
+                                                               .build();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+        completableFuture.completeExceptionally(exception);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).hasMessageContaining("An exception occurred when acquiring a connection");
+        assertThat(actualException).hasCause(exception);
+        assertThat(executeFuture).hasFailedWithThrowableThat().hasCause(exception).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void executeAsyncRequest_CrtRuntimeException_shouldInvokeOnError() {
+        CrtRuntimeException exception = new CrtRuntimeException("");
+        CrtAsyncRequestContext context = crtAsyncRequestContext();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+        completableFuture.complete(httpClientConnection);
+
+        Mockito.when(httpClientConnection.makeRequest(Mockito.any(HttpRequest.class), Mockito.any(CrtResponseAdapter.class)))
+               .thenThrow(exception);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).hasMessageContaining("An exception occurred when making the request");
+        assertThat(actualException).hasCause(exception);
+        assertThat(executeFuture).hasFailedWithThrowableThat().hasCause(exception).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void cancelRequest_shouldInvokeOnError() {
+        CrtAsyncRequestContext context = CrtAsyncRequestContext.builder()
+                                                               .crtConnPool(connectionManager)
+                                                               .request(AsyncExecuteRequest.builder()
+                                                                                 .responseHandler(responseHandler)
+                                                                                 .build())
+                                                               .build();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+        executeFuture.cancel(true);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).hasMessageContaining("The request was cancelled");
+        assertThat(actualException).isInstanceOf(SdkCancellationException.class);
+    }
+
+    @Test
+    public void execute_AcquireConnectionFailure_shouldAlwaysWrapIOException() {
+        CrtAsyncRequestContext context = crtAsyncRequestContext();
+        RuntimeException exception = new RuntimeException("some failure");
+        CompletableFuture<HttpClientConnection> completableFuture = CompletableFutureUtils.failedFuture(exception);
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+        assertThatThrownBy(executeFuture::join).hasCauseInstanceOf(IOException.class).hasRootCause(exception);
+    }
+
+    @Test
+    public void executeRequest_failedOfIllegalStateException_shouldWrapIOException() {
+        IllegalStateException exception = new IllegalStateException("connection closed");
+        CrtAsyncRequestContext context = crtAsyncRequestContext();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+        completableFuture.complete(httpClientConnection);
+
+        Mockito.when(httpClientConnection.makeRequest(Mockito.any(HttpRequest.class), Mockito.any(CrtResponseAdapter.class)))
+               .thenThrow(exception);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).hasMessageContaining("An exception occurred when making the request").hasCause(exception);
+        assertThatThrownBy(executeFuture::join).hasCauseInstanceOf(IOException.class).hasRootCause(exception);
+    }
+
+    @Test
+    public void executeRequest_failedOfRetryableHttpException_shouldWrapIOException() {
+        HttpException exception = new HttpException(0x080a); // AWS_ERROR_HTTP_CONNECTION_CLOSED
+        CrtAsyncRequestContext context = crtAsyncRequestContext();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+        completableFuture.complete(httpClientConnection);
+
+        Mockito.when(httpClientConnection.makeRequest(Mockito.any(HttpRequest.class), Mockito.any(CrtResponseAdapter.class)))
+               .thenThrow(exception);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).hasCause(exception);
+        assertThatThrownBy(executeFuture::join).hasCauseInstanceOf(IOException.class).hasRootCause(exception);
+    }
+
+    @Test
+    public void executeRequest_failedOfNonRetryableHttpException_shouldNotWrapIOException() {
+        HttpException exception = new HttpException(0x0801); // AWS_ERROR_HTTP_HEADER_NOT_FOUND
+        CrtAsyncRequestContext context = crtAsyncRequestContext();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+        completableFuture.complete(httpClientConnection);
+
+        Mockito.when(httpClientConnection.makeRequest(Mockito.any(HttpRequest.class), Mockito.any(CrtResponseAdapter.class)))
+               .thenThrow(exception);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).isEqualTo(exception);
+        assertThatThrownBy(executeFuture::join).hasCause(exception);
+    }
+
+    private CrtAsyncRequestContext crtAsyncRequestContext() {
+        SdkHttpFullRequest request = createRequest(URI.create("http://localhost"));
+        return CrtAsyncRequestContext.builder()
+                                     .readBufferSize(2000)
+                                     .crtConnPool(connectionManager)
+                                     .request(AsyncExecuteRequest.builder()
+                                                            .request(request)
+                                                            .requestContentPublisher(createProvider(""))
+                                                            .responseHandler(responseHandler)
+                                                            .build())
+                                     .build();
+    }
+}


### PR DESCRIPTION
… sync HTTP client was not retried.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed the issue where `AWS_ERROR_HTTP_CONNECTION_CLOSED` was not retried by the SDK.
Currently, if `
Caused by: java.lang.RuntimeException: software.amazon.awssdk.crt.CrtRuntimeException: HttpClientConnection.MakeRequest: Unable to Execute Request (aws_last_error: AWS_ERROR_HTTP_CONNECTION_CLOSED(2058), The connection has closed or is closing.) AWS_ERROR_HTTP_CONNECTION_CLOSED(2058)` is thrown from AWS CRT sync HTTP client, the error will not be retried by the SDK because it's not wrapped with IOException.

## Modifications
- Wrap `CrtRuntimeException` with IOException
- Split `CrtRequestExecutor` to `CrtAsyncRequestExecutor` and `CrtRequestExecutor`

## Testing
Added tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
