### PR TITLE
Add provider name when providers resolve identity

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AnonymousCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AnonymousCredentialsProvider.java
@@ -25,6 +25,8 @@ import software.amazon.awssdk.utils.ToString;
 @SdkPublicApi
 public final class AnonymousCredentialsProvider implements AwsCredentialsProvider {
 
+    private static final String PROVIDER_NAME = "AnonymousCredentialsProvider";
+
     private AnonymousCredentialsProvider() {
     }
 
@@ -34,11 +36,14 @@ public final class AnonymousCredentialsProvider implements AwsCredentialsProvide
 
     @Override
     public AwsCredentials resolveCredentials() {
-        return AwsBasicCredentials.ANONYMOUS_CREDENTIALS;
+        return AwsBasicCredentials.builder()
+                                  .validateCredentials(false)
+                                  .provider(PROVIDER_NAME)
+                                  .build();
     }
 
     @Override
     public String toString() {
-        return ToString.create("AnonymousCredentialsProvider");
+        return ToString.create(PROVIDER_NAME);
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -44,9 +44,8 @@ public final class AwsBasicCredentials implements AwsCredentials,
                                                   ToCopyableBuilder<AwsBasicCredentials.Builder, AwsBasicCredentials> {
     /**
      * A set of AWS credentials without an access key or secret access key, indicating that anonymous access should be used.
-     *
-     * This should be accessed via {@link AnonymousCredentialsProvider#resolveCredentials()}.
      */
+    // TODO(sra-identity-and-auth): Check if this static member can be removed after cleanup
     @SdkInternalApi
     static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = builder().validateCredentials(false).build();
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -72,6 +72,7 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
 public final class ContainerCredentialsProvider
     implements HttpCredentialsProvider,
                ToCopyableBuilder<ContainerCredentialsProvider.Builder, ContainerCredentialsProvider> {
+    private static final String PROVIDER_NAME = "ContainerCredentialsProvider";
     private static final Predicate<InetAddress> IS_LOOPBACK_ADDRESS = InetAddress::isLoopbackAddress;
     private static final Predicate<InetAddress> ALLOWED_HOSTS_RULES = IS_LOOPBACK_ADDRESS;
     private static final String HTTPS = "https";
@@ -97,7 +98,7 @@ public final class ContainerCredentialsProvider
         this.endpoint = builder.endpoint;
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
         this.asyncThreadName = builder.asyncThreadName;
-        this.httpCredentialsLoader = HttpCredentialsLoader.create();
+        this.httpCredentialsLoader = HttpCredentialsLoader.create(PROVIDER_NAME);
 
         if (Boolean.TRUE.equals(builder.asyncCredentialUpdateEnabled)) {
             Validate.paramNotBlank(builder.asyncThreadName, "asyncThreadName");
@@ -121,7 +122,7 @@ public final class ContainerCredentialsProvider
 
     @Override
     public String toString() {
-        return ToString.create("ContainerCredentialsProvider");
+        return ToString.create(PROVIDER_NAME);
     }
 
     private RefreshResult<AwsCredentials> refreshCredentials() {

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/EnvironmentVariableCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/EnvironmentVariableCredentialsProvider.java
@@ -28,6 +28,8 @@ import software.amazon.awssdk.utils.ToString;
 @SdkPublicApi
 public final class EnvironmentVariableCredentialsProvider extends SystemSettingsCredentialsProvider {
 
+    private static final String PROVIDER_NAME = "EnvironmentVariableCredentialsProvider";
+
     private EnvironmentVariableCredentialsProvider() {
     }
 
@@ -44,7 +46,12 @@ public final class EnvironmentVariableCredentialsProvider extends SystemSettings
     }
 
     @Override
+    protected String provider() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
     public String toString() {
-        return ToString.create("EnvironmentVariableCredentialsProvider");
+        return ToString.create(PROVIDER_NAME);
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -68,8 +68,8 @@ public final class InstanceProfileCredentialsProvider
     implements HttpCredentialsProvider,
                ToCopyableBuilder<InstanceProfileCredentialsProvider.Builder, InstanceProfileCredentialsProvider> {
     private static final Logger log = Logger.loggerFor(InstanceProfileCredentialsProvider.class);
+    private static final String PROVIDER_NAME = "InstanceProfileCredentialsProvider";
     private static final String EC2_METADATA_TOKEN_HEADER = "x-aws-ec2-metadata-token";
-
     private static final String SECURITY_CREDENTIALS_RESOURCE = "/latest/meta-data/iam/security-credentials/";
     private static final String TOKEN_RESOURCE = "/latest/api/token";
     private static final String EC2_METADATA_TOKEN_TTL_HEADER = "x-aws-ec2-metadata-token-ttl-seconds";
@@ -103,7 +103,7 @@ public final class InstanceProfileCredentialsProvider
         this.profileName = Optional.ofNullable(builder.profileName)
                                    .orElseGet(ProfileFileSystemSetting.AWS_PROFILE::getStringValueOrThrow);
 
-        this.httpCredentialsLoader = HttpCredentialsLoader.create();
+        this.httpCredentialsLoader = HttpCredentialsLoader.create(PROVIDER_NAME);
         this.configProvider =
             Ec2MetadataConfigProvider.builder()
                                      .profileFile(profileFile)
@@ -203,7 +203,7 @@ public final class InstanceProfileCredentialsProvider
 
     @Override
     public String toString() {
-        return ToString.create("InstanceProfileCredentialsProvider");
+        return ToString.create(PROVIDER_NAME);
     }
 
     private ResourcesEndpointProvider createEndpointProvider() {

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
@@ -64,6 +64,7 @@ public final class ProcessCredentialsProvider
     implements AwsCredentialsProvider,
                SdkAutoCloseable,
                ToCopyableBuilder<ProcessCredentialsProvider.Builder, ProcessCredentialsProvider> {
+    private static final String PROVIDER_NAME = "ProcessCredentialsProvider";
     private static final JsonNodeParser PARSER = JsonNodeParser.builder()
                                                                .removeErrorLocations(true)
                                                                .build();
@@ -170,11 +171,18 @@ public final class ProcessCredentialsProvider
         Validate.notEmpty(accessKeyId, "AccessKeyId cannot be empty.");
         Validate.notEmpty(secretAccessKey, "SecretAccessKey cannot be empty.");
 
-        if (sessionToken != null) {
-            return AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken);
-        } else {
-            return AwsBasicCredentials.create(accessKeyId, secretAccessKey);
-        }
+        return sessionToken != null ?
+               AwsSessionCredentials.builder()
+                                    .accessKeyId(accessKeyId)
+                                    .secretAccessKey(secretAccessKey)
+                                    .sessionToken(sessionToken)
+                                    .provider(PROVIDER_NAME)
+                                    .build() :
+               AwsBasicCredentials.builder()
+                                  .accessKeyId(accessKeyId)
+                                  .secretAccessKey(secretAccessKey)
+                                  .provider(PROVIDER_NAME)
+                                  .build();
     }
 
     /**
@@ -307,7 +315,7 @@ public final class ProcessCredentialsProvider
 
     @Override
     public String toString() {
-        return ToString.builder("ProcessCredentialsProvider")
+        return ToString.builder(PROVIDER_NAME)
                        .add("cmd", executableCommand)
                        .build();
     }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/SystemPropertyCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/SystemPropertyCredentialsProvider.java
@@ -28,6 +28,8 @@ import software.amazon.awssdk.utils.ToString;
 @SdkPublicApi
 public final class SystemPropertyCredentialsProvider extends SystemSettingsCredentialsProvider {
 
+    private static final String PROVIDER_NAME = "SystemSettingsCredentialsProvider";
+
     private SystemPropertyCredentialsProvider() {
     }
 
@@ -44,7 +46,12 @@ public final class SystemPropertyCredentialsProvider extends SystemSettingsCrede
     }
 
     @Override
+    protected String provider() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
     public String toString() {
-        return ToString.create("SystemPropertyCredentialsProvider");
+        return ToString.create(PROVIDER_NAME);
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.utils.SystemSetting;
  */
 @SdkInternalApi
 public abstract class SystemSettingsCredentialsProvider implements AwsCredentialsProvider {
+
     @Override
     public AwsCredentials resolveCredentials() {
         String accessKey = trim(loadSetting(SdkSystemSetting.AWS_ACCESS_KEY_ID).orElse(null));
@@ -67,12 +68,23 @@ public abstract class SystemSettingsCredentialsProvider implements AwsCredential
                                     .build();
         }
 
-        return StringUtils.isBlank(sessionToken) ? AwsBasicCredentials.create(accessKey, secretKey)
-                                                 : AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
+        return StringUtils.isBlank(sessionToken) ? AwsBasicCredentials.builder()
+                                                                      .accessKeyId(accessKey)
+                                                                      .secretAccessKey(secretKey)
+                                                                      .provider(provider())
+                                                                      .build()
+                                                 : AwsSessionCredentials.builder()
+                                                                        .accessKeyId(accessKey)
+                                                                        .secretAccessKey(secretKey)
+                                                                        .sessionToken(sessionToken)
+                                                                        .provider(provider())
+                                                                        .build();
     }
 
     /**
      * Implemented by child classes to load the requested setting.
      */
     protected abstract Optional<String> loadSetting(SystemSetting setting);
+
+    protected abstract String provider();
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/AnonymousCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/AnonymousCredentialsProviderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AnonymousCredentialsProviderTest {
+
+    @Test
+    void resolveCredentials_returnsAnonymousCredentials()  {
+        AwsCredentials credentials = AnonymousCredentialsProvider.create().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isNull();
+        assertThat(credentials.secretAccessKey()).isNull();
+        assertThat(credentials.provider()).isPresent().contains("AnonymousCredentialsProvider");
+    }
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
@@ -23,10 +23,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
-import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import java.net.URI;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -34,7 +32,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.util.SdkUserAgent;
-import software.amazon.awssdk.regions.util.ResourcesEndpointProvider;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
 /**
@@ -89,6 +86,7 @@ public class ContainerCredentialsProviderTest {
         assertThat(credentials.accessKeyId()).isEqualTo(ACCESS_KEY_ID);
         assertThat(credentials.secretAccessKey()).isEqualTo(SECRET_ACCESS_KEY);
         assertThat(credentials.sessionToken()).isEqualTo(TOKEN);
+        assertThat(credentials.provider()).isPresent().contains("ContainerCredentialsProvider");
     }
 
     /**
@@ -130,21 +128,5 @@ public class ContainerCredentialsProviderTest {
                "\"SecretAccessKey\":\"SECRET_ACCESS_KEY\"," +
                "\"Token\":\"TOKEN_TOKEN_TOKEN\"," +
                "\"Expiration\":\"3000-05-03T04:55:54Z\"}";
-    }
-
-    /**
-     * Dummy CredentialsPathProvider that overrides the endpoint and connects to the WireMock server.
-     */
-    private static class TestCredentialsEndpointProvider implements ResourcesEndpointProvider {
-        private final String host;
-
-        public TestCredentialsEndpointProvider(String host) {
-            this.host = host;
-        }
-
-        @Override
-        public URI endpoint() {
-            return invokeSafely(() -> new URI(host + CREDENTIALS_PATH));
-        }
     }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/HttpCredentialsLoaderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/HttpCredentialsLoaderTest.java
@@ -27,8 +27,6 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Date;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -48,6 +46,7 @@ public class HttpCredentialsLoaderTest {
     private static final long ONE_MINUTE = 1000L * 60;
     /** Environment variable name for the AWS ECS Container credentials path. */
     private static final String CREDENTIALS_PATH = "/dummy/credentials/path";
+    private static final String PROVIDER_NAME = "HttpCredentialsProvider";
     private static String successResponse;
 
     private static String successResponseWithInvalidBody;
@@ -70,7 +69,7 @@ public class HttpCredentialsLoaderTest {
     public void testLoadCredentialsParsesJsonResponseProperly() {
         stubForSuccessResponseWithCustomBody(successResponse);
 
-        HttpCredentialsLoader credentialsProvider = HttpCredentialsLoader.create();
+        HttpCredentialsLoader credentialsProvider = HttpCredentialsLoader.create(PROVIDER_NAME);
         AwsSessionCredentials credentials = (AwsSessionCredentials) credentialsProvider.loadCredentials(testEndpointProvider())
                                                                                        .getAwsCredentials();
 
@@ -88,7 +87,7 @@ public class HttpCredentialsLoaderTest {
         // Stub for success response but without keys in the response body
         stubForSuccessResponseWithCustomBody(successResponseWithInvalidBody);
 
-        HttpCredentialsLoader credentialsProvider = HttpCredentialsLoader.create();
+        HttpCredentialsLoader credentialsProvider = HttpCredentialsLoader.create(PROVIDER_NAME);
 
         assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> credentialsProvider.loadCredentials(testEndpointProvider()))
                                                            .withMessage("Failed to load credentials from metadata service.");
@@ -102,7 +101,7 @@ public class HttpCredentialsLoaderTest {
     public void testNoMetadataService() throws Exception {
         stubForErrorResponse();
 
-        HttpCredentialsLoader credentialsProvider = HttpCredentialsLoader.create();
+        HttpCredentialsLoader credentialsProvider = HttpCredentialsLoader.create(PROVIDER_NAME);
 
         // When there are no credentials, the provider should throw an exception if we can't connect
         assertThatExceptionOfType(SdkClientException.class).isThrownBy(() -> credentialsProvider.loadCredentials(testEndpointProvider()));

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderTest.java
@@ -131,10 +131,13 @@ public class InstanceProfileCredentialsProviderTest {
     }
 
     @Test
-    public void resolveCredentials_queriesTokenResource_includesTokenInCredentialsRequests() {
+    public void resolveCredentials_usesTokenByDefault() {
         stubSecureCredentialsResponse(aResponse().withBody(STUB_CREDENTIALS));
         InstanceProfileCredentialsProvider provider = InstanceProfileCredentialsProvider.builder().build();
-        provider.resolveCredentials();
+        AwsCredentials credentials = provider.resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("ACCESS_KEY_ID");
+        assertThat(credentials.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY");
+        assertThat(credentials.provider()).isPresent().contains("InstanceProfileCredentialsProvider");
         verifyImdsCallWithToken();
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
@@ -16,39 +16,32 @@ package software.amazon.awssdk.auth.credentials;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertNotNull;
+import static software.amazon.awssdk.auth.credentials.internal.ProcessCredentialsTestUtils.copyErrorCaseProcessCredentialsScript;
+import static software.amazon.awssdk.auth.credentials.internal.ProcessCredentialsTestUtils.copyHappyCaseProcessCredentialsScript;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.time.Instant;
-import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.utils.DateUtils;
-import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Platform;
 
-public class ProcessCredentialsProviderTest {
+class ProcessCredentialsProviderTest {
 
     private static final String PROCESS_RESOURCE_PATH = "/resources/process/";
     private static final String RANDOM_SESSION_TOKEN = "RANDOM_TOKEN";
     private static String scriptLocation;
     private static String errorScriptLocation;
  
-    @BeforeClass
+    @BeforeAll
     public static void setup()  {
         scriptLocation = copyHappyCaseProcessCredentialsScript();
         errorScriptLocation = copyErrorCaseProcessCredentialsScript();
     }
  
-    @AfterClass
+    @AfterAll
     public static void teardown() {
         if (scriptLocation != null && !new File(scriptLocation).delete()) {
             throw new IllegalStateException("Failed to delete file: " + scriptLocation);
@@ -60,20 +53,21 @@ public class ProcessCredentialsProviderTest {
     }
  
     @Test
-    public void staticCredentialsCanBeLoaded() {
+    void staticCredentialsCanBeLoaded() {
         AwsCredentials credentials =
                 ProcessCredentialsProvider.builder()
                                           .command(scriptLocation + " accessKeyId secretAccessKey")
                                           .build()
                                           .resolveCredentials();
  
-        Assert.assertFalse(credentials instanceof AwsSessionCredentials);
-        Assert.assertEquals("accessKeyId", credentials.accessKeyId());
-        Assert.assertEquals("secretAccessKey", credentials.secretAccessKey());
+        assertThat(credentials).isInstanceOf(AwsBasicCredentials.class);
+        assertThat(credentials.accessKeyId()).isEqualTo("accessKeyId");
+        assertThat(credentials.secretAccessKey()).isEqualTo("secretAccessKey");
+        assertThat(credentials.provider()).isPresent().contains("ProcessCredentialsProvider");
     }
  
     @Test
-    public void sessionCredentialsCanBeLoaded() {
+    void sessionCredentialsCanBeLoaded() {
         ProcessCredentialsProvider credentialsProvider =
                 ProcessCredentialsProvider.builder()
                                           .command(scriptLocation + " accessKeyId secretAccessKey sessionToken " +
@@ -83,17 +77,17 @@ public class ProcessCredentialsProviderTest {
 
         AwsCredentials credentials = credentialsProvider.resolveCredentials();
 
-        Assert.assertTrue(credentials instanceof AwsSessionCredentials);
+        assertThat(credentials).isInstanceOf(AwsSessionCredentials.class);
 
         AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentials;
 
-        Assert.assertEquals("accessKeyId", sessionCredentials.accessKeyId());
-        Assert.assertEquals("secretAccessKey", sessionCredentials.secretAccessKey());
-        assertNotNull(sessionCredentials.sessionToken());
+        assertThat(credentials.accessKeyId()).isEqualTo("accessKeyId");
+        assertThat(credentials.secretAccessKey()).isEqualTo("secretAccessKey");
+        assertThat(sessionCredentials.sessionToken()).isNotNull();
     }
 
     @Test
-    public void resultsAreCached() {
+    void resultsAreCached() {
         ProcessCredentialsProvider credentialsProvider =
             ProcessCredentialsProvider.builder()
                                       .command(scriptLocation + " accessKeyId secretAccessKey sessionToken " +
@@ -103,11 +97,11 @@ public class ProcessCredentialsProviderTest {
         AwsCredentials request1 = credentialsProvider.resolveCredentials();
         AwsCredentials request2 = credentialsProvider.resolveCredentials();
 
-        Assert.assertEquals(request1, request2);
+        assertThat(request1).isEqualTo(request2);
     }
 
     @Test
-    public void expirationBufferOverrideIsApplied() {
+    void expirationBufferOverrideIsApplied() {
         ProcessCredentialsProvider credentialsProvider =
                 ProcessCredentialsProvider.builder()
                                           .command(String.format("%s accessKeyId secretAccessKey %s %s",
@@ -120,11 +114,11 @@ public class ProcessCredentialsProviderTest {
         AwsCredentials request1 = credentialsProvider.resolveCredentials();
         AwsCredentials request2 = credentialsProvider.resolveCredentials();
 
-        Assert.assertNotEquals(request1, request2);
+        assertThat(request1).isNotEqualTo(request2);
     }
 
     @Test
-    public void processFailed_shouldContainErrorMessage() {
+    void processFailed_shouldContainErrorMessage() {
         ProcessCredentialsProvider credentialsProvider =
             ProcessCredentialsProvider.builder()
                                       .command(errorScriptLocation)
@@ -137,7 +131,7 @@ public class ProcessCredentialsProviderTest {
     }
 
     @Test
-    public void lackOfExpirationIsCachedForever() {
+    void lackOfExpirationIsCachedForever() {
         ProcessCredentialsProvider credentialsProvider =
             ProcessCredentialsProvider.builder()
                                       .command(scriptLocation + " accessKeyId secretAccessKey sessionToken")
@@ -147,20 +141,21 @@ public class ProcessCredentialsProviderTest {
         AwsCredentials request1 = credentialsProvider.resolveCredentials();
         AwsCredentials request2 = credentialsProvider.resolveCredentials();
 
-        Assert.assertEquals(request1, request2);
+        assertThat(request1).isEqualTo(request2);
     }
  
-    @Test(expected = IllegalStateException.class)
-    public void processOutputLimitIsEnforced() {
-        ProcessCredentialsProvider.builder()
-                                  .command(scriptLocation + " accessKeyId secretAccessKey")
-                                  .processOutputLimit(1)
-                                  .build()
-                                  .resolveCredentials();
+    @Test
+    void processOutputLimitIsEnforced() {
+        ProcessCredentialsProvider credentialsProvider =
+            ProcessCredentialsProvider.builder()
+                                      .command(scriptLocation + " accessKeyId secretAccessKey")
+                                      .processOutputLimit(1)
+                                      .build();
+        assertThatThrownBy(credentialsProvider::resolveCredentials).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void processOutputLimitDefaultPassesLargeInput() {
+    void processOutputLimitDefaultPassesLargeInput() {
 
         String LONG_SESSION_TOKEN = "lYzvmByqdS1E69QQVEavDDHabQ2GuYKYABKRA4xLbAXpdnFtV030UH4" +
                 "bQoZWCDcfADFvBwBm3ixEFTYMjn5XQozpFV2QAsWHirCVcEJ5DC60KPCNBcDi4KLNJfbsp3r6kKTOmYOeqhEyiC4emDX33X2ppZsa5" +
@@ -181,60 +176,17 @@ public class ProcessCredentialsProviderTest {
 
         AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
 
-        Assertions.assertThat(sessionCredentials.accessKeyId()).isEqualTo("accessKeyId");
-        Assertions.assertThat(sessionCredentials.sessionToken()).isNotNull();
+        assertThat(sessionCredentials.accessKeyId()).isEqualTo("accessKeyId");
+        assertThat(sessionCredentials.sessionToken()).isNotNull();
     }
     
     @Test
-    public void closeDoesNotRaise() {
+    void closeDoesNotRaise() {
         ProcessCredentialsProvider credentialsProvider =
             ProcessCredentialsProvider.builder()
                                       .command(scriptLocation + " accessKeyId secretAccessKey sessionToken")
                                       .build();
         credentialsProvider.resolveCredentials();
         credentialsProvider.close();
-    }
-
-    public static String copyHappyCaseProcessCredentialsScript() {
-        String scriptClasspathFilename = Platform.isWindows() ? "windows-credentials-script.bat"
-                                                              : "linux-credentials-script.sh";
-
-        return copyProcessCredentialsScript(scriptClasspathFilename);
-    }
-
-    public static String copyErrorCaseProcessCredentialsScript() {
-        String scriptClasspathFilename = Platform.isWindows() ? "windows-credentials-error-script.bat"
-                                                              : "linux-credentials-error-script.sh";
-
-        return copyProcessCredentialsScript(scriptClasspathFilename);
-    }
-
-    public static String copyProcessCredentialsScript(String scriptClasspathFilename) {
-        String scriptClasspathLocation = PROCESS_RESOURCE_PATH + scriptClasspathFilename;
-
-        InputStream scriptInputStream = null;
-        OutputStream scriptOutputStream = null;
-
-        try {
-            scriptInputStream = ProcessCredentialsProviderTest.class.getResourceAsStream(scriptClasspathLocation);
-
-            File scriptFileOnDisk = File.createTempFile("ProcessCredentialsProviderTest", scriptClasspathFilename);
-            scriptFileOnDisk.deleteOnExit();
-
-            if (!scriptFileOnDisk.setExecutable(true)) {
-                throw new IllegalStateException("Could not make " + scriptFileOnDisk + " executable.");
-            }
-
-            scriptOutputStream = new FileOutputStream(scriptFileOnDisk);
-
-            IoUtils.copy(scriptInputStream, scriptOutputStream);
-
-            return scriptFileOnDisk.getAbsolutePath();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        } finally {
-            IoUtils.closeQuietly(scriptInputStream, null);
-            IoUtils.closeQuietly(scriptOutputStream, null);
-        }
     }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
@@ -16,31 +16,31 @@
 package software.amazon.awssdk.auth.credentials;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StaticCredentialsProviderTest {
+class StaticCredentialsProviderTest {
     @Test
-    public void getAwsCredentials_ReturnsSameCredentials() throws Exception {
+    void getAwsCredentials_ReturnsSameCredentials() {
         AwsCredentials credentials = new AwsBasicCredentials("akid", "skid");
         AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
-        assertEquals(credentials, actualCredentials);
+        assertThat(credentials).isEqualTo(actualCredentials);
         assertThat(credentials.provider()).isNotPresent();
         assertThat(actualCredentials.provider()).isPresent();
     }
 
     @Test
-    public void getSessionAwsCredentials_ReturnsSameCredentials() throws Exception {
+    void getSessionAwsCredentials_ReturnsSameCredentials() {
         AwsSessionCredentials credentials = AwsSessionCredentials.create("akid", "skid", "token");
         AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
-        assertEquals(credentials, actualCredentials);
+        assertThat(credentials).isEqualTo(actualCredentials);
         assertThat(credentials.provider()).isNotPresent();
         assertThat(actualCredentials.provider()).isPresent();
     }
 
-    @Test(expected = RuntimeException.class)
-    public void nullCredentials_ThrowsIllegalArgumentException() {
-        StaticCredentialsProvider.create(null);
+    @Test
+    void nullCredentials_ThrowsRuntimeException() {
+        assertThatThrownBy(() -> StaticCredentialsProvider.create(null)).isInstanceOf(RuntimeException.class);
     }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/SystemSettingsCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/SystemSettingsCredentialsProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+class SystemSettingsCredentialsProviderTest {
+
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    @BeforeAll
+    public static void methodSetup() {
+        System.setProperty(SdkSystemSetting.AWS_ACCESS_KEY_ID.property(), "akid1");
+        System.setProperty(SdkSystemSetting.AWS_SECRET_ACCESS_KEY.property(), "skid1");
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_ACCESS_KEY_ID.environmentVariable(), "akid2");
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_SECRET_ACCESS_KEY.environmentVariable(), "skid2");
+    }
+
+    @AfterAll
+    public static void teardown() {
+        System.clearProperty(SdkSystemSetting.AWS_ACCESS_KEY_ID.property());
+        System.clearProperty(SdkSystemSetting.AWS_SECRET_ACCESS_KEY.property());
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+    }
+
+    @Test
+    void systemPropertyCredentialsProvider_resolveCredentials_returnsCredentialsWithProvider()  {
+        AwsCredentials credentials = SystemPropertyCredentialsProvider.create().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("akid1");
+        assertThat(credentials.secretAccessKey()).isEqualTo("skid1");
+        assertThat(credentials.provider()).isPresent().contains("SystemSettingsCredentialsProvider");
+    }
+
+    @Test
+    void environmentVariableCredentialsProvider_resolveCredentials_returnsCredentialsWithProvider()  {
+        AwsCredentials credentials = EnvironmentVariableCredentialsProvider.create().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("akid2");
+        assertThat(credentials.secretAccessKey()).isEqualTo("skid2");
+        assertThat(credentials.provider()).isPresent().contains("EnvironmentVariableCredentialsProvider");
+    }
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProcessCredentialsTestUtils.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProcessCredentialsTestUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.Platform;
+
+public final class ProcessCredentialsTestUtils {
+
+    private static final String PROCESS_RESOURCE_PATH = "/resources/process/";
+
+    private ProcessCredentialsTestUtils() {
+    }
+
+    public static String copyErrorCaseProcessCredentialsScript() {
+        String scriptClasspathFilename = Platform.isWindows() ? "windows-credentials-error-script.bat"
+                                                              : "linux-credentials-error-script.sh";
+
+        return copyProcessCredentialsScript(scriptClasspathFilename);
+    }
+
+    public static String copyHappyCaseProcessCredentialsScript() {
+        String scriptClasspathFilename = Platform.isWindows() ? "windows-credentials-script.bat"
+                                                              : "linux-credentials-script.sh";
+
+        return copyProcessCredentialsScript(scriptClasspathFilename);
+    }
+
+    public static String copyProcessCredentialsScript(String scriptClasspathFilename) {
+        InputStream scriptInputStream = null;
+        OutputStream scriptOutputStream = null;
+
+        try {
+            scriptInputStream = ProcessCredentialsTestUtils.class
+                .getResourceAsStream(PROCESS_RESOURCE_PATH + scriptClasspathFilename);
+
+            File scriptFileOnDisk = File.createTempFile("ProcessCredentialsProviderTest", scriptClasspathFilename);
+            scriptFileOnDisk.deleteOnExit();
+
+            if (!scriptFileOnDisk.setExecutable(true)) {
+                throw new IllegalStateException("Could not make " + scriptFileOnDisk + " executable.");
+            }
+
+            scriptOutputStream = Files.newOutputStream(scriptFileOnDisk.toPath());
+
+            IoUtils.copy(scriptInputStream, scriptOutputStream);
+
+            return scriptFileOnDisk.getAbsolutePath();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            IoUtils.closeQuietly(scriptInputStream, null);
+            IoUtils.closeQuietly(scriptOutputStream, null);
+        }
+    }
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
@@ -17,9 +17,9 @@ package software.amazon.awssdk.auth.credentials.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.auth.credentials.internal.ProcessCredentialsTestUtils.copyHappyCaseProcessCredentialsScript;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -32,9 +32,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.auth.credentials.ProcessCredentialsProviderTest;
-import software.amazon.awssdk.core.checksums.Algorithm;
-import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileProperty;
 import software.amazon.awssdk.utils.StringInputStream;
@@ -44,7 +41,7 @@ public class ProfileCredentialsUtilsTest {
 
     @BeforeAll
     public static void setup()  {
-        scriptLocation = ProcessCredentialsProviderTest.copyHappyCaseProcessCredentialsScript();
+        scriptLocation = copyHappyCaseProcessCredentialsScript();
     }
 
     @AfterAll

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -51,6 +51,7 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
 @SdkPublicApi
 public final class SsoCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable,
                                                      ToCopyableBuilder<SsoCredentialsProvider.Builder, SsoCredentialsProvider> {
+    private static final String PROVIDER_NAME = "SsoCredentialsProvider";
 
     private static final Duration DEFAULT_STALE_TIME = Duration.ofMinutes(1);
     private static final Duration DEFAULT_PREFETCH_TIME = Duration.ofMinutes(5);
@@ -106,9 +107,12 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
         GetRoleCredentialsRequest request = getRoleCredentialsRequestSupplier.get();
         notNull(request, "GetRoleCredentialsRequest can't be null.");
         RoleCredentials roleCredentials = ssoClient.getRoleCredentials(request).roleCredentials();
-        AwsSessionCredentials sessionCredentials = AwsSessionCredentials.create(roleCredentials.accessKeyId(),
-                                                                                roleCredentials.secretAccessKey(),
-                                                                                roleCredentials.sessionToken());
+        AwsSessionCredentials sessionCredentials = AwsSessionCredentials.builder()
+                                                                        .accessKeyId(roleCredentials.accessKeyId())
+                                                                        .secretAccessKey(roleCredentials.secretAccessKey())
+                                                                        .sessionToken(roleCredentials.sessionToken())
+                                                                        .provider(PROVIDER_NAME)
+                                                                        .build();
         return new SessionCredentialsHolder(sessionCredentials, Instant.ofEpochMilli(roleCredentials.expiration()));
     }
 

--- a/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProviderTest.java
+++ b/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProviderTest.java
@@ -133,6 +133,7 @@ public class SsoCredentialsProviderTest {
                 assertThat(actualCredentials.accessKeyId()).isEqualTo("a");
                 assertThat(actualCredentials.secretAccessKey()).isEqualTo("b");
                 assertThat(actualCredentials.sessionToken()).isEqualTo("c");
+                assertThat(actualCredentials.provider()).isPresent().contains("SsoCredentialsProvider");
             }
         }
 

--- a/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/internal/OnDiskTokenManager.java
+++ b/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/internal/OnDiskTokenManager.java
@@ -118,7 +118,7 @@ public final class OnDiskTokenManager implements TokenManager<SsoOidcToken> {
             .ifPresent(tokenBuilder::registrationExpiresAt);
         node.field("region").map(JsonNode::text).ifPresent(tokenBuilder::region);
         node.field("startUrl").map(JsonNode::text).ifPresent(tokenBuilder::startUrl);
-
+        tokenBuilder.provider(SsoOidcToken.PROVIDER_NAME);
         return tokenBuilder.build();
     }
 

--- a/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcToken.java
+++ b/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcToken.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkInternalApi
 public final class SsoOidcToken implements SdkToken {
+    public static final String PROVIDER_NAME = "SsoOidcTokenProvider";
     private final String accessToken;
     private final Instant expiresAt;
     private final String refreshToken;
@@ -49,6 +50,7 @@ public final class SsoOidcToken implements SdkToken {
     private final Instant registrationExpiresAt;
     private final String region;
     private final String startUrl;
+    private final String provider;
 
     private SsoOidcToken(BuilderImpl builder) {
         Validate.paramNotNull(builder.accessToken, "accessToken");
@@ -61,6 +63,7 @@ public final class SsoOidcToken implements SdkToken {
         this.registrationExpiresAt = builder.registrationExpiresAt;
         this.region = builder.region;
         this.startUrl = builder.startUrl;
+        this.provider = builder.provider;
     }
 
     @Override
@@ -71,6 +74,11 @@ public final class SsoOidcToken implements SdkToken {
     @Override
     public Optional<Instant> expirationTime() {
         return Optional.of(expiresAt);
+    }
+
+    @Override
+    public Optional<String> provider() {
+        return Optional.of(provider);
     }
 
     public String refreshToken() {
@@ -166,6 +174,8 @@ public final class SsoOidcToken implements SdkToken {
 
         Builder startUrl(String startUrl);
 
+        Builder provider(String provider);
+
         SsoOidcToken build();
     }
 
@@ -178,6 +188,7 @@ public final class SsoOidcToken implements SdkToken {
         private Instant registrationExpiresAt;
         private String region;
         private String startUrl;
+        private String provider;
 
         @Override
         public Builder accessToken(String accessToken) {
@@ -224,6 +235,12 @@ public final class SsoOidcToken implements SdkToken {
         @Override
         public Builder startUrl(String startUrl) {
             this.startUrl = startUrl;
+            return this;
+        }
+
+        @Override
+        public Builder provider(String provider) {
+            this.provider = provider;
             return this;
         }
 

--- a/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcTokenTransformer.java
+++ b/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcTokenTransformer.java
@@ -54,6 +54,7 @@ public final class SsoOidcTokenTransformer implements TokenTransformer<SsoOidcTo
                            .region(baseToken.region())
                            .clientSecret(baseToken.clientSecret())
                            .clientId(baseToken.clientId())
+                           .provider(SsoOidcToken.PROVIDER_NAME)
                            .build();
     }
 }

--- a/services/ssooidc/src/test/java/software/amazon/awssdk/services/ssooidc/internal/OnDiskTokenManagerTest.java
+++ b/services/ssooidc/src/test/java/software/amazon/awssdk/services/ssooidc/internal/OnDiskTokenManagerTest.java
@@ -68,6 +68,7 @@ public class OnDiskTokenManagerTest {
         SsoOidcToken token = SsoOidcToken.builder()
                                          .accessToken("accesstoken")
                                          .expiresAt(expiresAt)
+                                         .provider("test")
                                          .build();
         String tokenJson = String.format("{\n"
                                          + "    \"accessToken\": \"accesstoken\",\n"
@@ -110,6 +111,7 @@ public class OnDiskTokenManagerTest {
                                          .registrationExpiresAt(registrationExpiresAt)
                                          .region("region")
                                          .startUrl("starturl")
+                                         .provider("test")
                                          .build();
 
         String ssoSession = "admin";
@@ -157,6 +159,7 @@ public class OnDiskTokenManagerTest {
                                          .registrationExpiresAt(registrationExpiresAt)
                                          .region("region")
                                          .startUrl(startUrl)
+                                         .provider("test")
                                          .build();
 
         String expectedFile = "d033e22ae348aeb5660fc2140aec35850c4da997.json";
@@ -188,6 +191,7 @@ public class OnDiskTokenManagerTest {
                                          .registrationExpiresAt(registrationExpiresAt)
                                          .region("region")
                                          .startUrl(startUrl)
+                                         .provider("test")
                                          .build();
 
         OnDiskTokenManager onDiskTokenManager = OnDiskTokenManager.create(cache, sessionName);

--- a/services/ssooidc/src/test/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcTokenProviderTest.java
+++ b/services/ssooidc/src/test/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcTokenProviderTest.java
@@ -101,7 +101,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void resolveToken_usesTokenManager() {
+    void resolveToken_usesTokenManager() {
         SsoOidcToken ssoOidcToken = SsoOidcToken.builder()
                                                 .accessToken("accesstoken")
                                                 .expiresAt(Instant.now().plus(Duration.ofDays(1)))
@@ -109,7 +109,9 @@ public class SsoOidcTokenProviderTest {
         mockTokenManager.storeToken(ssoOidcToken);
 
         SsoOidcTokenProvider tokenProvider = getDefaultSsoOidcTokenProviderBuilder().build();
-        assertThat(tokenProvider.resolveToken()).isEqualTo(ssoOidcToken);
+        SdkToken resolvedToken = tokenProvider.resolveToken();
+        assertThat(resolvedToken).isEqualTo(ssoOidcToken);
+        assertThat(resolvedToken.provider()).isPresent().contains("SsoOidcTokenProvider");
     }
 
     private SsoOidcTokenProvider.Builder getDefaultSsoOidcTokenProviderBuilder() {
@@ -117,7 +119,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void resolveToken_cachedValueNotPresent_throws() {
+    void resolveToken_cachedValueNotPresent_throws() {
 
         SsoOidcTokenProvider tokenProvider = getDefaultSsoOidcTokenProviderBuilder().build();
 
@@ -145,7 +147,7 @@ public class SsoOidcTokenProviderTest {
     //             }
     //         },
     @Test
-    public void standardTest_Valid_token_with_all_fields() {
+    void standardTest_Valid_token_with_all_fields() {
         SsoOidcToken token = getDefaultTokenBuilder()
             .expiresAt(Instant.now().plusSeconds(10000)).registrationExpiresAt(Instant.now().plusSeconds(90000))
             .build();
@@ -160,7 +162,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void refresh_returns_cached_token_when_service_calls_fails() {
+    void refresh_returns_cached_token_when_service_calls_fails() {
         SsoOidcToken nearToExpiryToken = getDefaultTokenBuilder()
             .expiresAt(Instant.now().plusSeconds(5000)).registrationExpiresAt(Instant.now().plusSeconds(10000))
             .build();
@@ -177,7 +179,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void refresh_fails_when_supplier_fails_due_to_Non_service_issues() {
+    void refresh_fails_when_supplier_fails_due_to_Non_service_issues() {
         SsoOidcToken nearToExpiryToken = getDefaultTokenBuilder()
             .expiresAt(Instant.now().minusSeconds(2)).registrationExpiresAt(Instant.now().minusSeconds(2))
             .build();
@@ -201,7 +203,7 @@ public class SsoOidcTokenProviderTest {
     //             }
     //         },
     @Test
-    public void standardTest_Minimal_valid_cached_token() {
+    void standardTest_Minimal_valid_cached_token() {
         Instant expiresAt = Instant.now().plusSeconds(3600);
         SsoOidcToken ssoOidcToken = SsoOidcToken.builder().accessToken("cachedtoken").expiresAt(expiresAt).build();
         mockTokenManager.storeToken(ssoOidcToken);
@@ -219,7 +221,7 @@ public class SsoOidcTokenProviderTest {
     //             "expectedException": "ExpiredToken"
     //         }
     @Test
-    public void standardTest_Minimal_expired_cached_token() {
+    void standardTest_Minimal_expired_cached_token() {
         String startUrl = START_URL;
         Instant expiresAt = Instant.parse("2021-12-25T13:00:00Z");
         SsoOidcToken ssoOidcToken =
@@ -247,7 +249,7 @@ public class SsoOidcTokenProviderTest {
     //             "expectedException": "InvalidToken"
     //         },
     @Test
-    public void standardTest_Token_missing_the_expiresAt_field() {
+    void standardTest_Token_missing_the_expiresAt_field() {
         SsoOidcToken ssoOidcToken = SsoOidcToken.builder()
                                                 .startUrl(START_URL)
                                                 .accessToken("cachedtoken").clientId("client").clientSecret("secret")
@@ -272,7 +274,7 @@ public class SsoOidcTokenProviderTest {
     //             "expectedException": "InvalidToken"
     //         },
     @Test
-    public void standardTest_Token_missing_the_accessToken_field() {
+    void standardTest_Token_missing_the_accessToken_field() {
         SsoOidcToken ssoOidcToken = SsoOidcToken.builder()
                                                 .startUrl(START_URL)
                                                 .accessToken("cachedtoken").clientId("client").clientSecret("secret")
@@ -290,7 +292,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void refresh_token_from_service_when_token_outside_expiry_window() {
+    void refresh_token_from_service_when_token_outside_expiry_window() {
         SsoOidcToken nearToExpiryToken = getDefaultTokenBuilder()
             .expiresAt(Instant.now().plusSeconds(59))
             .registrationExpiresAt(Instant.now().plusSeconds(59)).build();
@@ -319,7 +321,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void refresh_token_does_not_fetch_from_service_when_token_inside_expiry_window() {
+    void refresh_token_does_not_fetch_from_service_when_token_inside_expiry_window() {
         SsoOidcToken cachedDiskToken = getDefaultTokenBuilder()
             .expiresAt(Instant.now().plusSeconds(120)).registrationExpiresAt(Instant.now().plusSeconds(120))
             .build();
@@ -333,7 +335,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void token_is_obtained_from_inmemory_when_token_is_within_inmemory_stale_time() {
+    void token_is_obtained_from_inmemory_when_token_is_within_inmemory_stale_time() {
         Instant futureExpiryDate = Instant.now().plus(Duration.ofDays(1));
         SsoOidcToken cachedDiskToken = getDefaultTokenBuilder()
             .expiresAt(futureExpiryDate).registrationExpiresAt(Instant.parse("2022-12-25T11:30:00Z")).build();
@@ -354,7 +356,7 @@ public class SsoOidcTokenProviderTest {
 
     // Test to make sure cache fetches from Cached values.
     @Test
-    public void token_is_obtained_from_refresher_and_then_refresher_cache_if_its_within_stale_time() {
+    void token_is_obtained_from_refresher_and_then_refresher_cache_if_its_within_stale_time() {
         Instant closeToExpireTime = Instant.now().plus(Duration.ofMinutes(4));
         SsoOidcToken cachedDiskToken = getDefaultTokenBuilder().accessToken("fourMinutesToExpire")
                                                                .expiresAt(closeToExpireTime)
@@ -383,7 +385,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void token_is_retrieved_from_service_when_service_returns_tokens_with_short_expiration() {
+    void token_is_retrieved_from_service_when_service_returns_tokens_with_short_expiration() {
         Instant closeToExpireTime = Instant.now().plus(Duration.ofSeconds(4));
         SsoOidcToken cachedDiskToken = getDefaultTokenBuilder().accessToken("fourMinutesToExpire")
                                                                .expiresAt(closeToExpireTime)
@@ -410,7 +412,7 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void token_is_retrieved_automatically_when_prefetch_time_is_set() throws InterruptedException {
+    void token_is_retrieved_automatically_when_prefetch_time_is_set() throws InterruptedException {
         Instant closeToExpireTime = Instant.now().plus(Duration.ofMillis(3));
 
         SsoOidcToken cachedDiskToken = getDefaultTokenBuilder().accessToken("closeToExpire")
@@ -450,13 +452,13 @@ public class SsoOidcTokenProviderTest {
     }
 
     @Test
-    public void tokenProvider_throws_exception_if_client_is_null() {
+    void tokenProvider_throws_exception_if_client_is_null() {
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(
             () -> SsoOidcTokenProvider.builder().sessionName(START_URL).build()).withMessage("ssoOidcClient must not be null.");
     }
 
     @Test
-    public void tokenProvider_throws_exception_if_start_url_is_null() {
+    void tokenProvider_throws_exception_if_start_url_is_null() {
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(
             () -> SsoOidcTokenProvider.builder().ssoOidcClient(ssoOidcClient).build()).withMessage("sessionName must not be "
                                                                                                    + "null.");

--- a/services/ssooidc/src/test/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcTokenTest.java
+++ b/services/ssooidc/src/test/java/software/amazon/awssdk/services/ssooidc/internal/SsoOidcTokenTest.java
@@ -26,6 +26,7 @@ public class SsoOidcTokenTest {
     @Test
     public void equalsAndHashCode_workCorrectly() {
         EqualsVerifier.forClass(SsoOidcToken.class)
+                      .withIgnoredFields("provider")
                       .usingGetClass()
                       .verify();
     }

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
@@ -26,7 +26,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -47,6 +46,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 public final class StsAssumeRoleCredentialsProvider
     extends StsCredentialsProvider
     implements ToCopyableBuilder<StsAssumeRoleCredentialsProvider.Builder, StsAssumeRoleCredentialsProvider> {
+    private static final String PROVIDER_NAME = "StsAssumeRoleCredentialsProvider";
     private Supplier<AssumeRoleRequest> assumeRoleRequestSupplier;
 
     /**
@@ -70,17 +70,17 @@ public final class StsAssumeRoleCredentialsProvider
     protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleRequest assumeRoleRequest = assumeRoleRequestSupplier.get();
         Validate.notNull(assumeRoleRequest, "Assume role request must not be null.");
-        return toAwsSessionCredentials(stsClient.assumeRole(assumeRoleRequest).credentials());
-    }
-
-    @Override
-    public String toString() {
-        return ToString.create("StsAssumeRoleCredentialsProvider");
+        return toAwsSessionCredentials(stsClient.assumeRole(assumeRoleRequest).credentials(), PROVIDER_NAME);
     }
 
     @Override
     public Builder toBuilder() {
         return new Builder(this);
+    }
+
+    @Override
+    String providerName() {
+        return PROVIDER_NAME;
     }
 
     /**

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -26,7 +26,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
-import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -47,6 +46,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 public final class StsAssumeRoleWithSamlCredentialsProvider
     extends StsCredentialsProvider
     implements ToCopyableBuilder<StsAssumeRoleWithSamlCredentialsProvider.Builder, StsAssumeRoleWithSamlCredentialsProvider> {
+    private static final String PROVIDER_NAME = "StsAssumeRoleWithSamlCredentialsProvider";
     private final Supplier<AssumeRoleWithSamlRequest> assumeRoleWithSamlRequestSupplier;
 
 
@@ -71,12 +71,7 @@ public final class StsAssumeRoleWithSamlCredentialsProvider
     protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithSamlRequest assumeRoleWithSamlRequest = assumeRoleWithSamlRequestSupplier.get();
         Validate.notNull(assumeRoleWithSamlRequest, "Assume role with saml request must not be null.");
-        return toAwsSessionCredentials(stsClient.assumeRoleWithSAML(assumeRoleWithSamlRequest).credentials());
-    }
-
-    @Override
-    public String toString() {
-        return ToString.create("StsAssumeRoleWithSamlCredentialsProvider");
+        return toAwsSessionCredentials(stsClient.assumeRoleWithSAML(assumeRoleWithSamlRequest).credentials(), PROVIDER_NAME);
     }
 
     @Override
@@ -84,6 +79,11 @@ public final class StsAssumeRoleWithSamlCredentialsProvider
         return new Builder(this);
     }
 
+    @Override
+    String providerName() {
+        return PROVIDER_NAME;
+    }
+    
     /**
      * A builder (created by {@link StsAssumeRoleWithSamlCredentialsProvider#builder()}) for creating a
      * {@link StsAssumeRoleWithSamlCredentialsProvider}.

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
@@ -27,7 +27,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
-import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
@@ -48,6 +47,7 @@ public final class StsAssumeRoleWithWebIdentityCredentialsProvider
     extends StsCredentialsProvider
     implements ToCopyableBuilder<StsAssumeRoleWithWebIdentityCredentialsProvider.Builder,
                                  StsAssumeRoleWithWebIdentityCredentialsProvider> {
+    private static final String PROVIDER_NAME = "StsAssumeRoleWithWebIdentityCredentialsProvider";
     private final Supplier<AssumeRoleWithWebIdentityRequest> assumeRoleWithWebIdentityRequest;
 
     /**
@@ -71,12 +71,7 @@ public final class StsAssumeRoleWithWebIdentityCredentialsProvider
     protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithWebIdentityRequest request = assumeRoleWithWebIdentityRequest.get();
         notNull(request, "AssumeRoleWithWebIdentityRequest can't be null");
-        return toAwsSessionCredentials(stsClient.assumeRoleWithWebIdentity(request).credentials());
-    }
-
-    @Override
-    public String toString() {
-        return ToString.create("StsAssumeRoleWithWebIdentityCredentialsProvider");
+        return toAwsSessionCredentials(stsClient.assumeRoleWithWebIdentity(request).credentials(), PROVIDER_NAME);
     }
 
     @Override
@@ -84,6 +79,11 @@ public final class StsAssumeRoleWithWebIdentityCredentialsProvider
         return new Builder(this);
     }
 
+    @Override
+    String providerName() {
+        return PROVIDER_NAME;
+    }
+    
     /**
      * A builder (created by {@link StsAssumeRoleWithWebIdentityCredentialsProvider#builder()}) for creating a
      * {@link StsAssumeRoleWithWebIdentityCredentialsProvider}.

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -130,10 +131,17 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
         return prefetchTime;
     }
 
+    @Override
+    public String toString() {
+        return ToString.create(providerName());
+    }
+
     /**
      * Implemented by a child class to call STS and get a new set of credentials to be used by this provider.
      */
     abstract AwsSessionCredentials getUpdatedCredentials(StsClient stsClient);
+
+    abstract String providerName();
 
     /**
      * Extended by child class's builders to share configuration across credential providers.

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetFederationTokenRequest;
-import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -46,6 +45,8 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 public class StsGetFederationTokenCredentialsProvider
     extends StsCredentialsProvider
     implements ToCopyableBuilder<StsGetFederationTokenCredentialsProvider.Builder, StsGetFederationTokenCredentialsProvider> {
+    private static final String PROVIDER_NAME = "StsGetFederationTokenCredentialsProvider";
+
     private final GetFederationTokenRequest getFederationTokenRequest;
 
     /**
@@ -67,12 +68,7 @@ public class StsGetFederationTokenCredentialsProvider
 
     @Override
     protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
-        return toAwsSessionCredentials(stsClient.getFederationToken(getFederationTokenRequest).credentials());
-    }
-
-    @Override
-    public String toString() {
-        return ToString.create("StsGetFederationTokenCredentialsProvider");
+        return toAwsSessionCredentials(stsClient.getFederationToken(getFederationTokenRequest).credentials(), PROVIDER_NAME);
     }
 
     @Override
@@ -80,6 +76,11 @@ public class StsGetFederationTokenCredentialsProvider
         return new Builder(this);
     }
 
+    @Override
+    String providerName() {
+        return PROVIDER_NAME;
+    }
+    
     /**
      * A builder (created by {@link StsGetFederationTokenCredentialsProvider#builder()}) for creating a
      * {@link StsGetFederationTokenCredentialsProvider}.

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenRequest;
-import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -46,6 +45,8 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 public class StsGetSessionTokenCredentialsProvider
     extends StsCredentialsProvider
     implements ToCopyableBuilder<StsGetSessionTokenCredentialsProvider.Builder, StsGetSessionTokenCredentialsProvider> {
+    private static final String PROVIDER_NAME = "StsGetSessionTokenCredentialsProvider";
+    
     private final GetSessionTokenRequest getSessionTokenRequest;
 
     /**
@@ -67,12 +68,7 @@ public class StsGetSessionTokenCredentialsProvider
 
     @Override
     protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
-        return toAwsSessionCredentials(stsClient.getSessionToken(getSessionTokenRequest).credentials());
-    }
-
-    @Override
-    public String toString() {
-        return ToString.create("StsGetSessionTokenCredentialsProvider");
+        return toAwsSessionCredentials(stsClient.getSessionToken(getSessionTokenRequest).credentials(), PROVIDER_NAME);
     }
 
     @Override
@@ -80,6 +76,11 @@ public class StsGetSessionTokenCredentialsProvider
         return new Builder(this);
     }
 
+    @Override
+    String providerName() {
+        return PROVIDER_NAME;
+    }
+    
     /**
      * A builder (created by {@link StsGetSessionTokenCredentialsProvider#builder()}) for creating a
      * {@link StsGetSessionTokenCredentialsProvider}.

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
@@ -32,7 +32,6 @@ import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.internal.AssumeRoleWithWebIdentityRequestSupplier;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
-import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
@@ -55,6 +54,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 public final class StsWebIdentityTokenFileCredentialsProvider
     extends StsCredentialsProvider
     implements ToCopyableBuilder<StsWebIdentityTokenFileCredentialsProvider.Builder, StsWebIdentityTokenFileCredentialsProvider> {
+    private static final String PROVIDER_NAME = "StsWebIdentityTokenFileCredentialsProvider";
 
     private final AwsCredentialsProvider credentialsProvider;
     private final RuntimeException loadException;
@@ -134,15 +134,10 @@ public final class StsWebIdentityTokenFileCredentialsProvider
     }
 
     @Override
-    public String toString() {
-        return ToString.create("StsWebIdentityTokenFileCredentialsProvider");
-    }
-
-    @Override
     protected AwsSessionCredentials getUpdatedCredentials(StsClient stsClient) {
         AssumeRoleWithWebIdentityRequest request = assumeRoleWithWebIdentityRequest.get();
         notNull(request, "AssumeRoleWithWebIdentityRequest can't be null");
-        return toAwsSessionCredentials(stsClient.assumeRoleWithWebIdentity(request).credentials());
+        return toAwsSessionCredentials(stsClient.assumeRoleWithWebIdentity(request).credentials(), PROVIDER_NAME);
     }
 
     @Override
@@ -150,6 +145,11 @@ public final class StsWebIdentityTokenFileCredentialsProvider
         return new Builder(this);
     }
 
+    @Override
+    String providerName() {
+        return PROVIDER_NAME;
+    }
+    
     public static final class Builder extends BaseBuilder<Builder, StsWebIdentityTokenFileCredentialsProvider> {
         private String roleArn;
         private String roleSessionName;

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsAuthUtils.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsAuthUtils.java
@@ -24,12 +24,13 @@ public final class StsAuthUtils {
     private StsAuthUtils() {
     }
 
-    public static AwsSessionCredentials toAwsSessionCredentials(Credentials credentials) {
+    public static AwsSessionCredentials toAwsSessionCredentials(Credentials credentials, String provider) {
         return AwsSessionCredentials.builder()
                                     .accessKeyId(credentials.accessKeyId())
                                     .secretAccessKey(credentials.secretAccessKey())
                                     .sessionToken(credentials.sessionToken())
                                     .expirationTime(credentials.expiration())
+                                    .provider(provider)
                                     .build();
     }
 }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProviderTest.java
@@ -44,4 +44,9 @@ public class StsAssumeRoleCredentialsProviderTest extends StsCredentialsProvider
     protected AssumeRoleResponse callClient(StsClient client, AssumeRoleRequest request) {
         return client.assumeRole(request);
     }
+
+    @Override
+    protected String providerName() {
+        return "StsAssumeRoleCredentialsProvider";
+    }
 }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
@@ -47,4 +47,9 @@ public class StsAssumeRoleWithSamlCredentialsProviderTest
     protected AssumeRoleWithSamlResponse callClient(StsClient client, AssumeRoleWithSamlRequest request) {
         return client.assumeRoleWithSAML(request);
     }
+
+    @Override
+    protected String providerName() {
+        return "StsAssumeRoleWithSamlCredentialsProvider";
+    }
 }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProviderTest.java
@@ -46,4 +46,9 @@ public class StsAssumeRoleWithWebIdentityCredentialsProviderTest
     protected AssumeRoleWithWebIdentityResponse callClient(StsClient client, AssumeRoleWithWebIdentityRequest request) {
         return client.assumeRoleWithWebIdentity(request);
     }
+
+    @Override
+    protected String providerName() {
+        return "StsAssumeRoleWithWebIdentityCredentialsProvider";
+    }
 }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -98,6 +98,8 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
 
     protected abstract ResponseT callClient(StsClient client, RequestT request);
 
+    protected abstract String providerName();
+
     public void callClientWithCredentialsProvider(Instant credentialsExpirationDate, int numTimesInvokeCredentialsProvider, boolean overrideStaleAndPrefetchTimes) {
         Credentials credentials = Credentials.builder().accessKeyId("a").secretAccessKey("b").sessionToken("c").expiration(credentialsExpirationDate).build();
         RequestT request = getRequest();
@@ -129,6 +131,7 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
                 assertThat(providedCredentials.accessKeyId()).isEqualTo("a");
                 assertThat(providedCredentials.secretAccessKey()).isEqualTo("b");
                 assertThat(providedCredentials.sessionToken()).isEqualTo("c");
+                assertThat(providedCredentials.provider()).isPresent().contains(providerName());
             }
         }
     }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProviderTest.java
@@ -46,4 +46,9 @@ public class StsGetFederationTokenCredentialsProviderTest
     protected GetFederationTokenResponse callClient(StsClient client, GetFederationTokenRequest request) {
         return client.getFederationToken(request);
     }
+
+    @Override
+    protected String providerName() {
+        return "StsGetFederationTokenCredentialsProvider";
+    }
 }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProviderTest.java
@@ -46,4 +46,9 @@ public class StsGetSessionTokenCredentialsProviderTest
     protected GetSessionTokenResponse callClient(StsClient client, GetSessionTokenRequest request) {
         return client.getSessionToken(request);
     }
+
+    @Override
+    protected String providerName() {
+        return "StsGetSessionTokenCredentialsProvider";
+    }
 }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialsProviderBaseTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialsProviderBaseTest.java
@@ -77,6 +77,11 @@ public class StsWebIdentityTokenCredentialsProviderBaseTest
         return client.assumeRoleWithWebIdentity(request);
     }
 
+    @Override
+    protected String providerName() {
+        return "StsAssumeRoleWithWebIdentityCredentialsProvider";
+    }
+
     private String getToken(Path file) {
         try (InputStream webIdentityTokenStream = Files.newInputStream(file)) {
             return IoUtils.toUtf8String(webIdentityTokenStream);

--- a/test/auth-tests/src/it/java/software/amazon/awssdk/auth/source/UserAgentProviderTest.java
+++ b/test/auth-tests/src/it/java/software/amazon/awssdk/auth/source/UserAgentProviderTest.java
@@ -75,8 +75,8 @@ class UserAgentProviderTest {
 
     private static Stream<Arguments> credentialProviders() {
         return Stream.of(
-            Arguments.of(StaticCredentialsProvider.create(SESSION_IDENTITY), "STAT"),
-            Arguments.of(StaticCredentialsProvider.create(BASIC_IDENTITY), "STAT")
+            Arguments.of(StaticCredentialsProvider.create(SESSION_IDENTITY), "stat"),
+            Arguments.of(StaticCredentialsProvider.create(BASIC_IDENTITY), "stat")
         );
     }
 


### PR DESCRIPTION
## Motivation and Context
In previous PRs (#5008), (#5029), `Identity` got a new field, `provider`, to identify the source of the identity and later extracting this value and adding it to the user agent. 

This PR adds support for this mechanism to all public SDK identity providers except for `StaticCredentialsProvider`, which was previously modified. 

