### PR TITLE
Improve HTTP2/PING timeout logic

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-9bd9da8.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-9bd9da8.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "akidambisrinivasan",
+    "description": "Improve HTTP2/PING timeout logic. Improvement avoids premature timeouts due to delays in scheduling the write of PING frame to the channel and/or flushing it to the socket."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandler.java
@@ -41,6 +41,11 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
     private static final NettyClientLogger log = NettyClientLogger.getLogger(Http2PingHandler.class);
     private static final Http2PingFrame DEFAULT_PING_FRAME = new DefaultHttp2PingFrame(0);
 
+    /**
+     * Time limit in ms for delays that results in a warning message being printed.
+     */
+    private final long delayWarningTimeLimitMs;
+
     private final long pingTimeoutMillis;
 
     private ScheduledFuture<?> periodicPing;
@@ -49,6 +54,7 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
 
     public Http2PingHandler(int pingTimeoutMillis) {
         this.pingTimeoutMillis = pingTimeoutMillis;
+        delayWarningTimeLimitMs = Math.min(100, pingTimeoutMillis / 10);
     }
 
     @Override
@@ -62,7 +68,7 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
         if (protocol == Protocol.HTTP2 && periodicPing == null) {
             periodicPing = ctx.channel()
                               .eventLoop()
-                              .scheduleAtFixedRate(() -> doPeriodicPing(ctx.channel()), 0, pingTimeoutMillis, MILLISECONDS);
+                              .schedule(() -> doPeriodicPing(ctx.channel()), 0, MILLISECONDS);
         }
     }
 
@@ -79,8 +85,8 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, Http2PingFrame frame) {
+        log.debug(ctx.channel(), () -> "Received PING from channel, ack=" + frame.ack());
         if (frame.ack()) {
-            log.debug(ctx.channel(), () -> "Received PING ACK from channel " + ctx.channel());
             lastPingAckTime = System.currentTimeMillis();
         } else {
             ctx.fireChannelRead(frame);
@@ -89,22 +95,48 @@ public class Http2PingHandler extends SimpleChannelInboundHandler<Http2PingFrame
 
     private void doPeriodicPing(Channel channel) {
         if (lastPingAckTime <= lastPingSendTime - pingTimeoutMillis) {
+            log.warn(channel, () -> "PING timeout occurred");
             long timeSinceLastPingSend = System.currentTimeMillis() - lastPingSendTime;
             channelIsUnhealthy(channel, new PingFailedException("Server did not respond to PING after " +
                                                                 timeSinceLastPingSend + "ms (limit: " +
                                                                 pingTimeoutMillis + "ms)"));
         } else {
+            log.debug(channel, () -> "Sending HTTP2/PING frame");
+            long scheduleTime = lastPingSendTime == 0 ? 0 : System.currentTimeMillis() - lastPingSendTime;
+            if (scheduleTime - pingTimeoutMillis > delayWarningTimeLimitMs) {
+                log.warn(channel, () -> "PING timer scheduled after " + scheduleTime + "ms");
+            }
             sendPing(channel);
         }
     }
 
     private void sendPing(Channel channel) {
+        long writeMs = System.currentTimeMillis();
         channel.writeAndFlush(DEFAULT_PING_FRAME).addListener(res -> {
             if (!res.isSuccess()) {
                 log.debug(channel, () -> "Failed to write and flush PING frame to connection", res.cause());
                 channelIsUnhealthy(channel, new PingFailedException("Failed to send PING to the service", res.cause()));
             } else {
+                log.debug(channel, () -> "Successfully flushed PING frame to connection");
                 lastPingSendTime = System.currentTimeMillis();
+                long flushTime = lastPingSendTime - writeMs;
+                if (flushTime > delayWarningTimeLimitMs) {
+                    log.warn(channel, () -> "Flushing PING frame took " + flushTime + "ms");
+                }
+                // ping frame was flushed to the socket, schedule to send the next ping now to avoid premature timeout.
+                //
+                // Scenario we want to avoid is shown below (NOTE: ptm - pingTimeoutMillis, Wx - Write Ping x,
+                // Fx - Flush Ping x, Rx - Receive ack x, T -Timeout)
+                // When timer is scheduled periodically, even though ack2 comes < ptm after being flushed to the socket, we
+                // will still timeout at 2ptm.
+                // 0          1ptm       2ptm       3ptm
+                // |----------|----------|----------|-------> time
+                // W1F1 R1    W2      F2 T  R2
+                // When timer is scheduled after flushing, we allow time for ack to come back and don't prematurely timeout.
+                // 0            ptm1               ptm2
+                // |-|----------|------|----------|-----------> time
+                // W1F1 R1      W2     F2   R2    W3
+                periodicPing = channel.eventLoop().schedule(() -> doPeriodicPing(channel), pingTimeoutMillis, MILLISECONDS);
             }
         });
     }


### PR DESCRIPTION
Improve PING timeout logic to avoid premature closing of the connection that can occur due to delays in scheduling of writing PING frame to the channel and/or flushing it to the socket.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Current PING timeout logic doesnt work well when there are delays in scheduling or flushing to socket.

```
Scenario we want to avoid is shown below (NOTE: ptm - pingTimeoutMillis, Wx - Write Ping x, Fx - Flush Ping x, Rx - Receive ack x, T -Timeout)

When timer is scheduled periodically, even though ack2 comes < ptm after being flushed to the socket, we
will still timeout at 2ptm.        
 0          1ptm       2ptm       3ptm
|----------|----------|----------|-------> time
W1F1 R1    W2      F2 T  R2
When timer is scheduled after flushing, we allow time for ack to come back and not prematurely timeout.
0            ptm1               ptm2
|-|----------|------|----------|-----------> time
 W1F1 R1      W2     F2   R2    W3
```

The change prevents premature closing of the HTTP2 connection. With this change, it will detect dead connections which are otherwise not detected due to inactivity while tolerating scheduling and flushing delays.

## Modifications
The callback to send the next ping is scheduled when the ping write is flushed, so it accounts for delays in flushing (because that delay doesnt mean the connection is dead)

## Testing
Added 2 new unit tests:

1. Add unit test to ensure that when there is a delay in writing to socket, if the ACK doesnt come within pingTimeoutMillis, the code still executes timeout logic and terminates the connection, but if it does come, resets the timer and continues pinging.
2. If there is a scheduling delay, it does not execute timeout. For scheduling delay, the system of jvm is unable to catchup and will do so slowly, the true issue that needs to be fixed is by addressing the slowness not timing out the connection.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
