### PR TITLE
Expose option in S3 Transfer Manager to allow users to configure the …

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-2dda0bc.json
+++ b/.changes/next-release/bugfix-S3TransferManager-2dda0bc.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Reduces the default max number of concurrent download file requests to 10 for `S3TransferManager#downloadDirectory`."
+}

--- a/.changes/next-release/feature-S3TransferManager-46ed8b9.json
+++ b/.changes/next-release/feature-S3TransferManager-46ed8b9.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Exposes an option in S3TransferManager Builder to allow users to configure the max allowed concurrent requests for `downloadDirectory` through `S3TransferManager.Builder#downloadDirectoryMaxConcurrency`. See [#4987](https://github.com/aws/aws-sdk-java-v2/issues/4987)."
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
@@ -16,8 +16,8 @@
 package software.amazon.awssdk.transfer.s3.internal;
 
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_DELIMITER;
-import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_PREFIX;
+import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DOWNLOAD_DIRECTORY_MAX_CONCURRENCY;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -111,7 +111,7 @@ public class DownloadDirectoryHelper {
             new AsyncBufferingSubscriber<>(downloadSingleFile(returnFuture, downloadDirectoryRequest, request,
                                                               failedFileDownloads),
                                            allOfFutures,
-                                           DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY);
+                                           transferConfiguration.option(DOWNLOAD_DIRECTORY_MAX_CONCURRENCY));
         listObjectsHelper.listS3ObjectsRecursively(request)
                          .filter(downloadDirectoryRequest.filter())
                          .subscribe(asyncBufferingSubscriber);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferConfigurationOption.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferConfigurationOption.java
@@ -29,6 +29,9 @@ public final class TransferConfigurationOption<T> extends AttributeMap.Key<T> {
     public static final TransferConfigurationOption<Integer> UPLOAD_DIRECTORY_MAX_DEPTH =
         new TransferConfigurationOption<>("UploadDirectoryMaxDepth", Integer.class);
 
+    public static final TransferConfigurationOption<Integer> DOWNLOAD_DIRECTORY_MAX_CONCURRENCY =
+        new TransferConfigurationOption<>("DownloadDirectoryMaxConcurrency", Integer.class);
+
     public static final TransferConfigurationOption<Boolean> UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS =
         new TransferConfigurationOption<>("UploadDirectoryFileVisitOption", Boolean.class);
 
@@ -37,7 +40,8 @@ public final class TransferConfigurationOption<T> extends AttributeMap.Key<T> {
 
     public static final String DEFAULT_DELIMITER = "/";
     public static final String DEFAULT_PREFIX = "";
-    public static final int DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY = 100;
+
+    public static final int DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY = 10;
 
     private static final int DEFAULT_UPLOAD_DIRECTORY_MAX_DEPTH = Integer.MAX_VALUE;
 
@@ -45,6 +49,7 @@ public final class TransferConfigurationOption<T> extends AttributeMap.Key<T> {
         .builder()
         .put(UPLOAD_DIRECTORY_MAX_DEPTH, DEFAULT_UPLOAD_DIRECTORY_MAX_DEPTH)
         .put(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS, false)
+        .put(DOWNLOAD_DIRECTORY_MAX_CONCURRENCY, DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY)
         .build();
 
     private final String name;

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerFactory.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerFactory.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.internal.multipart.MultipartS3AsyncClient;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
 
 
 /**
@@ -38,6 +39,7 @@ public final class TransferManagerFactory {
     }
 
     public static S3TransferManager createTransferManager(DefaultBuilder tmBuilder) {
+        Validate.isPositiveOrNull(tmBuilder.downloadDirectoryMaxConcurrency, "downloadDirectoryMaxConcurrency");
         TransferManagerConfiguration transferConfiguration = resolveTransferManagerConfiguration(tmBuilder);
         S3AsyncClient s3AsyncClient;
         boolean isDefaultS3AsyncClient;
@@ -86,11 +88,7 @@ public final class TransferManagerFactory {
     }
 
     private static TransferManagerConfiguration resolveTransferManagerConfiguration(DefaultBuilder tmBuilder) {
-        TransferManagerConfiguration.Builder transferConfigBuilder = TransferManagerConfiguration.builder();
-        transferConfigBuilder.uploadDirectoryFollowSymbolicLinks(tmBuilder.uploadDirectoryFollowSymbolicLinks);
-        transferConfigBuilder.uploadDirectoryMaxDepth(tmBuilder.uploadDirectoryMaxDepth);
-        transferConfigBuilder.executor(tmBuilder.executor);
-        return transferConfigBuilder.build();
+        return new TransferManagerConfiguration(tmBuilder);
     }
 
     public static final class DefaultBuilder implements S3TransferManager.Builder {
@@ -98,6 +96,7 @@ public final class TransferManagerFactory {
         private Executor executor;
         private Boolean uploadDirectoryFollowSymbolicLinks;
         private Integer uploadDirectoryMaxDepth;
+        private Integer downloadDirectoryMaxConcurrency;
 
         @Override
         public DefaultBuilder s3Client(S3AsyncClient s3AsyncClient) {
@@ -105,10 +104,18 @@ public final class TransferManagerFactory {
             return this;
         }
 
+        public S3AsyncClient getS3Client() {
+            return s3AsyncClient;
+        }
+
         @Override
         public DefaultBuilder executor(Executor executor) {
             this.executor = executor;
             return this;
+        }
+
+        public Executor getExecutor() {
+            return executor;
         }
 
         @Override
@@ -137,6 +144,16 @@ public final class TransferManagerFactory {
 
         public Integer getUploadDirectoryMaxDepth() {
             return uploadDirectoryMaxDepth;
+        }
+
+        @Override
+        public DefaultBuilder downloadDirectoryMaxConcurrency(Integer downloadDirectoryMaxConcurrency) {
+            this.downloadDirectoryMaxConcurrency = downloadDirectoryMaxConcurrency;
+            return this;
+        }
+
+        public Integer getDownloadDirectoryMaxConcurrency() {
+            return downloadDirectoryMaxConcurrency;
         }
 
         @Override

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/CrtS3TransferManagerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/CrtS3TransferManagerTest.java
@@ -64,7 +64,7 @@ public class CrtS3TransferManagerTest {
 
     @BeforeEach
     public void setUpPerMethod() {
-        transferManager = new CrtS3TransferManager(TransferManagerConfiguration.builder().build(),
+        transferManager = new CrtS3TransferManager(new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder()),
                                                                         s3AsyncClient, false);
     }
 

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
@@ -80,7 +80,7 @@ public class DownloadDirectoryHelperTest {
         directory = fs.getPath("test");
         listObjectsHelper = mock(ListObjectsHelper.class);
         singleDownloadFunction = mock(Function.class);
-        downloadDirectoryHelper = new DownloadDirectoryHelper(TransferManagerConfiguration.builder().build(),
+        downloadDirectoryHelper = new DownloadDirectoryHelper(new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder()),
                                                               listObjectsHelper,
                                                               singleDownloadFunction);
     }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
@@ -16,8 +16,11 @@
 package software.amazon.awssdk.transfer.s3.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY;
+import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DOWNLOAD_DIRECTORY_MAX_CONCURRENCY;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.EXECUTOR;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.UPLOAD_DIRECTORY_MAX_DEPTH;
@@ -26,6 +29,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.UploadDirectoryRequest;
 
 public class TransferManagerConfigurationTest {
@@ -33,9 +37,8 @@ public class TransferManagerConfigurationTest {
 
     @Test
     public void resolveMaxDepth_requestOverride_requestOverrideShouldTakePrecedence() {
-        transferManagerConfiguration = TransferManagerConfiguration.builder()
-                                                                   .uploadDirectoryMaxDepth(1)
-                                                                   .build();
+        transferManagerConfiguration = new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder()
+                                                                   .uploadDirectoryMaxDepth(1));
         UploadDirectoryRequest uploadDirectoryRequest = UploadDirectoryRequest.builder()
                                                                               .bucket("bucket")
                                                                               .source(Paths.get("."))
@@ -46,9 +49,8 @@ public class TransferManagerConfigurationTest {
 
     @Test
     public void resolveFollowSymlinks_requestOverride_requestOverrideShouldTakePrecedence() {
-        transferManagerConfiguration = TransferManagerConfiguration.builder()
-                                                                   .uploadDirectoryFollowSymbolicLinks(false)
-                                                                   .build();
+        transferManagerConfiguration = new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder()
+                                                                   .uploadDirectoryFollowSymbolicLinks(false));
         UploadDirectoryRequest uploadDirectoryRequest = UploadDirectoryRequest.builder()
                                                                               .bucket("bucket")
                                                                               .source(Paths.get("."))
@@ -59,15 +61,27 @@ public class TransferManagerConfigurationTest {
 
     @Test
     public void noOverride_shouldUseDefaults() {
-        transferManagerConfiguration = TransferManagerConfiguration.builder().build();
+        transferManagerConfiguration = new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder());
         assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS)).isFalse();
         assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_MAX_DEPTH)).isEqualTo(Integer.MAX_VALUE);
         assertThat(transferManagerConfiguration.option(EXECUTOR)).isNotNull();
+        assertThat(transferManagerConfiguration.option(DOWNLOAD_DIRECTORY_MAX_CONCURRENCY)).isEqualTo(DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY);
+    }
+
+    @Test
+    public void override_shouldHonor() {
+        transferManagerConfiguration =
+            new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder().downloadDirectoryMaxConcurrency(1)
+                                                 .uploadDirectoryFollowSymbolicLinks(true)
+                                                 .uploadDirectoryMaxDepth(10));
+        assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS)).isTrue();
+        assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_MAX_DEPTH)).isEqualTo(10);
+        assertThat(transferManagerConfiguration.option(DOWNLOAD_DIRECTORY_MAX_CONCURRENCY)).isEqualTo(1);
     }
 
     @Test
     public void close_noCustomExecutor_shouldCloseDefaultOne() {
-        transferManagerConfiguration = TransferManagerConfiguration.builder().build();
+        transferManagerConfiguration = new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder());
         transferManagerConfiguration.close();
         ExecutorService executor = (ExecutorService) transferManagerConfiguration.option(EXECUTOR);
         assertThat(executor.isShutdown()).isTrue();
@@ -76,7 +90,8 @@ public class TransferManagerConfigurationTest {
     @Test
     public void close_customExecutor_shouldNotCloseCustomExecutor() {
         ExecutorService executorService = Mockito.mock(ExecutorService.class);
-        transferManagerConfiguration = TransferManagerConfiguration.builder().executor(executorService).build();
+        transferManagerConfiguration =
+            new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder().executor(executorService));
         transferManagerConfiguration.close();
         verify(executorService, never()).shutdown();
     }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperTest.java
@@ -52,6 +52,7 @@ import software.amazon.awssdk.services.s3.multipart.PauseObservable;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.testutils.FileUtils;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.config.TransferRequestOverrideConfiguration;
 import software.amazon.awssdk.transfer.s3.internal.model.DefaultFileUpload;
 import software.amazon.awssdk.transfer.s3.internal.progress.DefaultTransferProgress;
@@ -102,7 +103,8 @@ public class UploadDirectoryHelperTest {
 
         singleUploadFunction = mock(Function.class);
 
-        uploadDirectoryHelper = new UploadDirectoryHelper(TransferManagerConfiguration.builder().build(), singleUploadFunction);
+        uploadDirectoryHelper = new UploadDirectoryHelper(new TransferManagerConfiguration(new TransferManagerFactory.DefaultBuilder()),
+                                                          singleUploadFunction);
     }
 
     @AfterEach


### PR DESCRIPTION
…max number of concurrent requests for downloadDirectory

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
#4987 

## Modifications
- Reduce the number of concurrent downloadFileRequests to 10 since 100 is a bit aggresive
- Expose a config in S3 transfer manager to allow users to customize max concurrency for download directory 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
