### PR TITLE
Fixed the issue in S3 multipart client where the list of parts could …

### DIFF
--- a/.changes/next-release/bugfix-AWSS3-b8d17fa.json
+++ b/.changes/next-release/bugfix-AWSS3-b8d17fa.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS S3",
+    "contributor": "",
+    "description": "Fixed the issue in S3 multipart client where the list of parts could be out of order in CompleteMultipartRequest, causing `The list of parts was not in ascending order` error to be thrown."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
@@ -18,13 +18,15 @@ package software.amazon.awssdk.services.s3.internal.multipart;
 import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.JAVA_PROGRESS_LISTENER;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -59,12 +61,16 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     private final Collection<CompletableFuture<CompletedPart>> futures = new ConcurrentLinkedQueue<>();
     private final PutObjectRequest putObjectRequest;
     private final CompletableFuture<PutObjectResponse> returnFuture;
-    private final Map<Integer, CompletedPart> completedParts;
+    private final AtomicReferenceArray<CompletedPart> completedParts;
     private final Map<Integer, CompletedPart> existingParts;
     private final PublisherListener<Long> progressListener;
     private Subscription subscription;
     private volatile boolean isDone;
     private volatile boolean isPaused;
+    /**
+     * Indicates whether CompleteMultipart has been initiated or not.
+     */
+    private final AtomicBoolean completedMultipartInitiated = new AtomicBoolean(false);
     private volatile CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture;
 
     KnownContentLengthAsyncRequestBodySubscriber(MpuRequestContext mpuRequestContext,
@@ -75,9 +81,9 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
         this.putObjectRequest = mpuRequestContext.request().left();
         this.returnFuture = returnFuture;
         this.uploadId = mpuRequestContext.uploadId();
-        this.existingParts = mpuRequestContext.existingParts();
+        this.existingParts = mpuRequestContext.existingParts() == null ? new HashMap<>() : mpuRequestContext.existingParts();
         this.numExistingParts = NumericUtils.saturatedCast(mpuRequestContext.numPartsCompleted());
-        this.completedParts = new ConcurrentHashMap<>();
+        this.completedParts = new AtomicReferenceArray<>(partCount);
         this.multipartUploadHelper = multipartUploadHelper;
         this.progressListener = putObjectRequest.overrideConfiguration().map(c -> c.executionAttributes()
                                                                                    .getAttribute(JAVA_PROGRESS_LISTENER))
@@ -154,8 +160,8 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
                                                                                      partNumber.getAndIncrement(),
                                                                                      uploadId);
 
-        Consumer<CompletedPart> completedPartConsumer =
-            completedPart -> completedParts.put(completedPart.partNumber(), completedPart);
+        Consumer<CompletedPart> completedPartConsumer = completedPart -> completedParts.set(completedPart.partNumber() - 1,
+                                                                                            completedPart);
         multipartUploadHelper.sendIndividualUploadPartRequest(uploadId, completedPartConsumer, futures,
                                                               Pair.of(uploadRequest, asyncRequestBody), progressListener)
                              .whenComplete((r, t) -> {
@@ -193,15 +199,16 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     }
 
     private void completeMultipartUploadIfFinished(int requestsInFlight) {
-        if (isDone && requestsInFlight == 0) {
+        if (isDone && requestsInFlight == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
             CompletedPart[] parts;
             if (existingParts.isEmpty()) {
-                parts = completedParts.values().toArray(new CompletedPart[0]);
-            } else if (!completedParts.isEmpty()) {
+                parts =
+                    IntStream.range(0, completedParts.length())
+                             .mapToObj(completedParts::get)
+                             .toArray(CompletedPart[]::new);
+            } else {
                 // List of CompletedParts needs to be in ascending order
                 parts = mergeCompletedParts();
-            } else {
-                parts = existingParts.values().toArray(new CompletedPart[0]);
             }
             completeMpuFuture = multipartUploadHelper.completeMultipartUpload(returnFuture, uploadId, parts, putObjectRequest);
         }
@@ -212,7 +219,7 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
         int currPart = 1;
         while (currPart < partCount + 1) {
             CompletedPart completedPart = existingParts.containsKey(currPart) ? existingParts.get(currPart) :
-                                          completedParts.get(currPart);
+                                          completedParts.get(currPart - 1);
             merged[currPart - 1] = completedPart;
             currPart++;
         }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MpuRequestContext.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MpuRequestContext.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.services.s3.internal.multipart;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -94,7 +93,7 @@ public class MpuRequestContext {
     }
 
     public Map<Integer, CompletedPart> existingParts() {
-        return existingParts != null ? Collections.unmodifiableMap(existingParts) : null;
+        return existingParts;
     }
 
     public static final class Builder {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
@@ -136,7 +136,6 @@ public final class UploadWithKnownContentLengthHelper {
                                                                .contentLength(contentLength)
                                                                .partSize(partSize)
                                                                .uploadId(uploadId)
-                                                               .existingParts(new ConcurrentHashMap<>())
                                                                .numPartsCompleted(numPartsCompleted)
                                                                .build();
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.multipart.S3ResumeToken;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.utils.Pair;
@@ -100,7 +101,8 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     private S3ResumeToken configureSubscriberAndPause(int numExistingParts,
                                                       CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture) {
         Map<Integer, CompletedPart> existingParts = existingParts(numExistingParts);
-        KnownContentLengthAsyncRequestBodySubscriber subscriber = subscriber(putObjectRequest, asyncRequestBody, existingParts);
+        KnownContentLengthAsyncRequestBodySubscriber subscriber = subscriber(putObjectRequest, asyncRequestBody, existingParts,
+                                                                             new CompletableFuture<>());
 
         when(multipartUploadHelper.completeMultipartUpload(any(CompletableFuture.class), any(String.class),
                                                            any(CompletedPart[].class), any(PutObjectRequest.class)))
@@ -111,7 +113,8 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
 
     private KnownContentLengthAsyncRequestBodySubscriber subscriber(PutObjectRequest putObjectRequest,
                                                                     AsyncRequestBody asyncRequestBody,
-                                                                    Map<Integer, CompletedPart> existingParts) {
+                                                                    Map<Integer, CompletedPart> existingParts,
+                                                                    CompletableFuture<PutObjectResponse> returnFuture) {
 
         MpuRequestContext mpuRequestContext = MpuRequestContext.builder()
                                                                .request(Pair.of(putObjectRequest, asyncRequestBody))
@@ -122,7 +125,7 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
                                                                .numPartsCompleted((long) existingParts.size())
                                                                .build();
 
-        return new KnownContentLengthAsyncRequestBodySubscriber(mpuRequestContext, new CompletableFuture<>(), multipartUploadHelper);
+        return new KnownContentLengthAsyncRequestBodySubscriber(mpuRequestContext, returnFuture, multipartUploadHelper);
     }
 
     private Map<Integer, CompletedPart> existingParts(int numExistingParts) {


### PR DESCRIPTION
…

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed the issue in S3 multipart client where the list of parts could be out of order in `CompleteMultipartRequest`, causing `The list of parts was not in ascending order` error to be thrown.

This was a regression introduced in #4908. The root cause is that the type of `completedParts` was changed from `AtomicReferenceArray` to `ConcurrentHashMap`, which is not sorted when the SDK sends the request.
## Modifications
<!--- Describe your changes in detail -->
- Change back to `AtomicReferenceArray` since it should provide better performance than ConcurrentHashMap
- Ensure completeMultipart is only invoked once.

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
