### PR TITLE
Use Content-Range in multipart download for totalBytes

### DIFF
--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -292,7 +292,9 @@ class GenericS3TransferManager implements S3TransferManager {
 
         TransferProgressUpdater progressUpdater = new TransferProgressUpdater(downloadRequest, null);
         progressUpdater.transferInitiated();
-        responseTransformer = progressUpdater.wrapResponseTransformer(responseTransformer);
+        responseTransformer = isS3ClientMultipartEnabled()
+                              ? progressUpdater.wrapResponseTransformerForMultipartDownload(responseTransformer)
+                              : progressUpdater.wrapResponseTransformer(responseTransformer);
         progressUpdater.registerCompletion(returnFuture);
 
         try {
@@ -335,7 +337,9 @@ class GenericS3TransferManager implements S3TransferManager {
         TransferProgressUpdater progressUpdater = new TransferProgressUpdater(downloadRequest, null);
         try {
             progressUpdater.transferInitiated();
-            responseTransformer = progressUpdater.wrapResponseTransformer(responseTransformer);
+            responseTransformer = isS3ClientMultipartEnabled()
+                                  ? progressUpdater.wrapResponseTransformerForMultipartDownload(responseTransformer)
+                                  : progressUpdater.wrapResponseTransformer(responseTransformer);
             progressUpdater.registerCompletion(returnFuture);
 
             assertNotUnsupportedArn(downloadRequest.getObjectRequest().bucket(), "download");

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParser.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParser.java
@@ -28,9 +28,12 @@ import software.amazon.awssdk.utils.StringUtils;
  * The only supported {@code <unit>} is the {@code bytes} value.
  */
 @SdkInternalApi
-public class ContentRangeParser {
+public final class ContentRangeParser {
 
     private static final Logger log = Logger.loggerFor(ContentRangeParser.class);
+
+    private ContentRangeParser() {
+    }
 
     /**
      * Parse the Content-Range to extract the total number of byte from the content. Only supports the {@code bytes} unit, any
@@ -41,7 +44,7 @@ public class ContentRangeParser {
      * @return The total number of bytes in the content range or an empty optional if the contentRange is null, empty or if the
      * total length is not a valid long.
      */
-    public OptionalLong totalBytes(String contentRange) {
+    public static OptionalLong totalBytes(String contentRange) {
         if (StringUtils.isEmpty(contentRange)) {
             return OptionalLong.empty();
         }

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParser.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParser.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal.progress;
+
+import java.util.OptionalLong;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * Parse a Content-Range header value into a total byte count. The expected format is the following: <p></p>
+ * {@code Content-Range: <unit> <range-start>-<range-end>\/<size>}<br>
+ * {@code Content-Range: <unit> <range-start>-<range-end>\/*}<br> {@code Content-Range: <unit> *\/<size>}<p></p>
+ * <p>
+ * The only supported {@code <unit>} is the {@code bytes} value.
+ */
+@SdkInternalApi
+public class ContentRangeParser {
+
+    private static final Logger log = Logger.loggerFor(ContentRangeParser.class);
+
+    /**
+     * Parse the Content-Range to extract the total number of byte from the content. Only supports the {@code bytes} unit, any
+     * other unit will result in an empty OptionalLong. If the total length in unknown, which is represented by a {@code *} symbol
+     * in the header value, an empty OptionalLong will be returned.
+     *
+     * @param contentRange the value of the Content-Range header to be parsed.
+     * @return The total number of bytes in the content range or an empty optional if the contentRange is null, empty or if the
+     * total length is not a valid long.
+     */
+    public OptionalLong totalBytes(String contentRange) {
+        if (StringUtils.isEmpty(contentRange)) {
+            return OptionalLong.empty();
+        }
+
+        String trimmed = contentRange.trim();
+        if (!trimmed.startsWith("bytes")) {
+            return OptionalLong.empty();
+        }
+
+        int lastSlash = trimmed.lastIndexOf('/');
+        if (lastSlash == -1) {
+            return OptionalLong.empty();
+        }
+
+        String totalBytes = trimmed.substring(lastSlash + 1);
+        if ("*".equals(totalBytes)) {
+            return OptionalLong.empty();
+        }
+
+        try {
+            long value = Long.parseLong(totalBytes);
+            return value > 0 ? OptionalLong.of(value) : OptionalLong.empty();
+        } catch (NumberFormatException e) {
+            log.warn(() -> "failed to parse content range", e);
+            return OptionalLong.empty();
+        }
+    }
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
@@ -143,8 +143,7 @@ public class TransferProgressUpdater {
             new BaseAsyncResponseTransformerListener() {
                 @Override
                 public void transformerOnResponse(GetObjectResponse response) {
-                    ContentRangeParser contentRangeParser = new ContentRangeParser();
-                    contentRangeParser.totalBytes(response.contentRange())
+                    ContentRangeParser.totalBytes(response.contentRange())
                         .ifPresent(totalBytes -> progress.updateAndGet(b -> b.totalBytes(totalBytes).sdkResponse(response)));
                 }
             }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParserTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParserTest.java
@@ -28,15 +28,10 @@ class ContentRangeParserTest {
 
     private ContentRangeParser parser;
 
-    @BeforeEach
-    void init() {
-        this.parser = new ContentRangeParser();
-    }
-
     @ParameterizedTest
     @MethodSource("argumentProvider")
     void testContentRangeParser(String contentRange, OptionalLong expected) {
-        assertThat(parser.totalBytes(contentRange)).isEqualTo(expected);
+        assertThat(ContentRangeParser.totalBytes(contentRange)).isEqualTo(expected);
     }
 
     static Stream<Arguments> argumentProvider() {

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParserTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/progress/ContentRangeParserTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal.progress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.OptionalLong;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ContentRangeParserTest {
+
+    private ContentRangeParser parser;
+
+    @BeforeEach
+    void init() {
+        this.parser = new ContentRangeParser();
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentProvider")
+    void testContentRangeParser(String contentRange, OptionalLong expected) {
+        assertThat(parser.totalBytes(contentRange)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> argumentProvider() {
+        return Stream.of(
+            Arguments.of(null, OptionalLong.empty()),
+            Arguments.of("", OptionalLong.empty()),
+            Arguments.of("bytes 0-0/1", OptionalLong.of(1)),
+            Arguments.of("bytes 1-2/3", OptionalLong.of(3)),
+            Arguments.of("bytes 0-23456/890890890", OptionalLong.of(890890890)),
+            Arguments.of("bytes 1023-81204/890890890", OptionalLong.of(890890890)),
+            Arguments.of("bytes 1023-81204/999999999999999999999999999999", OptionalLong.empty()),
+            Arguments.of("bytes 1023-81204/-1234", OptionalLong.empty()),
+            Arguments.of("bytes 1023-81204/not-a-number", OptionalLong.empty()),
+            Arguments.of("bytes 1-2/*", OptionalLong.empty()),
+            Arguments.of("mib 1-2/3", OptionalLong.empty()),
+            Arguments.of("mib/bla 1-2/3", OptionalLong.empty()),
+            Arguments.of("bla bla bla", OptionalLong.empty()));
+    }
+
+}


### PR DESCRIPTION
Change `TransferProgressUpdater` so it uses Content-Range header to determine the maximum number of bytes it tracks as part of the transfer progress listener.

## Motivation and Context
For downloads, `TransferProgressUpdater` was expecting the totalBytes of the whole s3 object to be the value of the `Content-Length` header, when in fact the `Content-Length` header only contains the size of the current part. This cause the value of transferred bytes to exceed to the number total byte expected as soon as a 2nd part was dowloaded.

## Modifications
Add a `ContentRangeParser` class to extract the total object size from the `Content-Range` header, following the **[MDN refgerence](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range)**. Only support `bytes` unit.

## Testing
- Added unit tests.
- Manual testing with s3 object.