### PR TITLE
Modify ARN toString to print a valid ARN when there's no region or acountId

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-51797eb.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-51797eb.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "Madrigal",
+    "description": "Modify ARN toString to print a valid ARN when there's no region or acountId"
+}

--- a/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
+++ b/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
@@ -198,9 +198,9 @@ public final class Arn implements ToCopyableBuilder<Arn.Builder, Arn> {
                + ":"
                + this.service
                + ":"
-               + region
+               + (region == null ? "" : region)
                + ":"
-               + this.accountId
+               + (this.accountId == null ? "" : this.accountId)
                + ":"
                + this.resource;
     }

--- a/core/arns/src/test/java/software/amazon/awssdk/arns/ArnTest.java
+++ b/core/arns/src/test/java/software/amazon/awssdk/arns/ArnTest.java
@@ -58,6 +58,22 @@ public class ArnTest {
     }
 
     @Test
+    public void arnWithMinimalResources_ParsesBackToString() {
+        String arnString = "arn:aws:s3:::bucket";
+        Arn arn = Arn.fromString(arnString);
+        assertThat(arn.toString()).isEqualTo(arnString);
+        assertThat(arn.resourceAsString()).isEqualTo("bucket");
+    }
+
+    @Test
+    public void arnWithoutRegion_ParsesBackToString() {
+        String arnString = "arn:aws:iam::123456789012:root";
+        Arn arn = Arn.fromString(arnString);
+        assertThat(arn.toString()).isEqualTo(arnString);
+        assertThat(arn.resourceAsString()).isEqualTo("root");
+    }
+
+    @Test
     public void arnWithResourceTypeAndResource_ParsesCorrectly() {
         String arnString = "arn:aws:s3:us-east-1:12345678910:bucket:foobar";
         Arn arn = Arn.fromString(arnString);


### PR DESCRIPTION
Fixes #2416

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Certain ARNs, like S3 or IAM, don't have to include region or accountId. This constructs a valid ARN

```
Arn.builder()
    .partition("aws")
    .service("s3")
    .resource("bucket")
    .build();
```

However, when `toString()` is called in this method, `region` and `account` are printed as literal `null`' so the ARN becomes

```
arn:aws:s3:null:null:bucket
```

instead of the valid

```
arn:aws:s3:::bucket
```

This causes the problem that ARNs produced by `toString` cannot be used as identifiers when passed to other services,since this ARN is not valid.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
Don't print `null` on `Arn.toString()` if region or accountId are not set.
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests to verify this behavior. Additionally, this has the nice property that the ARNs produced by `toString()` can be parsed by `Arn.fromString()`.
## Screenshots (if appropriate)
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
