### PR TITLE
Fix for Issue #4912 where Cross Region S3 Access using AWS_GLOBAL Endpoint failed.

### DIFF
--- a/.changes/next-release/bugfix-AmazonSimpleStorageService-7648336.json
+++ b/.changes/next-release/bugfix-AmazonSimpleStorageService-7648336.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon Simple Storage Service",
+    "contributor": "",
+    "description": "Fix for Issue [#4912](https://github.com/aws/aws-sdk-java-v2/issues/4912) where client region with AWS_GLOBAL calls failed for cross region access."
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionCrtIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionCrtIntegrationTest.java
@@ -46,7 +46,7 @@ public class S3CrossRegionCrtIntegrationTest extends S3CrossRegionAsyncIntegrati
     @BeforeEach
     public void initialize() {
         crossRegionS3Client = S3AsyncClient.crtBuilder()
-                                           .region(CROSS_REGION)
+                                           .region(Region.AWS_GLOBAL)
                                            .crossRegionAccessEnabled(true)
                                              .build();
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/endpointprovider/BucketEndpointProvider.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crossregion/endpointprovider/BucketEndpointProvider.java
@@ -43,9 +43,20 @@ public class BucketEndpointProvider implements S3EndpointProvider {
     @Override
     public CompletableFuture<Endpoint> resolveEndpoint(S3EndpointParams endpointParams) {
         Region crossRegion = regionSupplier.get();
-        return delegateEndPointProvider.resolveEndpoint(
-            endpointParams.copy(c -> c.region(crossRegion == null ? endpointParams.region() : crossRegion)
-                                      .useGlobalEndpoint(false)));
+        S3EndpointParams.Builder endpointParamsBuilder = endpointParams.toBuilder();
+        // Check if cross-region resolution has already occurred.
+        if (crossRegion != null) {
+            endpointParamsBuilder.region(crossRegion);
+        } else {
+            // For global regions, set the region to "us-east-1" to use regional endpoints.
+            if (Region.AWS_GLOBAL.equals(endpointParams.region())) {
+                endpointParamsBuilder.region(Region.US_EAST_1);
+            }
+            // Disable the global endpoint as S3 can properly redirect regions in the 'x-amz-bucket-region' header
+            // only for regional endpoints.
+            endpointParamsBuilder.useGlobalEndpoint(false);
+        }
+        return delegateEndPointProvider.resolveEndpoint(endpointParamsBuilder.build());
     }
 }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crossregion/S3CrossRegionSyncClientTest.java
@@ -256,7 +256,7 @@ class S3CrossRegionSyncClientTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"us-east-1", "us-east-2", "us-west-1", "aws-global"})
+    @ValueSource(strings = {"us-east-1", "us-east-2", "us-west-1"})
     void given_AnyRegion_Client_Updates_the_useGlobalEndpointFlag_asFalse(String region) {
         mockSyncHttpClient.stubResponses(successHttpResponse());
         S3EndpointProvider mockEndpointProvider = Mockito.mock(S3EndpointProvider.class);
@@ -273,6 +273,28 @@ class S3CrossRegionSyncClientTest {
         verify(mockEndpointProvider,  atLeastOnce()).resolveEndpoint(collectionCaptor.capture());
         collectionCaptor.getAllValues().forEach(resolvedParams ->{
             assertThat(resolvedParams.region()).isEqualTo(Region.of(region));
+            assertThat(resolvedParams.useGlobalEndpoint()).isFalse();
+        });
+    }
+
+    @Test
+    void given_globalRegion_Client_Updates_region_to_useast1_and_useGlobalEndpointFlag_as_False() {
+        String region = Region.AWS_GLOBAL.id();
+        mockSyncHttpClient.stubResponses(successHttpResponse());
+        S3EndpointProvider mockEndpointProvider = Mockito.mock(S3EndpointProvider.class);
+
+        when(mockEndpointProvider.resolveEndpoint(ArgumentMatchers.any(S3EndpointParams.class)))
+            .thenReturn(CompletableFuture.completedFuture(Endpoint.builder().url(URI.create("https://bucket.s3.amazonaws.com")).build()));
+
+        S3Client s3Client = clientBuilder().crossRegionAccessEnabled(true)
+                                           .region(Region.of(region))
+                                           .endpointProvider(mockEndpointProvider).build();
+        s3Client.getObject(getObjectBuilder().build());
+        assertThat(captureInterceptor.endpointProvider).isInstanceOf(BucketEndpointProvider.class);
+        ArgumentCaptor<S3EndpointParams> collectionCaptor = ArgumentCaptor.forClass(S3EndpointParams.class);
+        verify(mockEndpointProvider,  atLeastOnce()).resolveEndpoint(collectionCaptor.capture());
+        collectionCaptor.getAllValues().forEach(resolvedParams ->{
+            assertThat(resolvedParams.region()).isEqualTo(Region.US_EAST_1);
             assertThat(resolvedParams.useGlobalEndpoint()).isFalse();
         });
     }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
-  Issue #4912
- Note that PR #4849 add fix to enable regional endpoints by setting useGlobalEndpoint , however this doesnot work for AWS_GLOBAL region.
- Also if we try to make direct calls with AWS_GLOBAL without disabling useGlobalEndpoint then we will not get the Redirected region for `Head` Apis like "HeadObject" and "HeadBucket".
- Thus we need to update the AWS_GLOBAL as "US_EAST_1" in order to get the redirected region



## Modifications
<!--- Describe your changes in detail -->
- Update Region as  "US_EAST_1" if the call is made from AWS_GLOBAL.
- This makes sure we do a regional endpoint call to get the redirected region

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
