### PR TITLE
Add option to disable EC2 metadata (IMDS) calls without token

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-2c52c12.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-2c52c12.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Adds setting to disable making EC2 Instance Metadata Service (IMDS) calls for credentials without a token header when prefetching a token does not work. This feature can be configured through environment variables (AWS_EC2_METADATA_V1_DISABLED), system property (aws.disableEc2MetadataV1) or AWS config file (ec2_metadata_v1_disabled). When you configure this setting to true, no calls without token headers will be made to IMDS."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-2c52c12.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-2c52c12.json
@@ -2,5 +2,5 @@
     "type": "feature",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Adds setting to disable making EC2 Instance Metadata Service (IMDS) calls for credentials without a token header when prefetching a token does not work. This feature can be configured through environment variables (AWS_EC2_METADATA_V1_DISABLED), system property (aws.disableEc2MetadataV1) or AWS config file (ec2_metadata_v1_disabled). When you configure this setting to true, no calls without token headers will be made to IMDS."
+    "description": "Adds setting to disable making EC2 Instance Metadata Service (IMDS) calls without a token header when prefetching a token does not work. This feature can be configured through environment variables (AWS_EC2_METADATA_V1_DISABLED), system property (aws.disableEc2MetadataV1) or AWS config file (ec2_metadata_v1_disabled). When you configure this setting to true, no calls without token headers will be made to IMDS."
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/Ec2MetadataDisableV1Resolver.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/Ec2MetadataDisableV1Resolver.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials.internal;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.utils.OptionalUtils;
+
+@SdkInternalApi
+public final class Ec2MetadataDisableV1Resolver {
+    private final Supplier<ProfileFile> profileFile;
+    private final String profileName;
+
+    private Ec2MetadataDisableV1Resolver(Supplier<ProfileFile> profileFile, String profileName) {
+        this.profileFile = profileFile;
+        this.profileName = profileName;
+    }
+
+    public static Ec2MetadataDisableV1Resolver create(Supplier<ProfileFile> profileFile, String profileName) {
+        return new Ec2MetadataDisableV1Resolver(profileFile, profileName);
+    }
+
+    public boolean resolve() {
+        return OptionalUtils.firstPresent(fromSystemSettings(),
+                                          () -> fromProfileFile(profileFile, profileName))
+                            .orElse(false);
+    }
+
+    private static Optional<Boolean> fromSystemSettings() {
+        return SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.getBooleanValue();
+    }
+
+    private static Optional<Boolean> fromProfileFile(Supplier<ProfileFile> profileFile, String profileName) {
+        profileFile = profileFile != null ? profileFile : ProfileFile::defaultProfileFile;
+        profileName = profileName != null ? profileName : ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow();
+        if (profileFile.get() == null) {
+            return Optional.empty();
+        }
+        return profileFile.get()
+                          .profile(profileName)
+                          .flatMap(p -> p.property(ProfileProperty.EC2_METADATA_V1_DISABLED))
+                          .map(Ec2MetadataDisableV1Resolver::safeProfileStringToBoolean);
+    }
+
+    private static boolean safeProfileStringToBoolean(String value) {
+        if (value.equalsIgnoreCase("true")) {
+            return true;
+        }
+        if (value.equalsIgnoreCase("false")) {
+            return false;
+        }
+
+        throw new IllegalStateException("Profile property '" + ProfileProperty.EC2_METADATA_V1_DISABLED + "', "
+                                        + "was defined as '" + value + "', but should be 'false' or 'true'");
+    }
+
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
@@ -264,13 +264,14 @@ public final class ProfileCredentialsUtils {
             case EC2_INSTANCE_METADATA:
                 // The IMDS credentials provider should source the endpoint config properties from the currently active profile
                 Ec2MetadataConfigProvider configProvider = Ec2MetadataConfigProvider.builder()
-                        .profileFile(() -> profileFile)
-                        .profileName(name)
-                        .build();
-
+                                                                                    .profileFile(() -> profileFile)
+                                                                                    .profileName(name)
+                                                                                    .build();
                 return InstanceProfileCredentialsProvider.builder()
-                        .endpoint(configProvider.getEndpoint())
-                        .build();
+                                                         .endpoint(configProvider.getEndpoint())
+                                                         .profileFile(profileFile)
+                                                         .profileName(name)
+                                                         .build();
             case ENVIRONMENT:
                 return AwsCredentialsProviderChain.builder()
                     .addCredentialsProvider(SystemPropertyCredentialsProvider.create())

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/Ec2MetadataDisableV1ResolverTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/Ec2MetadataDisableV1ResolverTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.Pair;
+import software.amazon.awssdk.utils.StringInputStream;
+
+public class Ec2MetadataDisableV1ResolverTest {
+
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    @BeforeEach
+    public void methodSetup() {
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+        System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.property());
+    }
+
+    @ParameterizedTest(name = "{index} - EXPECTED:{3}  (sys:{0}, env:{1}, cfg:{2})")
+    @MethodSource("booleanConfigValues")
+    public void resolveDisableValue_whenBoolean_resolvesCorrectly(
+        String systemProperty, String envVar, ProfileFile profileFile, boolean expected) {
+
+        setUpSystemSettings(systemProperty, envVar);
+
+        Ec2MetadataDisableV1Resolver resolver = Ec2MetadataDisableV1Resolver.create(() -> profileFile, "test");
+        assertThat(resolver.resolve()).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> booleanConfigValues() {
+        Function<String, ProfileFile> profileDisableValues =
+            s -> configFile("profile test", Pair.of(ProfileProperty.EC2_METADATA_V1_DISABLED, s));
+
+        return Stream.of(
+            Arguments.of(null, null, null, false),
+            Arguments.of("false", null, null, false),
+            Arguments.of("true", null, null, true),
+            Arguments.of(null, "false", null, false),
+            Arguments.of(null, "true", null, true),
+            Arguments.of(null, null, profileDisableValues.apply("false"), false),
+            Arguments.of(null, null, profileDisableValues.apply("true"), true),
+            Arguments.of(null, null, configFile("profile test", Pair.of("bar", "baz")), false),
+            Arguments.of(null, null, configFile("profile foo", Pair.of(ProfileProperty.EC2_METADATA_V1_DISABLED, "true")),
+                         false),
+            Arguments.of("false", "true", null, false),
+            Arguments.of("true", "false", null, true),
+            Arguments.of("false", null, profileDisableValues.apply("true"), false),
+            Arguments.of("true", null, profileDisableValues.apply("false"), true)
+        );
+    }
+
+    @ParameterizedTest(name = "{index} - sys:{0}, env:{1}, cfg:{2}")
+    @MethodSource("nonBooleanConfigValues")
+    public void resolveDisableValue_whenNonBoolean_throws(
+        String systemProperty, String envVar, ProfileFile profileFile) {
+
+        setUpSystemSettings(systemProperty, envVar);
+
+        Ec2MetadataDisableV1Resolver resolver = Ec2MetadataDisableV1Resolver.create(() -> profileFile, "test");
+        assertThatThrownBy(resolver::resolve).isInstanceOf(IllegalStateException.class)
+                                             .hasMessageContaining("but should be 'false' or 'true'");
+    }
+
+    private static Stream<Arguments> nonBooleanConfigValues() {
+        Function<String, ProfileFile> profileDisableValues =
+            s -> configFile("profile test", Pair.of(ProfileProperty.EC2_METADATA_V1_DISABLED, s));
+
+        return Stream.of(
+            Arguments.of("foo", null, null),
+            Arguments.of(null, "foo", null),
+            Arguments.of(null, null, profileDisableValues.apply("foo"))
+        );
+    }
+
+    private static void setUpSystemSettings(String systemProperty, String envVar) {
+        if (systemProperty != null) {
+            System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.property(), systemProperty);
+
+        }
+        if (envVar != null) {
+            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.environmentVariable(),
+                                            envVar);
+        }
+    }
+
+    private static ProfileFile configFile(String name, Pair<?, ?>... pairs) {
+        String values = Arrays.stream(pairs)
+                              .map(pair -> String.format("%s=%s", pair.left(), pair.right()))
+                              .collect(Collectors.joining(System.lineSeparator()));
+        String contents = String.format("[%s]\n%s", name, values);
+
+        return configFile(contents);
+    }
+
+    private static ProfileFile configFile(String credentialFile) {
+        return ProfileFile.builder()
+                          .content(new StringInputStream(credentialFile))
+                          .type(ProfileFile.Type.CONFIGURATION)
+                          .build();
+    }
+}

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -143,6 +143,8 @@ public final class ProfileProperty {
 
     public static final String EC2_METADATA_SERVICE_ENDPOINT = "ec2_metadata_service_endpoint";
 
+    public static final String EC2_METADATA_V1_DISABLED = "ec2_metadata_v1_disabled";
+
     /**
      * Whether request compression is disabled for operations marked with the RequestCompression trait. The default value is
      * false, i.e., request compression is enabled.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/util/Ec2MetadataDisableV1Resolver.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/util/Ec2MetadataDisableV1Resolver.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions.internal.util;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.utils.OptionalUtils;
+
+@SdkInternalApi
+public final class Ec2MetadataDisableV1Resolver {
+
+    private Ec2MetadataDisableV1Resolver() {
+    }
+
+    public static Ec2MetadataDisableV1Resolver create() {
+        return new Ec2MetadataDisableV1Resolver();
+    }
+
+    public boolean resolve() {
+        return OptionalUtils.firstPresent(fromSystemSettings(), Ec2MetadataDisableV1Resolver::fromProfileFile)
+                            .orElse(false);
+    }
+
+    private static Optional<Boolean> fromSystemSettings() {
+        return SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.getBooleanValue();
+    }
+
+    private static Optional<Boolean> fromProfileFile() {
+        Supplier<ProfileFile> profileFile = ProfileFile::defaultProfileFile;
+        String profileName = ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow();
+        if (profileFile.get() == null) {
+            return Optional.empty();
+        }
+        return profileFile.get()
+                          .profile(profileName)
+                          .flatMap(p -> p.property(ProfileProperty.EC2_METADATA_V1_DISABLED))
+                          .map(Ec2MetadataDisableV1Resolver::safeProfileStringToBoolean);
+    }
+
+    private static boolean safeProfileStringToBoolean(String value) {
+        if (value.equalsIgnoreCase("true")) {
+            return true;
+        }
+        if (value.equalsIgnoreCase("false")) {
+            return false;
+        }
+
+        throw new IllegalStateException("Profile property '" + ProfileProperty.EC2_METADATA_V1_DISABLED + "', "
+                                        + "was defined as '" + value + "', but should be 'false' or 'true'");
+    }
+
+}

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProvider.java
@@ -18,16 +18,20 @@ package software.amazon.awssdk.regions.providers;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.profiles.ProfileProperty;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 /**
  * Attempts to load region information from the EC2 Metadata service. If the application is not
- * running on EC2 this provider will thrown an exception.
- *
- * <P>
+ * running on EC2 this provider will throw an exception.
+ * <p>
  * If {@link SdkSystemSetting#AWS_EC2_METADATA_DISABLED} is set to true, it will not try to load
  * region from EC2 metadata service and will return null.
+ * <p>
+ * If {@link SdkSystemSetting#AWS_EC2_METADATA_V1_DISABLED} or {@link ProfileProperty#EC2_METADATA_V1_DISABLED}
+ * is set to true, the region will only be loaded from EC2 metadata service if a token is successfully retrieved -
+ * fallback to load region without a token will be disabled.
  */
 @SdkProtectedApi
 public final class InstanceProfileRegionProvider implements AwsRegionProvider {

--- a/core/regions/src/test/java/software/amazon/awssdk/regions/internal/util/Ec2MetadataDisableV1ResolverTest.java
+++ b/core/regions/src/test/java/software/amazon/awssdk/regions/internal/util/Ec2MetadataDisableV1ResolverTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions.internal.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+public class Ec2MetadataDisableV1ResolverTest {
+
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    @BeforeEach
+    public void methodSetup() {
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+        System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.property());
+    }
+
+    @ParameterizedTest(name = "{index} - EXPECTED:{3}  (sys:{0}, env:{1}, cfg:{2})")
+    @MethodSource("booleanConfigValues")
+    public void resolveDisableValue_whenBoolean_resolvesCorrectly(
+        String systemProperty, String envVar, boolean expected) {
+
+        setUpSystemSettings(systemProperty, envVar);
+
+        Ec2MetadataDisableV1Resolver resolver = Ec2MetadataDisableV1Resolver.create();
+        assertThat(resolver.resolve()).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> booleanConfigValues() {
+        return Stream.of(
+            Arguments.of(null, null, false),
+            Arguments.of("false", null, false),
+            Arguments.of("true", null, true),
+            Arguments.of(null, "false", false),
+            Arguments.of(null, "true", true),
+            Arguments.of(null, null, false),
+            Arguments.of("false", "true", false),
+            Arguments.of("true", "false", true)
+        );
+    }
+
+    @ParameterizedTest(name = "{index} - sys:{0}, env:{1}")
+    @MethodSource("nonBooleanConfigValues")
+    public void resolveDisableValue_whenNonBoolean_throws(String systemProperty, String envVar) {
+        setUpSystemSettings(systemProperty, envVar);
+
+        Ec2MetadataDisableV1Resolver resolver = Ec2MetadataDisableV1Resolver.create();
+        assertThatThrownBy(resolver::resolve).isInstanceOf(IllegalStateException.class)
+                                             .hasMessageContaining("but should be 'false' or 'true'");
+    }
+
+    private static Stream<Arguments> nonBooleanConfigValues() {
+        return Stream.of(
+            Arguments.of("foo", null, null),
+            Arguments.of(null, "foo", null)
+        );
+    }
+
+    private static void setUpSystemSettings(String systemProperty, String envVar) {
+        if (systemProperty != null) {
+            System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.property(), systemProperty);
+
+        }
+        if (envVar != null) {
+            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.environmentVariable(),
+                                            envVar);
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -71,6 +71,11 @@ public enum SdkSystemSetting implements SystemSetting {
     AWS_EC2_METADATA_DISABLED("aws.disableEc2Metadata", "false"),
 
     /**
+     * Whether to disable fallback to insecure EC2 Metadata instance service v1 on errors or timeouts.
+     */
+    AWS_EC2_METADATA_V1_DISABLED("aws.disableEc2MetadataV1", null),
+
+    /**
      * The EC2 instance metadata service endpoint.
      *
      * This allows a service running in EC2 to automatically load its credentials and region without needing to configure them

--- a/test/auth-tests/src/it/java/software/amazon/awssdk/auth/sts/ProfileCredentialsProviderIntegrationTest.java
+++ b/test/auth-tests/src/it/java/software/amazon/awssdk/auth/sts/ProfileCredentialsProviderIntegrationTest.java
@@ -22,18 +22,23 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.util.SdkUserAgent;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.services.sts.model.StsException;
 import software.amazon.awssdk.utils.DateUtils;
+import software.amazon.awssdk.utils.StringInputStream;
 
 public class ProfileCredentialsProviderIntegrationTest {
     private static final String TOKEN_RESOURCE_PATH = "/latest/api/token";
@@ -41,48 +46,134 @@ public class ProfileCredentialsProviderIntegrationTest {
     private static final String STUB_CREDENTIALS = "{\"AccessKeyId\":\"ACCESS_KEY_ID\",\"SecretAccessKey\":\"SECRET_ACCESS_KEY\","
             + "\"Expiration\":\"" + DateUtils.formatIso8601Date(Instant.now().plus(Duration.ofDays(1)))
             + "\"}";
+    private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final String USER_AGENT = SdkUserAgent.create().userAgent();
+    private static final String PROFILE_NAME = "some-profile";
+    private static final String TOKEN_HEADER = "x-aws-ec2-metadata-token";
+    private static final String TOKEN_STUB = "some-token";
+
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+                                                               .options(wireMockConfig().dynamicPort().dynamicPort())
+                                                               .configureStaticDsl(true)
+                                                               .build();
+
+    private void stubSecureCredentialsResponse(ResponseDefinitionBuilder responseDefinitionBuilder) {
+        wireMockServer.stubFor(put(urlPathEqualTo(TOKEN_RESOURCE_PATH)).willReturn(aResponse().withBody(TOKEN_STUB)));
+        stubCredentialsResponse(responseDefinitionBuilder);
+    }
+
+    private void stubTokenFetchErrorResponse(ResponseDefinitionBuilder responseDefinitionBuilder, int statusCode) {
+        wireMockServer.stubFor(put(urlPathEqualTo(TOKEN_RESOURCE_PATH)).willReturn(aResponse().withStatus(statusCode)
+                                                                                              .withBody("oops")));
+        stubCredentialsResponse(responseDefinitionBuilder);
+    }
+
+    private void stubCredentialsResponse(ResponseDefinitionBuilder responseDefinitionBuilder) {
+        wireMockServer.stubFor(get(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH)).willReturn(aResponse().withBody(PROFILE_NAME)));
+        wireMockServer.stubFor(get(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH + PROFILE_NAME)).willReturn(responseDefinitionBuilder));
+    }
 
     @Test
-    public void profileWithCredentialSourceUsingEc2InstanceMetadataAndCustomEndpoint_usesEndpointInSourceProfile() {
+    public void resolveCredentials_instanceMetadataSourceAndCustomEndpoint_usesSourceEndpointAndMakesSecureCall() {
         String testFileContentsTemplate = "" +
-                "[profile a]\n" +
+                "[profile ec2Test]\n" +
                 "role_arn=arn:aws:iam::123456789012:role/testRole3\n" +
                 "credential_source = ec2instancemetadata\n" +
                 "ec2_metadata_service_endpoint = http://localhost:%d\n";
-
-        WireMockServer mockMetadataEndpoint = new WireMockServer(WireMockConfiguration.options().dynamicPort());
-        mockMetadataEndpoint.start();
-
-        String profileFileContents = String.format(testFileContentsTemplate, mockMetadataEndpoint.port());
-
-        ProfileFile profileFile = ProfileFile.builder()
-                .type(ProfileFile.Type.CONFIGURATION)
-                .content(new ByteArrayInputStream(profileFileContents.getBytes(StandardCharsets.UTF_8)))
-                .build();
+        String profileFileContents = String.format(testFileContentsTemplate, wireMockServer.getPort());
 
         ProfileCredentialsProvider profileCredentialsProvider = ProfileCredentialsProvider.builder()
-                .profileFile(profileFile)
-                .profileName("a")
+                .profileFile(configFile(profileFileContents))
+                .profileName("ec2Test")
                 .build();
 
-        String stubToken = "some-token";
-        mockMetadataEndpoint.stubFor(put(urlPathEqualTo(TOKEN_RESOURCE_PATH)).willReturn(aResponse().withBody(stubToken)));
-        mockMetadataEndpoint.stubFor(get(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH)).willReturn(aResponse().withBody("some-profile")));
-        mockMetadataEndpoint.stubFor(get(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH + "some-profile")).willReturn(aResponse().withBody(STUB_CREDENTIALS)));
+        stubSecureCredentialsResponse(aResponse().withBody(STUB_CREDENTIALS));
 
         try {
             profileCredentialsProvider.resolveCredentials();
-
         } catch (StsException e) {
             // ignored
-        } finally {
-            mockMetadataEndpoint.stop();
         }
-
-        String userAgentHeader = "User-Agent";
-        String userAgent = SdkUserAgent.create().userAgent();
-        mockMetadataEndpoint.verify(putRequestedFor(urlPathEqualTo(TOKEN_RESOURCE_PATH)).withHeader(userAgentHeader, equalTo(userAgent)));
-        mockMetadataEndpoint.verify(getRequestedFor(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH)).withHeader(userAgentHeader, equalTo(userAgent)));
-        mockMetadataEndpoint.verify(getRequestedFor(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH + "some-profile")).withHeader(userAgentHeader, equalTo(userAgent)));
+        verifyImdsCallWithToken();
     }
+
+    @Test
+    public void resolveCredentials_instanceMetadataSource_fallbackToInsecureWhenTokenFails() {
+        String testFileContentsTemplate = "" +
+                                          "[profile ec2Test]\n" +
+                                          "role_arn=arn:aws:iam::123456789012:role/testRole3\n" +
+                                          "credential_source = ec2instancemetadata\n" +
+                                          "ec2_metadata_service_endpoint = http://localhost:%d\n";
+        String profileFileContents = String.format(testFileContentsTemplate, wireMockServer.getPort());
+
+        ProfileCredentialsProvider profileCredentialsProvider = ProfileCredentialsProvider.builder()
+                                                                                          .profileFile(configFile(profileFileContents))
+                                                                                          .profileName("ec2Test")
+                                                                                          .build();
+
+        stubTokenFetchErrorResponse(aResponse().withBody(STUB_CREDENTIALS), 403);
+
+        try {
+            profileCredentialsProvider.resolveCredentials();
+        } catch (StsException e) {
+            // ignored
+        }
+        verifyImdsCallInsecure();
+    }
+
+    @Test
+    public void resolveCredentials_instanceMetadataSourceAndFallbackToInsecureDisabled_throwsWhenTokenFails() {
+        String testFileContentsTemplate = "" +
+                                          "[profile ec2Test]\n" +
+                                          "role_arn=arn:aws:iam::123456789012:role/testRole3\n" +
+                                          "credential_source = ec2instancemetadata\n" +
+                                          "ec2_metadata_v1_disabled = true\n" +
+                                          "ec2_metadata_service_endpoint = http://localhost:%d\n";
+        String profileFileContents = String.format(testFileContentsTemplate, wireMockServer.getPort());
+
+        ProfileCredentialsProvider profileCredentialsProvider = ProfileCredentialsProvider.builder()
+                                                                                          .profileFile(configFile(profileFileContents))
+                                                                                          .profileName("ec2Test")
+                                                                                          .build();
+
+        stubTokenFetchErrorResponse(aResponse().withBody(STUB_CREDENTIALS), 403);
+
+        try {
+            profileCredentialsProvider.resolveCredentials();
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(SdkClientException.class);
+            Throwable cause = e.getCause();
+            assertThat(cause).isInstanceOf(SdkClientException.class);
+            assertThat(cause).hasMessageContaining("fallback to IMDS v1 is disabled");
+        }
+    }
+
+    private void verifyImdsCallWithToken() {
+        WireMock.verify(putRequestedFor(urlPathEqualTo(TOKEN_RESOURCE_PATH))
+                            .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT)));
+        WireMock.verify(getRequestedFor(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH))
+                            .withHeader(TOKEN_HEADER, equalTo(TOKEN_STUB))
+                            .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT)));
+        WireMock.verify(getRequestedFor(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH + "some-profile"))
+                            .withHeader(TOKEN_HEADER, equalTo(TOKEN_STUB))
+                            .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT)));
+    }
+
+    private void verifyImdsCallInsecure() {
+        WireMock.verify(getRequestedFor(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH))
+                            .withoutHeader(TOKEN_HEADER)
+                            .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT)));
+        WireMock.verify(getRequestedFor(urlPathEqualTo(CREDENTIALS_RESOURCE_PATH + "some-profile"))
+                            .withoutHeader(TOKEN_HEADER)
+                            .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT)));
+    }
+
+    private ProfileFile configFile(String credentialFile) {
+        return ProfileFile.builder()
+                          .content(new StringInputStream(credentialFile))
+                          .type(ProfileFile.Type.CONFIGURATION)
+                          .build();
+    }
+
 }


### PR DESCRIPTION
## Motivation and Context
Currently, when the SDK calls the EC2 Instance Metadata Service (IMDS) to fetch regional or credential information, it attempts to fetch a token which is then attached to the credentials call, for security. If token fetching fails due to some errors (403, 404, 405) or timeouts, the provider makes an unsecure call without the token header. 

It's recommended to avoid fallback to unsecure, IMDS v1 style calls without a token and this PR adds a configuration option to facilitate that.

## Modifications
- Adds setting to disable IMDS v1 fallback through 
  - Environment variables (`AWS_EC2_METADATA_V1_DISABLED`)
  - System property (`aws.disableEc2MetadataV1`) 
  - Config file (`ec2_metadata_v1_disabled`). 
- Adds a resolver to resolve the disable value to 
  - `InstanceProfileCredentialsProvider` 
  - `InstanceProfileRegionProvider` (specifically, `EC2MetadataUtils`)
- Updates creating an InstanceProfileCredentialsProvider in ProfileCredentialsProvider to forward profile information to the InstanceProfileCredentialsProvider

Note that all changes except for the ones to `InstanceProfileRegionProvider` are reviewed in #4840.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
