### PR TITLE
Remove uses of legacy singer attributes

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/plugins/S3OverrideAuthSchemePropertiesPlugin.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/plugins/S3OverrideAuthSchemePropertiesPlugin.java
@@ -121,7 +121,6 @@ public final class S3OverrideAuthSchemePropertiesPlugin implements SdkPlugin {
         builder.putSignerProperty((SignerProperty<T>) key, (T) value);
     }
 
-
     private boolean addConfiguredProperties(AuthSchemeOption option, S3AuthSchemeParams params) {
         String schemeId = option.schemeId();
         // We check here that the scheme id is sigV4 or sigV4a or some other in the same family.

--- a/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/interceptors/PayloadSigningInterceptor.java
+++ b/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/interceptors/PayloadSigningInterceptor.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.services.s3control.internal.interceptors;
 
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -25,7 +24,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpMethod;
 
 /**
- * Turns on payload signing and prevents moving query params to body during a POST which S3 doesn't like.
+ * Prevents moving query params to body during a POST which S3 doesn't like.
  */
 @SdkInternalApi
 public class PayloadSigningInterceptor implements ExecutionInterceptor {
@@ -33,11 +32,10 @@ public class PayloadSigningInterceptor implements ExecutionInterceptor {
     @Override
     public Optional<RequestBody> modifyHttpContent(Context.ModifyHttpRequest context,
                                                    ExecutionAttributes executionAttributes) {
-        executionAttributes.putAttribute(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING, true);
-        if (!context.requestBody().isPresent() && context.httpRequest().method() == SdkHttpMethod.POST) {
+        Optional<RequestBody> bodyOptional = context.requestBody();
+        if (context.httpRequest().method() == SdkHttpMethod.POST && !bodyOptional.isPresent()) {
             return Optional.of(RequestBody.fromBytes(new byte[0]));
         }
-
-        return context.requestBody();
+        return bodyOptional;
     }
 }

--- a/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/interceptors/PayloadSigningInterceptorTest.java
+++ b/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/interceptors/PayloadSigningInterceptorTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute;
 import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -53,7 +52,6 @@ public class PayloadSigningInterceptorTest {
 
         assertThat(modified.isPresent()).isTrue();
         assertThat(modified.get().contentLength()).isEqualTo(0);
-        assertThat(executionAttributes.getAttribute(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING)).isTrue();
     }
 
     @Test
@@ -65,7 +63,6 @@ public class PayloadSigningInterceptorTest {
 
         assertThat(modified.isPresent()).isTrue();
         assertThat(modified.get().contentLength()).isEqualTo(5);
-        assertThat(executionAttributes.getAttribute(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING)).isTrue();
     }
 
     public final class Context implements software.amazon.awssdk.core.interceptor.Context.ModifyHttpRequest {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Follow up to #4804 but for S3Control. This change removes the remaining uses of the legacy attribute `S3SignerExecutionAttribute` and replaces its use with plugins when appropriate. Notice that setting

```
S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING, true
```

It's not needed, this is the default value (see [here](https://github.com/aws/aws-sdk-java-v2/blob/305363def2fd19f74ef8f91dacb58c3f2c5240ca/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4FamilyHttpSigner.java#L65-L66)).


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
