### PR TITLE
allow user to configure subscriber timeout for input stream

### DIFF
--- a/.changes/next-release/feature-AWSS3-1be6ddd.json
+++ b/.changes/next-release/feature-AWSS3-1be6ddd.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS S3",
+    "contributor": "benarnao",
+    "description": "allow user to configure subscriber timeout for input stream"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
@@ -384,6 +384,8 @@ public interface AsyncRequestBody extends SdkPublisher<ByteBuffer> {
     /**
      * Creates a {@link BlockingInputStreamAsyncRequestBody} to use for writing an input stream to the downstream service.
      *
+     * <p>By default, it will time out if streaming hasn't started within 10 seconds, and you can configure the timeout
+     * via {@link BlockingInputStreamAsyncRequestBody#builder()}
      * <p><b>Example Usage</b>
      *
      * <p>
@@ -408,7 +410,9 @@ public interface AsyncRequestBody extends SdkPublisher<ByteBuffer> {
      * }
      */
     static BlockingInputStreamAsyncRequestBody forBlockingInputStream(Long contentLength) {
-        return new BlockingInputStreamAsyncRequestBody(contentLength);
+        return BlockingInputStreamAsyncRequestBody.builder()
+                                                  .contentLength(contentLength)
+                                                  .build();
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.internal.io.SdkLengthAwareInputStream;
 import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.async.InputStreamConsumingPublisher;
 
 /**
@@ -43,13 +44,18 @@ public final class BlockingInputStreamAsyncRequestBody implements AsyncRequestBo
     private final Long contentLength;
     private final Duration subscribeTimeout;
 
-    BlockingInputStreamAsyncRequestBody(Long contentLength) {
-        this(contentLength, Duration.ofSeconds(10));
+    BlockingInputStreamAsyncRequestBody(Builder builder) {
+        this.contentLength = builder.contentLength;
+        this.subscribeTimeout = Validate.isPositiveOrNull(builder.subscribeTimeout, "subscribeTimeout") != null ?
+                                builder.subscribeTimeout :
+                                Duration.ofSeconds(10);
     }
 
-    BlockingInputStreamAsyncRequestBody(Long contentLength, Duration subscribeTimeout) {
-        this.contentLength = contentLength;
-        this.subscribeTimeout = subscribeTimeout;
+    /**
+     * Creates a default builder for {@link BlockingInputStreamAsyncRequestBody}.
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -112,4 +118,42 @@ public final class BlockingInputStreamAsyncRequestBody implements AsyncRequestBo
                                             + "BEFORE invoking doBlockingWrite if your caller is single-threaded.");
         }
     }
+
+    public static final class Builder {
+        private Duration subscribeTimeout;
+        private Long contentLength;
+
+        private Builder() {
+        }
+
+        /**
+         * Defines how long it should wait for this AsyncRequestBody to be subscribed (to start streaming) before timing out.
+         * By default, it's 10 seconds.
+         *
+         * <p>You may want to increase it if the request may not be executed right away.
+         *
+         * @param subscribeTimeout the timeout
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        public Builder subscribeTimeout(Duration subscribeTimeout) {
+            this.subscribeTimeout = subscribeTimeout;
+            return this;
+        }
+
+        /**
+         * The content length of the output stream.
+         *
+         * @param contentLength the content length
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        public Builder contentLength(Long contentLength) {
+            this.contentLength = contentLength;
+            return this;
+        }
+
+        public BlockingInputStreamAsyncRequestBody build() {
+            return new BlockingInputStreamAsyncRequestBody(this);
+        }
+    }
+}
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBodyTest.java
@@ -47,9 +47,9 @@ class BlockingInputStreamAsyncRequestBodyTest {
 
     @Test
     @Timeout(10)
-    public void doBlockingWrite_failsIfSubscriptionNeverComes()  {
+    public void doBlockingWrite_overrideSubscribeTimeout_failsIfSubscriptionNeverComes()  {
         BlockingInputStreamAsyncRequestBody requestBody =
-            new BlockingInputStreamAsyncRequestBody(0L, Duration.ofSeconds(1));
+            BlockingInputStreamAsyncRequestBody.builder().contentLength(0L).subscribeTimeout(Duration.ofSeconds(1)).build();
         assertThatThrownBy(() -> requestBody.writeInputStream(new StringInputStream("")))
             .hasMessageContaining("The service request was not made");
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Change is required when uploading large files via S3 (transfer manager/S# async client). Currently the sequence of events needed to perform this operation:

1) Create a `BlockingInputStreamAsyncRequestBody`
2) Use this body to create the upload
3) Write the input stream to the body

The second step can take longer than 10 seconds (default) for larger uploads.

## Modifications
Similar to https://github.com/aws/aws-sdk-java-v2/pull/5000 for output stream, allow user to configure this subscriber timeout value for input stream as well.

## Testing
Unit test to verify we can set the timeout now

## Types of changes
It is only exposing the ability to set a value. If user misconfigures the value it could potentially break their software.
Change is backward compatible and does not change the functionality of any existing code

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
