### PR TITLE
s3-becnhmarks - Change NoopTransformer type-param to Object

### DIFF
--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
@@ -25,11 +25,11 @@ import software.amazon.awssdk.core.async.SdkPublisher;
 /**
  * A no-op {@link AsyncResponseTransformer}
  */
-public class NoOpResponseTransformer<T> implements AsyncResponseTransformer<T, Void> {
-    private CompletableFuture<Void> future;
+public class NoOpResponseTransformer<T> implements AsyncResponseTransformer<T, Object> {
+    private CompletableFuture<Object> future;
 
     @Override
-    public CompletableFuture<Void> prepare() {
+    public CompletableFuture<Object> prepare() {
         future = new CompletableFuture<>();
         return future;
     }
@@ -50,10 +50,10 @@ public class NoOpResponseTransformer<T> implements AsyncResponseTransformer<T, V
     }
 
     static class NoOpSubscriber implements Subscriber<ByteBuffer> {
-        private final CompletableFuture<Void> future;
+        private final CompletableFuture<Object> future;
         private Subscription subscription;
 
-        NoOpSubscriber(CompletableFuture<Void> future) {
+        NoOpSubscriber(CompletableFuture<Object> future) {
             this.future = future;
         }
 
@@ -75,7 +75,7 @@ public class NoOpResponseTransformer<T> implements AsyncResponseTransformer<T, V
 
         @Override
         public void onComplete() {
-            future.complete(null);
+            future.complete(new Object());
         }
     }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
@@ -98,7 +98,7 @@ public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchma
 
     private void downloadOnceToMemory(List<Double> latencies) throws Exception {
         long start = System.currentTimeMillis();
-        AsyncResponseTransformer<GetObjectResponse, Void> responseTransformer = new NoOpResponseTransformer<>();
+        AsyncResponseTransformer<GetObjectResponse, Object> responseTransformer = new NoOpResponseTransformer<>();
         transferManager.download(DownloadRequest.builder()
                                                 .getObjectRequest(req -> req.bucket(bucket).key(key))
                                                 .responseTransformer(responseTransformer)


### PR DESCRIPTION
Transfer Manager Benchmarks that download to memory with java-based client would hang because the result of the future in `NoOpResponseTransformer` is set to null. Eventually, this null reaches the **[CompletedFileDownload constructor](https://github.com/aws/aws-sdk-java-v2/blob/cfcfb6d48a65eaae6167bbe382ee14399a9976d6/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/CompletedFileDownload.java#L36-L38)**  which assert that it must not be null. It is called from the **[generic transfer manager code path](https://github.com/aws/aws-sdk-java-v2/blob/cfcfb6d48a65eaae6167bbe382ee14399a9976d6/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java#L381-L384)**

## Motivation and Context
During java-based performance benchmarks, I notice some of the benchmarks would hang and not complete. This is the root cause of it. 

We also need to spend a little bit more time investigating how it impacts the java-based client, and if this is a bug that must be fixed in there too.

## Modifications
We now complete the future with a new Object instance.

## Testing
Ran the benchmarks with the change, they completed successfully