### PR TITLE
feat(StringArrayEndpointParams) Codegen String Array Enpoint params and Auth schemes params based on end-point-rule-set.json.

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
@@ -428,13 +429,11 @@ public class EndpointRulesSpecUtils {
         if ("stringarray".equalsIgnoreCase(parameterType)) {
             Iterator<JrsValue> elementValuesIter = defaultValue.elements();
             b.add("$T.asList(", Arrays.class);
+            StringJoiner joinerStr = new StringJoiner(",");
             while (elementValuesIter.hasNext()) {
-                JrsValue v = elementValuesIter.next();
-                b.add("\"" + v.asText() + "\"");
-                if (elementValuesIter.hasNext()) {
-                    b.add(",");
-                }
+                joinerStr.add("\"" + elementValuesIter.next().asText() + "\"");
             }
+            b.add(joinerStr.toString());
             b.add(")");
         }
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RuleSetCreationSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RuleSetCreationSpec.java
@@ -119,6 +119,10 @@ public class RuleSetCreationSpec {
                                                                  CodeBlock.builder()
                                                                           .add("$S", ((JrsString) defaultValue).getValue())
                                                                           .build());
+            } else if (token == JsonToken.START_ARRAY) {
+                validateStringArrayType(model);
+                value = endpointRulesSpecUtils.valueCreationCode("stringarray",
+                                                                 buildStringArrayDefaultValue((JrsArray) defaultValue));
             } else {
                 throw new RuntimeException("Can't set default value type " + token.name());
             }
@@ -399,5 +403,29 @@ public class RuleSetCreationSpec {
         String n = String.format("%s%d", RULE_METHOD_PREFIX, ruleCounter);
         ruleCounter += 1;
         return n;
+    }
+
+    private static void validateStringArrayType(ParameterModel model) {
+        if (!"stringarray".equalsIgnoreCase(model.getType())) {
+            throw new RuntimeException(String.format("Only String array is supported but the type received is %s",
+                                                     model.getType()));
+        }
+    }
+
+    private CodeBlock buildStringArrayDefaultValue(JrsArray defaultValue) {
+        CodeBlock.Builder builder = CodeBlock.builder();
+        Iterator<JrsValue> elementValuesIter = defaultValue.elements();
+        if (elementValuesIter.hasNext()) {
+            builder.add("$T.asList(", Arrays.class);
+        }
+        while (elementValuesIter.hasNext()) {
+            JrsValue v = elementValuesIter.next();
+            builder.add("\"" + v.asText() + "\"");
+            if (elementValuesIter.hasNext()) {
+                builder.add(",");
+            }
+        }
+        builder.add(")");
+        return builder.build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/EndpointProviderSpec2.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/EndpointProviderSpec2.java
@@ -67,6 +67,8 @@ public class EndpointProviderSpec2 implements ClassSpec {
                 return RuleRuntimeTypeMirror.BOOLEAN;
             case "string":
                 return RuleRuntimeTypeMirror.STRING;
+            case "stringarray":
+                return RuleRuntimeTypeMirror.LIST_OF_STRING;
             default:
                 throw new IllegalStateException("Cannot find rule type for: " + model.getType());
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-params-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-default-params-without-allowlist.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.query.auth.scheme.internal;
 
+import java.util.Arrays;
+import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.regions.Region;
@@ -32,6 +34,10 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
     private final Boolean useDualStackEndpoint;
 
     private final Boolean useFIPSEndpoint;
+
+    private final List<String> listOfStrings;
+
+    private final List<String> defaultListOfStrings;
 
     private final String endpointId;
 
@@ -54,6 +60,8 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
         this.region = builder.region;
         this.useDualStackEndpoint = builder.useDualStackEndpoint;
         this.useFIPSEndpoint = builder.useFIPSEndpoint;
+        this.listOfStrings = builder.listOfStrings;
+        this.defaultListOfStrings = Validate.paramNotNull(builder.defaultListOfStrings, "defaultListOfStrings");
         this.endpointId = builder.endpointId;
         this.defaultTrueParam = Validate.paramNotNull(builder.defaultTrueParam, "defaultTrueParam");
         this.defaultStringParam = Validate.paramNotNull(builder.defaultStringParam, "defaultStringParam");
@@ -86,6 +94,16 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
     @Override
     public Boolean useFipsEndpoint() {
         return useFIPSEndpoint;
+    }
+
+    @Override
+    public List<String> listOfStrings() {
+        return listOfStrings;
+    }
+
+    @Override
+    public List<String> defaultListOfStrings() {
+        return defaultListOfStrings;
     }
 
     @Override
@@ -143,6 +161,10 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
 
         private Boolean useFIPSEndpoint;
 
+        private List<String> listOfStrings;
+
+        private List<String> defaultListOfStrings = Arrays.asList("item1", "item2", "item3");
+
         private String endpointId;
 
         private Boolean defaultTrueParam = true;
@@ -167,6 +189,8 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
             this.region = params.region;
             this.useDualStackEndpoint = params.useDualStackEndpoint;
             this.useFIPSEndpoint = params.useFIPSEndpoint;
+            this.listOfStrings = params.listOfStrings;
+            this.defaultListOfStrings = params.defaultListOfStrings;
             this.endpointId = params.endpointId;
             this.defaultTrueParam = params.defaultTrueParam;
             this.defaultStringParam = params.defaultStringParam;
@@ -198,6 +222,21 @@ public final class DefaultQueryAuthSchemeParams implements QueryAuthSchemeParams
         @Override
         public Builder useFipsEndpoint(Boolean useFIPSEndpoint) {
             this.useFIPSEndpoint = useFIPSEndpoint;
+            return this;
+        }
+
+        @Override
+        public Builder listOfStrings(List<String> listOfStrings) {
+            this.listOfStrings = listOfStrings;
+            return this;
+        }
+
+        @Override
+        public Builder defaultListOfStrings(List<String> defaultListOfStrings) {
+            this.defaultListOfStrings = defaultListOfStrings;
+            if (this.defaultListOfStrings == null) {
+                this.defaultListOfStrings = Arrays.asList("item1", "item2", "item3");
+            }
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-endpoint-provider-without-allowlist.java
@@ -43,6 +43,7 @@ public final class DefaultQueryAuthSchemeProvider implements QueryAuthSchemeProv
     public List<AuthSchemeOption> resolveAuthScheme(QueryAuthSchemeParams params) {
         QueryEndpointParams endpointParameters = QueryEndpointParams.builder().region(params.region())
                                                                     .useDualStackEndpoint(params.useDualStackEndpoint()).useFipsEndpoint(params.useFipsEndpoint())
+                                                                    .listOfStrings(params.listOfStrings()).defaultListOfStrings(params.defaultListOfStrings())
                                                                     .endpointId(params.endpointId()).defaultTrueParam(params.defaultTrueParam())
                                                                     .defaultStringParam(params.defaultStringParam()).deprecatedParam(params.deprecatedParam())
                                                                     .booleanContextParam(params.booleanContextParam()).stringContextParam(params.stringContextParam())

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-params-without-allowlist.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-auth-scheme-params-without-allowlist.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.query.auth.scheme;
 
+import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.regions.Region;
@@ -49,6 +50,9 @@ public interface QueryAuthSchemeParams extends ToCopyableBuilder<QueryAuthScheme
 
     Boolean useFipsEndpoint();
 
+    List<String> listOfStrings();
+
+    List<String> defaultListOfStrings();
     String endpointId();
 
     /**
@@ -89,6 +93,10 @@ public interface QueryAuthSchemeParams extends ToCopyableBuilder<QueryAuthScheme
         Builder useDualStackEndpoint(Boolean useDualStackEndpoint);
 
         Builder useFipsEndpoint(Boolean useFIPSEndpoint);
+
+        Builder listOfStrings(List<String> listOfStrings);
+
+        Builder defaultListOfStrings(List<String> defaultListOfStrings);
 
         Builder endpointId(String endpointId);
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
@@ -90,6 +90,8 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
         builder.region(endpointParams.region());
         builder.useDualStackEndpoint(endpointParams.useDualStackEndpoint());
         builder.useFipsEndpoint(endpointParams.useFipsEndpoint());
+        builder.listOfStrings(endpointParams.listOfStrings());
+        builder.defaultListOfStrings(endpointParams.defaultListOfStrings());
         builder.endpointId(endpointParams.endpointId());
         builder.defaultTrueParam(endpointParams.defaultTrueParam());
         builder.defaultStringParam(endpointParams.defaultStringParam());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
@@ -16,6 +16,18 @@
       "type": "boolean",
       "builtIn": "AWS::UseFIPS"
     },
+    "listOfStrings": {
+      "type": "StringArray",
+      "required": false
+    },
+    "defaultListOfStrings": {
+      "type": "stringarray",
+      "default": [
+        "item1",
+        "item2",
+        "item3"
+      ]
+    },
     "endpointId": {
       "type": "string"
     },

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -1,5 +1,7 @@
 package software.amazon.awssdk.services.query.endpoints;
 
+import java.util.Arrays;
+import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.regions.Region;
@@ -17,6 +19,10 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
     private final Boolean useDualStackEndpoint;
 
     private final Boolean useFIPSEndpoint;
+
+    private final List<String> listOfStrings;
+
+    private final List<String> defaultListOfStrings;
 
     private final String endpointId;
 
@@ -36,6 +42,8 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
         this.region = builder.region;
         this.useDualStackEndpoint = builder.useDualStackEndpoint;
         this.useFIPSEndpoint = builder.useFIPSEndpoint;
+        this.listOfStrings = builder.listOfStrings;
+        this.defaultListOfStrings = builder.defaultListOfStrings;
         this.endpointId = builder.endpointId;
         this.defaultTrueParam = builder.defaultTrueParam;
         this.defaultStringParam = builder.defaultStringParam;
@@ -59,6 +67,14 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
 
     public Boolean useFipsEndpoint() {
         return useFIPSEndpoint;
+    }
+
+    public List<String> listOfStrings() {
+        return listOfStrings;
+    }
+
+    public List<String> defaultListOfStrings() {
+        return defaultListOfStrings;
     }
 
     public String endpointId() {
@@ -101,6 +117,10 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
 
         Builder useFipsEndpoint(Boolean useFIPSEndpoint);
 
+        Builder listOfStrings(List<String> listOfStrings);
+
+        Builder defaultListOfStrings(List<String> defaultListOfStrings);
+
         Builder endpointId(String endpointId);
 
         Builder defaultTrueParam(Boolean defaultTrueParam);
@@ -126,6 +146,10 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
 
         private Boolean useFIPSEndpoint;
 
+        private List<String> listOfStrings;
+
+        private List<String> defaultListOfStrings = Arrays.asList("item1", "item2", "item3");
+
         private String endpointId;
 
         private Boolean defaultTrueParam = true;
@@ -147,6 +171,8 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
             this.region = builder.region;
             this.useDualStackEndpoint = builder.useDualStackEndpoint;
             this.useFIPSEndpoint = builder.useFIPSEndpoint;
+            this.listOfStrings = builder.listOfStrings;
+            this.defaultListOfStrings = builder.defaultListOfStrings;
             this.endpointId = builder.endpointId;
             this.defaultTrueParam = builder.defaultTrueParam;
             this.defaultStringParam = builder.defaultStringParam;
@@ -171,6 +197,21 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
         @Override
         public Builder useFipsEndpoint(Boolean useFIPSEndpoint) {
             this.useFIPSEndpoint = useFIPSEndpoint;
+            return this;
+        }
+
+        @Override
+        public Builder listOfStrings(List<String> listOfStrings) {
+            this.listOfStrings = listOfStrings;
+            return this;
+        }
+
+        @Override
+        public Builder defaultListOfStrings(List<String> defaultListOfStrings) {
+            this.defaultListOfStrings = defaultListOfStrings;
+            if (this.defaultListOfStrings == null) {
+                this.defaultListOfStrings = Arrays.asList("item1", "item2", "item3");
+            }
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -54,6 +54,12 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         if (params.useFipsEndpoint() != null) {
             paramsMap.put(Identifier.of("useFIPSEndpoint"), Value.fromBool(params.useFipsEndpoint()));
         }
+        if (params.listOfStrings() != null) {
+            paramsMap.put(Identifier.of("listOfStrings"), Value.fromArray(params.listOfStrings()));
+        }
+        if (params.defaultListOfStrings() != null) {
+            paramsMap.put(Identifier.of("defaultListOfStrings"), Value.fromArray(params.defaultListOfStrings()));
+        }
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
         }
@@ -339,6 +345,13 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                 .addParameter(
                                         Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
                                                 .required(false).builtIn("AWS::UseFIPS").build())
+                                .addParameter(
+                                    Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
+                                             .required(false).build())
+                                .addParameter(
+                                    Parameter.builder().name("defaultListOfStrings")
+                                             .type(ParameterType.fromValue("stringarray")).required(false)
+                                             .defaultValue(Value.fromArray(Arrays.asList("item1", "item2", "item3"))).build())
                                 .addParameter(
                                         Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
                                                 .required(false).build())

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
@@ -53,6 +53,12 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         if (params.useFipsEndpoint() != null) {
             paramsMap.put(Identifier.of("useFIPSEndpoint"), Value.fromBool(params.useFipsEndpoint()));
         }
+        if (params.listOfStrings() != null) {
+            paramsMap.put(Identifier.of("listOfStrings"), Value.fromArray(params.listOfStrings()));
+        }
+        if (params.defaultListOfStrings() != null) {
+            paramsMap.put(Identifier.of("defaultListOfStrings"), Value.fromArray(params.defaultListOfStrings()));
+        }
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
         }
@@ -338,6 +344,13 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                 .addParameter(
                                         Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
                                                 .required(false).builtIn("AWS::UseFIPS").build())
+                                .addParameter(
+                                    Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
+                                             .required(false).build())
+                                .addParameter(
+                                    Parameter.builder().name("defaultListOfStrings")
+                                             .type(ParameterType.fromValue("stringarray")).required(false)
+                                             .defaultValue(Value.fromArray(Arrays.asList("item1", "item2", "item3"))).build())
                                 .addParameter(
                                         Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
                                                 .required(false).build())


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Generate Endpoint Params and Auth Scheme Params for StringArray type of parameters in  `endpoint-rule-set.json`

## Modifications
<!--- Describe your changes in detail -->
- Added case for StringArray parameter type

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits , 
- Generated a sample S3 code as below

## Screenshots (if appropriate)

### endpoint-rule-set.json
```json
{
    "version": "1.0",
    "parameters": {
        "Bucket": {
            "required": false,
            "documentation": "The S3 bucket used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 bucket.",
            "type": "String"
        },
        "DeleteObjectKeys": {
            "required": false,
            "documentation": "Need delete object keys",
            "type": "StringArray"
        },
        "DefaultDeleteObjectKeys": {
            "required": false,
            "default": ["one", "two", "three"],
            "type": "StringArray"
        },
```

### S3EndpointParams Class
```java
@Generated("software.amazon.awssdk:codegen")
@SdkPublicApi
public final class S3EndpointParams implements ToCopyableBuilder<S3EndpointParams.Builder, S3EndpointParams> {
    private final List<String> deleteObjectKeys;

    private final List<String> defaultDeleteObjectKeys;
    private S3EndpointParams(BuilderImpl builder) {
        this.deleteObjectKeys = builder.deleteObjectKeys;
        this.defaultDeleteObjectKeys = builder.defaultDeleteObjectKeys;
    }

    public static Builder builder() {
        return new BuilderImpl();
    }


    public List<String> deleteObjectKeys() {
        return deleteObjectKeys;
    }

    public List<String> defaultDeleteObjectKeys() {
        return defaultDeleteObjectKeys;
    }


    public Builder toBuilder() {
        return new BuilderImpl(this);
    }

    public interface Builder extends CopyableBuilder<Builder, S3EndpointParams> {

        Builder deleteObjectKeys(List<String> deleteObjectKeys);

        Builder defaultDeleteObjectKeys(List<String> defaultDeleteObjectKeys);
        S3EndpointParams build();
    }

    private static class BuilderImpl implements Builder {
        private List<String> deleteObjectKeys;

        private List<String> defaultDeleteObjectKeys = Arrays.asList("one", "two", "three");

        private BuilderImpl() {
        }

        private BuilderImpl(S3EndpointParams builder) {
            this.deleteObjectKeys = builder.deleteObjectKeys;
            this.defaultDeleteObjectKeys = builder.defaultDeleteObjectKeys;
        }
        
        @Override
        public Builder deleteObjectKeys(List<String> deleteObjectKeys) {
            this.deleteObjectKeys = deleteObjectKeys;
            return this;
        }

        @Override
        public Builder defaultDeleteObjectKeys(List<String> defaultDeleteObjectKeys) {
            this.defaultDeleteObjectKeys = defaultDeleteObjectKeys;
            if (this.defaultDeleteObjectKeys == null) {
                this.defaultDeleteObjectKeys = Arrays.asList("one", "two", "three");
            }
            return this;
        }
        @Override
        public S3EndpointParams build() {
            return new S3EndpointParams(this);
        }
    }
}
```

### DefaultS3AuthSchemeParams
```java
@Generated("software.amazon.awssdk:codegen")
@SdkInternalApi
public final class DefaultS3AuthSchemeParams implements S3AuthSchemeParams, S3EndpointResolverAware {
    private final List<String> deleteObjectKeys;
    private final List<String> defaultDeleteObjectKeys;
    private DefaultS3AuthSchemeParams(Builder builder) {
        this.deleteObjectKeys = builder.deleteObjectKeys;
        this.defaultDeleteObjectKeys = Validate.paramNotNull(builder.defaultDeleteObjectKeys, "defaultDeleteObjectKeys");
    }
    public static S3AuthSchemeParams.Builder builder() {
        return new Builder();
    }
    @Override
    public List<String> deleteObjectKeys() {
        return deleteObjectKeys;
    }
    @Override
    public List<String> defaultDeleteObjectKeys() {
        return defaultDeleteObjectKeys;
    }
    @Override
    public S3AuthSchemeParams.Builder toBuilder() {
        return new Builder(this);
    }
    private static final class Builder implements S3AuthSchemeParams.Builder, S3EndpointResolverAware.Builder {
        private List<String> deleteObjectKeys;
        private List<String> defaultDeleteObjectKeys = Arrays.asList("one", "two", "three");
        Builder() {
        }
        Builder(DefaultS3AuthSchemeParams params) {
            this.deleteObjectKeys = params.deleteObjectKeys;
            this.defaultDeleteObjectKeys = params.defaultDeleteObjectKeys;
        }
        @Override
        public Builder deleteObjectKeys(List<String> deleteObjectKeys) {
            this.deleteObjectKeys = deleteObjectKeys;
            return this;
        }
        @Override
        public Builder defaultDeleteObjectKeys(List<String> defaultDeleteObjectKeys) {
            this.defaultDeleteObjectKeys = defaultDeleteObjectKeys;
            if (this.defaultDeleteObjectKeys == null) {
                this.defaultDeleteObjectKeys = Arrays.asList("one", "two", "three");
            }
            return this;
        }
        @Override
        public S3AuthSchemeParams build() {
            return new DefaultS3AuthSchemeParams(this);
        }
    }
}
```
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
