### PR TITLE
Add NewV1ClassToBuilder recipe

### DIFF
--- a/migration-tool/pom.xml
+++ b/migration-tool/pom.xml
@@ -89,6 +89,11 @@
             <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Used in UpgradeSdkDependenciesTest -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/NewV1ClassToBuilder.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/NewV1ClassToBuilder.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import java.util.Collections;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.migration.internal.utils.NamingUtils;
+import software.amazon.awssdk.migration.internal.utils.SdkTypeUtils;
+import software.amazon.awssdk.migration.recipe.NewV1ModelClassToV2;
+
+/**
+ * Internal recipe that converts V1 model creation to the builder pattern.
+ *
+ * @see NewV1ModelClassToV2
+ */
+@SdkInternalApi
+public class NewV1ClassToBuilder extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Transform 'new' expressions to builders";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transforms 'new' expression for V1 model objects to the equivalent builder()..build() expression in V2.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new NewV1ClassToBuilderVisitor();
+    }
+
+    // Change a new Foo() to Foo.builder().build()
+    // Any withers called on new Foo() are moved to before .build()
+    // Make any appropriate v1 -> v2 type changes
+    private static class NewV1ClassToBuilderVisitor extends JavaVisitor<ExecutionContext> {
+        // Rearrange a [...].build().with*() to [...].with*().build()
+        @Override
+        public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            method = super.visitMethodInvocation(method, executionContext).cast();
+
+            // [...].with*()
+            if (!NamingUtils.isWither(method.getSimpleName())) {
+                return method;
+            }
+
+            Expression select = method.getSelect();
+
+            if (!(select instanceof J.MethodInvocation)) {
+                return method;
+            }
+
+            // [...]
+            J.MethodInvocation selectInvoke = (J.MethodInvocation) select;
+
+            // [...] == [...].build()
+            if (!selectInvoke.getSimpleName().equals("build")) {
+                return method;
+            }
+
+            // Do the reordering
+            Expression selectInvokeSelect = selectInvoke.getSelect();
+
+            J.MethodInvocation newWith = method.withSelect(selectInvokeSelect);
+
+            return selectInvoke.withSelect(newWith);
+        }
+
+        // new Foo() -> Foo.builder().build()
+        @Override
+        public J visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
+            newClass = super.visitNewClass(newClass, executionContext).cast();
+
+            JavaType classType = newClass.getType();
+            if (!SdkTypeUtils.isV1ModelClass(classType)) {
+                return newClass;
+            }
+
+            JavaType.FullyQualified v2Type = SdkTypeUtils.asV2Type((JavaType.FullyQualified) classType);
+            JavaType.FullyQualified v2TypeBuilder = SdkTypeUtils.v2ModelBuilder(v2Type);
+
+            J.Identifier modelId = new J.Identifier(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                Collections.emptyList(),
+                v2Type.getClassName(),
+                v2Type,
+                null
+            );
+
+            J.Identifier builderMethod = new J.Identifier(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                Collections.emptyList(),
+                "builder",
+                null,
+                null
+            );
+
+            JavaType.Method methodType = new JavaType.Method(
+                null,
+                0L,
+                v2Type,
+                "builder",
+                v2TypeBuilder,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList()
+            );
+
+            J.MethodInvocation builderInvoke = new J.MethodInvocation(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                JRightPadded.build(modelId),
+                null,
+                builderMethod,
+                JContainer.empty(),
+                methodType
+
+            );
+
+            J.MethodInvocation buildInvoke = new J.MethodInvocation(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                JRightPadded.build(builderInvoke),
+                null,
+                new J.Identifier(
+                    Tree.randomId(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    Collections.emptyList(),
+                    "build",
+                    v2Type,
+                    null
+                ),
+                JContainer.empty(),
+                new JavaType.Method(
+                    null,
+                    0L,
+                    v2TypeBuilder,
+                    "build",
+                    v2Type,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList()
+                )
+            );
+
+            return buildInvoke;
+        }
+    }
+}

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/V1SetterToV2.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/V1SetterToV2.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.migration.internal.utils.NamingUtils;
+import software.amazon.awssdk.migration.internal.utils.SdkTypeUtils;
+import software.amazon.awssdk.migration.recipe.NewV1ModelClassToV2;
+
+/**
+ * Internal recipe that renames fluent V1 setters (withers), to V2 equivalents.
+ *
+ * @see NewV1ModelClassToV2
+ */
+@SdkInternalApi
+public class V1SetterToV2 extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "V1 Setter to V2";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transforms a setter on a V1 model object to the equivalent in V2.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new V1SetterToV2Visitor();
+    }
+
+    private static class V1SetterToV2Visitor extends JavaIsoVisitor<ExecutionContext> {
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            method = super.visitMethodInvocation(method, executionContext);
+
+            JavaType selectType = null;
+
+            Expression select = method.getSelect();
+            if (select != null) {
+                selectType = select.getType();
+            }
+
+            if (selectType == null) {
+                return method;
+            }
+
+            if (SdkTypeUtils.isV2ModelBuilder(selectType) && !SdkTypeUtils.isV2ModelBuilder(method.getType())) {
+                String methodName = method.getSimpleName();
+
+                if (NamingUtils.isWither(methodName)) {
+                    methodName = NamingUtils.removeWith(methodName);
+                } else if (NamingUtils.isSetter(methodName)) {
+                    methodName = NamingUtils.removeSet(methodName);
+                }
+
+                JavaType.Method mt = method.getMethodType();
+
+                if (mt != null) {
+                    mt = mt.withName(methodName)
+                           .withReturnType(selectType);
+
+                    JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(selectType);
+
+                    if (fullyQualified != null) {
+                        mt = mt.withDeclaringType(fullyQualified);
+                    }
+
+                    method = method.withName(method.getName()
+                                                   .withSimpleName(methodName)
+                                                   .withType(mt))
+                                   .withMethodType(mt);
+                }
+            }
+
+            return method;
+        }
+    }
+}

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.migration.recipe.utils;
+package software.amazon.awssdk.migration.internal.utils;
 
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkInternalApi;

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.utils;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.internal.CodegenNamingUtils;
+
+@SdkInternalApi
+public final class NamingUtils {
+    private NamingUtils() {
+    }
+
+    public static String removeWith(String name) {
+        return removePrefix(name, "with");
+    }
+
+    public static String removeSet(String name) {
+        return removePrefix(name, "set");
+    }
+
+    private static String removePrefix(String name, String prefix) {
+        if (StringUtils.isBlank(name)) {
+            return name;
+        }
+
+        if (!name.startsWith(prefix)) {
+            return name;
+        }
+
+        name = StringUtils.replaceOnce(name, prefix, "");
+
+        return StringUtils.uncapitalize(CodegenNamingUtils.pascalCase(name));
+    }
+
+    public static boolean isWither(String name) {
+        return !StringUtils.isBlank(name) && name.startsWith("with");
+    }
+
+    public static boolean isSetter(String name) {
+        return !StringUtils.isBlank(name) && name.startsWith("set");
+    }
+}

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.utils;
+
+import java.util.regex.Pattern;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * Type creation and checking utilities.
+ */
+@SdkInternalApi
+public final class SdkTypeUtils {
+    private static final Pattern V1_SERVICE_CLASS_PATTERN =
+        Pattern.compile("com\\.amazonaws\\.services\\.[a-zA-Z0-9]+\\.[a-zA-Z0-9]+");
+    private static final Pattern V1_SERVICE_MODEL_CLASS_PATTERN =
+        Pattern.compile("com\\.amazonaws\\.services\\.[a-zA-Z0-9]+\\.model\\.[a-zA-Z0-9]+");
+    private static final Pattern V2_MODEL_BUILDER_PATTERN =
+        Pattern.compile("software\\.amazon\\.awssdk\\.services\\.[a-zA-Z0-9]+\\.model\\.[a-zA-Z0-9]+\\.Builder");
+    private static final Pattern V2_MODEL_CLASS_PATTERN = Pattern.compile(
+        "software\\.amazon\\.awssdk\\.services\\.[a-zA-Z0-9]+\\.model\\..[a-zA-Z0-9]+");
+
+    private SdkTypeUtils() {
+    }
+
+    public static boolean isV1Class(JavaType type) {
+        return type != null && type.isAssignableFrom(V1_SERVICE_CLASS_PATTERN);
+    }
+
+    public static boolean isV1ModelClass(JavaType type) {
+        return type != null
+                && type instanceof JavaType.FullyQualified
+                && type.isAssignableFrom(V1_SERVICE_MODEL_CLASS_PATTERN);
+    }
+
+    public static boolean isV2ModelBuilder(JavaType type) {
+        return type != null
+                && type.isAssignableFrom(V2_MODEL_BUILDER_PATTERN);
+    }
+
+    public static boolean isV2ModelClass(JavaType type) {
+        return type != null
+                && type.isAssignableFrom(V2_MODEL_CLASS_PATTERN);
+    }
+
+    public static JavaType.FullyQualified asV2Type(JavaType.FullyQualified type) {
+        if (!isV1ModelClass(type)) {
+            throw new IllegalArgumentException(String.format("%s is not a V1 SDK model type", type));
+        }
+
+        String className = type.getClassName();
+        String packageName = type.getPackageName();
+
+        packageName = StringUtils.replaceOnce(packageName, "com.amazonaws", "software.amazon.awssdk");
+
+        return TypeUtils.asFullyQualified(JavaType.buildType(String.format("%s.%s", packageName, className)));
+    }
+
+    public static JavaType.FullyQualified v2ModelBuilder(JavaType.FullyQualified type) {
+        if (!isV2ModelClass(type)) {
+            throw new IllegalArgumentException(String.format("%s is not a V2 model class", type));
+        }
+
+        String fqcn = String.format("%s.%s", type.getFullyQualifiedName(), "Builder");
+
+        return TypeUtils.asFullyQualified(JavaType.buildType(fqcn));
+    }
+}

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/recipe/ChangeSdkType.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/recipe/ChangeSdkType.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.migration.recipe;
 
-import static software.amazon.awssdk.migration.recipe.utils.NamingConversionUtils.getV2Equivalent;
+import static software.amazon.awssdk.migration.internal.utils.NamingConversionUtils.getV2Equivalent;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/recipe/NewV1ModelClassToV2.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/recipe/NewV1ModelClassToV2.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.recipe;
+
+import java.util.Arrays;
+import java.util.List;
+import org.openrewrite.Recipe;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.migration.internal.recipe.NewV1ClassToBuilder;
+import software.amazon.awssdk.migration.internal.recipe.V1SetterToV2;
+
+/**
+ * Recipe that converts V1 model creation using {@code new} such as
+ *
+ * {@snippet :
+ *     SendMessageRequest sendMessage = new SendMessageRequest()
+ *             .withQueueUrl("url")
+ *             .withMessageBody("hello world")
+ *             .withMessageGroupId("my-group");
+ *
+ *     sqs.sendMessage(sendMessage);
+ * }
+ *
+ * to the V2 equivalent of
+ *
+ * {@snippet :
+ *     SendMessageRequest sendMessage = SendMessageRequest.builder()
+ *             .queueUrl("url")
+ *             .messageBody("hello world")
+ *             .messageGroupId("my-group").build();
+ *
+ *     sqs.sendMessage(sendMessage);
+ * }
+ */
+@SdkPublicApi
+public class NewV1ModelClassToV2 extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Change new V1 Model to Builder";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transform the creation of a V1 model class using 'new' to builder pattern.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return Arrays.asList(
+                new NewV1ClassToBuilder(),
+                new V1SetterToV2()
+        );
+    }
+}

--- a/migration-tool/src/main/resources/META-INF/rewrite/java-sdk-v1-to-v2.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/java-sdk-v1-to-v2.yml
@@ -22,4 +22,5 @@ tags:
   - sdk
 recipeList:
   - software.amazon.awssdk.UpgradeSdkDependencies
+  - software.amazon.awssdk.migration.recipe.NewV1ModelClassToV2
   - software.amazon.awssdk.migration.recipe.ChangeSdkType

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
@@ -13,11 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.migration.recipe.utils;
+package software.amazon.awssdk.migration.internal.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.migration.internal.utils.NamingConversionUtils;
 
 public class NamingConversionUtilsTest {
     @Test

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class NamingUtilsTest {
+    @Test
+    public void removeSet_startsWithSet_removed() {
+        assertThat(NamingUtils.removeSet("setFoo")).isEqualTo("foo");
+    }
+
+    @Test
+    public void removeSet_containsTwoInstances_removesOnlyFirst() {
+        assertThat(NamingUtils.removeSet("setSet")).isEqualTo("set");
+    }
+
+    @Test
+    public void removeSet_doesNotStartWithSet_unchanged() {
+        String n = "fooSet";
+        assertThat(NamingUtils.removeSet(n)).isEqualTo(n);
+    }
+
+    @Test
+    public void removeWith_startsWithSet_removed() {
+        assertThat(NamingUtils.removeWith("withFoo")).isEqualTo("foo");
+    }
+
+    @Test
+    public void removeWith_containsTwoInstances_removesOnlyFirst() {
+        assertThat(NamingUtils.removeWith("withWith")).isEqualTo("with");
+    }
+
+    @Test
+    public void removeWith_doesNotStartWithSet_unchanged() {
+        String n = "fooWith";
+        assertThat(NamingUtils.removeWith(n)).isEqualTo(n);
+    }
+
+    @Test
+    public void isSetter_startsWithSet_returnsTrue() {
+        assertThat(NamingUtils.isSetter("setFoo")).isTrue();
+    }
+
+    @Test
+    public void isSetter_doesNotStartWithSet_returnsFalse() {
+        assertThat(NamingUtils.isSetter("foo")).isFalse();
+    }
+
+    @Test
+    public void isWither_startsWithWith_returnsTrue() {
+        assertThat(NamingUtils.isWither("withFoo")).isTrue();
+    }
+
+    @Test
+    public void isWither_doesNotStartWithWith_returnsFalse() {
+        assertThat(NamingUtils.isWither("foo")).isFalse();
+    }
+
+    @Test
+    public void removeSet_null_returnsValue() {
+        assertThat(NamingUtils.removeSet(null)).isNull();
+    }
+
+    @Test
+    public void removeWith_null_returnsValue() {
+        assertThat(NamingUtils.removeWith(null)).isNull();
+    }
+
+    @Test
+    public void removeSet_empty_returnsValue() {
+        assertThat(NamingUtils.removeSet("")).isEqualTo("");
+    }
+
+    @Test
+    public void removeWith_empty_returnsValue() {
+        assertThat(NamingUtils.removeWith("")).isEqualTo("");
+    }
+}

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtilsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+public class SdkTypeUtilsTest {
+
+    @Test
+    public void isV1ModelClass_v1Request_returnsTrue() {
+        JavaType sendMessage = JavaType.buildType(SendMessageRequest.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV1ModelClass(sendMessage)).isTrue();
+    }
+
+    @Test
+    public void isV1ModelClass_v2Request_returnsFalse() {
+        JavaType sendMessage =
+            JavaType.buildType(software.amazon.awssdk.services.sqs.model.SendMessageRequest.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV1ModelClass(sendMessage)).isFalse();
+    }
+
+    @Test
+    public void isV1ModelClass_v1ServiceClass_returnsFalse() {
+        JavaType sqs = JavaType.buildType(AmazonSQS.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV1ModelClass(sqs)).isFalse();
+    }
+
+    @Test
+    public void isV1Class_v1Request_returnsFalse() {
+        JavaType sendMessage = JavaType.buildType(SendMessageRequest.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV1Class(sendMessage)).isFalse();
+    }
+
+    @Test
+    public void isV1Class_v1ServiceClass_returnsTrue() {
+        JavaType sqs = JavaType.buildType(AmazonSQS.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV1Class(sqs)).isTrue();
+    }
+
+    @Test
+    public void isV2ModelClass_v1ModelClass_returnsFalse() {
+        JavaType sendMessage = JavaType.buildType(SendMessageRequest.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV2ModelClass(sendMessage)).isFalse();
+    }
+
+    @Test
+    public void isV2ModelClass_v2Request_returnsTrue() {
+        JavaType sendMessage =
+            JavaType.buildType(software.amazon.awssdk.services.sqs.model.SendMessageRequest.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV2ModelClass(sendMessage)).isTrue();
+    }
+
+    @Test
+    public void isV2ModelBuilder_v1Request_returnsFalse() {
+        JavaType sendMessage = JavaType.buildType(SendMessageRequest.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV2ModelBuilder(sendMessage)).isFalse();
+    }
+
+    @Test
+    public void isV2ModelBuilder_v2Request_returnsFalse() {
+        JavaType sendMessage =
+            JavaType.buildType(software.amazon.awssdk.services.sqs.model.SendMessageRequest.class.getCanonicalName());
+        assertThat(SdkTypeUtils.isV2ModelBuilder(sendMessage)).isFalse();
+    }
+
+    @Test
+    public void asV2Type_convertsClassCorrectly() {
+        JavaType.FullyQualified v1Type = TypeUtils.asFullyQualified(JavaType.buildType(SendMessageRequest.class.getCanonicalName()));
+        assertThat(SdkTypeUtils.asV2Type(v1Type).getFullyQualifiedName()).isEqualTo(software.amazon.awssdk.services.sqs.model.SendMessageRequest.class.getCanonicalName());
+    }
+
+    @Test
+    public void asV2Type_typeIsNotV1_throws() {
+        JavaType.FullyQualified v2Type =
+            TypeUtils.asFullyQualified(JavaType.buildType(software.amazon.awssdk.services.sqs.model.SendMessageRequest.class.getCanonicalName()));
+
+        assertThatThrownBy(() -> SdkTypeUtils.asV2Type(v2Type))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void v2ModelBuilder_typeIsNotV2_throws() {
+        JavaType.FullyQualified v1Type =
+            TypeUtils.asFullyQualified(JavaType.buildType(SendMessageRequest.class.getCanonicalName()));
+
+        assertThatThrownBy(() -> SdkTypeUtils.v2ModelBuilder(v1Type))
+            .isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    public void v2ModelBuilder_typeIsV2_convertsClassCorrectly() {
+        JavaType.FullyQualified sendMessageRequest =
+            TypeUtils.asFullyQualified(JavaType.buildType(software.amazon.awssdk.services.sqs.model.SendMessageRequest.class.getCanonicalName()));
+
+        assertThat(SdkTypeUtils.v2ModelBuilder(sendMessageRequest).getFullyQualifiedName())
+            .isEqualTo(software.amazon.awssdk.services.sqs.model.SendMessageRequest.Builder.class.getCanonicalName());
+    }
+}

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/NewV1ModelClassToV2Test.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/NewV1ModelClassToV2Test.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.recipe;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.openrewrite.java.Java8Parser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class NewV1ModelClassToV2Test implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new NewV1ModelClassToV2());
+        spec.parser(Java8Parser.builder().classpath(
+            "aws-java-sdk-sqs",
+            "sqs",
+            "sdk-core"));
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void request_assignedToVariable_isRewritten() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.sqs.AmazonSQS;\n"
+                + "import com.amazonaws.services.sqs.model.SendMessageRequest;\n"
+                + "\n"
+                + "public class SqsExample {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonSQS sqs = null;\n"
+                + "\n"
+                + "        SendMessageRequest sendMessage = new SendMessageRequest()\n"
+                + "                .withQueueUrl(\"url\")\n"
+                + "                .withMessageBody(\"hello world\")\n"
+                + "                .withMessageGroupId(\"my-group\");\n"
+                + "\n"
+                + "        sqs.sendMessage(sendMessage);\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.sqs.AmazonSQS;\n"
+                + "import com.amazonaws.services.sqs.model.SendMessageRequest;\n"
+                + "\n"
+                + "public class SqsExample {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonSQS sqs = null;\n"
+                + "\n"
+                + "        SendMessageRequest sendMessage = SendMessageRequest.builder()\n"
+                + "                .queueUrl(\"url\")\n"
+                + "                .messageBody(\"hello world\")\n"
+                + "                .messageGroupId(\"my-group\").build();\n"
+                + "\n"
+                + "        sqs.sendMessage(sendMessage);\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    public void request_createdInline_isRewritten() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.sqs.AmazonSQS;\n"
+                + "import com.amazonaws.services.sqs.model.SendMessageRequest;\n"
+                + "\n"
+                + "public class SqsExample {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonSQS sqs = null;\n"
+                + "\n"
+                + "        sqs.sendMessage(new SendMessageRequest()\n"
+                + "                .withQueueUrl(\"url\")\n"
+                + "                .withMessageBody(\"hello world\")\n"
+                + "                .withMessageGroupId(\"my-group\"));\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.sqs.AmazonSQS;\n"
+                + "import com.amazonaws.services.sqs.model.SendMessageRequest;\n"
+                + "\n"
+                + "public class SqsExample {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonSQS sqs = null;\n"
+                + "\n"
+                + "        sqs.sendMessage(SendMessageRequest.builder()\n"
+                + "                .queueUrl(\"url\")\n"
+                + "                .messageBody(\"hello world\")\n"
+                + "                .messageGroupId(\"my-group\").build());\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    public void request_returnedFromMethod_isRewritten() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.sqs.AmazonSQS;\n"
+                + "import com.amazonaws.services.sqs.model.SendMessageRequest;\n"
+                + "\n"
+                + "public class SqsExample {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonSQS sqs = null;\n"
+                + "\n"
+                + "        sqs.sendMessage(createRequest());\n"
+                + "    }\n"
+                + "\n"
+                + "    private static SendMessageRequest createRequest() {\n"
+                + "        return new SendMessageRequest()\n"
+                + "                .withQueueUrl(\"url\")\n"
+                + "                .withMessageBody(\"hello world\")\n"
+                + "                .withMessageGroupId(\"my-group\");\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.sqs.AmazonSQS;\n"
+                + "import com.amazonaws.services.sqs.model.SendMessageRequest;\n"
+                + "\n"
+                + "public class SqsExample {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonSQS sqs = null;\n"
+                + "\n"
+                + "        sqs.sendMessage(createRequest());\n"
+                + "    }\n"
+                + "\n"
+                + "    private static SendMessageRequest createRequest() {\n"
+                + "        return SendMessageRequest.builder()\n"
+                + "                .queueUrl(\"url\")\n"
+                + "                .messageBody(\"hello world\")\n"
+                + "                .messageGroupId(\"my-group\").build();\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+}

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/NewV1ModelClassToV2Test.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/NewV1ModelClassToV2Test.java
@@ -74,6 +74,7 @@ public class NewV1ModelClassToV2Test implements RewriteTest {
     }
 
     @Test
+    @EnabledOnJre({JRE.JAVA_8})
     public void request_createdInline_isRewritten() {
         rewriteRun(
             java(
@@ -108,6 +109,7 @@ public class NewV1ModelClassToV2Test implements RewriteTest {
     }
 
     @Test
+    @EnabledOnJre({JRE.JAVA_8})
     public void request_returnedFromMethod_isRewritten() {
         rewriteRun(
             java(

--- a/test/migration-tool-tests/src/test/resources/after/src/main/java/software/amazon/awssdk/migration/tool/Application.java
+++ b/test/migration-tool-tests/src/test/resources/after/src/main/java/software/amazon/awssdk/migration/tool/Application.java
@@ -28,7 +28,10 @@ public class Application {
 
     public static void main(String... args) {
         SqsClient sqs = SqsClient.builder().build();
-        ListQueuesRequest request = new ListQueuesRequest();
+        ListQueuesRequest request = ListQueuesRequest.builder()
+            .maxResults(5)
+            .queueNamePrefix("MyQueue-")
+            .nextToken("token").build();
         ListQueuesResponse listQueuesResult = sqs.listQueues(request);
         System.out.println(listQueuesResult);
     }

--- a/test/migration-tool-tests/src/test/resources/before/src/main/java/software/amazon/awssdk/migration/tool/Application.java
+++ b/test/migration-tool-tests/src/test/resources/before/src/main/java/software/amazon/awssdk/migration/tool/Application.java
@@ -28,7 +28,10 @@ public class Application {
 
     public static void main(String... args) {
         AmazonSQS sqs = AmazonSQSClient.builder().build();
-        ListQueuesRequest request = new ListQueuesRequest();
+        ListQueuesRequest request = new ListQueuesRequest()
+            .withMaxResults(5)
+            .withQueueNamePrefix("MyQueue-")
+            .withNextToken("token");
         ListQueuesResult listQueuesResult = sqs.listQueues(request);
         System.out.println(listQueuesResult);
     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This recipe transforms the usage of a V1 request class using the `new`
keyword to using the V2 class and its builder.

This recipe migrates many common uses for making API calls using the V1
SDK:

Creating the request outside of the API call and then passing it in as a
name variable:

```
SendMessageRequest request = new SendMessage().withQueueUrl(..);

sqs.sendMessage(request);
```

or creating it inline

```
sqs.sendMessage(new SendMessageRequest().withQueueUrl(...));
```


## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
