### PR TITLE
Bump CRT version and expose setting memory limits for S3 calls

### DIFF
--- a/.changes/next-release/feature-AWSCRTbasedS3Client-353870f.json
+++ b/.changes/next-release/feature-AWSCRTbasedS3Client-353870f.json
@@ -1,6 +1,6 @@
 {
     "type": "feature",
-    "category": "AWS CRT-based S3 Client",
+    "category": "AWS SDK for Java v2",
     "contributor": "",
     "description": "Bump `aws-crt` version to `0.29.9`"
 }

--- a/.changes/next-release/feature-AWSCRTbasedS3Client-353870f.json
+++ b/.changes/next-release/feature-AWSCRTbasedS3Client-353870f.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS CRT-based S3 Client",
+    "contributor": "",
+    "description": "Bump `aws-crt` version to `0.29.9`"
+}

--- a/.changes/next-release/feature-AmazonS3-c28f9de.json
+++ b/.changes/next-release/feature-AmazonS3-c28f9de.json
@@ -1,6 +1,6 @@
 {
     "type": "feature",
-    "category": "Amazon S3",
+    "category": "AWS CRT-based S3 Client",
     "contributor": "",
     "description": "Exposes a setting to set the memory limit when making asynchronous calls with the CRT-based S3 client"
 }

--- a/.changes/next-release/feature-AmazonS3-c28f9de.json
+++ b/.changes/next-release/feature-AmazonS3-c28f9de.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Exposes a setting to set the memory limit when making asynchronous calls with the CRT-based S3 client"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.15</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.29.7</awscrt.version>
+        <awscrt.version>0.29.9</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.10.0</junit5.version>

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
@@ -115,11 +115,29 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
     S3CrtAsyncClientBuilder minimumPartSizeInBytes(Long uploadPartSize);
 
     /**
+     * The amount of memory that CRT is allowed to use when making requests to S3.
+     * <p>
+     * If not provided, the CRT attempts to limit memory usage in an optimal way, based on a number of parameters
+     * such as target throughput. Therefore, only configure the memory limit explicitly when needed.
+     * <p>
+     * Supported range:
+     * <ul>
+     *     <li><b>Min: </b>1 GB</li>
+     *     <li><b>Max: </b>The lowest value of the supplied value and the SIZE_MAX of the system</li>
+     * </ul>
+     *
+     * @param memoryLimitInBytes the memory limit in bytes
+     * @return this builder for method chaining.
+     * @see #targetThroughputInGbps(Double)
+     */
+    S3CrtAsyncClientBuilder memoryLimitInBytes(Long memoryLimitInBytes);
+
+    /**
      * The target throughput for transfer requests. Higher value means more connections will be established with S3.
      *
      * <p>
      * Whether the transfer manager can achieve the configured target throughput depends on various factors such as the network
-     * bandwidth of the environment and whether {@link #maxConcurrency} is configured.
+     * bandwidth of the environment, whether {@link #maxConcurrency} is configured and amount of available memory.
      *
      * <p>
      * By default, it is 10 gigabits per second. If users want to transfer as fast as possible, it's recommended to set it to the
@@ -128,10 +146,14 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      * instance type in <a href="https://aws.amazon.com/ec2/instance-types/">Amazon EC2 instance type page</a>.
      * If you are running into out of file descriptors error, consider using {@link #maxConcurrency(Integer)} to limit the
      * number of connections.
+     * <p>
+     * <b>Note: </b> this setting affects the memory usage of CRT; a higher throughput value will result in a larger memory
+     * usage. Typically, a range of throughput values maps to a discrete memory limit value in CRT, with a maximum upper limit.
      *
      * @param targetThroughputInGbps the target throughput in Gbps
      * @return this builder for method chaining.
      * @see #maxConcurrency(Integer)
+     * @see #memoryLimitInBytes(Long)
      */
     S3CrtAsyncClientBuilder targetThroughputInGbps(Double targetThroughputInGbps);
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
@@ -115,9 +115,9 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
     S3CrtAsyncClientBuilder minimumPartSizeInBytes(Long uploadPartSize);
 
     /**
-     * The amount of memory that CRT is allowed to use when making requests to S3.
+     * The amount of native memory that CRT is allowed to use when making requests to S3.
      * <p>
-     * If not provided, the CRT attempts to limit memory usage in an optimal way, based on a number of parameters
+     * If not provided, the CRT attempts to limit native memory usage in an optimal way, based on a number of parameters
      * such as target throughput. Therefore, only configure the memory limit explicitly when needed.
      * <p>
      * Supported range:
@@ -126,11 +126,13 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      *     <li><b>Max: </b>The lowest value of the supplied value and the SIZE_MAX of the system</li>
      * </ul>
      *
-     * @param memoryLimitInBytes the memory limit in bytes
+     * @param maxNativeMemoryLimitInBytes
+ the native memory limit in bytes
      * @return this builder for method chaining.
      * @see #targetThroughputInGbps(Double)
      */
-    S3CrtAsyncClientBuilder memoryLimitInBytes(Long memoryLimitInBytes);
+    S3CrtAsyncClientBuilder maxNativeMemoryLimitInBytes(Long maxNativeMemoryLimitInBytes
+);
 
     /**
      * The target throughput for transfer requests. Higher value means more connections will be established with S3.
@@ -147,13 +149,14 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      * If you are running into out of file descriptors error, consider using {@link #maxConcurrency(Integer)} to limit the
      * number of connections.
      * <p>
-     * <b>Note: </b> this setting affects the memory usage of CRT; a higher throughput value will result in a larger memory
-     * usage. Typically, a range of throughput values maps to a discrete memory limit value in CRT, with a maximum upper limit.
+     * <b>Note: </b> This setting affects the native memory usage used by CRT; a higher throughput value will result in a larger
+     * memory usage. Typically, a range of throughput values maps to a discrete memory limit value in CRT, with a maximum upper
+     * limit.
      *
      * @param targetThroughputInGbps the target throughput in Gbps
      * @return this builder for method chaining.
      * @see #maxConcurrency(Integer)
-     * @see #memoryLimitInBytes(Long)
+     * @see #maxNativeMemoryLimitInBytes(Long)
      */
     S3CrtAsyncClientBuilder targetThroughputInGbps(Double targetThroughputInGbps);
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -157,7 +157,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                        .credentialsProvider(builder.credentialsProvider)
                                        .readBufferSizeInBytes(builder.readBufferSizeInBytes)
                                        .httpConfiguration(builder.httpConfiguration)
-                                       .thresholdInBytes(builder.thresholdInBytes);
+                                       .thresholdInBytes(builder.thresholdInBytes)
+                                       .memoryLimitInBytes(builder.memoryLimitInBytes);
 
         if (builder.retryConfiguration != null) {
             nativeClientBuilder.standardRetryOptions(
@@ -175,6 +176,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         private Region region;
         private Long minimalPartSizeInBytes;
         private Double targetThroughputInGbps;
+        private Long memoryLimitInBytes;
         private Integer maxConcurrency;
         private URI endpointOverride;
         private Boolean checksumValidationEnabled;
@@ -209,6 +211,12 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         @Override
         public S3CrtAsyncClientBuilder targetThroughputInGbps(Double targetThroughputInGbps) {
             this.targetThroughputInGbps = targetThroughputInGbps;
+            return this;
+        }
+
+        @Override
+        public S3CrtAsyncClientBuilder memoryLimitInBytes(Long memoryLimitInBytes) {
+            this.memoryLimitInBytes = memoryLimitInBytes;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -158,7 +158,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                        .readBufferSizeInBytes(builder.readBufferSizeInBytes)
                                        .httpConfiguration(builder.httpConfiguration)
                                        .thresholdInBytes(builder.thresholdInBytes)
-                                       .memoryLimitInBytes(builder.memoryLimitInBytes);
+                                       .maxNativeMemoryLimitInBytes(builder.maxNativeMemoryLimitInBytes);
 
         if (builder.retryConfiguration != null) {
             nativeClientBuilder.standardRetryOptions(
@@ -176,7 +176,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         private Region region;
         private Long minimalPartSizeInBytes;
         private Double targetThroughputInGbps;
-        private Long memoryLimitInBytes;
+        private Long maxNativeMemoryLimitInBytes
+;
         private Integer maxConcurrency;
         private URI endpointOverride;
         private Boolean checksumValidationEnabled;
@@ -215,8 +216,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         }
 
         @Override
-        public S3CrtAsyncClientBuilder memoryLimitInBytes(Long memoryLimitInBytes) {
-            this.memoryLimitInBytes = memoryLimitInBytes;
+        public S3CrtAsyncClientBuilder maxNativeMemoryLimitInBytes(Long maxNativeMemoryLimitInBytes) {
+            this.maxNativeMemoryLimitInBytes = maxNativeMemoryLimitInBytes;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -106,7 +106,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
                                  .withComputeContentMd5(false)
                                  .withEnableS3Express(true)
                                  .withMaxConnections(s3NativeClientConfiguration.maxConcurrency())
-                                 .withMemoryLimitInBytes(s3NativeClientConfiguration.memoryLimitInBytes())
+                                 .withMemoryLimitInBytes(s3NativeClientConfiguration.maxNativeMemoryLimitInBytes())
                                  .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps())
                                  .withInitialReadWindowSize(initialWindowSize)
                                  .withReadBackpressureEnabled(true);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -106,6 +106,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
                                  .withComputeContentMd5(false)
                                  .withEnableS3Express(true)
                                  .withMaxConnections(s3NativeClientConfiguration.maxConcurrency())
+                                 .withMemoryLimitInBytes(s3NativeClientConfiguration.memoryLimitInBytes())
                                  .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps())
                                  .withInitialReadWindowSize(initialWindowSize)
                                  .withReadBackpressureEnabled(true);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -59,13 +59,12 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final boolean checksumValidationEnabled;
     private final Long readBufferSizeInBytes;
     private final TlsContext tlsContext;
-
     private final TlsContextOptions clientTlsContextOptions;
     private final HttpProxyOptions proxyOptions;
     private final Duration connectionTimeout;
     private final HttpMonitoringOptions httpMonitoringOptions;
-
     private final Boolean useEnvironmentVariableProxyOptionsValues;
+    private final long memoryLimitInBytes;
 
     public S3NativeClientConfiguration(Builder builder) {
         this.signingRegion = builder.signingRegion == null ? DefaultAwsRegionProviderChain.builder().build().getRegion().id() :
@@ -98,6 +97,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         // Using 0 so that CRT will calculate it based on targetThroughputGbps
         this.maxConcurrency = builder.maxConcurrency == null ? 0 : builder.maxConcurrency;
+        this.memoryLimitInBytes = builder.memoryLimitInBytes == null ? 0 : builder.memoryLimitInBytes;
 
         this.endpointOverride = builder.endpointOverride;
 
@@ -177,6 +177,10 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         return targetThroughputInGbps;
     }
 
+    public long memoryLimitInBytes() {
+        return memoryLimitInBytes;
+    }
+
     public int maxConcurrency() {
         return maxConcurrency;
     }
@@ -218,6 +222,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         private S3CrtHttpConfiguration httpConfiguration;
         private StandardRetryOptions standardRetryOptions;
         private Long thresholdInBytes;
+        private Long memoryLimitInBytes;
 
         private Builder() {
         }
@@ -244,6 +249,11 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         public Builder maxConcurrency(Integer maxConcurrency) {
             this.maxConcurrency = maxConcurrency;
+            return this;
+        }
+
+        public Builder memoryLimitInBytes(Long memoryLimitInBytes) {
+            this.memoryLimitInBytes = memoryLimitInBytes;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -64,7 +64,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final Duration connectionTimeout;
     private final HttpMonitoringOptions httpMonitoringOptions;
     private final Boolean useEnvironmentVariableProxyOptionsValues;
-    private final long memoryLimitInBytes;
+    private final long maxNativeMemoryLimitInBytes;
 
     public S3NativeClientConfiguration(Builder builder) {
         this.signingRegion = builder.signingRegion == null ? DefaultAwsRegionProviderChain.builder().build().getRegion().id() :
@@ -97,7 +97,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         // Using 0 so that CRT will calculate it based on targetThroughputGbps
         this.maxConcurrency = builder.maxConcurrency == null ? 0 : builder.maxConcurrency;
-        this.memoryLimitInBytes = builder.memoryLimitInBytes == null ? 0 : builder.memoryLimitInBytes;
+        this.maxNativeMemoryLimitInBytes = builder.maxNativeMemoryLimitInBytes == null ? 0 : builder.maxNativeMemoryLimitInBytes;
 
         this.endpointOverride = builder.endpointOverride;
 
@@ -177,8 +177,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         return targetThroughputInGbps;
     }
 
-    public long memoryLimitInBytes() {
-        return memoryLimitInBytes;
+    public long maxNativeMemoryLimitInBytes() {
+        return maxNativeMemoryLimitInBytes;
     }
 
     public int maxConcurrency() {
@@ -222,7 +222,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         private S3CrtHttpConfiguration httpConfiguration;
         private StandardRetryOptions standardRetryOptions;
         private Long thresholdInBytes;
-        private Long memoryLimitInBytes;
+        private Long maxNativeMemoryLimitInBytes;
 
         private Builder() {
         }
@@ -252,8 +252,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
             return this;
         }
 
-        public Builder memoryLimitInBytes(Long memoryLimitInBytes) {
-            this.memoryLimitInBytes = memoryLimitInBytes;
+        public Builder maxNativeMemoryLimitInBytes(Long maxNativeMemoryLimitInBytes) {
+            this.maxNativeMemoryLimitInBytes = maxNativeMemoryLimitInBytes;
             return this;
         }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
@@ -380,7 +380,7 @@ public class S3CrtAsyncHttpClientTest {
                                        .signingRegion(signingRegion)
                                        .thresholdInBytes(1024L)
                                        .targetThroughputInGbps(3.5)
-                                       .memoryLimitInBytes(5L * 1024 * 1024 * 1024)
+                                       .maxNativeMemoryLimitInBytes(5L * 1024 * 1024 * 1024)
                                        .standardRetryOptions(
                                            new StandardRetryOptions()
                                                .withBackoffRetryOptions(new ExponentialBackoffRetryOptions().withMaxRetries(7)))

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
@@ -379,6 +379,8 @@ public class S3CrtAsyncHttpClientTest {
                                        .maxConcurrency(100)
                                        .signingRegion(signingRegion)
                                        .thresholdInBytes(1024L)
+                                       .targetThroughputInGbps(3.5)
+                                       .memoryLimitInBytes(5L * 1024 * 1024 * 1024)
                                        .standardRetryOptions(
                                            new StandardRetryOptions()
                                                .withBackoffRetryOptions(new ExponentialBackoffRetryOptions().withMaxRetries(7)))
@@ -409,6 +411,8 @@ public class S3CrtAsyncHttpClientTest {
                 assertThat(options.getMinThroughputBytesPerSecond()).isEqualTo(1024);
             });
             assertThat(clientOptions.getMaxConnections()).isEqualTo(100);
+            assertThat(clientOptions.getThroughputTargetGbps()).isEqualTo(3.5);
+            assertThat(clientOptions.getMemoryLimitInBytes()).isEqualTo(5L * 1024 * 1024 * 1024);
         }
     }
 


### PR DESCRIPTION
## Motivation and Context
CRT has published a new setting to limit memory used when making S3 calls.

## Modifications
- Updated CRT version
- Added new parameter
- Added Javadoc description for parameter, and for throughput

## Testing
Unit tested


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
