### PR TITLE
Performance improvements

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-8b416ff.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-8b416ff.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed bug where the ProfileCredentialsProvider would re-read the credentials file with each request by default."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-9014236.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-9014236.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Improved performance of chunk-encoded streaming uploads, like S3's PutObject."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
@@ -71,9 +71,9 @@ public final class ProfileCredentialsProvider
         try {
             selectedProfileName = Optional.ofNullable(builder.profileName)
                                           .orElseGet(ProfileFileSystemSetting.AWS_PROFILE::getStringValueOrThrow);
-
-            selectedProfileSupplier = Optional.ofNullable(builder.profileFile)
-                                              .orElseGet(() -> builder.defaultProfileFileLoader);
+            selectedProfileSupplier =
+                Optional.ofNullable(builder.profileFile)
+                        .orElseGet(() -> ProfileFileSupplier.fixedProfileFile(builder.defaultProfileFileLoader.get()));
 
         } catch (RuntimeException e) {
             // If we couldn't load the credentials provider for some reason, save an exception describing why. This exception

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java
@@ -77,11 +77,20 @@ public final class ChunkedEncodedInputStream extends InputStream {
 
     @Override
     public int read() throws IOException {
+        return currentChunk().stream().read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return currentChunk().stream().read(b, off, len);
+    }
+
+    private Chunk currentChunk() throws IOException {
         if (currentChunk == null || !currentChunk.hasRemaining() && !isFinished) {
             currentChunk = getChunk(inputStream);
         }
 
-        return currentChunk.stream().read();
+        return currentChunk;
     }
 
     /**


### PR DESCRIPTION
The following changes were made:
- Fixed bug where the ProfileCredentialsProvider would re-read the credentials file with each request by default
- Improved performance of chunk-encoded streaming uploads, like S3's PutObject