### PR TITLE
Add "ca-west-1" endpoint for the ec2 service

### DIFF
--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/test-endpoints.json
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/test-endpoints.json
@@ -3652,6 +3652,12 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ca-west-1" : {
+            "variants" : [ {
+              "hostname" : "ec2-fips.ca-west-1.amazonaws.com",
+              "tags" : [ "fips" ]
+            } ]
+          },
           "eu-central-1" : { },
           "eu-north-1" : { },
           "eu-south-1" : { },
@@ -3669,6 +3675,13 @@
             },
             "deprecated" : true,
             "hostname" : "ec2-fips.ca-central-1.amazonaws.com"
+          },
+          "fips-ca-west-1" : {
+            "credentialScope" : {
+              "region" : "ca-west-1"
+            },
+            "deprecated" : true,
+            "hostname" : "ec2-fips.ca-west-1.amazonaws.com"
           },
           "fips-us-east-1" : {
             "credentialScope" : {

--- a/core/regions/src/main/resources/software/amazon/awssdk/regions/internal/region/endpoints.json
+++ b/core/regions/src/main/resources/software/amazon/awssdk/regions/internal/region/endpoints.json
@@ -5802,6 +5802,12 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ca-west-1" : {
+            "variants" : [ {
+              "hostname" : "ec2-fips.ca-west-1.amazonaws.com",
+              "tags" : [ "fips" ]
+            } ]
+          },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -5821,6 +5827,13 @@
             },
             "deprecated" : true,
             "hostname" : "ec2-fips.ca-central-1.amazonaws.com"
+          },
+          "fips-ca-west-1" : {
+            "credentialScope" : {
+              "region" : "ca-west-1"
+            },
+            "deprecated" : true,
+            "hostname" : "ec2-fips.ca-west-1.amazonaws.com"
           },
           "fips-us-east-1" : {
             "credentialScope" : {

--- a/services/ec2/src/main/resources/codegen-resources/endpoint-tests.json
+++ b/services/ec2/src/main/resources/codegen-resources/endpoint-tests.json
@@ -157,6 +157,32 @@
             }
         },
         {
+            "documentation": "For region ca-west-1 with FIPS disabled and DualStack disabled",
+            "expect": {
+                "endpoint": {
+                    "url": "https://ec2.ca-west-1.amazonaws.com"
+                }
+            },
+            "params": {
+                "Region": "ca-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+            }
+        },
+        {
+            "documentation": "For region ca-west-1 with FIPS enabled and DualStack disabled",
+            "expect": {
+                "endpoint": {
+                    "url": "https://ec2-fips.ca-west-1.amazonaws.com"
+                }
+            },
+            "params": {
+                "Region": "ca-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+            }
+        },
+        {
             "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
             "expect": {
                 "endpoint": {


### PR DESCRIPTION
## Motivation and Context
It seems that the ca-west-1 region endpoint is missing for ec2 service.
#4805

## Modifications
I have added the region endpoint for ec2 service.

## Testing

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
