### PR TITLE
Cache whether CRT is available in the flexible checksum algorithm.

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/Crc32CChecksum.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/Crc32CChecksum.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.utils.ClassLoaderHelper;
 public class Crc32CChecksum implements SdkChecksum {
 
     private static final String CRT_CLASSPATH_FOR_CRC32C = "software.amazon.awssdk.crt.checksums.CRC32C";
+    private static final ThreadLocal<Boolean> IS_CRT_AVAILABLE = ThreadLocal.withInitial(Crc32CChecksum::isCrtAvailable);
 
     private Checksum crc32c;
     private Checksum lastMarkedCrc32C;
@@ -37,7 +38,7 @@ public class Crc32CChecksum implements SdkChecksum {
      * Creates CRT Based Crc32C checksum if Crt classpath for Crc32c is loaded, else create Sdk Implemented Crc32c
      */
     public Crc32CChecksum() {
-        if (isCrtAvailable()) {
+        if (IS_CRT_AVAILABLE.get()) {
             crc32c = new CRC32C();
         } else {
             crc32c = SdkCrc32CChecksum.create();

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/Crc32Checksum.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/Crc32Checksum.java
@@ -27,17 +27,18 @@ import software.amazon.awssdk.utils.ClassLoaderHelper;
  */
 @SdkInternalApi
 public class Crc32Checksum implements SdkChecksum {
-
     private static final String CRT_CLASSPATH_FOR_CRC32 = "software.amazon.awssdk.crt.checksums.CRC32";
+    private static final ThreadLocal<Boolean> IS_CRT_AVAILABLE = ThreadLocal.withInitial(Crc32Checksum::isCrtAvailable);
 
     private Checksum crc32;
     private Checksum lastMarkedCrc32;
+
 
     /**
      * Creates CRT Based Crc32 checksum if Crt classpath for Crc32 is loaded, else create Sdk Implemented Crc32.
      */
     public Crc32Checksum() {
-        if (isCrtAvailable()) {
+        if (IS_CRT_AVAILABLE.get()) {
             crc32 = new CRC32();
         } else {
             crc32 = SdkCrc32Checksum.create();


### PR DESCRIPTION
We use a thread local, because the classpath helper used to load the CRT may use the thread-level class loader.