### PR TITLE
Make conversion of multi-auth opt-in

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -47,12 +47,14 @@ final class AddOperations {
     private final NamingStrategy namingStrategy;
     private final Map<String, PaginatorDefinition> paginators;
     private final List<String> deprecatedShapes;
+    private final boolean useMultiAuth;
 
     AddOperations(IntermediateModelBuilder builder) {
         this.serviceModel = builder.getService();
         this.namingStrategy = builder.getNamingStrategy();
         this.paginators = builder.getPaginators().getPagination();
         this.deprecatedShapes = builder.getCustomConfig().getDeprecatedShapes();
+        this.useMultiAuth = builder.getCustomConfig().useMultiAuth();
     }
 
     private static boolean isAuthenticated(Operation op) {
@@ -234,13 +236,16 @@ final class AddOperations {
     }
 
     /**
-     * Returns the list of authTypes defined for an operation. If the new auth member is defined we use it, otherwise we retrofit
-     * the list with the value of the authType member if present or return an empty list if not.
+     * Returns the list of authTypes defined for an operation. If useMultiAuth is enabled, then
+     * {@code operation.auth} will be used in the conversion if present. Otherwise, use
+     * {@code operation.authtype} if present.
      */
     private List<AuthType> getAuthFromOperation(Operation op) {
-        List<String> opAuth = op.getAuth();
-        if (opAuth != null) {
-            return opAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
+        if (useMultiAuth) {
+            List<String> opAuth = op.getAuth();
+            if (opAuth != null) {
+                return opAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
+            }
         }
         AuthType legacyAuthType = op.getAuthtype();
         if (legacyAuthType != null) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -311,6 +311,13 @@ public class CustomizationConfig {
      */
     private String rootPackageName;
 
+    /**
+     * Set to true to read from c2j multi-auth values. Currently defaults to false.
+     *
+     * TODO(multi-auth): full multi-auth support is not implemented
+     */
+    private boolean useMultiAuth;
+
     private CustomizationConfig() {
     }
 
@@ -827,5 +834,13 @@ public class CustomizationConfig {
     public CustomizationConfig withRootPackageName(String packageName) {
         this.rootPackageName = packageName;
         return this;
+    }
+
+    public void setUseMultiAuth(boolean useMultiAuth) {
+        this.useMultiAuth = useMultiAuth;
+    }
+
+    public boolean useMultiAuth() {
+        return useMultiAuth;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/AuthType.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/AuthType.java
@@ -41,10 +41,21 @@ public enum AuthType {
     }
 
     public static AuthType fromValue(String value) {
-        String normalizedValue = StringUtils.lowerCase(value);
-        return Arrays.stream(values())
-                     .filter(authType -> authType.value.equals(normalizedValue))
-                     .findFirst()
-                     .orElseThrow(() -> new IllegalArgumentException(String.format("Unknown AuthType '%s'", normalizedValue)));
+        switch (value) {
+            // TODO(multi-auth): review conversion of smithy auth trait shape IDs
+            case "smithy.api#httpBearerAuth":
+                return BEARER;
+            case "smithy.api#noAuth":
+                return NONE;
+            case "aws.auth#sigv4":
+                return V4;
+            default:
+                String normalizedValue = StringUtils.lowerCase(value);
+                return Arrays.stream(values())
+                            .filter(authType -> authType.value.equals(normalizedValue))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                String.format("Unknown AuthType '%s'", normalizedValue)));
+        }
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/model/service/AuthTypeTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/model/service/AuthTypeTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class AuthTypeTest {
+    @Test
+    public void authTypeConvertBearer() {
+        String smithyAuthTypeInput = "smithy.api#httpBearerAuth";
+        String c2jAuthTypeInput = "bearer";
+
+        AuthType smithyAuthType = AuthType.fromValue(smithyAuthTypeInput);
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(smithyAuthType, equalTo(AuthType.BEARER));
+        assertThat(c2jAuthType, equalTo(AuthType.BEARER));
+        assertThat(smithyAuthType, equalTo(c2jAuthType));
+    }
+
+    @Test
+    public void authTypeConvertNone() {
+        String smithyAuthTypeInput = "smithy.api#noAuth";
+        String c2jAuthTypeInput = "none";
+
+        AuthType smithyAuthType = AuthType.fromValue(smithyAuthTypeInput);
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(smithyAuthType, equalTo(AuthType.NONE));
+        assertThat(c2jAuthType, equalTo(AuthType.NONE));
+        assertThat(smithyAuthType, equalTo(c2jAuthType));
+    }
+
+    @Test
+    public void authTypeConvertV4() {
+        String smithyAuthTypeInput = "aws.auth#sigv4";
+        String c2jAuthTypeInput = "v4";
+
+        AuthType smithyAuthType = AuthType.fromValue(smithyAuthTypeInput);
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(smithyAuthType, equalTo(AuthType.V4));
+        assertThat(c2jAuthType, equalTo(AuthType.V4));
+        assertThat(smithyAuthType, equalTo(c2jAuthType));
+    }
+
+    @Test
+    public void authTypeConvertCustom() {
+        String c2jAuthTypeInput = "custom";
+
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(c2jAuthType, equalTo(AuthType.CUSTOM));
+    }
+
+    @Test
+    public void authTypeConvertIam() {
+        String c2jAuthTypeInput = "iam";
+
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(c2jAuthType, equalTo(AuthType.IAM));
+    }
+
+    @Test
+    public void authTypeConvertV4UnsignedBody() {
+        String c2jAuthTypeInput = "v4-unsigned-body";
+
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(c2jAuthType, equalTo(AuthType.V4_UNSIGNED_BODY));
+    }
+
+    @Test
+    public void authTypeConvertS3() {
+        String c2jAuthTypeInput = "s3";
+
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(c2jAuthType, equalTo(AuthType.S3));
+    }
+
+    @Test
+    public void authTypeConvertS3v4() {
+        String c2jAuthTypeInput = "s3v4";
+
+        AuthType c2jAuthType = AuthType.fromValue(c2jAuthTypeInput);
+        assertThat(c2jAuthType, equalTo(AuthType.S3V4));
+    }
+
+    @Test
+    public void authTypeConvertUnknownAuthType() {
+        String c2jAuthTypeInput = "unknown";
+
+        assertThatThrownBy(() -> AuthType.fromValue(c2jAuthTypeInput))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unknown AuthType 'unknown'");
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-different-value/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-different-value/customization.config
@@ -1,2 +1,3 @@
 {
+    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-same-value/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-same-value/customization.config
@@ -1,2 +1,3 @@
 {
+    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/fine-grained-auth/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/fine-grained-auth/customization.config
@@ -1,2 +1,3 @@
 {
+    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-no-auth/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-no-auth/customization.config
@@ -1,2 +1,3 @@
 {
+    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/service-with-no-auth/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/service-with-no-auth/customization.config
@@ -1,2 +1,3 @@
 {
+    "useMultiAuth": true
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Make conversion of multi-auth opt-in

Currently, `metadata.auth` and `operation.auth` are read although full
support for multi-auth is not implemented yet.

This change allows reading these `auth` values to be opt-in, especially
for `useSraAuth` tests.

Also, allows conversions of select smithy auth trait shape IDs into
`AuthType`s:

- `smithy.api#httpBearerAuth => BEARER`
- `smithy.api#noAuth => NONE`
- `aws.auth#sigv4 => V4`

## Modifications
<!--- Describe your changes in detail -->

Only read from `metadata.auth` and `operation.auth` if `useMultiAuth` is true in the customization config.

The tests using `auth` have their customization config `useMultiAuth` set to true.

In `AuthType::fromValue()`, allow converting smithy auth trait IDs to `AuthType`.

- `smithy.api#httpBearerAuth => BEARER`
- `smithy.api#noAuth => NONE`
- `aws.auth#sigv4 => V4`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a test for `AuthType::fromValue()` conversions.

If the new tests pass, the same codegen path as the equivalent `AuthType` value should work.

Updated the customization config of tests using `auth` to have `useMultiAuth` set to true.

## Screenshots (if appropriate)

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
