### PR TITLE
Enable compiled endpoint rules for the second wave

### DIFF
--- a/services/backupstorage/src/main/resources/codegen-resources/customization.config
+++ b/services/backupstorage/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,4 @@
 {
+    "enableGenerateCompiledEndpointRules": true,
     "useSraAuth": true
 }

--- a/services/codecatalyst/src/main/resources/codegen-resources/customization.config
+++ b/services/codecatalyst/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,4 @@
 {
+    "enableGenerateCompiledEndpointRules": true,
     "useSraAuth": true
 }

--- a/services/cognitoidentity/src/main/resources/codegen-resources/customization.config
+++ b/services/cognitoidentity/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,4 @@
 {
+    "enableGenerateCompiledEndpointRules": true,
     "useSraAuth": true
 }

--- a/services/kinesis/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesis/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,6 @@
 {
   "useSraAuth": true,
+  "enableGenerateCompiledEndpointRules": true,
   "verifiedSimpleMethods": [
     "describeLimits",
     "listStreams"

--- a/services/mediastoredata/src/main/resources/codegen-resources/customization.config
+++ b/services/mediastoredata/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,6 @@
 {
   "useSraAuth": true,
+  "enableGenerateCompiledEndpointRules": true,
   "excludedSimpleMethods" : [
     "listItems"
   ]

--- a/services/transcribe/src/main/resources/codegen-resources/customization.config
+++ b/services/transcribe/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,6 @@
 {
     "useSraAuth": true,
+    "enableGenerateCompiledEndpointRules": true,
     "verifiedSimpleMethods" : [
         "listTranscriptionJobs",
         "listVocabularies"

--- a/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
+++ b/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,6 @@
 {
     "useSraAuth": true,
+    "enableGenerateCompiledEndpointRules": true,
     "serviceSpecificHttpConfig": "software.amazon.awssdk.services.transcribestreaming.internal.DefaultHttpConfigurationOptions",
     "skipSyncClientGeneration": true,
     "useLegacyEventGenerationScheme": {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Enable compiled endpoint rules for the second wave of services.

Services included are: 

* backupstorage, 
* codecatalyst, 
* cognitoidentity, 
* kinesis, 
* mediastoredata, 
* transcribe, 
* transcribestreaming

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
