### PR TITLE
Close the underlying crt connection and stream properly if the stream…

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTHTTPClient-32100be.json
+++ b/.changes/next-release/bugfix-AWSCRTHTTPClient-32100be.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT HTTP Client",
+    "contributor": "",
+    "description": "Fixed the issue in the AWS CRT sync HTTP client where the connection was left open after the stream was aborted."
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/AbortableInputStreamSubscriber.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/AbortableInputStreamSubscriber.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal.response;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.Abortable;
+import software.amazon.awssdk.utils.async.InputStreamSubscriber;
+
+/**
+ * Wrapper of {@link InputStreamSubscriber} that also implements {@link Abortable} and closes the underlying connections when
+ * {@link #close()} or {@link #abort()} is invoked.
+ */
+@SdkInternalApi
+public final class AbortableInputStreamSubscriber extends InputStream implements Subscriber<ByteBuffer>, Abortable {
+
+    private final InputStreamSubscriber delegate;
+    private final Runnable closeConnection;
+
+    public AbortableInputStreamSubscriber(Runnable onClose, InputStreamSubscriber inputStreamSubscriber) {
+        this.delegate = inputStreamSubscriber;
+        this.closeConnection = onClose;
+    }
+
+    @Override
+    public void abort() {
+        close();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return delegate.read(b, off, len);
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return delegate.read(b);
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        delegate.onSubscribe(s);
+    }
+
+    @Override
+    public void onNext(ByteBuffer byteBuffer) {
+        delegate.onNext(byteBuffer);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        delegate.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+        delegate.onComplete();
+    }
+
+    @Override
+    public void close() {
+        closeConnection.run();
+        delegate.close();
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
@@ -126,7 +126,7 @@ public final class CrtResponseAdapter implements HttpStreamResponseHandler {
 
     private void handlePublisherError(HttpStream stream, Throwable failure) {
         failResponseHandlerAndFuture(stream, failure);
-        responseHandlerHelper.releaseConnection(stream);
+        responseHandlerHelper.closeConnection(stream);
     }
 
     private void onFailedResponseComplete(HttpStream stream, HttpException error) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AbortableInputStreamSubscriberTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AbortableInputStreamSubscriberTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.http.crt.internal.response.AbortableInputStreamSubscriber;
+import software.amazon.awssdk.utils.async.InputStreamSubscriber;
+
+@ExtendWith(MockitoExtension.class)
+public class AbortableInputStreamSubscriberTest {
+
+    private AbortableInputStreamSubscriber abortableInputStreamSubscriber;
+
+    @Mock
+    private Runnable onClose;
+
+    @BeforeEach
+    void setUp() {
+        abortableInputStreamSubscriber = new AbortableInputStreamSubscriber(onClose, new InputStreamSubscriber());
+    }
+
+    @Test
+    void close_shouldInvokeOnClose() {
+        abortableInputStreamSubscriber.close();
+        verify(onClose).run();
+    }
+
+    @Test
+    void abort_shouldInvokeOnClose() {
+        abortableInputStreamSubscriber.abort();
+        verify(onClose).run();
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/BaseHttpStreamResponseHandlerTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/BaseHttpStreamResponseHandlerTest.java
@@ -42,9 +42,9 @@ public abstract class BaseHttpStreamResponseHandlerTest {
     CompletableFuture requestFuture;
 
     @Mock
-    private HttpStream httpStream;
+    HttpStream httpStream;
 
-    private HttpStreamResponseHandler responseHandler;
+    HttpStreamResponseHandler responseHandler;
 
     abstract HttpStreamResponseHandler responseHandler();
 
@@ -113,7 +113,7 @@ public abstract class BaseHttpStreamResponseHandlerTest {
         verify(httpStream, never()).incrementWindow(anyInt());
     }
 
-    private static HttpHeader[] getHttpHeaders() {
+    static HttpHeader[] getHttpHeaders() {
         HttpHeader[] httpHeaders = new HttpHeader[1];
         httpHeaders[0] = new HttpHeader("Content-Length", "1");
         return httpHeaders;

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtResponseHandlerTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtResponseHandlerTest.java
@@ -15,14 +15,29 @@
 
 package software.amazon.awssdk.http.crt.internal;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.internal.http.async.AsyncResponseHandler;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpHeaderBlock;
 import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 import software.amazon.awssdk.http.crt.internal.response.CrtResponseAdapter;
 import software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler;
@@ -36,5 +51,63 @@ public class CrtResponseHandlerTest extends BaseHttpStreamResponseHandlerTest {
 
         responseHandler.prepare();
         return CrtResponseAdapter.toCrtResponseHandler(crtConn, requestFuture, responseHandler);
+    }
+
+    @Test
+    void publisherFailedToDeliverEvents_shouldShutDownConnection() {
+        SdkAsyncHttpResponseHandler responseHandler = new TestAsyncHttpResponseHandler();
+
+        HttpStreamResponseHandler crtResponseHandler = CrtResponseAdapter.toCrtResponseHandler(crtConn, requestFuture, responseHandler);
+        HttpHeader[] httpHeaders = getHttpHeaders();
+        crtResponseHandler.onResponseHeaders(httpStream, 200, HttpHeaderBlock.MAIN.getValue(),
+                                          httpHeaders);
+        crtResponseHandler.onResponseHeadersDone(httpStream, 0);
+        crtResponseHandler.onResponseBody(httpStream, "{}".getBytes(StandardCharsets.UTF_8));
+
+        crtResponseHandler.onResponseComplete(httpStream, 0);
+        assertThatThrownBy(() -> requestFuture.join()).isInstanceOf(CancellationException.class).hasMessageContaining(
+            "subscription has been cancelled");
+        verify(crtConn).shutdown();
+        verify(crtConn).close();
+        verify(httpStream).close();
+    }
+
+    private static class TestAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandler {
+
+        @Override
+        public void onHeaders(SdkHttpResponse headers) {
+        }
+
+        @Override
+        public void onStream(Publisher<ByteBuffer> stream) {
+            stream.subscribe(new Subscriber<ByteBuffer>() {
+                private Subscription subscription;
+                @Override
+                public void onSubscribe(Subscription s) {
+                    subscription = s;
+                    s.request(1);
+                }
+
+                @Override
+                public void onNext(ByteBuffer byteBuffer) {
+                    subscription.cancel();
+                }
+
+                @Override
+                public void onError(Throwable t) {
+
+                }
+
+                @Override
+                public void onComplete() {
+
+                }
+            });
+        }
+
+        @Override
+        public void onError(Throwable error) {
+
+        }
     }
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/InputStreamAdaptingHttpStreamResponseHandlerTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/InputStreamAdaptingHttpStreamResponseHandlerTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.crt.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import io.reactivex.Completable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import net.bytebuddy.utility.RandomString;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -40,6 +42,8 @@ import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.crt.internal.response.CrtResponseAdapter;
 import software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler;
 
 public class InputStreamAdaptingHttpStreamResponseHandlerTest extends BaseHttpStreamResponseHandlerTest {
@@ -66,6 +70,41 @@ public class InputStreamAdaptingHttpStreamResponseHandlerTest extends BaseHttpSt
         abortableInputStream.read();
         abortableInputStream.abort();
 
+        verify(crtConn).shutdown();
+        verify(crtConn).close();
+        verify(httpStream).close();
+    }
+
+    @Test
+    void closeStream_shouldShutdownConnection() throws IOException {
+        HttpHeader[] httpHeaders = getHttpHeaders();
+
+        responseHandler.onResponseHeaders(httpStream, 500, HttpHeaderBlock.MAIN.getValue(),
+                                          httpHeaders);
+        responseHandler.onResponseHeadersDone(httpStream, 0);
+        responseHandler.onResponseBody(httpStream,
+                                       RandomStringUtils.random(1 * 1024 * 1024).getBytes(StandardCharsets.UTF_8));
+
+        SdkHttpFullResponse response = ((CompletableFuture<SdkHttpFullResponse>) requestFuture).join();
+        assertThat(response.content()).isPresent();
+        AbortableInputStream abortableInputStream = response.content().get();
+
+        abortableInputStream.read();
+        abortableInputStream.abort();
+
+        verify(crtConn).shutdown();
+        verify(crtConn).close();
+        verify(httpStream).close();
+    }
+
+    @Test
+    void cancelFuture_shouldCloseConnection() {
+        HttpHeader[] httpHeaders = getHttpHeaders();
+
+        responseHandler.onResponseHeaders(httpStream, 200, HttpHeaderBlock.MAIN.getValue(),
+                                          httpHeaders);
+
+        requestFuture.completeExceptionally(new RuntimeException());
         verify(crtConn).shutdown();
         verify(crtConn).close();
         verify(httpStream).close();


### PR DESCRIPTION
… is aborted or closed in the AWS CRT HTTP client

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Currently, if users invoke stream.abort(), the CRT connection and stream will be left open until it's closed on the server side, which will cause latency increase and resource leak.

## Modifications
Make sure the underlying CRT resources are closed when the stream is closed or aborted.

## Testing
Added unit tests. Also ran integ tests locally

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
