### PR TITLE
Fixed an issue where ByteBufferStoringSubscriber is requesting more t…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-b56c8a4.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-b56c8a4.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue in `ByteBufferStoringSubscriber` where it could buffer more data than configured, resulting in out of memory error. See [#4999](https://github.com/aws/aws-sdk-java-v2/issues/4999)."
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/ByteBufferStoringSubscriber.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/ByteBufferStoringSubscriber.java
@@ -99,7 +99,9 @@ public class ByteBufferStoringSubscriber implements Subscriber<ByteBuffer> {
             next = storingSubscriber.peek();
         }
 
-        addBufferedDataAmount(-transferred);
+        if (transferred != 0) {
+            addBufferedDataAmount(-transferred);
+        }
 
         if (!next.isPresent()) {
             return TransferResult.SUCCESS;
@@ -178,8 +180,9 @@ public class ByteBufferStoringSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
+        int remaining = byteBuffer.remaining();
         storingSubscriber.onNext(byteBuffer.duplicate());
-        addBufferedDataAmount(byteBuffer.remaining());
+        addBufferedDataAmount(remaining);
         phaser.arrive();
     }
 


### PR DESCRIPTION
…

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed an issue where `ByteBufferStoringSubscriber` is requesting more data than what's specified in `minimumBytesBuffered`. The root cause is that it is requesting data from upstream even when no data is being transferred out. #4999 

## Modifications
- Updated the code to not request data if 0 is transferred

## Testing
Tested it on an EC2 instance and verified there's no memory leak

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
