### PR TITLE
Update codebuild-ci.yml to trigger CI on doc changes

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -1,10 +1,5 @@
 name: AWS CodeBuild CI
 on:
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - '.all-contributorsrc'
-      - 'docs/**'
   push:
     branches:
       - master


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Update codebuild-ci.yml to trigger CI on doc changes so that PRs like https://github.com/aws/aws-sdk-java-v2/pull/4853 can be merged w/o requiring me to run the scrip to trigger CI. 

