### PR TITLE
allow unsigned-payload for http requests when explictly requested

### DIFF
--- a/core/auth-crt/src/main/java/software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtS3V4aSigner.java
+++ b/core/auth-crt/src/main/java/software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtS3V4aSigner.java
@@ -124,15 +124,19 @@ public final class DefaultAwsCrtS3V4aSigner implements AwsCrtS3V4aSigner {
     }
 
     private boolean shouldSignPayload(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {
+        Boolean payloadSigning =
+            executionAttributes.getAttribute(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING);
+        if (payloadSigning != null && !booleanValue(payloadSigning)) {
+            return false;
+        }
+
         if (!request.protocol().equals("https") && request.contentStreamProvider().isPresent()) {
             return true;
         }
-        boolean payloadSigning =
-            booleanValue(executionAttributes.getAttribute(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING));
         boolean chunkedEncoding =
             booleanValue(executionAttributes.getAttribute(S3SignerExecutionAttribute.ENABLE_CHUNKED_ENCODING));
 
-        return payloadSigning && chunkedEncoding;
+        return booleanValue(payloadSigning) && chunkedEncoding;
     }
 
     private void setHeaderContentLength(SdkHttpFullRequest.Builder mutableRequest, SignerChecksumParams signerChecksumParams) {

--- a/core/auth-crt/src/test/java/software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtS3V4aSignerTest.java
+++ b/core/auth-crt/src/test/java/software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtS3V4aSignerTest.java
@@ -132,6 +132,18 @@ public class DefaultAwsCrtS3V4aSignerTest {
         verifySignedChecksumPayload(signedRequest);
     }
 
+    @Test
+    public void protocol_http_does_not_trigger_payload_signing_when_explicitly_configured() {
+        SigningTestCase testCase = SignerTestUtils.createBasicHeaderSigningTestCase();
+        ExecutionAttributes executionAttributes = SignerTestUtils.buildBasicExecutionAttributes(testCase);
+        executionAttributes.putAttribute(ENABLE_PAYLOAD_SIGNING, false);
+        SdkHttpFullRequest.Builder requestBuilder = testCase.requestBuilder;
+        requestBuilder.uri(URI.create("http://demo.us-east-1.amazonaws.com"));
+
+        SdkHttpFullRequest signedRequest = s3V4aSigner.sign(requestBuilder.build(), executionAttributes);
+        verifyUnsignedPayload(signedRequest);
+    }
+
 
     @Test
     public void unsigned_payload_signing_with_trailer_checksums() {


### PR DESCRIPTION
If client explicitly configures that the request body is not signed, don't sign the body.

## Motivation and Context
Lattice does not support payload signing

https://docs.aws.amazon.com/vpc-lattice/latest/ug/sigv4-authenticated-requests.html but does support GRPC over HTTP. The java SDK for sigv4a forces payload signing when the protocol is http.

There may be other implementations of the java signer but I'm not familiar with the code enough to patch all of them.

## Modifications
modifies if we should sign payload decision when signing with DefaultAwsCrtS3V4aSigner to prioritize client configuration.

## Testing
Added a unit test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [z ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
