### PR TITLE
Fix for threads hanging with forwardTransformedResultTo

### DIFF
--- a/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
@@ -167,7 +167,7 @@ public final class CompletableFutureUtils {
             DestT result = null;
             try {
                 result = function.apply(r);
-            } catch (Exception functionException) {
+            } catch (Throwable functionException) {
                 dst.completeExceptionally(functionException);
                 return;
             }

--- a/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
@@ -67,7 +67,7 @@ public final class CompletableFutureUtils {
 
     /**
      * Forward the {@code Throwable} from {@code src} to {@code dst}.
-
+     *
      * @param src The source of the {@code Throwable}.
      * @param dst The destination where the {@code Throwable} will be forwarded to.
      *
@@ -148,8 +148,9 @@ public final class CompletableFutureUtils {
     }
 
     /**
-     * Completes the {@code dst} future based on the result of the {@code src} future, synchronously,
-     * after applying the provided transformation {@link Function} if successful.
+     * Completes the {@code dst} future based on the result of the {@code src} future, synchronously, after applying the provided
+     * transformation {@link Function} if successful. If the function threw an exception, the destination
+     * future will be completed exceptionally with that exception.
      *
      * @param src The source {@link CompletableFuture}
      * @param dst The destination where the {@code Throwable} or transformed result will be forwarded to.
@@ -161,9 +162,16 @@ public final class CompletableFutureUtils {
         src.whenComplete((r, e) -> {
             if (e != null) {
                 dst.completeExceptionally(e);
-            } else {
-                dst.complete(function.apply(r));
+                return;
             }
+            DestT result = null;
+            try {
+                result = function.apply(r);
+            } catch (Exception functionException) {
+                dst.completeExceptionally(functionException);
+                return;
+            }
+            dst.complete(result);
         });
 
         return src;

--- a/utils/src/test/java/software/amazon/awssdk/utils/CompletableFutureUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/CompletableFutureUtilsTest.java
@@ -109,6 +109,18 @@ public class CompletableFutureUtilsTest {
     }
 
     @Test(timeout = 1000)
+    public void forwardTransformedResultTo_functionThrowsException_shouldCompleteExceptionally() {
+        CompletableFuture<Integer> src = new CompletableFuture<>();
+        CompletableFuture<String> dst = new CompletableFuture<>();
+
+        CompletableFutureUtils.forwardTransformedResultTo(src, dst, x -> { throw new RuntimeException("foobar"); });
+        src.complete(0);
+        assertThatThrownBy(dst::join)
+            .hasMessageContaining("foobar")
+            .hasCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test(timeout = 1000)
     public void anyFail_shouldCompleteWhenAnyFutureFails() {
         RuntimeException exception = new RuntimeException("blah");
         CompletableFuture[] completableFutures = new CompletableFuture[2];
@@ -206,4 +218,6 @@ public class CompletableFutureUtilsTest {
             .hasNoSuppressedExceptions()
             .hasNoCause()
             .isInstanceOf(CancellationException.class);
-    }}
+    }
+
+}


### PR DESCRIPTION
When using `CompletableFutureUtils.forwardTransformedResultTo` if the provided function throws an exception, it would not be catch which can prevent the destination future to be completed and hang on a `.join()` call.


## Motivation and Context
Discovered during perf testing multipart s3 async client, as one of the test returned a null value.

## Modifications
Surround the call to `Function.apply()` with a try-catch and complete the destination future with the caught exception.

## Testing
Added unit test to CompletableUtils and TransferManager
