### PR TITLE
Check if stream is closed before trying to increment window.

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTHTTPClient-7e448e2.json
+++ b/.changes/next-release/bugfix-AWSCRTHTTPClient-7e448e2.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT HTTP Client",
+    "contributor": "",
+    "description": "Fixed the issue in the AWS CRT HTTP client where the application could crash if stream.incrementWindow was invoked on a closed stream"
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
@@ -95,7 +95,9 @@ public final class CrtResponseAdapter implements HttpStreamResponseHandler {
                 return;
             }
 
-            stream.incrementWindow(bodyBytesIn.length);
+            if (!responseHandlerHelper.connectionClosed().get()) {
+                stream.incrementWindow(bodyBytesIn.length);
+            }
         });
 
         return 0;

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/InputStreamAdaptingHttpStreamResponseHandler.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/InputStreamAdaptingHttpStreamResponseHandler.java
@@ -92,8 +92,10 @@ public final class InputStreamAdaptingHttpStreamResponseHandler implements HttpS
                 return;
             }
 
-            // increment the window upon buffer consumption.
-            stream.incrementWindow(bodyBytesIn.length);
+            if (!responseHandlerHelper.connectionClosed().get()) {
+                // increment the window upon buffer consumption.
+                stream.incrementWindow(bodyBytesIn.length);
+            }
         });
 
         // Window will be incremented after the subscriber consumes the data, returning 0 here to disable it.

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/ResponseHandlerHelper.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/ResponseHandlerHelper.java
@@ -82,4 +82,8 @@ public class ResponseHandlerHelper {
             releaseConnection(stream);
         }
     }
+
+    public AtomicBoolean connectionClosed() {
+        return connectionClosed;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.15</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.29.2</awscrt.version>
+        <awscrt.version>0.29.7</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.10.0</junit5.version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
If stream is null and `stream.incrementWindow` is invoked, JVM will crash. This can happen if [onResponseComplete](https://github.com/aws/aws-sdk-java-v2/blob/master/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java#L107) gets invoked before [responsePublisher.send() future](https://github.com/aws/aws-sdk-java-v2/blob/master/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java#L92) completes in onResponseBody.

CRT is working on the change to make `stream.incrementWindow` no-op if the stream is closed. Meanwhile this change checks if stream is closed before trying to increment window.

This change also bumps crt version.

## Testing
Added unit tests. Running our test suites.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
