### PR TITLE
Revert "Revert "Handle header lists in URLConnection client (#4897)" (#4960)"

### DIFF
--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -152,7 +152,7 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
     private HttpURLConnection createAndConfigureConnection(HttpExecuteRequest request) {
         SdkHttpRequest sdkHttpRequest = request.httpRequest();
         HttpURLConnection connection = connectionFactory.createConnection(sdkHttpRequest.getUri());
-        sdkHttpRequest.forEachHeader((key, values) -> values.forEach(value -> connection.setRequestProperty(key, value)));
+        setHeaders(connection, sdkHttpRequest);
 
         // connection.setRequestProperty("Transfer-Encoding", "chunked") does not work, i.e., property does not get set
         if (sdkHttpRequest.matchingHeaders("Transfer-Encoding").contains("chunked")) {
@@ -178,6 +178,13 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
                       .ifPresent(connection::setFixedLengthStreamingMode);
 
         return connection;
+    }
+
+    private void setHeaders(HttpURLConnection connection, SdkHttpRequest request) {
+        request.forEachHeader((name, values) -> {
+            String commaSeparated = String.join(",", values);
+            connection.addRequestProperty(name, commaSeparated);
+        });
     }
 
     private HttpURLConnection createDefaultConnection(URI uri, SSLSocketFactory socketFactory) {

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/HeadersListTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/HeadersListTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.urlconnection;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+
+public class HeadersListTest {
+    private static final WireMockServer WIRE_MOCK = new WireMockServer(0);
+    private static SdkHttpClient client;
+
+    @BeforeAll
+    public static void setup() {
+        WIRE_MOCK.start();
+        client = UrlConnectionHttpClient.create();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        client.close();
+        WIRE_MOCK.stop();
+    }
+
+    @Test
+    public void execute_requestHeaderHasMultipleValues_allValuesSent() throws IOException {
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(new byte[0]);
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.PUT)
+                                                           .host("localhost")
+                                                           .port(WIRE_MOCK.port())
+                                                           .protocol("http")
+                                                           .putHeader("my-header", Arrays.asList("value1", "value2"))
+                                                           .encodedPath("/test")
+                                                           .build();
+
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        client.prepareRequest(request).call();
+
+        WIRE_MOCK.verify(putRequestedFor(urlEqualTo("/test"))
+                             .withHeader("my-header", equalTo("value1,value2")));
+    }
+}


### PR DESCRIPTION
This reverts commit e715bb6c9554de9ee39a8e8c33f5c7a2626f4615.

X-ray has fixed a risk of customers double-adding the x-ray interceptor, and SQS will no longer reject requests with "invalid" x-ray trace IDs. It should be safe to re-release this URL connection fix for multi-value headers.