### PR TITLE
Fix for issue #4720 , Cross Region enabled Clients created in US-EAST-1 will by internally disable global endpoint and do a regional endpoint call.

### DIFF
--- a/.changes/next-release/bugfix-AmazonSimpleStorageService-4b6b8dd.json
+++ b/.changes/next-release/bugfix-AmazonSimpleStorageService-4b6b8dd.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon Simple Storage Service",
+    "contributor": "",
+    "description": "Fix for issue [#4720](https://github.com/aws/aws-sdk-java-v2/issues/4720) , Cross Region enabled Clients created in US-EAST-1 will by internally disable global endpoint and do a regional endpoint call."
+}

--- a/.changes/next-release/bugfix-AmazonSimpleStorageService-4b6b8dd.json
+++ b/.changes/next-release/bugfix-AmazonSimpleStorageService-4b6b8dd.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "Amazon Simple Storage Service",
     "contributor": "",
-    "description": "Fix for issue [#4720](https://github.com/aws/aws-sdk-java-v2/issues/4720) , Cross Region enabled Clients created in US-EAST-1 will by internally disable global endpoint and do a regional endpoint call."
+    "description": "S3 client configured with crossRegionEnabled(true) will now use us-east-1 regional endpoint instead of the global endpoint. See [#4720](https://github.com/aws/aws-sdk-java-v2/issues/4720)."
 }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionAsyncIntegrationTestBase.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionAsyncIntegrationTestBase.java
@@ -30,6 +30,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -73,5 +75,10 @@ public abstract class S3CrossRegionAsyncIntegrationTestBase extends S3CrossRegio
     @Override
     protected ResponseBytes<GetObjectResponse> getAPICall(GetObjectRequest getObjectRequest) {
         return crossRegionS3Client.getObject(getObjectRequest, AsyncResponseTransformer.toBytes()).join();
+    }
+
+    @Override
+    protected HeadObjectResponse headObjectAPICall(HeadObjectRequest headObjectRequest) {
+        return crossRegionS3Client.headObject(headObjectRequest).join();
     }
 }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionIntegrationTestBase.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionIntegrationTestBase.java
@@ -35,6 +35,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -56,6 +58,16 @@ public abstract class S3CrossRegionIntegrationTestBase extends S3IntegrationTest
             GetObjectRequest.builder().bucket(bucketName()).checksumMode(ChecksumMode.ENABLED).key(KEY).build();
         ResponseBytes<GetObjectResponse> response = getAPICall(getObjectRequest);
         assertThat(new String(response.asByteArray())).isEqualTo("TEST_STRING");
+    }
+
+    @Test
+    void headObjectApi_CrossRegionCall() {
+        s3.putObject(p -> p.bucket(bucketName()).checksumAlgorithm(ChecksumAlgorithm.CRC32).key(KEY), RequestBody.fromString(
+            "TEST_STRING"));
+        HeadObjectRequest headObjectRequest =
+            HeadObjectRequest.builder().bucket(bucketName()).checksumMode(ChecksumMode.ENABLED).key(KEY).build();
+        HeadObjectResponse response = headObjectAPICall(headObjectRequest);
+        assertThat(response.contentLength()).isEqualTo("TEST_STRING".length());
     }
 
     @Test
@@ -136,6 +148,7 @@ public abstract class S3CrossRegionIntegrationTestBase extends S3IntegrationTest
     protected abstract PutObjectResponse putAPICall(PutObjectRequest putObjectRequest, String testString);
 
     protected abstract ResponseBytes<GetObjectResponse> getAPICall(GetObjectRequest getObjectRequest);
+    protected abstract HeadObjectResponse headObjectAPICall(HeadObjectRequest headObjectRequest);
 
     protected abstract String bucketName();
 

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionSyncIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionSyncIntegrationTest.java
@@ -36,6 +36,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -99,6 +101,11 @@ public class S3CrossRegionSyncIntegrationTest extends S3CrossRegionIntegrationTe
     @Override
     protected ResponseBytes<GetObjectResponse> getAPICall(GetObjectRequest getObjectRequest) {
         return crossRegionS3Client.getObject(getObjectRequest, ResponseTransformer.toBytes());
+    }
+
+    @Override
+    protected HeadObjectResponse headObjectAPICall(HeadObjectRequest headObjectRequest) {
+        return crossRegionS3Client.headObject(headObjectRequest);
     }
 
     @Override

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClient.java
@@ -64,13 +64,10 @@ public final class S3CrossRegionSyncClient extends DelegatingS3Client {
         }
         String bucketName = bucketRequest.get();
         try {
-            if (bucketToRegionCache.containsKey(bucketName)) {
-                return operation.apply(
-                    requestWithDecoratedEndpointProvider(userAgentUpdatedRequest,
-                                                         () -> bucketToRegionCache.get(bucketName),
-                                                         serviceClientConfiguration().endpointProvider().get()));
-            }
-            return operation.apply(userAgentUpdatedRequest);
+            return operation.apply(
+                requestWithDecoratedEndpointProvider(userAgentUpdatedRequest,
+                                                     () -> bucketToRegionCache.get(bucketName),
+                                                     serviceClientConfiguration().endpointProvider().get()));
         } catch (S3Exception exception) {
             if (isS3RedirectException(exception)) {
                 updateCacheFromRedirectException(exception, bucketName);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/endpointprovider/BucketEndpointProvider.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/endpointprovider/BucketEndpointProvider.java
@@ -44,7 +44,8 @@ public class BucketEndpointProvider implements S3EndpointProvider {
     public CompletableFuture<Endpoint> resolveEndpoint(S3EndpointParams endpointParams) {
         Region crossRegion = regionSupplier.get();
         return delegateEndPointProvider.resolveEndpoint(
-            crossRegion != null ? endpointParams.copy(c -> c.region(crossRegion)) : endpointParams);
+            endpointParams.copy(c -> c.region(crossRegion == null ? endpointParams.region() : crossRegion)
+                                      .useGlobalEndpoint(false)));
     }
 }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/utils/CrossRegionUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/utils/CrossRegionUtils.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.services.s3.internal.crossregion.utils;
 
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
@@ -25,7 +24,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
-import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.regions.Region;
@@ -41,7 +39,6 @@ public final class CrossRegionUtils {
     public static final String AMZ_BUCKET_REGION_HEADER = "x-amz-bucket-region";
     private static final List<Integer> REDIRECT_STATUS_CODES =
         Arrays.asList(REDIRECT_STATUS_CODE, TEMPORARY_REDIRECT_STATUS_CODE);
-    private static final List<String> REDIRECT_ERROR_CODES = Collections.singletonList("AuthorizationHeaderMalformed");
     private static final ApiName API_NAME = ApiName.builder().version("cross-region").name("hll").build();
     private static final Consumer<AwsRequestOverrideConfiguration.Builder> USER_AGENT_APPLIER = b -> b.addApiName(API_NAME);
 
@@ -65,12 +62,7 @@ public final class CrossRegionUtils {
         if (REDIRECT_STATUS_CODES.stream().anyMatch(status -> status.equals(exceptionToBeChecked.statusCode()))) {
             return true;
         }
-        if (getBucketRegionFromException(exceptionToBeChecked).isPresent()) {
-            return true;
-        }
-        AwsErrorDetails awsErrorDetails = exceptionToBeChecked.awsErrorDetails();
-        return awsErrorDetails != null
-               && REDIRECT_ERROR_CODES.stream().anyMatch(code -> code.equals(awsErrorDetails.errorCode()));
+        return getBucketRegionFromException(exceptionToBeChecked).isPresent();
     }
 
     @SuppressWarnings("unchecked")

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientRedirectTest.java
@@ -132,14 +132,6 @@ public class S3CrossRegionAsyncClientRedirectTest extends S3CrossRegionRedirectT
     }
 
     @Override
-    protected void stubApiWithAuthorizationHeaderMalformedError() {
-        when(mockDelegateAsyncClient.listObjects(any(ListObjectsRequest.class)))
-            .thenReturn(CompletableFutureUtils.failedFuture(
-                new CompletionException(redirectException(400, null, "AuthorizationHeaderMalformed", null))))
-            .thenReturn(CompletableFuture.completedFuture(ListObjectsResponse.builder().contents(S3_OBJECTS).build()));
-    }
-
-    @Override
     protected void stubApiWithAuthorizationHeaderWithInternalSoftwareError() {
 
         when(mockDelegateAsyncClient.headBucket(any(HeadBucketRequest.class)))
@@ -148,16 +140,6 @@ public class S3CrossRegionAsyncClientRedirectTest extends S3CrossRegionRedirectT
         when(mockDelegateAsyncClient.headBucket(any(Consumer.class)))
             .thenReturn(CompletableFutureUtils.failedFuture(new CompletionException(redirectException(500,null,
                                                                                                       "InternalError", null))));
-    }
-
-    @Override
-    protected void stubHeadBucketRedirectWithAuthorizationHeaderMalformed() {
-        when(mockDelegateAsyncClient.headBucket(any(HeadBucketRequest.class)))
-            .thenReturn(CompletableFutureUtils.failedFuture(
-                new CompletionException(redirectException(400,CROSS_REGION.id(), "AuthorizationHeaderMalformed", null))));
-        when(mockDelegateAsyncClient.headBucket(any(Consumer.class)))
-            .thenReturn(CompletableFutureUtils.failedFuture(
-                new CompletionException(redirectException(400,CROSS_REGION.id(), "AuthorizationHeaderMalformed", null))));
     }
 
     @Override

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionAsyncClientTest.java
@@ -445,7 +445,7 @@ class S3CrossRegionAsyncClientTest {
         verify(mockEndpointProvider).resolveEndpoint(collectionCaptor.capture());
         S3EndpointParams resolvedParams = collectionCaptor.getAllValues().get(0);
         assertThat(resolvedParams.region()).isEqualTo(Region.of(region));
-        assertThat(resolvedParams.useGlobalEndpoint()).isEqualTo(false);
+        assertThat(resolvedParams.useGlobalEndpoint()).isFalse();
     }
 
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionRedirectTestBase.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionRedirectTestBase.java
@@ -65,7 +65,8 @@ public abstract class S3CrossRegionRedirectTestBase {
         ArgumentCaptor<ListObjectsRequest> requestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(2, requestArgumentCaptor);
 
-        assertThat(requestArgumentCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider()).isNotPresent();
+        assertThat(requestArgumentCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider().get())
+            .isInstanceOf(BucketEndpointProvider.class);
         verifyTheEndPointProviderOverridden(1, requestArgumentCaptor, CROSS_REGION.id());
 
         verifyHeadBucketServiceCall(0);
@@ -86,7 +87,8 @@ public abstract class S3CrossRegionRedirectTestBase {
         ArgumentCaptor<ListObjectsRequest> requestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(3, requestArgumentCaptor);
 
-        assertThat(requestArgumentCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider()).isNotPresent();
+        assertThat(requestArgumentCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider().get())
+            .isInstanceOf(BucketEndpointProvider.class);
         verifyTheEndPointProviderOverridden(1, requestArgumentCaptor, CROSS_REGION.id());
         verifyTheEndPointProviderOverridden(2, requestArgumentCaptor, CROSS_REGION.id());
         verifyHeadBucketServiceCall(0);
@@ -120,7 +122,8 @@ public abstract class S3CrossRegionRedirectTestBase {
         ArgumentCaptor<ListObjectsRequest> requestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(2, requestArgumentCaptor);
 
-        assertThat(requestArgumentCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider()).isNotPresent();
+        assertThat(requestArgumentCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider().get())
+            .isInstanceOf(BucketEndpointProvider.class);
         verifyTheEndPointProviderOverridden(1, requestArgumentCaptor, CROSS_REGION.id());
         verifyHeadBucketServiceCall(1);
     }
@@ -144,7 +147,8 @@ public abstract class S3CrossRegionRedirectTestBase {
         // We need to captor again so that we get the args used in second API Call
         ArgumentCaptor<ListObjectsRequest> overAllPostCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
         verifyTheApiServiceCall(3, overAllPostCacheCaptor);
-        assertThat(overAllPostCacheCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider()).isNotPresent();
+        assertThat(overAllPostCacheCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider().get())
+            .isInstanceOf(BucketEndpointProvider.class);
         verifyTheEndPointProviderOverridden(1, overAllPostCacheCaptor, CROSS_REGION.id());
         verifyTheEndPointProviderOverridden(2, overAllPostCacheCaptor, CROSS_REGION.id());
         verifyHeadBucketServiceCall(1);
@@ -163,61 +167,7 @@ public abstract class S3CrossRegionRedirectTestBase {
         verifyHeadBucketServiceCall(0);
     }
 
-    @Test
-    void given_CrossRegionClient_when_AuthorizationFailureInMainCall_then_RegionRetrievedFromHeadBucketFailureResponse() throws Throwable {
-        stubServiceClientConfiguration();
-        stubApiWithAuthorizationHeaderMalformedError() ;
-        stubHeadBucketRedirect();
-        ListObjectsResponse firstListObjectCall = apiCallToService();
-        assertThat(firstListObjectCall.contents()).isEqualTo(S3_OBJECTS);
-
-        ArgumentCaptor<ListObjectsRequest> preCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        verifyTheApiServiceCall(2, preCacheCaptor);
-        // We need to get the BucketEndpointProvider in order to update the cache
-        verifyTheEndPointProviderOverridden(1, preCacheCaptor, CROSS_REGION.id());
-
-
-        ListObjectsResponse secondListObjectCall = apiCallToService();
-        assertThat(secondListObjectCall.contents()).isEqualTo(S3_OBJECTS);
-        // We need to captor again so that we get the args used in second API Call
-        ArgumentCaptor<ListObjectsRequest> overAllPostCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        verifyTheApiServiceCall(3, overAllPostCacheCaptor);
-        assertThat(overAllPostCacheCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider()).isNotPresent();
-        verifyTheEndPointProviderOverridden(1, overAllPostCacheCaptor, CROSS_REGION.id());
-        verifyTheEndPointProviderOverridden(2, overAllPostCacheCaptor, CROSS_REGION.id());
-        verifyHeadBucketServiceCall(1);
-    }
-
-
-    @Test
-    void given_CrossRegionClient_when_AuthorizationFailureInHeadBucketWithRegion_then_CrossRegionCallSucceeds() throws Throwable {
-        stubServiceClientConfiguration();
-        stubApiWithAuthorizationHeaderMalformedError() ;
-        stubHeadBucketRedirectWithAuthorizationHeaderMalformed();
-        ListObjectsResponse firstListObjectCall = apiCallToService();
-        assertThat(firstListObjectCall.contents()).isEqualTo(S3_OBJECTS);
-
-        ArgumentCaptor<ListObjectsRequest> preCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        verifyTheApiServiceCall(2, preCacheCaptor);
-        // We need to get the BucketEndpointProvider in order to update the cache
-        verifyTheEndPointProviderOverridden(1, preCacheCaptor, CROSS_REGION.id());
-        ListObjectsResponse secondListObjectCall = apiCallToService();
-        assertThat(secondListObjectCall.contents()).isEqualTo(S3_OBJECTS);
-        // We need to captor again so that we get the args used in second API Call
-        ArgumentCaptor<ListObjectsRequest> overAllPostCacheCaptor = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        verifyTheApiServiceCall(3, overAllPostCacheCaptor);
-        assertThat(overAllPostCacheCaptor.getAllValues().get(0).overrideConfiguration().get().endpointProvider()).isNotPresent();
-        verifyTheEndPointProviderOverridden(1, overAllPostCacheCaptor, CROSS_REGION.id());
-        verifyTheEndPointProviderOverridden(2, overAllPostCacheCaptor, CROSS_REGION.id());
-        verifyHeadBucketServiceCall(1);
-    }
-
     protected abstract void stubApiWithAuthorizationHeaderWithInternalSoftwareError();
-
-
-    protected abstract void stubHeadBucketRedirectWithAuthorizationHeaderMalformed();
-
-    protected abstract void stubApiWithAuthorizationHeaderMalformedError();
 
     protected abstract void verifyNoBucketCall();
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientRedirectTest.java
@@ -49,19 +49,6 @@ public class S3CrossRegionSyncClientRedirectTest extends S3CrossRegionRedirectTe
         when(mockDelegateClient.headBucket(any(HeadBucketRequest.class)))
             .thenThrow(redirectException(500, null, "InternalError", null));
     }
-    @Override
-    protected void stubHeadBucketRedirectWithAuthorizationHeaderMalformed() {
-        when(mockDelegateClient.headBucket(any(HeadBucketRequest.class)))
-            .thenThrow(redirectException(400, CROSS_REGION.id(), "AuthorizationHeaderMalformed", null))
-            .thenReturn(HeadBucketResponse.builder().build());
-    }
-
-    @Override
-    protected void stubApiWithAuthorizationHeaderMalformedError() {
-        when(mockDelegateClient.listObjects(any(ListObjectsRequest.class)))
-            .thenThrow(redirectException(400, null, "AuthorizationHeaderMalformed", null))
-            .thenReturn(ListObjectsResponse.builder().contents(S3_OBJECTS).build());
-    }
 
     @Override
     protected void verifyNoBucketCall() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
@@ -274,7 +274,7 @@ class S3CrossRegionSyncClientTest {
         verify(mockEndpointProvider).resolveEndpoint(collectionCaptor.capture());
         S3EndpointParams resolvedParams = collectionCaptor.getAllValues().get(0);
         assertThat(resolvedParams.region()).isEqualTo(Region.of(region));
-        assertThat(resolvedParams.useGlobalEndpoint()).isEqualTo(false);
+        assertThat(resolvedParams.useGlobalEndpoint()).isFalse();
     }
 
     private static GetObjectRequest.Builder getObjectBuilder() {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix for issue #4720 , Cross Region enabled Clients created in US-EAST-1 will by internally disable global endpoint and do a regional endpoint call.

In Version 2 (V2), when calling from "US-EAST-1" and "AWS_GLOBAL" regions, we directly address the global endpoint. For instance:
`Host: mumbai-crossregion-bucket.s3.amazonaws.com`
Here, the region is global, and the signing region is "us-east-1". 

For other client regions (e.g., us-east-2), we send requests to regional endpoints:
`Host: mumbai-crossregion-bucket.us-east-2.s3.amazonaws.com`
In this case, the signing region is "us-east-2". When HeadObject is called on the global endpoint, the service does not throw redirect errors; it redirects only for regional endpoints.

However , the S3 Cross region relies on the service to send the redirect error when a cross region bucket is addressed.
Because of above reason the Cross region features failed to redirect when called from `us-east-1`
 Thus we had to disable "GlobalEndpoints" while doing Cross region enabled calls.

## Modifications
<!--- Describe your changes in detail -->
- Updated the BucketEndpointProvider to disable "GlobalEndpoints"

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits
- And tested integ .
- Note that this issue is recreated only when a Object and bucket is there in cloud for a long time.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)



## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
