### PR TITLE
Performance improvements for SRA changes.

### DIFF
--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/BaseSignRequest.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/BaseSignRequest.java
@@ -70,7 +70,7 @@ public interface BaseSignRequest<PayloadT, IdentityT extends Identity> {
      * The value, {@link T}, is return when present, and an exception is thrown otherwise.
      */
     default <T> T requireProperty(SignerProperty<T> property) {
-        return Validate.notNull(property(property), property.toString() + " must not be null!");
+        return Validate.notNull(property(property), "%s must not be null!", property);
     }
 
     /**


### PR DESCRIPTION
1. Do not call SignerProperty.toString() whenever required properties are read. 
2. Check if an SdkHttpRequest is an SdkHttpFullRequest before performing a full conversion to the latter.