### PR TITLE
Salande/user agent cred source add agent

### DIFF
--- a/build-tools/src/main/resources/software/amazon/awssdk/spotbugs-suppressions.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/spotbugs-suppressions.xml
@@ -293,6 +293,11 @@
         <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
     </Match>
 
+    <Match>
+        <Class name="software.amazon.awssdk.auth.credentials.AwsSessionCredentials$Builder"/>
+        <Bug pattern="BAD_TO_BUILDER"/>
+    </Match>
+
     <!-- New flags as of spotbogs 4.7.3.5 -->
     <!-- TODO: Fix or explicitly exclude each occurrence -->
      <Match>

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -52,8 +52,8 @@ public final class AwsBasicCredentials implements AwsCredentials,
 
     private final String accessKeyId;
     private final String secretAccessKey;
-    private boolean validateCredentials;
-    private String provider;
+    private final boolean validateCredentials;
+    private final String provider;
 
     private AwsBasicCredentials(Builder builder) {
         this.accessKeyId = trimToNull(builder.accessKeyId);
@@ -76,6 +76,8 @@ public final class AwsBasicCredentials implements AwsCredentials,
     protected AwsBasicCredentials(String accessKeyId, String secretAccessKey) {
         this.accessKeyId = trimToNull(accessKeyId);
         this.secretAccessKey = trimToNull(secretAccessKey);
+        this.validateCredentials = false;
+        this.provider = null;
     }
 
     public static Builder builder() {

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -18,11 +18,15 @@ package software.amazon.awssdk.auth.credentials;
 import static software.amazon.awssdk.utils.StringUtils.trimToNull;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * Provides access to the AWS credentials used for accessing services: AWS access key ID and secret access key. These
@@ -36,33 +40,28 @@ import software.amazon.awssdk.utils.Validate;
  */
 @Immutable
 @SdkPublicApi
-public final class AwsBasicCredentials implements AwsCredentials {
+public final class AwsBasicCredentials implements AwsCredentials,
+                                                  ToCopyableBuilder<AwsBasicCredentials.Builder, AwsBasicCredentials> {
     /**
      * A set of AWS credentials without an access key or secret access key, indicating that anonymous access should be used.
      *
      * This should be accessed via {@link AnonymousCredentialsProvider#resolveCredentials()}.
      */
     @SdkInternalApi
-    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = new AwsBasicCredentials(null, null, false);
+    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().validateCredentials(false).build();
 
     private final String accessKeyId;
     private final String secretAccessKey;
+    private boolean validateCredentials;
+    private String provider;
 
-    /**
-     * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
-     *
-     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
-     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
-     */
-    protected AwsBasicCredentials(String accessKeyId, String secretAccessKey) {
-        this(accessKeyId, secretAccessKey, true);
-    }
+    private AwsBasicCredentials(Builder builder) {
+        this.accessKeyId = trimToNull(builder.accessKeyId);
+        this.secretAccessKey = trimToNull(builder.secretAccessKey);
+        this.validateCredentials = builder.validateCredentials;
+        this.provider = builder.provider;
 
-    private AwsBasicCredentials(String accessKeyId, String secretAccessKey, boolean validateCredentials) {
-        this.accessKeyId = trimToNull(accessKeyId);
-        this.secretAccessKey = trimToNull(secretAccessKey);
-
-        if (validateCredentials) {
+        if (builder.validateCredentials) {
             Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
             Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
         }
@@ -73,9 +72,26 @@ public final class AwsBasicCredentials implements AwsCredentials {
      *
      * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
+     */
+    protected AwsBasicCredentials(String accessKeyId, String secretAccessKey) {
+        this.accessKeyId = trimToNull(accessKeyId);
+        this.secretAccessKey = trimToNull(secretAccessKey);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
      * */
     public static AwsBasicCredentials create(String accessKeyId, String secretAccessKey) {
-        return new AwsBasicCredentials(accessKeyId, secretAccessKey);
+        return builder().accessKeyId(accessKeyId)
+                        .secretAccessKey(secretAccessKey)
+                        .build();
     }
 
     /**
@@ -94,10 +110,19 @@ public final class AwsBasicCredentials implements AwsCredentials {
         return secretAccessKey;
     }
 
+    /**
+     * The name of the identity provider that created this credential identity.
+     */
+    @Override
+    public Optional<String> provider() {
+        return Optional.ofNullable(provider);
+    }
+
     @Override
     public String toString() {
         return ToString.builder("AwsCredentials")
                        .add("accessKeyId", accessKeyId)
+                       .add("provider", provider)
                        .build();
     }
 
@@ -120,5 +145,68 @@ public final class AwsBasicCredentials implements AwsCredentials {
         hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
         hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
         return hashCode;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().accessKeyId(accessKeyId)
+                        .secretAccessKey(secretAccessKey)
+                        .validateCredentials(validateCredentials)
+                        .provider(provider);
+    }
+
+    @Override
+    public AwsBasicCredentials copy(Consumer<? super AwsBasicCredentials.Builder> modifier) {
+        return ToCopyableBuilder.super.copy(modifier);
+    }
+
+    /**
+     * A builder for creating an instance of {@link AwsBasicCredentials}. This can be created with the static
+     * {@link #builder()} method.
+     */
+    public static final class Builder implements CopyableBuilder<AwsBasicCredentials.Builder, AwsBasicCredentials> {
+        private String accessKeyId;
+        private String secretAccessKey;
+        private String provider;
+        private boolean validateCredentials = true;
+
+        private Builder() {
+        }
+
+        /**
+         * The AWS access key, used to identify the user interacting with services.
+         */
+        public Builder accessKeyId(String accessKeyId) {
+            this.accessKeyId = accessKeyId;
+            return this;
+        }
+
+        /**
+         * The AWS secret access key, used to authenticate the user interacting with services.
+         */
+        public Builder secretAccessKey(String secretAccessKey) {
+            this.secretAccessKey = secretAccessKey;
+            return this;
+        }
+
+        /**
+         * The name of the identity provider that created this credential identity.
+         */
+        public Builder provider(String provider) {
+            this.provider = provider;
+            return this;
+        }
+
+        /**
+         * Whether this class should verify that accessKeyId and secretAccessKey are not null.
+         */
+        public Builder validateCredentials(Boolean validateCredentials) {
+            this.validateCredentials = validateCredentials;
+            return this;
+        }
+
+        public AwsBasicCredentials build() {
+            return new AwsBasicCredentials(this);
+        }
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
@@ -147,7 +147,11 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
 
     @Override
     public Builder toBuilder() {
-        return new Builder(this);
+        return builder().accessKeyId(accessKeyId)
+                        .secretAccessKey(secretAccessKey)
+                        .sessionToken(sessionToken)
+                        .expirationTime(expirationTime)
+                        .provider(provider);
     }
 
     @Override
@@ -165,17 +169,6 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         private String sessionToken;
         private Instant expirationTime;
         private String provider;
-
-        Builder() {
-        }
-
-        private Builder(AwsSessionCredentials sessionCredentials) {
-            this.accessKeyId = sessionCredentials.accessKeyId;
-            this.secretAccessKey = sessionCredentials.secretAccessKey;
-            this.sessionToken = sessionCredentials.sessionToken;
-            this.expirationTime = sessionCredentials.expirationTime;
-            this.provider = sessionCredentials.provider;
-        }
 
         /**
          * The AWS access key, used to identify the user interacting with services. Required.

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
@@ -18,11 +18,14 @@ package software.amazon.awssdk.auth.credentials;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * A special type of {@link AwsCredentials} that provides a session token to be used in service authentication. Session
@@ -31,19 +34,21 @@ import software.amazon.awssdk.utils.Validate;
  */
 @Immutable
 @SdkPublicApi
-public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCredentialsIdentity {
-
+public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCredentialsIdentity,
+                                                    ToCopyableBuilder<AwsSessionCredentials.Builder, AwsSessionCredentials> {
     private final String accessKeyId;
     private final String secretAccessKey;
     private final String sessionToken;
 
     private final Instant expirationTime;
+    private final String provider;
 
     private AwsSessionCredentials(Builder builder) {
         this.accessKeyId = Validate.paramNotNull(builder.accessKeyId, "accessKey");
         this.secretAccessKey = Validate.paramNotNull(builder.secretAccessKey, "secretKey");
         this.sessionToken = Validate.paramNotNull(builder.sessionToken, "sessionToken");
         this.expirationTime = builder.expirationTime;
+        this.provider = builder.provider;
     }
 
     /**
@@ -93,14 +98,24 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
      * Retrieve the AWS session token. This token is retrieved from an AWS token service, and is used for authenticating that this
      * user has received temporary permission to access some resource.
      */
+    @Override
     public String sessionToken() {
         return sessionToken;
+    }
+
+    /**
+     * The name of the identity provider that created this credential identity.
+     */
+    @Override
+    public Optional<String> provider() {
+        return Optional.ofNullable(provider);
     }
 
     @Override
     public String toString() {
         return ToString.builder("AwsSessionCredentials")
                        .add("accessKeyId", accessKeyId())
+                       .add("provider", provider)
                        .build();
     }
 
@@ -130,15 +145,37 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
         return hashCode;
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    @Override
+    public AwsSessionCredentials copy(Consumer<? super Builder> modifier) {
+        return ToCopyableBuilder.super.copy(modifier);
+    }
+
     /**
      * A builder for creating an instance of {@link AwsSessionCredentials}. This can be created with the static
      * {@link #builder()} method.
      */
-    public static final class Builder {
+    public static final class Builder implements CopyableBuilder<AwsSessionCredentials.Builder, AwsSessionCredentials> {
         private String accessKeyId;
         private String secretAccessKey;
         private String sessionToken;
         private Instant expirationTime;
+        private String provider;
+
+        Builder() {
+        }
+
+        private Builder(AwsSessionCredentials sessionCredentials) {
+            this.accessKeyId = sessionCredentials.accessKeyId;
+            this.secretAccessKey = sessionCredentials.secretAccessKey;
+            this.sessionToken = sessionCredentials.sessionToken;
+            this.expirationTime = sessionCredentials.expirationTime;
+            this.provider = sessionCredentials.provider;
+        }
 
         /**
          * The AWS access key, used to identify the user interacting with services. Required.
@@ -172,6 +209,14 @@ public final class AwsSessionCredentials implements AwsCredentials, AwsSessionCr
          */
         public Builder expirationTime(Instant expirationTime) {
             this.expirationTime = expirationTime;
+            return this;
+        }
+
+        /**
+         * The name of the identity provider that created this credential identity.
+         */
+        public Builder provider(String provider) {
+            this.provider = provider;
             return this;
         }
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProvider.java
@@ -24,10 +24,22 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkPublicApi
 public final class StaticCredentialsProvider implements AwsCredentialsProvider {
+    private static final String PROVIDER_NAME = "StaticCredentialsProvider";
     private final AwsCredentials credentials;
 
     private StaticCredentialsProvider(AwsCredentials credentials) {
-        this.credentials = Validate.notNull(credentials, "Credentials must not be null.");
+        Validate.notNull(credentials, "Credentials must not be null.");
+        this.credentials = withProviderName(credentials);
+    }
+
+    private AwsCredentials withProviderName(AwsCredentials credentials) {
+        if (credentials instanceof AwsBasicCredentials) {
+            return ((AwsBasicCredentials) credentials).copy(c -> c.provider(PROVIDER_NAME));
+        }
+        if (credentials instanceof AwsSessionCredentials) {
+            return ((AwsSessionCredentials) credentials).copy(c -> c.provider(PROVIDER_NAME));
+        }
+        return credentials;
     }
 
     /**
@@ -44,7 +56,7 @@ public final class StaticCredentialsProvider implements AwsCredentialsProvider {
 
     @Override
     public String toString() {
-        return ToString.builder("StaticCredentialsProvider")
+        return ToString.builder(PROVIDER_NAME)
                        .add("credentials", credentials)
                        .build();
     }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.auth.credentials;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -22,17 +23,20 @@ import org.junit.Test;
 public class StaticCredentialsProviderTest {
     @Test
     public void getAwsCredentials_ReturnsSameCredentials() throws Exception {
-        final AwsCredentials credentials = new AwsBasicCredentials("akid", "skid");
-        final AwsCredentials actualCredentials =
-                StaticCredentialsProvider.create(credentials).resolveCredentials();
+        AwsCredentials credentials = new AwsBasicCredentials("akid", "skid");
+        AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
         assertEquals(credentials, actualCredentials);
+        assertThat(credentials.provider()).isNotPresent();
+        assertThat(actualCredentials.provider()).isPresent();
     }
 
     @Test
     public void getSessionAwsCredentials_ReturnsSameCredentials() throws Exception {
-        final AwsSessionCredentials credentials = AwsSessionCredentials.create("akid", "skid", "token");
-        final AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
+        AwsSessionCredentials credentials = AwsSessionCredentials.create("akid", "skid", "token");
+        AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
         assertEquals(credentials, actualCredentials);
+        assertThat(credentials.provider()).isNotPresent();
+        assertThat(actualCredentials.provider()).isPresent();
     }
 
     @Test(expected = RuntimeException.class)

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/AwsBasicCredentialsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/AwsBasicCredentialsTest.java
@@ -20,76 +20,61 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 
-class AwsSessionCredentialsTest {
+class AwsBasicCredentialsTest {
 
     private static final String ACCESS_KEY_ID = "accessKeyId";
     private static final String SECRET_ACCESS_KEY = "secretAccessKey";
-    private static final String SESSION_TOKEN = "sessionToken";
     private static final String PROVIDER_NAME = "StaticCredentialsProvider";
 
     @Test
     void equalsHashcode() {
-        EqualsVerifier.forClass(AwsSessionCredentials.class)
+        EqualsVerifier.forClass(AwsBasicCredentials.class)
+                      .withIgnoredFields("validateCredentials")
                       .withIgnoredFields("provider")
                       .verify();
     }
 
     @Test
     void emptyBuilder_ThrowsException() {
-        assertThrows(NullPointerException.class, () -> AwsSessionCredentials.builder().build());
-    }
-
-    @Test
-    void builderMissingSessionToken_ThrowsException() {
-        assertThrows(NullPointerException.class, () -> AwsSessionCredentials.builder()
-                                                                            .accessKeyId(ACCESS_KEY_ID)
-                                                                            .secretAccessKey(SECRET_ACCESS_KEY)
-                                                                            .build());
+        assertThrows(NullPointerException.class, () -> AwsBasicCredentials.builder().build());
     }
 
     @Test
     void builderMissingAccessKeyId_ThrowsException() {
-        assertThrows(NullPointerException.class, () -> AwsSessionCredentials.builder()
+        assertThrows(NullPointerException.class, () -> AwsBasicCredentials.builder()
                                                                             .secretAccessKey(SECRET_ACCESS_KEY)
-                                                                            .sessionToken(SESSION_TOKEN)
                                                                             .build());
     }
 
     @Test
     void create_isSuccessful() {
-        AwsSessionCredentials identity = AwsSessionCredentials.create(ACCESS_KEY_ID,
-                                                                      SECRET_ACCESS_KEY,
-                                                                      SESSION_TOKEN);
+        AwsBasicCredentials identity = AwsBasicCredentials.create(ACCESS_KEY_ID,
+                                                                  SECRET_ACCESS_KEY);
         assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
         assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
-        assertEquals(SESSION_TOKEN, identity.sessionToken());
     }
 
     @Test
     void build_isSuccessful() {
-        AwsSessionCredentials identity = AwsSessionCredentials.builder()
+        AwsBasicCredentials identity = AwsBasicCredentials.builder()
                                                               .accessKeyId(ACCESS_KEY_ID)
                                                               .secretAccessKey(SECRET_ACCESS_KEY)
-                                                              .sessionToken(SESSION_TOKEN)
                                                               .build();
         assertEquals(ACCESS_KEY_ID, identity.accessKeyId());
         assertEquals(SECRET_ACCESS_KEY, identity.secretAccessKey());
-        assertEquals(SESSION_TOKEN, identity.sessionToken());
     }
 
     @Test
     void copy_isSuccessful() {
-        AwsSessionCredentials identity = AwsSessionCredentials.builder()
+        AwsBasicCredentials identity = AwsBasicCredentials.builder()
                                                               .accessKeyId(ACCESS_KEY_ID)
                                                               .secretAccessKey(SECRET_ACCESS_KEY)
-                                                              .sessionToken(SESSION_TOKEN)
                                                               .build();
-        AwsSessionCredentials copy = identity.copy(c -> c.provider(PROVIDER_NAME));
+        AwsBasicCredentials copy = identity.copy(c -> c.provider(PROVIDER_NAME));
         assertEquals(ACCESS_KEY_ID, copy.accessKeyId());
         assertEquals(SECRET_ACCESS_KEY, copy.secretAccessKey());
-        assertEquals(SESSION_TOKEN, copy.sessionToken());
         assertEquals(PROVIDER_NAME, copy.provider().get());
     }
 }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentity.java
@@ -42,6 +42,7 @@ public interface AwsCredentialsIdentity extends Identity {
      */
     String secretAccessKey();
 
+
     static Builder builder() {
         return DefaultAwsCredentialsIdentity.builder();
     }
@@ -68,6 +69,13 @@ public interface AwsCredentialsIdentity extends Identity {
          * The AWS secret access key, used to authenticate the user interacting with services.
          */
         Builder secretAccessKey(String secretAccessKey);
+
+        /**
+         * The name of the identity provider that created this credential identity.
+         */
+        default Builder provider(String provider) {
+            return this;
+        }
 
         AwsCredentialsIdentity build();
     }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentity.java
@@ -67,6 +67,9 @@ public interface AwsSessionCredentialsIdentity extends AwsCredentialsIdentity {
         Builder sessionToken(String sessionToken);
 
         @Override
+        Builder provider(String provider);
+
+        @Override
         AwsSessionCredentialsIdentity build();
     }
 }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/Identity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/Identity.java
@@ -19,7 +19,7 @@ import java.time.Instant;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
-import software.amazon.awssdk.identity.spi.internal.ProviderSource;
+import software.amazon.awssdk.identity.spi.internal.ProviderNameAware;
 
 /**
  * Interface to represent <b>who</b> is using the SDK, i.e., the identity of the caller, used for authentication.
@@ -30,7 +30,7 @@ import software.amazon.awssdk.identity.spi.internal.ProviderSource;
  */
 @SdkPublicApi
 @ThreadSafe
-public interface Identity extends ProviderSource {
+public interface Identity extends ProviderNameAware {
     /**
      * The time after which this identity will no longer be valid. If this is empty,
      * an expiration time is not known (but the identity may still expire at some

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsCredentialsIdentity.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.identity.spi.internal;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.utils.ToString;
@@ -26,10 +27,12 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
 
     private final String accessKeyId;
     private final String secretAccessKey;
+    private final String provider;
 
     private DefaultAwsCredentialsIdentity(Builder builder) {
         this.accessKeyId = builder.accessKeyId;
         this.secretAccessKey = builder.secretAccessKey;
+        this.provider = builder.provider;
 
         Validate.paramNotNull(accessKeyId, "accessKeyId");
         Validate.paramNotNull(secretAccessKey, "secretAccessKey");
@@ -50,9 +53,15 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
     }
 
     @Override
+    public Optional<String> provider() {
+        return Optional.ofNullable(provider);
+    }
+
+    @Override
     public String toString() {
         return ToString.builder("AwsCredentialsIdentity")
                        .add("accessKeyId", accessKeyId)
+                       .add("provider", provider)
                        .build();
     }
 
@@ -80,6 +89,7 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
     private static final class Builder implements AwsCredentialsIdentity.Builder {
         private String accessKeyId;
         private String secretAccessKey;
+        private String provider;
 
         private Builder() {
         }
@@ -93,6 +103,12 @@ public final class DefaultAwsCredentialsIdentity implements AwsCredentialsIdenti
         @Override
         public Builder secretAccessKey(String secretAccessKey) {
             this.secretAccessKey = secretAccessKey;
+            return this;
+        }
+
+        @Override
+        public Builder provider(String provider) {
+            this.provider = provider;
             return this;
         }
 

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsSessionCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/DefaultAwsSessionCredentialsIdentity.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.identity.spi.internal;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.utils.ToString;
@@ -27,11 +28,13 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
     private final String accessKeyId;
     private final String secretAccessKey;
     private final String sessionToken;
+    private final String provider;
 
     private DefaultAwsSessionCredentialsIdentity(Builder builder) {
         this.accessKeyId = builder.accessKeyId;
         this.secretAccessKey = builder.secretAccessKey;
         this.sessionToken = builder.sessionToken;
+        this.provider = builder.provider;
 
         Validate.paramNotNull(accessKeyId, "accessKeyId");
         Validate.paramNotNull(secretAccessKey, "secretAccessKey");
@@ -58,9 +61,15 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
     }
 
     @Override
+    public Optional<String> provider() {
+        return Optional.ofNullable(provider);
+    }
+
+    @Override
     public String toString() {
         return ToString.builder("AwsSessionCredentialsIdentity")
                        .add("accessKeyId", accessKeyId)
+                       .add("provider", provider)
                        .build();
     }
 
@@ -91,6 +100,7 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
         private String accessKeyId;
         private String secretAccessKey;
         private String sessionToken;
+        private String provider;
 
         private Builder() {
         }
@@ -110,6 +120,12 @@ public final class DefaultAwsSessionCredentialsIdentity implements AwsSessionCre
         @Override
         public Builder sessionToken(String sessionToken) {
             this.sessionToken = sessionToken;
+            return this;
+        }
+
+        @Override
+        public Builder provider(String provider) {
+            this.provider = provider;
             return this;
         }
 

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/ProviderNameAware.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/ProviderNameAware.java
@@ -16,15 +16,15 @@
 package software.amazon.awssdk.identity.spi.internal;
 
 import java.util.Optional;
-import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 
 /**
  * Interface to represent the provider that is the source of this identity.
  */
-@SdkInternalApi
 @ThreadSafe
-public interface ProviderSource {
+@SdkPublicApi
+public interface ProviderNameAware {
 
     /**
      * The source that resolved this identity, normally an identity provider.

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/ProviderSource.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/internal/ProviderSource.java
@@ -13,30 +13,23 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.identity.spi;
+package software.amazon.awssdk.identity.spi.internal;
 
-import java.time.Instant;
 import java.util.Optional;
-import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
-import software.amazon.awssdk.identity.spi.internal.ProviderSource;
 
 /**
- * Interface to represent <b>who</b> is using the SDK, i.e., the identity of the caller, used for authentication.
- *
- * <p>Examples include {@link AwsCredentialsIdentity} and {@link TokenIdentity}.</p>
- *
- * @see IdentityProvider
+ * Interface to represent the provider that is the source of this identity.
  */
-@SdkPublicApi
+@SdkInternalApi
 @ThreadSafe
-public interface Identity extends ProviderSource {
+public interface ProviderSource {
+
     /**
-     * The time after which this identity will no longer be valid. If this is empty,
-     * an expiration time is not known (but the identity may still expire at some
-     * time in the future).
+     * The source that resolved this identity, normally an identity provider.
      */
-    default Optional<Instant> expirationTime() {
+    default Optional<String> provider() {
         return Optional.empty();
     }
 }

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentityTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentityTest.java
@@ -30,6 +30,7 @@ public class AwsCredentialsIdentityTest {
     @Test
     public void equalsHashcode() {
         EqualsVerifier.forClass(DefaultAwsCredentialsIdentity.class)
+                      .withIgnoredFields("provider")
                       .verify();
     }
 

--- a/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentityTest.java
+++ b/core/identity-spi/src/test/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentityTest.java
@@ -31,6 +31,7 @@ public class AwsSessionCredentialsIdentityTest {
     @Test
     public void equalsHashcode() {
         EqualsVerifier.forClass(DefaultAwsSessionCredentialsIdentity.class)
+                      .withIgnoredFields("provider")
                       .verify();
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApplyUserAgentStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApplyUserAgentStage.java
@@ -16,43 +16,56 @@
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BinaryOperator;
+import java.util.function.UnaryOperator;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.MutableRequestToRequestPipeline;
+import software.amazon.awssdk.core.internal.useragent.IdentityProviderNameMapping;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.util.SdkUserAgent;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
-/**
- * Apply any custom user agent supplied, otherwise instrument the user agent with info about the SDK and environment.
- */
 @SdkInternalApi
 public class ApplyUserAgentStage implements MutableRequestToRequestPipeline {
+
+    public static final String HEADER_USER_AGENT = "User-Agent";
+
     private static final Logger log = Logger.loggerFor(ApplyUserAgentStage.class);
 
     private static final String COMMA = ", ";
+    private static final String SLASH = "/";
     private static final String SPACE = " ";
-
+    private static final String HASH = "#";
     private static final String IO = "io";
     private static final String HTTP = "http";
     private static final String CONFIG = "cfg";
     private static final String RETRY_MODE = "retry-mode";
-
+    private static final String AUTH_HEADER = "auth-source";
     private static final String AWS_EXECUTION_ENV_PREFIX = "exec-env/";
 
-    private static final String HEADER_USER_AGENT = "User-Agent";
+    private static final BinaryOperator<String> API_NAMES = (name, version) -> name + "/" + version;
+    private static final BinaryOperator<String> CONFIG_METADATA = (param, name) -> CONFIG + SLASH + param + HASH + name;
+    private static final UnaryOperator<String> AUTH_CONFIG = name -> CONFIG_METADATA.apply(AUTH_HEADER, name);
 
     private final SdkClientConfiguration clientConfig;
 
@@ -115,10 +128,10 @@ public class ApplyUserAgentStage implements MutableRequestToRequestPipeline {
     @Override
     public SdkHttpFullRequest.Builder execute(SdkHttpFullRequest.Builder request, RequestExecutionContext context)
             throws Exception {
-        return request.putHeader(HEADER_USER_AGENT, getUserAgent(clientConfig, context.requestConfig().apiNames()));
+        return request.putHeader(HEADER_USER_AGENT, getUserAgent(clientConfig, context));
     }
 
-    private String getUserAgent(SdkClientConfiguration config, List<ApiName> requestApiNames) {
+    private String getUserAgent(SdkClientConfiguration config, RequestExecutionContext context) {
         String clientUserAgent = clientConfig.option(SdkClientOption.CLIENT_USER_AGENT);
         if (clientUserAgent == null) {
             log.warn(() -> "Client user agent configuration is missing, so request user agent will be incomplete.");
@@ -126,18 +139,45 @@ public class ApplyUserAgentStage implements MutableRequestToRequestPipeline {
         }
         StringBuilder userAgent = new StringBuilder(clientUserAgent);
 
-        if (!requestApiNames.isEmpty()) {
-            requestApiNames.forEach(apiName -> {
-                userAgent.append(SPACE).append(apiName.name()).append("/").append(apiName.version());
-            });
-        }
+        //additional cfg information
+        identityProviderName(context.executionAttributes()).ifPresent(i -> userAgent.append(SPACE).append(AUTH_CONFIG.apply(i)));
 
+        //request API names
+        requestApiNames(context.requestConfig().apiNames()).ifPresent(userAgent::append);
+
+        //suffix
         String userDefinedSuffix = config.option(SdkAdvancedClientOption.USER_AGENT_SUFFIX);
         if (!StringUtils.isEmpty(userDefinedSuffix)) {
             userAgent.append(COMMA).append(userDefinedSuffix.trim());
         }
 
         return userAgent.toString();
+    }
+
+    private static Optional<String> identityProviderName(ExecutionAttributes executionAttributes) {
+        SelectedAuthScheme<?> selectedAuthScheme = executionAttributes
+            .getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+        if (selectedAuthScheme == null) {
+            return Optional.empty();
+        }
+        return providerNameFromIdentity(selectedAuthScheme);
+    }
+
+    private static <T extends Identity> Optional<String> providerNameFromIdentity(SelectedAuthScheme<T> selectedAuthScheme) {
+        CompletableFuture<? extends T> identityFuture = selectedAuthScheme.identity();
+        T identity = CompletableFutureUtils.joinLikeSync(identityFuture);
+        return identity.provider().flatMap(IdentityProviderNameMapping::fromValue);
+    }
+
+    private Optional<String> requestApiNames(List<ApiName> requestApiNames) {
+        if (requestApiNames.isEmpty()) {
+            return Optional.empty();
+        }
+        StringBuilder concatenatedNames = new StringBuilder();
+        requestApiNames.forEach(apiName -> concatenatedNames.append(SPACE)
+                                                            .append(API_NAMES.apply(apiName.name(),
+                                                                                    apiName.version())));
+        return Optional.of(concatenatedNames.toString());
     }
 
     private static String clientName(ClientType clientType, SdkHttpClient syncHttpClient, SdkAsyncHttpClient asyncHttpClient) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/useragent/IdentityProviderNameMapping.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/useragent/IdentityProviderNameMapping.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.useragent;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * A enum class representing a short form of identity providers to record in the UA string.
+ */
+public enum IdentityProviderNameMapping {
+
+    SYS("SystemPropertyCredentialsProvider"),
+    ENV("EnvironmentVariableCredentialsProvider"),
+    STSWEB("StsAssumeRoleWithWebIdentity"),
+    STSROLE("StsAssumeRoleCredentialsProvider"),
+    STSSAML("StsAssumeRoleWithWebIdentityCredentialsProvider"),
+    STSFED("StsGetFederationTokenCredentialsProvider"),
+    STSSESS("StsGetSessionTokenCredentialsProvider"),
+    SSO("SsoCredentialsProvider"),
+    PROF("ProfileCredentialsProvider"),
+    CONT("ContainerCredentialsProvider"),
+    IMDS("InstanceProfileCredentialsProvider"),
+    STAT("StaticCredentialsProvider"),
+    PROC("ProcessCredentialsProvider");
+
+    private static final Pattern CLASS_NAME_CHARACTERS = Pattern.compile("[a-zA-Z_$\\d]{0,62}");
+    private final String value;
+
+    IdentityProviderNameMapping(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static Optional<String> fromValue(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        for (IdentityProviderNameMapping provider : values()) {
+            if (provider.value().equals(value)) {
+                return Optional.of(provider.name());
+            }
+        }
+        return Optional.ofNullable(sanitizedProviderOrNull(value));
+    }
+
+    private static String sanitizedProviderOrNull(String value) {
+        if (containsAllowedCharacters(value) && value.toLowerCase(Locale.US).endsWith("provider")) {
+            return value;
+        }
+        return null;
+    }
+
+    private static boolean containsAllowedCharacters(String input) {
+        return CLASS_NAME_CHARACTERS.matcher(input).matches();
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApplyUserAgentStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApplyUserAgentStageTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.core.internal.http.pipeline.stages.ApplyUserAgentStage.HEADER_USER_AGENT;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SelectedAuthScheme;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.http.NoopTestRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.Identity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplyUserAgentStageTest {
+    private static final SelectedAuthScheme<Identity> EMPTY_SELECTED_AUTH_SCHEME =
+        new SelectedAuthScheme<>(CompletableFuture.completedFuture(Mockito.mock(Identity.class)),
+                                 (HttpSigner<Identity>) Mockito.mock(HttpSigner.class),
+                                 AuthSchemeOption.builder().schemeId("mock").build());
+
+    private static final String SDK_UA_STRING = "aws-sdk-java/version vendor/unknown";
+    private static final String PROVIDER_SOURCE = "ProcessCredentialsProvider";
+    private static final AwsCredentialsIdentity IDENTITY_WITHOUT_SOURCE =
+        AwsCredentialsIdentity.create("akid", "secret");
+
+    private static final AwsCredentialsIdentity IDENTITY_WITH_SOURCE =
+        AwsSessionCredentialsIdentity.builder().accessKeyId("akid").secretAccessKey("secret").sessionToken("token")
+                                     .provider(PROVIDER_SOURCE).build();
+
+    @Test
+    public void when_noAdditionalDataIsPresent_outputStringEqualsInputString() throws Exception {
+        String clientBuildTimeUserAgentString = SDK_UA_STRING;
+
+        ApplyUserAgentStage stage = new ApplyUserAgentStage(dependenciesWithUserAgent(clientBuildTimeUserAgentString));
+
+        RequestExecutionContext ctx = requestExecutionContext(executionAttributes(IDENTITY_WITHOUT_SOURCE), noOpRequest());
+        SdkHttpFullRequest.Builder request = stage.execute(SdkHttpFullRequest.builder(), ctx);
+
+        List<String> userAgentHeaders = request.headers().get(HEADER_USER_AGENT);
+        assertThat(userAgentHeaders).isNotNull().hasSize(1);
+        assertThat(userAgentHeaders.get(0)).isEqualTo(SDK_UA_STRING);
+    }
+
+    @Test
+    public void when_identityContainsProvider_authSourceIsPresent() throws Exception {
+        String clientBuildTimeUserAgentString = SDK_UA_STRING;
+
+        ApplyUserAgentStage stage = new ApplyUserAgentStage(dependenciesWithUserAgent(clientBuildTimeUserAgentString));
+
+        RequestExecutionContext ctx = requestExecutionContext(executionAttributes(IDENTITY_WITH_SOURCE), noOpRequest());
+        SdkHttpFullRequest.Builder request = stage.execute(SdkHttpFullRequest.builder(), ctx);
+
+        List<String> userAgentHeaders = request.headers().get(HEADER_USER_AGENT);
+        assertThat(userAgentHeaders).isNotNull().hasSize(1);
+        assertThat(userAgentHeaders.get(0)).contains("auth-source#PROC");
+    }
+
+    @Test
+    public void when_requestContainsApiName_apiNamesArePresent() throws Exception {
+        String clientBuildTimeUserAgentString = SDK_UA_STRING;
+
+        ApplyUserAgentStage stage = new ApplyUserAgentStage(dependenciesWithUserAgent(clientBuildTimeUserAgentString));
+
+        RequestExecutionContext ctx = requestExecutionContext(executionAttributes(IDENTITY_WITH_SOURCE),
+                                                              requestWithApiName("myLib", "1.0"));
+        SdkHttpFullRequest.Builder request = stage.execute(SdkHttpFullRequest.builder(), ctx);
+
+        List<String> userAgentHeaders = request.headers().get(HEADER_USER_AGENT);
+        assertThat(userAgentHeaders).isNotNull().hasSize(1);
+        assertThat(userAgentHeaders.get(0)).contains("myLib/1.0");
+    }
+
+    private static HttpClientDependencies dependenciesWithUserAgent(String userAgent) {
+        SdkClientConfiguration clientConfiguration = SdkClientConfiguration.builder()
+                                                                           .option(SdkClientOption.CLIENT_USER_AGENT, userAgent)
+                                                                           .build();
+        return HttpClientDependencies.builder()
+                                     .clientConfiguration(clientConfiguration)
+                                     .build();
+    }
+
+    private static SdkRequest noOpRequest() {
+        return requestWithOverrideConfig(null);
+    }
+
+    private static SdkRequest requestWithApiName(String apiName, String version) {
+        SdkRequestOverrideConfiguration requestOverrideConfiguration =
+            SdkRequestOverrideConfiguration.builder()
+                                           .addApiName(a -> a.name(apiName).version(version))
+                                           .build();
+        return requestWithOverrideConfig(requestOverrideConfiguration);
+    }
+
+    private static SdkRequest requestWithOverrideConfig(SdkRequestOverrideConfiguration overrideConfiguration) {
+        return NoopTestRequest.builder()
+                              .overrideConfiguration(overrideConfiguration)
+                              .build();
+    }
+
+    private static ExecutionAttributes executionAttributes(AwsCredentialsIdentity identity) {
+        ExecutionAttributes executionAttributes = new ExecutionAttributes();
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                         new SelectedAuthScheme<>(CompletableFuture.completedFuture(identity),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.signer(),
+                                                         EMPTY_SELECTED_AUTH_SCHEME.authSchemeOption()));
+        return executionAttributes;
+    }
+
+    private RequestExecutionContext requestExecutionContext(ExecutionAttributes executionAttributes,
+                                                            SdkRequest request) {
+        ExecutionContext executionContext = ExecutionContext.builder()
+                                                            .executionAttributes(executionAttributes)
+                                                            .build();
+        return RequestExecutionContext.builder()
+                                      .executionContext(executionContext)
+                                      .originalRequest(request).build();
+
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/useragent/IdentityProviderNameMappingTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/useragent/IdentityProviderNameMappingTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.useragent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class IdentityProviderNameMappingTest {
+
+    @Test
+    void when_providerIsKnown_shortValueIsReturned() {
+        Optional<String> mappedProviderName = IdentityProviderNameMapping.fromValue("StaticCredentialsProvider");
+        assertThat(mappedProviderName).isPresent();
+        assertThat(mappedProviderName.get()).isEqualTo("STAT");
+    }
+
+    @Test
+    void when_providerIsUnknown_stringIsReturned() {
+        Optional<String> mappedProviderName = IdentityProviderNameMapping.fromValue("MyHomebrewedCredentialsProvider");
+        assertThat(mappedProviderName).isPresent();
+        assertThat(mappedProviderName.get()).isEqualTo("MyHomebrewedCredentialsProvider");
+    }
+
+    @Test
+    void when_providerIsIllegal_noValueIsReturned() {
+        Optional<String> mappedProviderName = IdentityProviderNameMapping.fromValue("My@#$%$CredentialsProvider");
+        assertThat(mappedProviderName).isNotPresent();
+    }
+
+    @Test
+    void when_providerIsTooLong_noValueIsReturned() {
+        Optional<String> mappedProviderName = IdentityProviderNameMapping.fromValue(
+            "MyMegaGinormousBubbaBubbaBubbaBubbaBubbaBubbaCredentialsProvider");
+        assertThat(mappedProviderName).isNotPresent();
+    }
+}

--- a/test/auth-tests/pom.xml
+++ b/test/auth-tests/pom.xml
@@ -49,6 +49,18 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>identity-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
             <version>${awsjavasdk.version}</version>
             <scope>test</scope>
@@ -96,6 +108,17 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>service-test-utils</artifactId>
+            <version>${awsjavasdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test/auth-tests/src/it/java/software/amazon/awssdk/auth/source/UserAgentProviderTest.java
+++ b/test/auth-tests/src/it/java/software/amazon/awssdk/auth/source/UserAgentProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.core.internal.http.pipeline.stages.ApplyUserAgentStage.HEADER_USER_AGENT;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+import software.amazon.awssdk.utils.StringInputStream;
+
+class UserAgentProviderTest {
+    private static final AwsCredentials BASIC_IDENTITY = basicCredentialsBuilder().build();
+    private static final AwsCredentials SESSION_IDENTITY = sessionCredentialsBuilder().build();
+
+    private MockSyncHttpClient mockHttpClient;
+
+    @BeforeEach
+    public void setup() throws UnsupportedEncodingException {
+        mockHttpClient = new MockSyncHttpClient();
+        mockHttpClient.stubNextResponse(mockResponse());
+    }
+
+    public static HttpExecuteResponse mockResponse() {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder().statusCode(200).build())
+                                  .responseBody(AbortableInputStream.create(new StringInputStream("")))
+                                  .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("credentialProviders")
+    void userAgentString_containsCredentialProviderNames_IfPresent(IdentityProvider<? extends AwsCredentialsIdentity> provider,
+                                                                   String expected) throws Exception {
+        stsClient(provider, mockHttpClient).getCallerIdentity();
+
+        SdkHttpRequest lastRequest = mockHttpClient.getLastRequest();
+        assertThat(lastRequest).isNotNull();
+
+        List<String> userAgentHeaders = lastRequest.headers().get(HEADER_USER_AGENT);
+        assertThat(userAgentHeaders).isNotNull().hasSize(1);
+        assertThat(userAgentHeaders.get(0)).contains(expected);
+    }
+
+    private static Stream<Arguments> credentialProviders() {
+        return Stream.of(
+            Arguments.of(StaticCredentialsProvider.create(SESSION_IDENTITY), "STAT"),
+            Arguments.of(StaticCredentialsProvider.create(BASIC_IDENTITY), "STAT")
+        );
+    }
+
+    private static StsClient stsClient(IdentityProvider<? extends AwsCredentialsIdentity> provider, SdkHttpClient httpClient) {
+        return StsClient.builder()
+                        .credentialsProvider(provider)
+                        .httpClient(httpClient)
+                        .build();
+    }
+
+    private static AwsSessionCredentials.Builder sessionCredentialsBuilder() {
+        return AwsSessionCredentials.builder()
+                                    .accessKeyId("akid")
+                                    .secretAccessKey("secret")
+                                    .sessionToken("token");
+    }
+
+    private static AwsBasicCredentials.Builder basicCredentialsBuilder() {
+        return AwsBasicCredentials.builder()
+                                  .accessKeyId("akid")
+                                  .secretAccessKey("secret");
+    }
+}


### PR DESCRIPTION
## Motivation and Context
This PR adds the identity source (which credentials provider that was used to resolve the identity / credentials) to the user agent string. 

The `provider` of the identity is added to the `cfg` part of the user agent as an `auth-source`. Auth source is a new section and not ratified in any specification, but should be parseable by the ua metrics system. 

We choose to add a short form of the credentials provider class as an identifier for now. This can easily be changed as the requirements for the user agent string format and contents are changed, and is backwards compatible.

## Modifications


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
