### PR TITLE
Activating SRA auth for services with specific signer behaviors, and iam

### DIFF
--- a/.changes/next-release/feature-AWSBackupStorageAmazonCodeCatalystAmazonCognitoIdentityAmazonCognitoIdentityProviderAWSIdentityandAccessManagementIAMAmazonKinesisAWSElementalMediaStoreDataPlaneAmazonTranscribeServiceAmazonTranscribeStreamingService-9088dc7.json
+++ b/.changes/next-release/feature-AWSBackupStorageAmazonCodeCatalystAmazonCognitoIdentityAmazonCognitoIdentityProviderAWSIdentityandAccessManagementIAMAmazonKinesisAWSElementalMediaStoreDataPlaneAmazonTranscribeServiceAmazonTranscribeStreamingService-9088dc7.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS Backup Storage, Amazon CodeCatalyst, Amazon Cognito Identity, Amazon Cognito Identity Provider, AWS Identity and Access Management (IAM), Amazon Kinesis, AWS Elemental MediaStore Data Plane, Amazon Transcribe Service, Amazon Transcribe Streaming Service",
+    "contributor": "",
+    "description": "Switching a set of services onto the new SRA (Smithy Reference Architecture) identity and auth logic that was released in v2.21.0."
+}

--- a/services/backupstorage/src/main/resources/codegen-resources/customization.config
+++ b/services/backupstorage/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,3 @@
+{
+    "useSraAuth": true
+}

--- a/services/codecatalyst/src/main/resources/codegen-resources/customization.config
+++ b/services/codecatalyst/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,3 @@
+{
+    "useSraAuth": true
+}

--- a/services/cognitoidentity/src/main/resources/codegen-resources/customization.config
+++ b/services/cognitoidentity/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,3 @@
+{
+    "useSraAuth": true
+}

--- a/services/cognitoidentityprovider/src/main/resources/codegen-resources/customization.config
+++ b/services/cognitoidentityprovider/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,5 @@
 {
+    "useSraAuth": true,
     "excludedSimpleMethods" : [
         "associateSoftwareToken"
     ],

--- a/services/iam/src/main/resources/codegen-resources/customization.config
+++ b/services/iam/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,5 @@
 {
+  "useSraAuth": true,
   "verifiedSimpleMethods": [
     "createAccessKey",
     "deleteAccountPasswordPolicy",

--- a/services/kinesis/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesis/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,5 @@
 {
+  "useSraAuth": true,
   "verifiedSimpleMethods": [
     "describeLimits",
     "listStreams"

--- a/services/mediastoredata/src/main/resources/codegen-resources/customization.config
+++ b/services/mediastoredata/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,5 @@
 {
+  "useSraAuth": true,
   "excludedSimpleMethods" : [
     "listItems"
   ]

--- a/services/transcribe/src/main/resources/codegen-resources/customization.config
+++ b/services/transcribe/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,5 @@
 {
+    "useSraAuth": true,
     "verifiedSimpleMethods" : [
         "listTranscriptionJobs",
         "listVocabularies"

--- a/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
+++ b/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,5 @@
 {
+    "useSraAuth": true,
     "serviceSpecificHttpConfig": "software.amazon.awssdk.services.transcribestreaming.internal.DefaultHttpConfigurationOptions",
     "skipSyncClientGeneration": true,
     "useLegacyEventGenerationScheme": {


### PR DESCRIPTION
## Motivation and Context
Switching a set of services onto the new SRA (Smithy Reference Architecture) identity and auth logic that was released in v2.21.0. 

## Modifications
Services (service id):
- backupstorage
- codecatalyst
- cognitoidentity
- cognitoidentityprovider
- iam
- kinesis
- mediastoredata
- transcribe
- transcribestreaming

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
