### PR TITLE
Fix request cancellation logic in the AWS CRT Sync HTTP client

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTSyncHTTPClient-660cc21.json
+++ b/.changes/next-release/bugfix-AWSCRTSyncHTTPClient-660cc21.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT Sync HTTP Client",
+    "contributor": "",
+    "description": "Fixed an issue where `CancellationException` was thrown incorrectly from AWS CRT Sync HTTP client when execution time exceeded the total configured API call attempt timeout or API call timeout. Now it throws `ApiCallAttemptTimeoutException`/`ApiCallTimeoutException` accordingly. See [#4820](https://github.com/aws/aws-sdk-java-v2/issues/4820)"
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
@@ -129,6 +129,10 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
                     throw (HttpException) cause;
                 }
 
+                if (cause instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Request was cancelled");
+                }
                 throw new RuntimeException(e.getCause());
             }
         }
@@ -136,7 +140,7 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
         @Override
         public void abort() {
             if (responseFuture != null) {
-                responseFuture.cancel(true);
+                responseFuture.completeExceptionally(new IOException("Request ws cancelled"));
             }
         }
     }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
@@ -131,7 +131,7 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
 
                 if (cause instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
-                    throw new IOException("Request was cancelled");
+                    throw new IOException("Request was cancelled", cause);
                 }
                 throw new RuntimeException(e.getCause());
             }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
@@ -28,7 +28,11 @@ import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createReque
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -51,16 +55,20 @@ public class AwsCrtHttpClientWireMockTest {
     public WireMockRule mockServer = new WireMockRule(wireMockConfig()
                                                           .dynamicPort());
 
+    private static ScheduledExecutorService executorService;
+
     @BeforeClass
     public static void setup() {
         System.setProperty("aws.crt.debugnative", "true");
         Log.initLoggingToStdout(Log.LogLevel.Warn);
+        executorService = Executors.newScheduledThreadPool(1);
     }
 
     @AfterClass
     public static void tearDown() {
         // Verify there is no resource leak.
         CrtResource.waitForNoResources();
+        executorService.shutdown();
     }
 
     @Test
@@ -104,6 +112,26 @@ public class AwsCrtHttpClientWireMockTest {
 
         try (SdkHttpClient anotherClient = AwsCrtHttpClient.create()) {
             makeSimpleRequest(anotherClient, null);
+        }
+    }
+
+    @Test
+    public void abortRequest_shouldFailTheExceptionWithIOException() throws Exception {
+        try (SdkHttpClient client = AwsCrtHttpClient.create()) {
+            String body = randomAlphabetic(10);
+            URI uri = URI.create("http://localhost:" + mockServer.port());
+            stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withFixedDelay(1000).withBody(body)));
+            SdkHttpRequest request = createRequest(uri);
+
+            HttpExecuteRequest.Builder executeRequestBuilder = HttpExecuteRequest.builder();
+            executeRequestBuilder.request(request)
+                                 .contentStreamProvider(() -> new ByteArrayInputStream(new byte[0]));
+
+            ExecutableHttpRequest executableRequest = client.prepareRequest(executeRequestBuilder.build());
+            executorService.schedule(() -> executableRequest.abort(), 100, TimeUnit.MILLISECONDS);
+                executableRequest.abort();
+            assertThatThrownBy(() -> executableRequest.call()).isInstanceOf(IOException.class)
+                .hasMessageContaining("cancelled");
         }
     }
 

--- a/test/protocol-tests/pom.xml
+++ b/test/protocol-tests/pom.xml
@@ -219,6 +219,12 @@
             <artifactId>rxjava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/CrtHttpClientApiCallTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/CrtHttpClientApiCallTimeoutTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests.timeout;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+
+@WireMockTest
+public class CrtHttpClientApiCallTimeoutTest {
+
+    private ProtocolRestJsonClientBuilder clientBuilder;
+
+    @BeforeEach
+    public void setup(WireMockRuntimeInfo wiremock) {
+        clientBuilder = ProtocolRestJsonClient.builder()
+                                              .region(Region.US_WEST_1)
+                                              .endpointOverride(URI.create("http://localhost:" + wiremock.getHttpPort()))
+                                              .httpClientBuilder(AwsCrtHttpClient.builder())
+                                              .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"));
+    }
+
+    @Test
+    void apiCallAttemptExceeded_shouldThrowApiCallAttemptTimeoutException() {
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}").withFixedDelay(2000)));
+        try (ProtocolRestJsonClient client =
+                 clientBuilder.overrideConfiguration(b -> b.apiCallAttemptTimeout(Duration.ofMillis(10)))
+                                                          .build()) {
+
+
+            assertThatThrownBy(() -> client.allTypes()).isInstanceOf(ApiCallAttemptTimeoutException.class);
+        }
+    }
+
+    @Test
+    void apiCallExceeded_shouldThrowApiCallAttemptTimeoutException() {
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}").withFixedDelay(2000)));
+        try (ProtocolRestJsonClient client = clientBuilder.overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMillis(10)))
+                                                          .build()) {
+
+            assertThatThrownBy(() -> client.allTypes()).isInstanceOf(ApiCallTimeoutException.class);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed an issue where `CancellationException` was thrown incorrectly from AWS CRT Sync HTTP client when execution time exceeded the total configured API call attempt timeout or API call timeout. Now it throws `ApiCallAttemptTimeoutException`/`ApiCallTimeoutException` accordingly. Closes [#4820](https://github.com/aws/aws-sdk-java-v2/issues/4820)

## Modifications
Ensure the right exception is thrown the request is aborted so that the SDK core can translate the exception to the corresponding `ApiCallAttemptTimeoutException` and `ApiCallTimeoutException`.


https://github.com/aws/aws-sdk-java-v2/blob/767b527f17ca295f48e9c9ab0e3dc9036e993e1b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/TimeoutExceptionHandlingStage.java#L92-L97

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
