### PR TITLE
Update documentation for FUTURE_COMPLETION_EXECUTOR

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
@@ -45,10 +45,12 @@ public final class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
      *     <li>You want more fine-grained control over the {@link ThreadPoolExecutor} used, such as configuring the pool size
      *     or sharing a single pool between multiple clients.
      *     <li>You want to add instrumentation (i.e., metrics) around how the {@link Executor} is used.
-     *     <li>You know, for certain, that all of your {@link CompletableFuture} usage is strictly non-blocking, and you wish to
-     *     remove the minor overhead incurred by using a separate thread. In this case, you can use
-     *     {@code Runnable::run} to execute the future-completion directly from within the I/O thread.
      * </ol>
+     * <b>Note</b>
+     * <p>
+     * We strongly recommend <strong>against</strong> using {@code Runnable::run}, which executes the future-completion directly from
+     * within the I/O thread because it may block the IO thread and cause deadlock, especially if you are sending
+     * another SDK request in the {@link CompletableFuture} chain since the SDK may perform blocking calls in some cases.
      */
     public static final SdkAdvancedAsyncClientOption<Executor> FUTURE_COMPLETION_EXECUTOR =
             new SdkAdvancedAsyncClientOption<>(Executor.class);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
@@ -48,8 +48,8 @@ public final class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
      * </ol>
      * <b>WARNING</b>
      * <p>
-     * We strongly recommend <strong>against</strong> using {@code Runnable::run}, which executes the future-completion directly from
-     * within the I/O thread because it may block the IO thread and cause deadlock, especially if you are sending
+     * We strongly <strong>discourage</strong> using {@code Runnable::run}, which executes the future-completion directly from
+     * within the I/O thread because it may block the I/O thread and cause deadlock, especially if you are sending
      * another SDK request in the {@link CompletableFuture} chain since the SDK may perform blocking calls in some cases.
      */
     public static final SdkAdvancedAsyncClientOption<Executor> FUTURE_COMPLETION_EXECUTOR =

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
@@ -46,7 +46,7 @@ public final class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
      *     or sharing a single pool between multiple clients.
      *     <li>You want to add instrumentation (i.e., metrics) around how the {@link Executor} is used.
      * </ol>
-     * <b>Note</b>
+     * <b>WARNING</b>
      * <p>
      * We strongly recommend <strong>against</strong> using {@code Runnable::run}, which executes the future-completion directly from
      * within the I/O thread because it may block the IO thread and cause deadlock, especially if you are sending


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Using `Runnable::run` as future completion thread is dangerous if users send another SDK request in the completablefuture chain since the SDK may perform blocking calls.

## Modifications
Update documentation for `FUTURE_COMPLETION_EXECUTOR` to discourage the use of `Runnable::run`

