### PR TITLE
Don't shade org.apache.log4j

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1e17bfe.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1e17bfe.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix shading of artifacts in the `bundle` by not `org.apache.log4j.*` packages. This allows proper binding of `commons-logging` to Log4J and enables dependencies that use commons logging (e.g. Apache HTTP Client) to properly bind to Log4j."
+}

--- a/bundle-sdk/pom.xml
+++ b/bundle-sdk/pom.xml
@@ -83,6 +83,9 @@
                             <relocation>
                                 <pattern>org.apache</pattern>
                                 <shadedPattern>software.amazon.awssdk.thirdparty.org.apache</shadedPattern>
+                                <excludes>
+                                    <exclude>org.apache.log4j.*</exclude>
+                                </excludes>
                             </relocation>
                             <relocation>
                                 <pattern>io.netty</pattern>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This fixes #4799.

 - This is not a direct dependency of the SDK, and no log4j classes are actually included in the bundle, so we should not be shading it.
 - By not shading it, classes that we *do* include in the bundle, i.e. from apache-commons-logging can reference the log4j classes properly.



## Modifications
<!--- Describe your changes in detail -->

## Testing

Build the SDK using

```
mvn clean install -P publishing  -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Dgpg.skip=true
```

Use created `bundle` in a test Maven project with the following Log4j config:

```xml
<Configuration status="WARN">
    <Appenders>
        <Console name="ConsoleAppender" target="SYSTEM_OUT">
            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c:%L - %m%n" />
        </Console>
    </Appenders>

    <Loggers>
        <Root level="DEBUG">
            <AppenderRef ref="ConsoleAppender"/>
        </Root>
        <Logger name="software.amazon.awssdk" level="WARN" />
        <Logger name="software.amazon.awssdk.request" level="DEBUG" />
        <Logger name="software.amazon.awssdk.thirdparty.org.apache.http.wire" level="DEBUG" />
    </Loggers>
</Configuration>
```

Verify logs are shown:

```
2024-01-11 15:10:12 [main] DEBUG software.amazon.awssdk.request:105 - Sending Request: DefaultSdkHttpFullRequest(httpMethod=GET, protocol=https, host=s3.us-west-2.amazonaws.com, encodedPath=/, headers=[amz-sdk-invocation-id, User-Agent], queryParameters=[])
2024-01-11 15:10:12 [main] DEBUG software.amazon.awssdk.thirdparty.org.apache.http.wire:73 - http-outgoing-0 >> "GET / HTTP/1.1[\r][\n]"
2024-01-11 15:10:12 [main] DEBUG software.amazon.awssdk.thirdparty.org.apache.http.wire:73 - http-outgoing-0 >> "Host: s3.us-west-2.amazonaws.com[\r][\n]"
2024-01-11 15:10:12 [main] DEBUG software.amazon.awssdk.thirdparty.org.apache.http.wire:73 - http-outgoing-0 >> "amz-sdk-invocation-id: d8ecad14-9993-d0d3-dff2-3eb4151f4c97[\r][\n]"
2024-01-11 15:10:12 [main] DEBUG software.amazon.awssdk.thirdparty.org.apache.http.wire:73 - http-outgoing-0 >> "amz-sdk-request: attempt=1; max=4[\r][\n]"
...
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
