### PR TITLE
Enable CRC32 for PUT for MultipartS3AsyncClient

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-04d48e6.json
+++ b/.changes/next-release/bugfix-AmazonS3-04d48e6.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon S3", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix bug where PUT/COPY fails when using SSE-C with Checksum when using S3AsyncClient with multipart enabled. Enable CRC32 for putObject when using multipart client if checksum validation is not disabled and checksum is not set by user"
+}

--- a/.changes/next-release/bugfix-AmazonS3-04d48e6.json
+++ b/.changes/next-release/bugfix-AmazonS3-04d48e6.json
@@ -2,5 +2,5 @@
     "category": "Amazon S3", 
     "contributor": "", 
     "type": "bugfix", 
-    "description": "Fix bug where PUT/COPY fails when using SSE-C with Checksum when using S3AsyncClient with multipart enabled. Enable CRC32 for putObject when using multipart client if checksum validation is not disabled and checksum is not set by user"
+    "description": "Fix bug where PUT fails when using SSE-C with Checksum when using S3AsyncClient with multipart enabled. Enable CRC32 for putObject when using multipart client if checksum validation is not disabled and checksum is not set by user"
 }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/multipart/S3ClientMultiPartCopyIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/multipart/S3ClientMultiPartCopyIntegrationTest.java
@@ -222,7 +222,9 @@ public class S3ClientMultiPartCopyIntegrationTest extends S3IntegrationTestBase 
             Map<String, List<String>> headers = sdkHttpRequest.headers();
             String checksumHeaderName = "x-amz-checksum-algorithm";
             if (headers.containsKey(checksumHeaderName)) {
-                checksumHeader = headers.get(checksumHeaderName).get(0);
+                List<String> checksumHeaderVals = headers.get(checksumHeaderName);
+                assertThat(checksumHeaderVals).hasSize(1);
+                checksumHeader = checksumHeaderVals.get(0);
             }
         }
 

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/multipart/S3MultipartClientPutObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/multipart/S3MultipartClientPutObjectIntegrationTest.java
@@ -168,8 +168,7 @@ public class S3MultipartClientPutObjectIntegrationTest extends S3IntegrationTest
                                     .key(TEST_KEY)
                                     .sseCustomerKey(b64Key)
                                     .sseCustomerAlgorithm(AES256.name())
-                                    .sseCustomerKeyMD5(b64KeyMd5)
-                                    .checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                                    .sseCustomerKeyMD5(b64KeyMd5),
                               body).join();
 
         assertThat(CAPTURING_INTERCEPTOR.checksumHeader).isEqualTo("CRC32");
@@ -204,9 +203,9 @@ public class S3MultipartClientPutObjectIntegrationTest extends S3IntegrationTest
         public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
             SdkHttpRequest sdkHttpRequest = context.httpRequest();
             Map<String, List<String>> headers = sdkHttpRequest.headers();
-            String headerName = "x-amz-sdk-checksum-algorithm";
-            if (headers.containsKey(headerName)) {
-                checksumHeader = headers.get(headerName).get(0);
+            String checksumHeaderName = "x-amz-sdk-checksum-algorithm";
+            if (headers.containsKey(checksumHeaderName)) {
+                checksumHeader = headers.get(checksumHeaderName).get(0);
 
                 System.out.println(headers);
             }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/GenericMultipartHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/GenericMultipartHelper.java
@@ -15,13 +15,13 @@
 
 package software.amazon.awssdk.services.s3.internal.multipart;
 
+import static software.amazon.awssdk.services.s3.internal.multipart.SdkPojoConversionUtils.toCompleteMultipartUploadRequest;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.IntStream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -29,8 +29,8 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
-import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Request;
 import software.amazon.awssdk.services.s3.model.S3Response;
 import software.amazon.awssdk.utils.Logger;
@@ -81,28 +81,13 @@ public final class GenericMultipartHelper<RequestT extends S3Request, ResponseT 
     }
 
     public CompletableFuture<CompleteMultipartUploadResponse> completeMultipartUpload(
-        RequestT request, String uploadId, CompletedPart[] parts) {
+        PutObjectRequest request, String uploadId, CompletedPart[] parts) {
         log.debug(() -> String.format("Sending completeMultipartUploadRequest, uploadId: %s",
                                       uploadId));
-        CompleteMultipartUploadRequest completeMultipartUploadRequest =
-            CompleteMultipartUploadRequest.builder()
-                                          .bucket(request.getValueForField("Bucket", String.class).get())
-                                          .key(request.getValueForField("Key", String.class).get())
-                                          .uploadId(uploadId)
-                                          .multipartUpload(CompletedMultipartUpload.builder()
-                                                                                   .parts(parts)
-                                                                                   .build())
-                                          .build();
-        return s3AsyncClient.completeMultipartUpload(completeMultipartUploadRequest);
-    }
 
-    public CompletableFuture<CompleteMultipartUploadResponse> completeMultipartUpload(
-        RequestT request, String uploadId, AtomicReferenceArray<CompletedPart> completedParts) {
-        CompletedPart[] parts =
-            IntStream.range(0, completedParts.length())
-                     .mapToObj(completedParts::get)
-                     .toArray(CompletedPart[]::new);
-        return completeMultipartUpload(request, uploadId, parts);
+        CompleteMultipartUploadRequest completeMultipartUploadRequest = toCompleteMultipartUploadRequest(request, uploadId,
+                                                                                                         parts);
+        return s3AsyncClient.completeMultipartUpload(completeMultipartUploadRequest);
     }
 
     public BiFunction<CompleteMultipartUploadResponse, Throwable, Void> handleExceptionOrResponse(

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClient.java
@@ -43,7 +43,7 @@ import software.amazon.awssdk.utils.Validate;
 
 /**
  * An {@link S3AsyncClient} that automatically converts PUT, COPY requests to their respective multipart call. CRC32 will be
- * enabled for the PUT and COPY requests.
+ * enabled for the PUT and COPY requests, unless the the checksum is specified or checksum validation is disabled.
  * Note: GET is not yet supported.
  *
  * @see MultipartConfiguration

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClient.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.internal.UserAgentUtils;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -36,8 +37,9 @@ import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * An {@link S3AsyncClient} that automatically converts put, copy requests to their respective multipart call. Note: get is not
- * yet supported.
+ * An {@link S3AsyncClient} that automatically converts PUT, COPY requests to their respective multipart call. CRC32 will be
+ * enabled for the PUT and COPY requests.
+ * Note: GET is not yet supported.
  *
  * @see MultipartConfiguration
  */
@@ -62,11 +64,13 @@ public final class MultipartS3AsyncClient extends DelegatingS3AsyncClient {
 
     @Override
     public CompletableFuture<PutObjectResponse> putObject(PutObjectRequest putObjectRequest, AsyncRequestBody requestBody) {
+        putObjectRequest = putObjectRequest.toBuilder().checksumAlgorithm(ChecksumAlgorithm.CRC32).build();
         return mpuHelper.uploadObject(putObjectRequest, requestBody);
     }
 
     @Override
     public CompletableFuture<CopyObjectResponse> copyObject(CopyObjectRequest copyObjectRequest) {
+        copyObjectRequest = copyObjectRequest.toBuilder().checksumAlgorithm(ChecksumAlgorithm.CRC32).build();
         return copyObjectHelper.copyObject(copyObjectRequest);
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/SdkPojoConversionUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/SdkPojoConversionUtils.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.services.s3.internal.multipart;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +24,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
@@ -47,18 +47,13 @@ import software.amazon.awssdk.utils.Logger;
 public final class SdkPojoConversionUtils {
     private static final Logger log = Logger.loggerFor(SdkPojoConversionUtils.class);
 
-    private static final HashSet<String> PUT_OBJECT_REQUEST_TO_UPLOAD_PART_FIELDS_TO_IGNORE =
-        new HashSet<>(Arrays.asList("ChecksumSHA1", "ChecksumSHA256", "ContentMD5", "ChecksumCRC32C", "ChecksumCRC32"));
-
     private SdkPojoConversionUtils() {
     }
 
     public static UploadPartRequest toUploadPartRequest(PutObjectRequest putObjectRequest, int partNumber, String uploadId) {
 
         UploadPartRequest.Builder builder = UploadPartRequest.builder();
-
-        setSdkFields(builder, putObjectRequest, PUT_OBJECT_REQUEST_TO_UPLOAD_PART_FIELDS_TO_IGNORE);
-
+        setSdkFields(builder, putObjectRequest);
         return builder.uploadId(uploadId).partNumber(partNumber).build();
     }
 
@@ -67,6 +62,13 @@ public final class SdkPojoConversionUtils {
         CreateMultipartUploadRequest.Builder builder = CreateMultipartUploadRequest.builder();
         setSdkFields(builder, putObjectRequest);
         return builder.build();
+    }
+
+    public static CompleteMultipartUploadRequest toCompleteMultipartUploadRequest(PutObjectRequest putObjectRequest,
+                                                                                  String uploadId, CompletedPart[] parts) {
+        CompleteMultipartUploadRequest.Builder builder = CompleteMultipartUploadRequest.builder();
+        setSdkFields(builder, putObjectRequest);
+        return builder.uploadId(uploadId).multipartUpload(c -> c.parts(parts)).build();
     }
 
     public static HeadObjectRequest toHeadObjectRequest(CopyObjectRequest copyObjectRequest) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/SdkPojoConversionUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/SdkPojoConversionUtils.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.s3.internal.multipart;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -47,13 +48,16 @@ import software.amazon.awssdk.utils.Logger;
 public final class SdkPojoConversionUtils {
     private static final Logger log = Logger.loggerFor(SdkPojoConversionUtils.class);
 
+    private static final HashSet<String> PUT_OBJECT_REQUEST_TO_UPLOAD_PART_FIELDS_TO_IGNORE =
+        new HashSet<>(Arrays.asList("ChecksumSHA1", "ChecksumSHA256", "ContentMD5", "ChecksumCRC32C", "ChecksumCRC32"));
+
     private SdkPojoConversionUtils() {
     }
 
     public static UploadPartRequest toUploadPartRequest(PutObjectRequest putObjectRequest, int partNumber, String uploadId) {
 
         UploadPartRequest.Builder builder = UploadPartRequest.builder();
-        setSdkFields(builder, putObjectRequest);
+        setSdkFields(builder, putObjectRequest, PUT_OBJECT_REQUEST_TO_UPLOAD_PART_FIELDS_TO_IGNORE);
         return builder.uploadId(uploadId).partNumber(partNumber).build();
     }
 

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -240,7 +240,7 @@
   "multipartCustomization": {
     "multipartConfigurationClass": "software.amazon.awssdk.services.s3.multipart.MultipartConfiguration",
     "multipartConfigMethodDoc": "Configuration for multipart operation of this client.",
-    "multipartEnableMethodDoc": "Enables automatic conversion of PUT and COPY methods to their equivalent multipart operation. CRC32 checksum will be enabled for these requests.",
+    "multipartEnableMethodDoc": "Enables automatic conversion of PUT and COPY methods to their equivalent multipart operation. CRC32 checksum will be enabled for these requests, unless the checksum is specified or checksum validation is disabled.",
     "contextParamEnabledKey": "S3AsyncClientDecorator.MULTIPART_ENABLED_KEY",
     "contextParamConfigKey": "S3AsyncClientDecorator.MULTIPART_CONFIGURATION_KEY"
   },

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -240,7 +240,7 @@
   "multipartCustomization": {
     "multipartConfigurationClass": "software.amazon.awssdk.services.s3.multipart.MultipartConfiguration",
     "multipartConfigMethodDoc": "Configuration for multipart operation of this client.",
-    "multipartEnableMethodDoc": "Enables automatic conversion of put and copy method to their equivalent multipart operation.",
+    "multipartEnableMethodDoc": "Enables automatic conversion of PUT and COPY methods to their equivalent multipart operation. CRC32 checksum will be enabled for these requests.",
     "contextParamEnabledKey": "S3AsyncClientDecorator.MULTIPART_ENABLED_KEY",
     "contextParamConfigKey": "S3AsyncClientDecorator.MULTIPART_CONFIGURATION_KEY"
   },

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -240,7 +240,7 @@
   "multipartCustomization": {
     "multipartConfigurationClass": "software.amazon.awssdk.services.s3.multipart.MultipartConfiguration",
     "multipartConfigMethodDoc": "Configuration for multipart operation of this client.",
-    "multipartEnableMethodDoc": "Enables automatic conversion of PUT and COPY methods to their equivalent multipart operation. CRC32 checksum will be enabled for these requests, unless the checksum is specified or checksum validation is disabled.",
+    "multipartEnableMethodDoc": "Enables automatic conversion of PUT and COPY methods to their equivalent multipart operation. CRC32 checksum will be enabled for PUT, unless the checksum is specified or checksum validation is disabled.",
     "contextParamEnabledKey": "S3AsyncClientDecorator.MULTIPART_ENABLED_KEY",
     "contextParamConfigKey": "S3AsyncClientDecorator.MULTIPART_CONFIGURATION_KEY"
   },

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartClientChecksumTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartClientChecksumTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.multipart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+
+class MultipartClientChecksumTest {
+    private MockAsyncHttpClient mockAsyncHttpClient;
+    private ChecksumCapturingInterceptor checksumCapturingInterceptor;
+    private S3AsyncClient s3Client;
+
+    @BeforeEach
+    void init() {
+        this.mockAsyncHttpClient = new MockAsyncHttpClient();
+        this.checksumCapturingInterceptor = new ChecksumCapturingInterceptor();
+        s3Client = S3AsyncClient.builder()
+                                .httpClient(mockAsyncHttpClient)
+                                .endpointOverride(URI.create("http://localhost"))
+                                .overrideConfiguration(c -> c.addExecutionInterceptor(checksumCapturingInterceptor))
+                                .multipartEnabled(true)
+                                .region(Region.US_EAST_1)
+                                .build();
+    }
+
+    @AfterEach
+    void reset() {
+        this.mockAsyncHttpClient.reset();
+    }
+
+    @Test
+    public void putObject_default_shouldAddCrc32() {
+        HttpExecuteResponse response = HttpExecuteResponse.builder()
+                                                          .response(SdkHttpResponse.builder().statusCode(200).build())
+                                                          .build();
+        mockAsyncHttpClient.stubResponses(response);
+
+        PutObjectRequest putObjectRequest = putObjectRequestBuilder().build();
+
+        s3Client.putObject(putObjectRequest, AsyncRequestBody.fromString("hello world"));
+        assertThat(checksumCapturingInterceptor.checksumHeader).isEqualTo("CRC32");
+    }
+
+    @Test
+    public void putObject_withNonCrc32ChecksumType_shouldNotAddCrc32() {
+        HttpExecuteResponse response = HttpExecuteResponse.builder()
+                                                          .response(SdkHttpResponse.builder().statusCode(200).build())
+                                                          .build();
+        mockAsyncHttpClient.stubResponses(response);
+
+        PutObjectRequest putObjectRequest =
+            putObjectRequestBuilder()
+                .checksumAlgorithm(ChecksumAlgorithm.SHA256)
+                .build();
+
+        s3Client.putObject(putObjectRequest, AsyncRequestBody.fromString("hello world"));
+        assertThat(checksumCapturingInterceptor.checksumHeader).isEqualTo("SHA256");
+    }
+
+    @Test
+    public void putObject_withNonCrc32ChecksumValue_shouldNotAddCrc32() {
+        HttpExecuteResponse response = HttpExecuteResponse.builder()
+                                                          .response(SdkHttpResponse.builder().statusCode(200).build())
+                                                          .build();
+        mockAsyncHttpClient.stubResponses(response);
+
+        PutObjectRequest putObjectRequest =
+            putObjectRequestBuilder()
+                .checksumSHA256("checksumVal")
+                .build();
+
+        s3Client.putObject(putObjectRequest, AsyncRequestBody.fromString("hello world"));
+        assertThat(checksumCapturingInterceptor.checksumHeader).isNull();
+        assertThat(checksumCapturingInterceptor.headers.get("x-amz-checksum-sha256")).contains("checksumVal");
+    }
+
+    @Test
+    public void putObject_withCrc32Value_shouldNotAddCrc32TypeHeader() {
+        HttpExecuteResponse response = HttpExecuteResponse.builder()
+                                                          .response(SdkHttpResponse.builder().statusCode(200).build())
+                                                          .build();
+        mockAsyncHttpClient.stubResponses(response);
+
+        PutObjectRequest putObjectRequest =
+            putObjectRequestBuilder()
+                .checksumCRC32("checksumVal")
+                .build();
+
+        s3Client.putObject(putObjectRequest, AsyncRequestBody.fromString("hello world"));
+        assertThat(checksumCapturingInterceptor.checksumHeader).isNull();
+        assertThat(checksumCapturingInterceptor.headers.get("x-amz-checksum-crc32")).contains("checksumVal");
+    }
+
+    private PutObjectRequest.Builder putObjectRequestBuilder() {
+        return PutObjectRequest.builder().bucket("bucket").key("key");
+    }
+
+    private static final class ChecksumCapturingInterceptor implements ExecutionInterceptor {
+        String checksumHeader;
+        Map<String, List<String>> headers;
+
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            SdkHttpRequest sdkHttpRequest = context.httpRequest();
+            headers = sdkHttpRequest.headers();
+            String checksumHeaderName = "x-amz-sdk-checksum-algorithm";
+            if (headers.containsKey(checksumHeaderName)) {
+                List<String> checksumHeaderVals = headers.get(checksumHeaderName);
+                assertThat(checksumHeaderVals).hasSize(1);
+                checksumHeader = checksumHeaderVals.get(0);
+            }
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/SdkPojoConversionUtilsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/SdkPojoConversionUtilsTest.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.services.s3.internal.multipart.SdkPojoConversionUtils;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
@@ -182,7 +183,6 @@ class SdkPojoConversionUtilsTest {
         PutObjectRequest randomObject = randomPutObjectRequest();
         CreateMultipartUploadRequest convertedObject = SdkPojoConversionUtils.toCreateMultipartUploadRequest(randomObject);
         Set<String> fieldsToIgnore = new HashSet<>();
-        System.out.println(convertedObject);
         verifyFieldsAreCopied(randomObject, convertedObject, fieldsToIgnore,
                               PutObjectRequest.builder().sdkFields(),
                               CreateMultipartUploadRequest.builder().sdkFields());
@@ -199,6 +199,23 @@ class SdkPojoConversionUtilsTest {
                               UploadPartResponse.builder().sdkFields(),
                               CompletedPart.builder().sdkFields());
         assertThat(convertedCompletedPart.partNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void toCompleteMultipartUploadRequest_putObject_shouldCopyProperties() {
+        PutObjectRequest randomObject = randomPutObjectRequest();
+        CompletedPart parts[] = new CompletedPart[1];
+        CompletedPart completedPart = CompletedPart.builder().partNumber(1).build();
+        parts[0] = completedPart;
+        CompleteMultipartUploadRequest convertedObject =
+            SdkPojoConversionUtils.toCompleteMultipartUploadRequest(randomObject, "uploadId", parts);
+
+        Set<String> fieldsToIgnore = new HashSet<>();
+        verifyFieldsAreCopied(randomObject, convertedObject, fieldsToIgnore,
+                              PutObjectRequest.builder().sdkFields(),
+                              CompleteMultipartUploadRequest.builder().sdkFields());
+        assertThat(convertedObject.uploadId()).isEqualTo("uploadId");
+        assertThat(convertedObject.multipartUpload().parts()).contains(completedPart);
     }
 
     private static void verifyFieldsAreCopied(SdkPojo requestConvertedFrom,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
1) Fix bug where PUT fails when using SSE-C with Checksum
2) Enable CRC32 for PUT for MultipartS3AsyncClient -> Keep behavior consistent between CRT TransferManager and Java TransferManager

## Modifications
<!--- Describe your changes in detail -->
Copy over SSE-C fields when converting requests.
Set CRC32 for PUT in multipart client IF checksum is not set by user && checksum validation is not disabled

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
added unit + integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
