### PR TITLE
Fix check for release tag

### DIFF
--- a/buildspecs/release-to-github.yml
+++ b/buildspecs/release-to-github.yml
@@ -22,7 +22,7 @@ phases:
     -
     - git remote add --fetch public $PUBLIC_REPOSITORY_URL
     - |
-      if git show-ref --tags $RELEASE_VERSION --quiet; then
+      if [ `git ls-remote --tags public  | grep refs/tags/$RELEASE_VERSION | wc -l` -ge "1" ]; then
         git push -d public :refs/tags/$RELEASE_VERSION
       fi
     - git tag -a $RELEASE_VERSION -m "AWS SDK for Java v2 ($RELEASE_VERSION)"


### PR DESCRIPTION
The original check checks whether the tag *exists* in the local and then tries to remove it from the public repo. However, it's possible that the tag is in the private repo, where it might not exists (refs from both remotes are present locally).

This commit fixes this by explicitly check if the tag exists in the public repo and only then will it try to delete it.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
