### PR TITLE
Reduce memory usage for chunk-encoded streaming uploads, like those used by flexible checksums in S3.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-a5aec87.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-a5aec87.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Reduce how many times input data is copied when writing to chunked encoded operations, like S3's PutObject."
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
@@ -74,7 +74,7 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
             .builder()
             .inputStream(inputStream)
             .chunkSize(chunkSize)
-            .header(chunk -> Integer.toHexString(chunk.length).getBytes(StandardCharsets.UTF_8));
+            .header(chunk -> Integer.toHexString(chunk.remaining()).getBytes(StandardCharsets.UTF_8));
 
         preExistingTrailers.forEach(trailer -> chunkedEncodedInputStreamBuilder.addTrailer(() -> trailer));
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/SigV4aChunkExtensionProvider.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.auth.aws.crt.internal.signer;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
@@ -38,11 +39,8 @@ public class SigV4aChunkExtensionProvider implements ChunkExtensionProvider {
     }
 
     @Override
-    public Pair<byte[], byte[]> get(byte[] chunk) {
+    public Pair<byte[], byte[]> get(ByteBuffer chunk) {
         byte[] chunkSig = signer.sign(chunk);
-        return Pair.of(
-            "chunk-signature".getBytes(StandardCharsets.UTF_8),
-            chunkSig
-        );
+        return Pair.of("chunk-signature".getBytes(StandardCharsets.UTF_8), chunkSig);
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
@@ -84,7 +84,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
             .builder()
             .inputStream(payload.newStream())
             .chunkSize(chunkSize)
-            .header(chunk -> Integer.toHexString(chunk.length).getBytes(StandardCharsets.UTF_8));
+            .header(chunk -> Integer.toHexString(chunk.remaining()).getBytes(StandardCharsets.UTF_8));
 
         preExistingTrailers.forEach(trailer -> chunkedEncodedInputStreamBuilder.addTrailer(() -> trailer));
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkExtensionProvider.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 
+import java.nio.ByteBuffer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.utils.Pair;
 
@@ -32,5 +33,5 @@ import software.amazon.awssdk.utils.Pair;
 @FunctionalInterface
 @SdkInternalApi
 public interface ChunkExtensionProvider extends Resettable {
-    Pair<byte[], byte[]> get(byte[] chunk);
+    Pair<byte[], byte[]> get(ByteBuffer chunk);
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkHeaderProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkHeaderProvider.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 
+import java.nio.ByteBuffer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
@@ -27,5 +28,5 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @FunctionalInterface
 @SdkInternalApi
 public interface ChunkHeaderProvider extends Resettable {
-    byte[] get(byte[] chunk);
+    byte[] get(ByteBuffer chunk);
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4ChunkExtensionProvider.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/SigV4ChunkExtensionProvider.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerUtils.hash;
 import static software.amazon.awssdk.utils.BinaryUtils.toHex;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
@@ -42,7 +43,7 @@ public class SigV4ChunkExtensionProvider implements ChunkExtensionProvider {
         signer.reset();
     }
 
-    private String getStringToSign(String previousSignature, byte[] chunk) {
+    private String getStringToSign(String previousSignature, ByteBuffer chunk) {
         // build the string-to-sign template for the rolling-signer to sign
         return String.join("\n",
                            "AWS4-HMAC-SHA256-PAYLOAD",
@@ -55,11 +56,9 @@ public class SigV4ChunkExtensionProvider implements ChunkExtensionProvider {
     }
 
     @Override
-    public Pair<byte[], byte[]> get(byte[] chunk) {
+    public Pair<byte[], byte[]> get(ByteBuffer chunk) {
         String chunkSig = signer.sign(previousSig -> getStringToSign(previousSig, chunk));
-        return Pair.of(
-            "chunk-signature".getBytes(StandardCharsets.UTF_8),
-            chunkSig.getBytes(StandardCharsets.UTF_8)
-        );
+        return Pair.of("chunk-signature".getBytes(StandardCharsets.UTF_8),
+                       chunkSig.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
@@ -20,6 +20,7 @@ import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerCo
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Instant;
@@ -232,6 +233,16 @@ public final class SignerUtils {
                 read = input.read(buf);
                 md.update(buf, 0, read);
             }
+            return md.digest();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to compute hash while signing request: ", e);
+        }
+    }
+
+    public static byte[] hash(ByteBuffer input) {
+        try {
+            MessageDigest md = getMessageDigestInstance();
+            md.update(input);
             return md.digest();
         } catch (Exception e) {
             throw new RuntimeException("Unable to compute hash while signing request: ", e);

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStreamTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStreamTest.java
@@ -54,7 +54,7 @@ public class ChunkedEncodedInputStreamTest {
             .builder()
             .inputStream(payload)
             .chunkSize(chunkSize)
-            .header(chunk -> Integer.toHexString(chunk.length).getBytes())
+            .header(chunk -> Integer.toHexString(chunk.remaining()).getBytes())
             .build();
 
         byte[] tmp = new byte[64];
@@ -90,7 +90,7 @@ public class ChunkedEncodedInputStreamTest {
             .builder()
             .inputStream(payload)
             .chunkSize(chunkSize)
-            .header(chunk -> Integer.toHexString(chunk.length).getBytes())
+            .header(chunk -> Integer.toHexString(chunk.remaining()).getBytes())
             .extensions(Collections.singletonList(helloWorldExt))
             .build();
 
@@ -128,7 +128,7 @@ public class ChunkedEncodedInputStreamTest {
             .builder()
             .inputStream(payload)
             .chunkSize(chunkSize)
-            .header(chunk -> Integer.toHexString(chunk.length).getBytes())
+            .header(chunk -> Integer.toHexString(chunk.remaining()).getBytes())
             .trailers(Collections.singletonList(helloWorldTrailer))
             .build();
 
@@ -168,7 +168,7 @@ public class ChunkedEncodedInputStreamTest {
             .builder()
             .inputStream(payload)
             .chunkSize(chunkSize)
-            .header(chunk -> Integer.toHexString(chunk.length).getBytes())
+            .header(chunk -> Integer.toHexString(chunk.remaining()).getBytes())
             .addExtension(aExt)
             .addExtension(bExt)
             .addTrailer(aTrailer)
@@ -243,7 +243,7 @@ public class ChunkedEncodedInputStreamTest {
             .builder()
             .inputStream(payload)
             .chunkSize(chunkSize)
-            .header(chunk -> Integer.toHexString(chunk.length).getBytes())
+            .header(chunk -> Integer.toHexString(chunk.remaining()).getBytes())
             .extensions(Collections.singletonList(ext))
             .trailers(Arrays.asList(checksumTrailer, signatureTrailer))
             .build();
@@ -274,8 +274,8 @@ public class ChunkedEncodedInputStreamTest {
                            "\r\n").getBytes(StandardCharsets.UTF_8)
         );
 
-        assertEquals(expectedBytesRead, bytesRead);
         assertArrayEquals(expected.toByteArray(), actualBytes);
+        assertEquals(expectedBytesRead, bytesRead);
     }
 
     @ParameterizedTest
@@ -316,10 +316,9 @@ public class ChunkedEncodedInputStreamTest {
         int read = 0;
         int offset = 0;
         while (read >= 0) {
-            read = src.read();
+            read = src.read(dst, offset, dst.length - offset);
             if (read >= 0) {
-                dst[offset] = (byte) read;
-                offset += 1;
+                offset += read;
             }
         }
         return offset;


### PR DESCRIPTION
Before this change, our chunk encoding logic would copy customer data five times:
1. [From the customer's stream into a byte array.](https://github.com/aws/aws-sdk-java-v2/blob/6040b2be6731e4b5ef64e775a2cfffb07d76766c/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java#L106-L107)
2. [From the byte array into a slightly smaller byte array.](https://github.com/aws/aws-sdk-java-v2/blob/6040b2be6731e4b5ef64e775a2cfffb07d76766c/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java#L111)
3. [From the smaller byte array into a byte array output stream.](https://github.com/aws/aws-sdk-java-v2/blob/6040b2be6731e4b5ef64e775a2cfffb07d76766c/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java#L171)
4. [From the byte array output stream into an array.](https://github.com/aws/aws-sdk-java-v2/blob/6040b2be6731e4b5ef64e775a2cfffb07d76766c/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java#L149)
5. [From the array into the output array.](https://github.com/aws/aws-sdk-java-v2/blob/6040b2be6731e4b5ef64e775a2cfffb07d76766c/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedInputStream.java#L85)

After this change, the logic will copy the data twice:
1. From the customer's stream into a byte array.
2. From the byte array into the output array.

There's a path to make it only one copy, but it requires the chunk encoded input stream to know the length of the underlying stream so that it can detect when the last chunk will be encountered. This will require additional piping, so we can do it in a follow-up PR.

Before this change:
<img width="1422" alt="Flame graph showing 159.78 MB usage for putObject before change" src="https://github.com/aws/aws-sdk-java-v2/assets/24903526/a9cc6a6f-2672-432e-b545-102d8133bfeb">

After this change:
<img width="1420" alt="Flame graph showing 81.67 MB usage for putObject after change" src="https://github.com/aws/aws-sdk-java-v2/assets/24903526/7d9826e7-0c1d-44fc-9208-3e97a73945d5">