### PR TITLE
Choose next potential scheme if signer not found

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -101,7 +101,8 @@
         "test-utils": { "skipImport": true },
         "tests-coverage-reporting": { "skipImport": true },
         "third-party": { "skipImport": true },
-        "third-party-slf4j-api": { "skipImport": true }
+        "third-party-slf4j-api": { "skipImport": true },
+        "crt-unavailable-tests": { "skipImport": true }
     },
 
     "dependencies": {

--- a/buildspecs/release-javadoc.yml
+++ b/buildspecs/release-javadoc.yml
@@ -18,7 +18,7 @@ phases:
     commands:
     - python ./scripts/doc_crosslinks/generate_cross_link_data.py --apiDefinitionsBasePath ./services/ --apiDefinitionsRelativeFilePath src/main/resources/codegen-resources/service-2.json  --templateFilePath ./scripts/doc_crosslinks/crosslink_redirect.html --outputFilePath ./scripts/crosslink_redirect.html
     - mvn install -P quick -T1C
-    - mvn clean install javadoc:aggregate -B -Ppublic-javadoc -Dcheckstyle.skip -Dspotbugs.skip -DskipTests -Ddoclint=none -pl '!:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:s3-benchmarks,!:module-path-tests,!:test-utils,!:http-client-tests,!:tests-coverage-reporting,!:sdk-native-image-test,!:ruleset-testing-core,!:old-client-version-compatibility-test'
+    - mvn clean install javadoc:aggregate -B -Ppublic-javadoc -Dcheckstyle.skip -Dspotbugs.skip -DskipTests -Ddoclint=none -pl '!:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:s3-benchmarks,!:module-path-tests,!:test-utils,!:http-client-tests,!:tests-coverage-reporting,!:sdk-native-image-test,!:ruleset-testing-core,!:old-client-version-compatibility-test,!:crt-unavailable-tests'
     - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
     -
     - aws s3 sync target/site/apidocs/ $DOC_PATH/$RELEASE_VERSION/ --acl="public-read"

--- a/buildspecs/release-to-maven.yml
+++ b/buildspecs/release-to-maven.yml
@@ -34,7 +34,7 @@ phases:
             awk 'BEGIN { var=ENVIRON["SDK_SIGNING_GPG_KEYNAME"] } { gsub("\\$SDK_SIGNING_GPG_KEYNAME", var, $0); print }' > \
             $SETTINGS_XML
 
-          mvn clean deploy -B -s $SETTINGS_XML -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests,!:sdk-native-image-test,!:auth-tests,!:s3-benchmarks,!:region-testing,!:old-client-version-compatibility-test -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+          mvn clean deploy -B -s $SETTINGS_XML -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests,!:sdk-native-image-test,!:auth-tests,!:s3-benchmarks,!:region-testing,!:old-client-version-compatibility-test,!:crt-unavailable-tests -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
         else
           echo "This version was already released."
         fi

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeInterceptorSpec.java
@@ -280,10 +280,7 @@ public final class AuthSchemeInterceptorSpec implements ClassSpec {
         builder.beginControlFlow("try");
         {
             builder.addStatement("signer = authScheme.signer()");
-            builder.endControlFlow();
-        }
-        builder.beginControlFlow("catch (RuntimeException e)");
-        {
+            builder.nextControlFlow("catch (RuntimeException e)");
             builder.addStatement("discardedReasons.add(() -> String.format($S, authOption.schemeId(), e.getMessage()))",
                                  "'%s' signer could not be retrieved: %s")
                    .addStatement("return null")

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-interceptor.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.core.internal.util.MetricUtils;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
@@ -100,6 +101,14 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
                 .add(() -> String.format("'%s' does not have an identity provider configured.", authOption.schemeId()));
             return null;
         }
+        HttpSigner<T> signer;
+        try {
+            signer = authScheme.signer();
+        } catch (RuntimeException e) {
+            discardedReasons.add(() -> String.format("'%s' signer could not be retrieved: %s", authOption.schemeId(),
+                                                     e.getMessage()));
+            return null;
+        }
         ResolveIdentityRequest.Builder identityRequestBuilder = ResolveIdentityRequest.builder();
         authOption.forEachIdentityProperty(identityRequestBuilder::putProperty);
         CompletableFuture<? extends T> identity;
@@ -110,7 +119,7 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
             identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(identityRequestBuilder.build()),
                                                   metricCollector, metric);
         }
-        return new SelectedAuthScheme<>(identity, authScheme.signer(), authOption);
+        return new SelectedAuthScheme<>(identity, signer, authOption);
     }
 
     private SdkMetric<Duration> getIdentityMetric(IdentityProvider<?> identityProvider) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-with-allowlist-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-with-allowlist-auth-scheme-interceptor.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
@@ -117,6 +118,14 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
                 .add(() -> String.format("'%s' does not have an identity provider configured.", authOption.schemeId()));
             return null;
         }
+        HttpSigner<T> signer;
+        try {
+            signer = authScheme.signer();
+        } catch (RuntimeException e) {
+            discardedReasons.add(() -> String.format("'%s' signer could not be retrieved: %s", authOption.schemeId(),
+                                                     e.getMessage()));
+            return null;
+        }
         ResolveIdentityRequest.Builder identityRequestBuilder = ResolveIdentityRequest.builder();
         authOption.forEachIdentityProperty(identityRequestBuilder::putProperty);
         CompletableFuture<? extends T> identity;
@@ -127,7 +136,7 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
             identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(identityRequestBuilder.build()),
                                                   metricCollector, metric);
         }
-        return new SelectedAuthScheme<>(identity, authScheme.signer(), authOption);
+        return new SelectedAuthScheme<>(identity, signer, authOption);
     }
 
     private SdkMetric<Duration> getIdentityMetric(IdentityProvider<?> identityProvider) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
@@ -120,6 +121,14 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
                 .add(() -> String.format("'%s' does not have an identity provider configured.", authOption.schemeId()));
             return null;
         }
+        HttpSigner<T> signer;
+        try {
+            signer = authScheme.signer();
+        } catch (RuntimeException e) {
+            discardedReasons.add(() -> String.format("'%s' signer could not be retrieved: %s", authOption.schemeId(),
+                                                     e.getMessage()));
+            return null;
+        }
         ResolveIdentityRequest.Builder identityRequestBuilder = ResolveIdentityRequest.builder();
         authOption.forEachIdentityProperty(identityRequestBuilder::putProperty);
         CompletableFuture<? extends T> identity;
@@ -130,7 +139,7 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
             identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(identityRequestBuilder.build()),
                                                   metricCollector, metric);
         }
-        return new SelectedAuthScheme<>(identity, authScheme.signer(), authOption);
+        return new SelectedAuthScheme<>(identity, signer, authOption);
     }
 
     private SdkMetric<Duration> getIdentityMetric(IdentityProvider<?> identityProvider) {

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/scheme/DefaultAwsV4aAuthScheme.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/scheme/DefaultAwsV4aAuthScheme.java
@@ -52,10 +52,27 @@ public final class DefaultAwsV4aAuthScheme implements AwsV4aAuthScheme {
      */
     @Override
     public AwsV4aHttpSigner signer() {
+        if (SignerSingletonHolder.ERROR != null) {
+            throw SignerSingletonHolder.ERROR;
+        }
         return SignerSingletonHolder.INSTANCE;
     }
 
     private static class SignerSingletonHolder {
-        private static final AwsV4aHttpSigner INSTANCE = AwsV4aHttpSigner.create();
+        private static final AwsV4aHttpSigner INSTANCE;
+        private static final RuntimeException ERROR;
+
+        // Attempt to load the Sigv4a signer and cache the error if CRT is not available on the classpath.
+        static {
+            AwsV4aHttpSigner instance = null;
+            RuntimeException error = null;
+            try {
+                instance = AwsV4aHttpSigner.create();
+            } catch (RuntimeException e) {
+                error = e;
+            }
+            INSTANCE = instance;
+            ERROR = error;
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <module>test/ruleset-testing-core</module>
         <module>test/old-client-version-compatibility-test</module>
         <module>test/bundle-logging-bridge-binding-test</module>
+        <module>test/crt-unavailable-tests</module>
     </modules>
     <scm>
         <url>${scm.github.url}</url>

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AuthSchemeInterceptorTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/AuthSchemeInterceptorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.SelectedAuthScheme;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
+import software.amazon.awssdk.services.protocolrestjson.auth.scheme.ProtocolRestJsonAuthSchemeParams;
+import software.amazon.awssdk.services.protocolrestjson.auth.scheme.ProtocolRestJsonAuthSchemeProvider;
+import software.amazon.awssdk.services.protocolrestjson.auth.scheme.internal.ProtocolRestJsonAuthSchemeInterceptor;
+
+public class AuthSchemeInterceptorTest {
+    private static final ProtocolRestJsonAuthSchemeInterceptor INTERCEPTOR = new ProtocolRestJsonAuthSchemeInterceptor();
+
+    private Context.BeforeExecution mockContext;
+
+    @BeforeEach
+    public void setup() {
+        mockContext = mock(Context.BeforeExecution.class);
+    }
+
+    @Test
+    public void resolveAuthScheme_authSchemeSignerThrows_continuesToNextAuthScheme() {
+        ProtocolRestJsonAuthSchemeProvider mockAuthSchemeProvider = mock(ProtocolRestJsonAuthSchemeProvider.class);
+        List<AuthSchemeOption> authSchemeOptions = Arrays.asList(
+            AuthSchemeOption.builder().schemeId(TestAuthScheme.SCHEME_ID).build(),
+            AuthSchemeOption.builder().schemeId(AwsV4AuthScheme.SCHEME_ID).build()
+        );
+        when(mockAuthSchemeProvider.resolveAuthScheme(any(ProtocolRestJsonAuthSchemeParams.class))).thenReturn(authSchemeOptions);
+
+        IdentityProviders mockIdentityProviders = mock(IdentityProviders.class);
+        when(mockIdentityProviders.identityProvider(any(Class.class))).thenReturn(AnonymousCredentialsProvider.create());
+
+        Map<String, AuthScheme<?>> authSchemes = new HashMap<>();
+        authSchemes.put(AwsV4AuthScheme.SCHEME_ID, AwsV4AuthScheme.create());
+
+        TestAuthScheme notProvidedAuthScheme = spy(new TestAuthScheme());
+        authSchemes.put(TestAuthScheme.SCHEME_ID, notProvidedAuthScheme);
+
+        ExecutionAttributes attributes = new ExecutionAttributes();
+        attributes.putAttribute(SdkExecutionAttribute.OPERATION_NAME, "GetFoo");
+        attributes.putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER, mockAuthSchemeProvider);
+        attributes.putAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDERS, mockIdentityProviders);
+        attributes.putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES, authSchemes);
+
+        INTERCEPTOR.beforeExecution(mockContext, attributes);
+
+        SelectedAuthScheme<?> selectedAuthScheme = attributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+
+        verify(notProvidedAuthScheme).signer();
+        assertThat(selectedAuthScheme.authSchemeOption().schemeId()).isEqualTo(AwsV4AuthScheme.SCHEME_ID);
+    }
+
+    private static class TestAuthScheme implements AuthScheme<AwsCredentialsIdentity> {
+        public static final String SCHEME_ID = "codegen-test-scheme";
+
+        @Override
+        public String schemeId() {
+            return SCHEME_ID;
+        }
+
+        @Override
+        public IdentityProvider<AwsCredentialsIdentity> identityProvider(IdentityProviders providers) {
+            return providers.identityProvider(AwsCredentialsIdentity.class);
+        }
+
+        @Override
+        public HttpSigner<AwsCredentialsIdentity> signer() {
+            throw new RuntimeException("Not on classpath");
+        }
+    }
+}

--- a/test/crt-unavailable-tests/pom.xml
+++ b/test/crt-unavailable-tests/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>aws-sdk-java-pom</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.24.8-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>crt-unavailable-tests</artifactId>
+    <name>AWS Java SDK :: Test :: Crt Unavailable Tests</name>
+    <description>Test package for testing components that use CRT when CRT is not on the classpath.</description>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom-internal</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/crt-unavailable-tests/src/test/java/software/amazon/awssdk/auth/aws/AwsV4aAuthSchemeTest.java
+++ b/test/crt-unavailable-tests/src/test/java/software/amazon/awssdk/auth/aws/AwsV4aAuthSchemeTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.aws;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
+
+public class AwsV4aAuthSchemeTest {
+    @Test
+    public void signer_throwsRuntimeException() {
+        assertThatThrownBy(AwsV4aAuthScheme.create()::signer).hasMessageContaining("Could not load class");
+    }
+}


### PR DESCRIPTION
## Motivation and Context
This commit fixes the generated auth scheme selection mechanism by ensuring that auth scheme is able to provide a signer implementation (i.e. does not throw an exception) before selecting the auth scheme. This is useful in situations where the signer implementation relies on components thay may not be available at runtime, such as the AwsV4aAuthScheme, which relies on CRT which is an optional dependency.

Additional changes:
 - introduce crt-unavailable-tests which is a good candidate for testing behavior of components that use CRT when CRT is not present.
 - modify DefaultAwsV4aAuthScheme so that errors thrown during static initialization of the singleton holder for the Sigv4a signer are caught and thrown directly instead of resulting in ExceptionInInitializerError
## Modifications
<!--- Describe your changes in detail -->

## Testing
 - New unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
