### PR TITLE
Add ADAPTIVE_V2 retry mode to support the legacy behavior

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
@@ -55,7 +55,7 @@ public final class AwsRetryStrategy {
         switch (mode) {
             case STANDARD:
                 return standardRetryStrategy();
-            case ADAPTIVE2:
+            case ADAPTIVE_V2:
                 return adaptiveRetryStrategy();
             case LEGACY:
                 return legacyRetryStrategy();

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
@@ -137,6 +137,9 @@ public final class AwsRetryStrategy {
      * @return The given builder
      */
     public static RetryStrategy.Builder<?, ?> configureStrategy(RetryStrategy.Builder<?, ?> builder) {
+        if (builder instanceof RetryPolicyAdapter.Builder) {
+            return builder;
+        }
         return builder.retryOnException(AwsRetryStrategy::retryOnAwsRetryableErrors);
     }
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.awscore.retry;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.internal.AwsErrorCode;
+import software.amazon.awssdk.core.internal.retry.RetryPolicyAdapter;
 import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.retries.AdaptiveRetryStrategy;
@@ -54,10 +55,12 @@ public final class AwsRetryStrategy {
         switch (mode) {
             case STANDARD:
                 return standardRetryStrategy();
-            case ADAPTIVE:
+            case ADAPTIVE2:
                 return adaptiveRetryStrategy();
             case LEGACY:
                 return legacyRetryStrategy();
+            case ADAPTIVE:
+                return legacyAdaptiveRetryStrategy();
             default:
                 throw new IllegalArgumentException("unknown retry mode: " + mode);
         }
@@ -83,7 +86,6 @@ public final class AwsRetryStrategy {
     public static RetryStrategy<?, ?> none() {
         return DefaultRetryStrategy.none();
     }
-
 
     /**
      * Returns a {@link StandardRetryStrategy} with AWS-specific conditions added.
@@ -121,8 +123,8 @@ public final class AwsRetryStrategy {
      * Configures a retry strategy using its builder to add AWS-specific retry exceptions.
      *
      * @param builder The builder to add the AWS-specific retry exceptions
+     * @param <T>     The type of the builder extending {@link RetryStrategy.Builder}
      * @return The given builder
-     * @param <T> The type of the builder extending {@link RetryStrategy.Builder}
      */
     public static <T extends RetryStrategy.Builder<T, ?>> T configure(T builder) {
         return builder.retryOnException(AwsRetryStrategy::retryOnAwsRetryableErrors);
@@ -145,4 +147,16 @@ public final class AwsRetryStrategy {
         }
         return false;
     }
+
+    /**
+     * Returns a {@link RetryStrategy<?, ?>} that implements the legacy {@link RetryMode#ADAPTIVE} mode.
+     *
+     * @return a {@link RetryStrategy<?, ?>} that implements the legacy {@link RetryMode#ADAPTIVE} mode.
+     */
+    private static RetryStrategy<?, ?> legacyAdaptiveRetryStrategy() {
+        return RetryPolicyAdapter.builder()
+                                 .retryPolicy(AwsRetryPolicy.forRetryMode(RetryMode.ADAPTIVE))
+                                 .build();
+    }
+
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/RetryPolicyAdapter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/RetryPolicyAdapter.java
@@ -173,7 +173,7 @@ public final class RetryPolicyAdapter implements RetryStrategy<RetryPolicyAdapte
 
         @Override
         public Builder maxAttempts(int maxAttempts) {
-            throw new UnsupportedOperationException("RetryPolicyAdapter does not support calling retryOnException");
+            throw new UnsupportedOperationException("RetryPolicyAdapter does not support calling maxAttempts");
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetryStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetryStrategy.java
@@ -57,7 +57,7 @@ public final class SdkDefaultRetryStrategy {
                 return standardRetryStrategy();
             case ADAPTIVE:
                 return legacyAdaptiveRetryStrategy();
-            case ADAPTIVE2:
+            case ADAPTIVE_V2:
                 return adaptiveRetryStrategy();
             case LEGACY:
                 return legacyRetryStrategy();
@@ -77,7 +77,7 @@ public final class SdkDefaultRetryStrategy {
             return RetryMode.STANDARD;
         }
         if (retryStrategy instanceof AdaptiveRetryStrategy) {
-            return RetryMode.ADAPTIVE2;
+            return RetryMode.ADAPTIVE_V2;
         }
         if (retryStrategy instanceof LegacyRetryStrategy) {
             return RetryMode.LEGACY;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
@@ -85,9 +85,9 @@ public enum RetryMode {
      *
      * @see RetryPolicy#isFastFailRateLimiting()
      * @deprecated As of 2.25.xx, replaced by {@link #ADAPTIVE_V2}. The ADAPTIVE implementation has a bug that prevents it
-     * from remembering its state across requests which is needed to correctly estimate its sending rate. Given that the
+     * from remembering its state across requests which is needed to correctly estimate its sending rate. Given that
      * this bug has been present since its introduction and that correct version might change the traffic patterns of the SDK we
-     * deemed too risky to fix this implementation..
+     * deemed too risky to fix this implementation.
      */
     @Deprecated
     ADAPTIVE,
@@ -95,13 +95,12 @@ public enum RetryMode {
     /**
      * Adaptive V2 retry mode builds on {@link #STANDARD} mode.
      * <p>
-     * Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate. This may be at the
+     * Adaptive retry mode qdynamically limits the rate of AWS requests to maximize success rate. This may be at the
      * expense of request latency. Adaptive V2 retry mode is not recommended when predictable latency is important.
      * <p>
-     * Adaptive V2 mode differs from {@link #ADAPTIVE} mode in the computed delays between calls, including the fist attempt
-     * that might be delayed if the algorithm considers that it's needed to increase the odds of a successful response. The
-     * previous Adaptive mode is also designed to work like so but a bug present since its introduction prevents it from
-     * preserving its internal state across requests.
+     * {@code ADAPTIVE_V2} mode differs from {@link #ADAPTIVE} mode in the computed delays between calls, including the first 
+     * attempt
+     * that might be delayed if the algorithm considers that it's needed to increase the odds of a successful response.
      * <p>
      * <b>Warning:</b> Adaptive V2 retry mode assumes that the client is working against a single resource (e.g. one
      * DynamoDB Table or one S3 Bucket). If you use a single client for multiple resources, throttling or outages

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
@@ -178,6 +178,8 @@ public enum RetryMode {
                     return Optional.of(STANDARD);
                 case "adaptive":
                     return Optional.of(ADAPTIVE);
+                case "adaptive2":
+                    return Optional.of(ADAPTIVE2);
                 default:
                     throw new IllegalStateException("Unsupported retry policy mode configured: " + string);
             }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
@@ -87,6 +87,8 @@ public enum RetryMode {
      */
     ADAPTIVE,
 
+    ADAPTIVE2,
+
     ;
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
@@ -84,10 +84,31 @@ public enum RetryMode {
      * the same client. When using adaptive retry mode, we recommend using a single client per resource.
      *
      * @see RetryPolicy#isFastFailRateLimiting()
+     * @deprecated As of 2.25.xx, replaced by {@link #ADAPTIVE_V2}. The ADAPTIVE implementation has a bug that prevents it
+     * from remembering its state across requests which is needed to correctly estimate its sending rate. Given that the
+     * this bug has been present since its introduction and that correct version might change the traffic patterns of the SDK we
+     * deemed too risky to fix this implementation..
      */
+    @Deprecated
     ADAPTIVE,
 
-    ADAPTIVE2,
+    /**
+     * Adaptive V2 retry mode builds on {@code STANDARD} mode.
+     * <p>
+     * Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate. This may be at the
+     * expense of request latency. Adaptive V2 retry mode is not recommended when predictable latency is important.
+     * <p>
+     * Adaptive V2 mode differs from {@link #ADAPTIVE} mode in the computed delays between calls, including the fist attempt
+     * that might be delayed if the algorithm considers that it's needed to increase the odds of a successful response. The
+     * previous Adaptive mode is also designed to work like so but a bug present since its introduction prevents it from
+     * preserving its internal state across requests.
+     * <p>
+     * <b>Warning:</b> Adaptive V2 retry mode assumes that the client is working against a single resource (e.g. one
+     * DynamoDB Table or one S3 Bucket). If you use a single client for multiple resources, throttling or outages
+     * associated with one resource will result in increased latency and failures when accessing all other resources via
+     * the same client. When using adaptive retry mode, we recommend using a single client per resource.
+     */
+    ADAPTIVE_V2,
 
     ;
 
@@ -179,7 +200,7 @@ public enum RetryMode {
                 case "adaptive":
                     return Optional.of(ADAPTIVE);
                 case "adaptive2":
-                    return Optional.of(ADAPTIVE2);
+                    return Optional.of(ADAPTIVE_V2);
                 default:
                     throw new IllegalStateException("Unsupported retry policy mode configured: " + string);
             }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
@@ -73,7 +73,7 @@ public enum RetryMode {
     STANDARD,
 
     /**
-     * Adaptive retry mode builds on {@code STANDARD} mode.
+     * Adaptive retry mode builds on {@link #STANDARD} mode.
      * <p>
      * Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate. This may be at the
      * expense of request latency. Adaptive retry mode is not recommended when predictable latency is important.
@@ -93,7 +93,7 @@ public enum RetryMode {
     ADAPTIVE,
 
     /**
-     * Adaptive V2 retry mode builds on {@code STANDARD} mode.
+     * Adaptive V2 retry mode builds on {@link #STANDARD} mode.
      * <p>
      * Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate. This may be at the
      * expense of request latency. Adaptive V2 retry mode is not recommended when predictable latency is important.
@@ -199,7 +199,7 @@ public enum RetryMode {
                     return Optional.of(STANDARD);
                 case "adaptive":
                     return Optional.of(ADAPTIVE);
-                case "adaptive2":
+                case "adaptive_v2":
                     return Optional.of(ADAPTIVE_V2);
                 default:
                     throw new IllegalStateException("Unsupported retry policy mode configured: " + string);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
@@ -113,10 +113,6 @@ public final class RetryPolicy implements ToCopyableBuilder<RetryPolicy.Builder,
         Validate.paramNotNull(retryMode, "The retry mode cannot be set as null. If you don't want to set the retry mode,"
                                     + " please use the other builder method without setting retry mode, and the default retry"
                                     + " mode will be used.");
-        if (retryMode == RetryMode.ADAPTIVE_V2) {
-            throw new UnsupportedOperationException("ADAPTIVE_V2 is not supported by retry policies, use a RetryStrategy "
-                                                    + "instead");
-        }
         return new BuilderImpl(retryMode);
     }
 
@@ -376,6 +372,10 @@ public final class RetryPolicy implements ToCopyableBuilder<RetryPolicy.Builder,
         private Boolean fastFailRateLimiting;
 
         private BuilderImpl(RetryMode retryMode) {
+            if (retryMode == RetryMode.ADAPTIVE_V2) {
+                throw new UnsupportedOperationException("ADAPTIVE_V2 is not supported by retry policies, use a RetryStrategy "
+                                                        + "instead");
+            }
             this.retryMode = retryMode;
             this.numRetries = SdkDefaultRetrySetting.maxAttempts(retryMode) - 1;
             this.additionalRetryConditionsAllowed = true;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
@@ -113,7 +113,7 @@ public final class RetryPolicy implements ToCopyableBuilder<RetryPolicy.Builder,
         Validate.paramNotNull(retryMode, "The retry mode cannot be set as null. If you don't want to set the retry mode,"
                                     + " please use the other builder method without setting retry mode, and the default retry"
                                     + " mode will be used.");
-        if (retryMode == RetryMode.ADAPTIVE2) {
+        if (retryMode == RetryMode.ADAPTIVE_V2) {
             throw new UnsupportedOperationException("ADAPTIVE2 is not supported by retry policies, use a RetryStrategy instead");
         }
         return new BuilderImpl(retryMode);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
@@ -114,7 +114,8 @@ public final class RetryPolicy implements ToCopyableBuilder<RetryPolicy.Builder,
                                     + " please use the other builder method without setting retry mode, and the default retry"
                                     + " mode will be used.");
         if (retryMode == RetryMode.ADAPTIVE_V2) {
-            throw new UnsupportedOperationException("ADAPTIVE2 is not supported by retry policies, use a RetryStrategy instead");
+            throw new UnsupportedOperationException("ADAPTIVE_V2 is not supported by retry policies, use a RetryStrategy "
+                                                    + "instead");
         }
         return new BuilderImpl(retryMode);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
@@ -113,6 +113,9 @@ public final class RetryPolicy implements ToCopyableBuilder<RetryPolicy.Builder,
         Validate.paramNotNull(retryMode, "The retry mode cannot be set as null. If you don't want to set the retry mode,"
                                     + " please use the other builder method without setting retry mode, and the default retry"
                                     + " mode will be used.");
+        if (retryMode == RetryMode.ADAPTIVE2) {
+            throw new UnsupportedOperationException("ADAPTIVE2 is not supported by retry policies, use a RetryStrategy instead");
+        }
         return new BuilderImpl(retryMode);
     }
 

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
@@ -88,7 +88,7 @@ class DynamoDbRetryPolicyTest {
         RetryStrategy<?, ?> retryStrategy = DynamoDbRetryPolicy.resolveRetryStrategy(sdkClientConfiguration);
         RetryMode retryMode = SdkDefaultRetryStrategy.retryMode(retryStrategy);
 
-        assertThat(retryMode).isEqualTo(RetryMode.ADAPTIVE_V2);
+        assertThat(retryMode).isEqualTo(RetryMode.ADAPTIVE);
     }
 
     @Test

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
@@ -77,7 +77,7 @@ class DynamoDbRetryPolicyTest {
     void resolve_retryModeSetWithSupplier_resolvesFromSupplier() {
         ProfileFile profileFile = ProfileFile.builder()
                                              .content(new StringInputStream("[profile default]\n"
-                                                                            + "retry_mode = adaptive"))
+                                                                            + "retry_mode = adaptive2"))
                                              .type(ProfileFile.Type.CONFIGURATION)
                                              .build();
         SdkClientConfiguration sdkClientConfiguration = SdkClientConfiguration
@@ -88,7 +88,7 @@ class DynamoDbRetryPolicyTest {
         RetryStrategy<?, ?> retryStrategy = DynamoDbRetryPolicy.resolveRetryStrategy(sdkClientConfiguration);
         RetryMode retryMode = SdkDefaultRetryStrategy.retryMode(retryStrategy);
 
-        assertThat(retryMode).isEqualTo(RetryMode.ADAPTIVE);
+        assertThat(retryMode).isEqualTo(RetryMode.ADAPTIVE2);
     }
 
     @Test

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
@@ -77,7 +77,7 @@ class DynamoDbRetryPolicyTest {
     void resolve_retryModeSetWithSupplier_resolvesFromSupplier() {
         ProfileFile profileFile = ProfileFile.builder()
                                              .content(new StringInputStream("[profile default]\n"
-                                                                            + "retry_mode = adaptive2"))
+                                                                            + "retry_mode = adaptive"))
                                              .type(ProfileFile.Type.CONFIGURATION)
                                              .build();
         SdkClientConfiguration sdkClientConfiguration = SdkClientConfiguration

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
@@ -88,7 +88,7 @@ class DynamoDbRetryPolicyTest {
         RetryStrategy<?, ?> retryStrategy = DynamoDbRetryPolicy.resolveRetryStrategy(sdkClientConfiguration);
         RetryMode retryMode = SdkDefaultRetryStrategy.retryMode(retryStrategy);
 
-        assertThat(retryMode).isEqualTo(RetryMode.ADAPTIVE2);
+        assertThat(retryMode).isEqualTo(RetryMode.ADAPTIVE_V2);
     }
 
     @Test

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/Adaptive2ModeCorrectnessTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/Adaptive2ModeCorrectnessTest.java
@@ -68,7 +68,7 @@ public class Adaptive2ModeCorrectnessTest {
         CapturingInterceptor interceptor = new CapturingInterceptor();
         ProtocolRestJsonClient client = clientBuilder()
             .overrideConfiguration(o -> o.addExecutionInterceptor(interceptor)
-                                         .retryStrategy(RetryMode.ADAPTIVE2))
+                                         .retryStrategy(RetryMode.ADAPTIVE_V2))
             .build();
 
         int totalRequests = 250;

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/Adaptive2ModeCorrectnessTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/Adaptive2ModeCorrectnessTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+
+/**
+ * Tests that the ADAPTIVE2 mode behaves as designed. The setup is an API that is rate limited, and a single client is used by
+ * multiple threads to make calls to this API. The ADAPTIVE2 mode should "adapt" its calling rate to closely match the expected
+ * rate of the API with little overhead (wasted calls).
+ *
+ * This test might be brittle depending on the hardware is run-on. If proven so we should
+ * remove it or tweak the expected assertions.
+ */
+public class Adaptive2ModeCorrectnessTest {
+    private WireMockServer wireMock;
+    private AtomicInteger successful;
+    private AtomicInteger failed;
+
+    @Test
+    public void adaptive2RetryModeBehavesCorrectly() throws InterruptedException {
+        stubResponse();
+        ExecutorService executor = Executors.newFixedThreadPool(20);
+        CapturingInterceptor interceptor = new CapturingInterceptor();
+        ProtocolRestJsonClient client = clientBuilder()
+            .overrideConfiguration(o -> o.addExecutionInterceptor(interceptor)
+                                         .retryStrategy(RetryMode.ADAPTIVE2))
+            .build();
+
+        int totalRequests = 250;
+        for (int i = 0; i < totalRequests; ++i) {
+            executor.execute(callAllTypes(client));
+        }
+        executor.shutdown();
+        assertThat(executor.awaitTermination(120, TimeUnit.SECONDS)).isTrue();
+        double perceivedAvailability = ((double) successful.get() / totalRequests) * 100;
+        double overhead = ((double) interceptor.attemptsCount.get() / totalRequests) * 100 - 100;
+        assertThat(perceivedAvailability).isCloseTo(100.0, withinPercentage(20.0));
+        assertThat(overhead).isCloseTo(10.0, withinPercentage(100.0));
+    }
+
+    private Runnable callAllTypes(ProtocolRestJsonClient client) {
+        return () -> {
+            try {
+                client.allTypes();
+                successful.incrementAndGet();
+            } catch (SdkException e) {
+                failed.incrementAndGet();
+            }
+        };
+    }
+
+    private ProtocolRestJsonClientBuilder clientBuilder() {
+        return ProtocolRestJsonClient
+            .builder()
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                             "skid")))
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create("http://localhost:" + wireMock.port()));
+    }
+
+    @Before
+    public void setup() {
+        successful = new AtomicInteger(0);
+        failed = new AtomicInteger(0);
+        wireMock = new WireMockServer(wireMockConfig()
+                                          .extensions(RateLimiterResponseTransformer.class));
+        wireMock.start();
+    }
+
+    @After
+    public void tearDown() {
+        wireMock.stop();
+    }
+
+    private void stubResponse() {
+        wireMock.stubFor(post(anyUrl())
+                             .willReturn(aResponse()
+                                             .withTransformers("rate-limiter-transformer")));
+    }
+
+    public static class RateLimiterResponseTransformer extends ResponseTransformer {
+        private final RateLimiter rateLimiter = new RateLimiter();
+
+        @Override
+        public String getName() {
+            return "rate-limiter-transformer";
+        }
+
+        @Override
+        public Response transform(Request request, Response response, FileSource files, Parameters parameters) {
+            if (rateLimiter.allowRequest()) {
+                return Response.Builder.like(response)
+                                       .but().body("{}")
+                                       .status(200)
+                                       .build();
+            }
+            return Response.Builder.like(response)
+                                   .but().body("{}")
+                                   .status(429)
+                                   .build();
+        }
+    }
+
+    static class RateLimiter {
+        private final long capacity;
+        private final long refillRate;
+        private final AtomicLong tokens;
+        private long lastRefillTimestamp;
+
+        public RateLimiter() {
+            this.capacity = 50;
+            this.refillRate = 50;
+            this.tokens = new AtomicLong(capacity);
+            this.lastRefillTimestamp = System.currentTimeMillis();
+        }
+
+        public synchronized boolean allowRequest() {
+            int tokensRequested = 1;
+            refillTokens();
+            long currentTokens = tokens.get();
+            if (currentTokens >= tokensRequested) {
+                tokens.getAndAdd(-tokensRequested);
+                return true;
+            }
+            return false;
+        }
+
+        private void refillTokens() {
+            long now = System.currentTimeMillis();
+            long elapsed = now - lastRefillTimestamp;
+            long refillAmount = elapsed * refillRate / 1000;
+            tokens.set(Math.min(capacity, tokens.get() + refillAmount));
+            lastRefillTimestamp = now;
+        }
+    }
+
+    static class CapturingInterceptor implements ExecutionInterceptor {
+        private AtomicInteger attemptsCount = new AtomicInteger();
+
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            attemptsCount.incrementAndGet();
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/AsyncRetrySetupTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/AsyncRetrySetupTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+public class AsyncRetrySetupTest extends BaseRetrySetupTest<ProtocolRestJsonAsyncClient, ProtocolRestJsonAsyncClientBuilder> {
+    @Override
+    protected ProtocolRestJsonAsyncClientBuilder newClientBuilder() {
+        return ProtocolRestJsonAsyncClient.builder();
+    }
+
+    @Override
+    protected AllTypesResponse callAllTypes(ProtocolRestJsonAsyncClient client, List<SdkPlugin> requestPlugins) {
+        try {
+            return client.allTypes(r -> r.overrideConfiguration(c -> {
+                for (SdkPlugin plugin : requestPlugins) {
+                    c.addPlugin(plugin);
+                }
+            })).join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+
+            throw e;
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
@@ -184,7 +184,7 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
     private static int expectedCount(RetryMode mode) {
         switch (mode) {
             case ADAPTIVE:
-            case ADAPTIVE2:
+            case ADAPTIVE_V2:
             case STANDARD:
                 return 3;
             case LEGACY:
@@ -239,7 +239,7 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
 
         // Retry policies only support the legacy ADAPTIVE mode.
         if (scenario.retryImplementation() == RetryImplementation.POLICY
-            && scenario.mode() == RetryMode.ADAPTIVE2) {
+            && scenario.mode() == RetryMode.ADAPTIVE_V2) {
             return false;
         }
 
@@ -284,7 +284,7 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
                            .expectedClass(RetryPolicyAdapter.class)
                            .build()
             , RetryScenario.builder()
-                           .mode(RetryMode.ADAPTIVE2)
+                           .mode(RetryMode.ADAPTIVE_V2)
                            .retryImplementation(RetryImplementation.STRATEGY)
                            .expectedClass(AdaptiveRetryStrategy.class)
                            .build()

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
@@ -166,8 +166,6 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
     private void setupScenarioBefore(RetryScenario scenario) {
         if (scenario.setup() == RetryModeSetup.SYSTEM_PROPERTY_USING_MODE) {
             System.setProperty("aws.retryMode", scenario.mode().name().toLowerCase(Locale.ROOT));
-        } else {
-            System.setProperty("aws.retryMode", "");
         }
     }
 
@@ -178,6 +176,7 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
 
     @AfterEach
     private void afterEach() {
+        System.clearProperty("aws.retryMode");
         wireMock.stop();
     }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.SdkServiceClientConfiguration;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.internal.retry.RetryPolicyAdapter;
+import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.AdaptiveRetryStrategy;
+import software.amazon.awssdk.retries.LegacyRetryStrategy;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+import software.amazon.awssdk.utils.StringInputStream;
+
+public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuilder<BuilderT, ClientT>> {
+
+    protected WireMockServer wireMock = new WireMockServer(0);
+
+    protected abstract BuilderT newClientBuilder();
+
+    protected abstract AllTypesResponse callAllTypes(ClientT client, List<SdkPlugin> requestPlugins);
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("allScenarios")
+    public void testAllScenarios(RetryScenario scenario) {
+        stubThrottlingResponse();
+        setupScenarioBefore(scenario);
+        ClientT client = setupClientBuilder(scenario).build();
+        List<SdkPlugin> requestPlugins = setupRequestPlugins(scenario);
+        assertThatThrownBy(() -> callAllTypes(client, requestPlugins))
+            .isInstanceOf(SdkException.class);
+        verifyRequestCount(expectedCount(scenario.mode()));
+    }
+
+    private BuilderT setupClientBuilder(RetryScenario scenario) {
+        BuilderT builder = clientBuilder();
+        RetryImplementation kind = scenario.retryImplementation();
+        if (kind == RetryImplementation.POLICY) {
+            setupRetryPolicy(builder, scenario);
+        } else if (kind == RetryImplementation.STRATEGY) {
+            setupRetryStrategy(builder, scenario);
+        } else {
+            throw new IllegalArgumentException();
+        }
+        return builder;
+    }
+
+    private void setupRetryPolicy(BuilderT builder, RetryScenario scenario) {
+        RetryMode mode = scenario.mode();
+        RetryModeSetup setup = scenario.setup();
+        switch (setup) {
+            case PROFILE_USING_MODE:
+                setupProfile(builder, scenario.mode());
+                break;
+            case CLIENT_OVERRIDE_USING_MODE:
+                builder.overrideConfiguration(o -> o.retryPolicy(mode));
+                break;
+            case CLIENT_OVERRIDE_USING_INSTANCE:
+                builder.overrideConfiguration(o -> o.retryPolicy(AwsRetryPolicy.forRetryMode(mode)));
+                break;
+            case CLIENT_PLUGIN_OVERRIDE_USING_INSTANCE:
+            case CLIENT_PLUGIN_OVERRIDE_USING_MODE:
+                builder.addPlugin(new ConfigureRetryScenario(scenario));
+                break;
+        }
+    }
+
+    private void setupRetryStrategy(BuilderT builder, RetryScenario scenario) {
+        RetryMode mode = scenario.mode();
+        // Note, we don't setup the request level plugins, those need to be added at request time and not when we build the
+        // client.
+        switch (scenario.setup()) {
+            case PROFILE_USING_MODE:
+                setupProfile(builder, scenario.mode());
+                break;
+            case CLIENT_OVERRIDE_USING_MODE:
+                builder.overrideConfiguration(o -> o.retryStrategy(mode));
+                break;
+            case CLIENT_OVERRIDE_USING_INSTANCE:
+                builder.overrideConfiguration(o -> o.retryStrategy(AwsRetryStrategy.forRetryMode(mode)));
+                break;
+            case CLIENT_PLUGIN_OVERRIDE_USING_INSTANCE:
+            case CLIENT_PLUGIN_OVERRIDE_USING_MODE:
+                builder.addPlugin(new ConfigureRetryScenario(scenario));
+                break;
+        }
+    }
+
+    private void setupProfile(BuilderT builder, RetryMode mode) {
+        String modeName = mode.toString().toLowerCase(Locale.ROOT);
+        ProfileFile profileFile = ProfileFile.builder()
+                                             .content(new StringInputStream("[profile retry_test]\n" +
+                                                                            "retry_mode = " + modeName))
+                                             .type(ProfileFile.Type.CONFIGURATION)
+                                             .build();
+        builder.overrideConfiguration(o -> o.defaultProfileFile(profileFile)
+                                            .defaultProfileName("retry_test")).build();
+
+    }
+
+    private List<SdkPlugin> setupRequestPlugins(RetryScenario scenario) {
+        List<SdkPlugin> plugins = new ArrayList<>();
+        RetryModeSetup setup = scenario.setup();
+        if (setup == RetryModeSetup.REQUEST_PLUGIN_OVERRIDE_USING_MODE
+            || setup == RetryModeSetup.REQUEST_PLUGIN_OVERRIDE_USING_INSTANCE) {
+            plugins.add(new ConfigureRetryScenario(scenario));
+        }
+        // Plugin to validate the scenarios, must go after plugin to the configure the retry
+        // scenario.
+        plugins.add(new ValidateRetryScenario(scenario));
+        return plugins;
+    }
+
+    private BuilderT clientBuilder() {
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+        return newClientBuilder().credentialsProvider(credentialsProvider)
+                                 .region(Region.US_EAST_1)
+                                 .endpointOverride(URI.create("http://localhost:" + wireMock.port()));
+    }
+
+    private void setupScenarioBefore(RetryScenario scenario) {
+        if (scenario.setup() == RetryModeSetup.SYSTEM_PROPERTY_USING_MODE) {
+            System.setProperty("aws.retryMode", scenario.mode().name().toLowerCase(Locale.ROOT));
+        } else {
+            System.setProperty("aws.retryMode", "");
+        }
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        wireMock.start();
+    }
+
+    @AfterEach
+    private void afterEach() {
+        wireMock.stop();
+    }
+
+    private static int expectedCount(RetryMode mode) {
+        switch (mode) {
+            case ADAPTIVE:
+            case ADAPTIVE2:
+            case STANDARD:
+                return 3;
+            case LEGACY:
+                return 4;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private void verifyRequestCount(int count) {
+        wireMock.verify(count, anyRequestedFor(anyUrl()));
+    }
+
+    private void stubThrottlingResponse() {
+        wireMock.stubFor(post(anyUrl())
+                             .willReturn(aResponse().withStatus(429)));
+    }
+
+    /**
+     * For each base scenario we add each possible setup of the retry mode.
+     */
+    private static List<RetryScenario> allScenarios() {
+        List<RetryScenario> result = new ArrayList<>();
+        for (RetryScenario scenario : baseScenarios()) {
+            for (RetryModeSetup setupMode : RetryModeSetup.values()) {
+                RetryScenario newScenario = scenario.toBuilder().setup(setupMode).build();
+                if (isSupportedScenario(newScenario)) {
+                    result.add(newScenario);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Not all scenarios are supported, this methods filter those that are not.
+     */
+    private static boolean isSupportedScenario(RetryScenario scenario) {
+        // Profile now only returns strategies, not policies, except for ADAPTIVE mode for which an adapter
+        // is used. That case is tested using RetryImplementation.STRATEGY.
+        if (scenario.retryImplementation() == RetryImplementation.POLICY
+            && scenario.setup() == RetryModeSetup.PROFILE_USING_MODE) {
+            return false;
+        }
+
+        // Using system properties  only returns strategies, not policies, except for ADAPTIVE mode for
+        // which an adapter is used. That case is tested using RetryImplementation.STRATEGY.
+        if (scenario.retryImplementation() == RetryImplementation.POLICY
+            && scenario.setup() == RetryModeSetup.SYSTEM_PROPERTY_USING_MODE) {
+            return false;
+        }
+
+        // Retry policies only support the legacy ADAPTIVE mode.
+        if (scenario.retryImplementation() == RetryImplementation.POLICY
+            && scenario.mode() == RetryMode.ADAPTIVE2) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Base retry scenarios.
+     */
+    private static List<RetryScenario> baseScenarios() {
+        return Arrays.asList(
+            // Retry Policy
+            RetryScenario.builder()
+                         .mode(RetryMode.LEGACY)
+                         .retryImplementation(RetryImplementation.POLICY)
+                         .expectedClass(RetryPolicy.class)
+                         .build()
+            , RetryScenario.builder()
+                           .mode(RetryMode.STANDARD)
+                           .retryImplementation(RetryImplementation.POLICY)
+                           .expectedClass(RetryPolicy.class)
+                           .build()
+            , RetryScenario.builder()
+                           .mode(RetryMode.ADAPTIVE)
+                           .retryImplementation(RetryImplementation.POLICY)
+                           .expectedClass(RetryPolicy.class)
+                           .build()
+            // Retry Strategy
+            , RetryScenario.builder()
+                           .mode(RetryMode.LEGACY)
+                           .retryImplementation(RetryImplementation.STRATEGY)
+                           .expectedClass(LegacyRetryStrategy.class)
+                           .build()
+            , RetryScenario.builder()
+                           .mode(RetryMode.STANDARD)
+                           .retryImplementation(RetryImplementation.STRATEGY)
+                           .expectedClass(StandardRetryStrategy.class)
+                           .build()
+            , RetryScenario.builder()
+                           .mode(RetryMode.ADAPTIVE)
+                           .retryImplementation(RetryImplementation.STRATEGY)
+                           .expectedClass(RetryPolicyAdapter.class)
+                           .build()
+            , RetryScenario.builder()
+                           .mode(RetryMode.ADAPTIVE2)
+                           .retryImplementation(RetryImplementation.STRATEGY)
+                           .expectedClass(AdaptiveRetryStrategy.class)
+                           .build()
+        );
+    }
+
+    static class RetryScenario {
+        private final RetryMode mode;
+        private final Class<?> expectedClass;
+        private final RetryModeSetup setup;
+        private final RetryImplementation retryImplementation;
+
+        RetryScenario(Builder builder) {
+            this.mode = builder.mode;
+            this.expectedClass = builder.expectedClass;
+            this.setup = builder.setup;
+            this.retryImplementation = builder.retryImplementation;
+        }
+
+        public RetryMode mode() {
+            return mode;
+        }
+
+        public Class<?> expectedClass() {
+            return expectedClass;
+        }
+
+        public RetryModeSetup setup() {
+            return setup;
+        }
+
+        public RetryImplementation retryImplementation() {
+            return retryImplementation;
+        }
+
+        public Builder toBuilder() {
+            return new Builder(this);
+        }
+
+        @Override
+        public String toString() {
+            return mode + " " + retryImplementation + " " + setup;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        static class Builder {
+            private RetryMode mode;
+            private Class<?> expectedClass;
+            private RetryModeSetup setup;
+            private RetryImplementation retryImplementation;
+
+            public Builder() {
+            }
+
+            public Builder(RetryScenario retrySetup) {
+                this.mode = retrySetup.mode;
+                this.expectedClass = retrySetup.expectedClass;
+                this.setup = retrySetup.setup;
+                this.retryImplementation = retrySetup.retryImplementation;
+            }
+
+            public Builder mode(RetryMode mode) {
+                this.mode = mode;
+                return this;
+            }
+
+            public Builder expectedClass(Class<?> expectedClass) {
+                this.expectedClass = expectedClass;
+                return this;
+            }
+
+            public Builder setup(RetryModeSetup setup) {
+                this.setup = setup;
+                return this;
+            }
+
+            public Builder retryImplementation(RetryImplementation retryImplementation) {
+                this.retryImplementation = retryImplementation;
+                return this;
+            }
+
+            public RetryScenario build() {
+                return new RetryScenario(this);
+            }
+        }
+    }
+
+    enum RetryModeSetup {
+        CLIENT_OVERRIDE_USING_MODE,
+        CLIENT_OVERRIDE_USING_INSTANCE,
+        CLIENT_PLUGIN_OVERRIDE_USING_MODE,
+        CLIENT_PLUGIN_OVERRIDE_USING_INSTANCE,
+        REQUEST_PLUGIN_OVERRIDE_USING_MODE,
+        REQUEST_PLUGIN_OVERRIDE_USING_INSTANCE,
+        PROFILE_USING_MODE,
+        SYSTEM_PROPERTY_USING_MODE,
+    }
+
+    enum RetryImplementation {
+        POLICY, STRATEGY
+    }
+
+    static class ConfigureRetryScenario implements SdkPlugin {
+        private RetryScenario scenario;
+
+        ConfigureRetryScenario(RetryScenario scenario) {
+            this.scenario = scenario;
+        }
+
+        @Override
+        public void configureClient(SdkServiceClientConfiguration.Builder config) {
+            RetryModeSetup setup = scenario.setup();
+            if (setup == RetryModeSetup.CLIENT_PLUGIN_OVERRIDE_USING_MODE
+                || setup == RetryModeSetup.REQUEST_PLUGIN_OVERRIDE_USING_MODE) {
+                if (scenario.retryImplementation() == RetryImplementation.POLICY) {
+                    config.overrideConfiguration(o -> o.retryPolicy(scenario.mode()));
+                } else if (scenario.retryImplementation() == RetryImplementation.STRATEGY) {
+                    config.overrideConfiguration(o -> o.retryStrategy(scenario.mode()));
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            } else if (setup == RetryModeSetup.CLIENT_PLUGIN_OVERRIDE_USING_INSTANCE
+                       || setup == RetryModeSetup.REQUEST_PLUGIN_OVERRIDE_USING_INSTANCE) {
+                if (scenario.retryImplementation() == RetryImplementation.POLICY) {
+                    config.overrideConfiguration(o -> o.retryPolicy(AwsRetryPolicy.forRetryMode(scenario.mode())));
+                } else if (scenario.retryImplementation() == RetryImplementation.STRATEGY) {
+                    config.overrideConfiguration(o -> o.retryStrategy(AwsRetryStrategy.forRetryMode(scenario.mode())));
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
+        }
+    }
+
+    static class ValidateRetryScenario implements SdkPlugin {
+        private RetryScenario scenario;
+
+        public ValidateRetryScenario(RetryScenario scenario) {
+            this.scenario = scenario;
+        }
+
+        @Override
+        public void configureClient(SdkServiceClientConfiguration.Builder config) {
+            if (scenario.retryImplementation() == RetryImplementation.POLICY) {
+                assertThat(config.overrideConfiguration().retryPolicy()).isNotEmpty();
+                RetryPolicy policy = config.overrideConfiguration().retryPolicy().get();
+                assertThat(policy.retryMode()).isEqualTo(scenario.mode());
+                assertThat(policy).isInstanceOf(scenario.expectedClass());
+            } else if (scenario.retryImplementation() == RetryImplementation.STRATEGY) {
+                assertThat(config.overrideConfiguration().retryPolicy()).isEmpty();
+                assertThat(config.overrideConfiguration().retryStrategy()).isNotEmpty();
+                RetryStrategy<?, ?> strategy = config.overrideConfiguration().retryStrategy().get();
+                assertThat(SdkDefaultRetryStrategy.retryMode(strategy)).isEqualTo(scenario.mode());
+                assertThat(strategy).isInstanceOf(scenario.expectedClass());
+            }
+        }
+    }
+
+    public static class CapturingInterceptor implements ExecutionInterceptor {
+        private Context.BeforeTransmission context;
+        private ExecutionAttributes executionAttributes;
+
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            this.context = context;
+            this.executionAttributes = executionAttributes;
+            throw new RuntimeException("boom!");
+        }
+
+        public ExecutionAttributes executionAttributes() {
+            return executionAttributes;
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/SyncRetrySetupTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/SyncRetrySetupTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import java.util.List;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+public class SyncRetrySetupTest extends BaseRetrySetupTest<ProtocolRestJsonClient, ProtocolRestJsonClientBuilder> {
+    @Override
+    protected ProtocolRestJsonClientBuilder newClientBuilder() {
+        return ProtocolRestJsonClient.builder();
+    }
+
+    @Override
+    protected AllTypesResponse callAllTypes(ProtocolRestJsonClient client, List<SdkPlugin> requestPlugins) {
+        return client.allTypes(r -> r.overrideConfiguration(c -> {
+            for (SdkPlugin plugin : requestPlugins) {
+                c.addPlugin(plugin);
+            }
+        }));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This change is aimed to prevent breaking existing users of the legacy adaptive mode while introducing the means needed for new users to onboard and use the correct adaptive implementation.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->


## Modifications
<!--- Describe your changes in detail -->

This change introduces a new `RetryMode` constant, `ADAPTIVE_V2` and uses the legacy `ADAPTIVE` retry policy by adapting it to a retry strategy using the existing adapter when the `ADAPTIVE` mode is requested, either by using `AwsRetryStrategy.forRetryMode(RetryMode.ADAPTIVE)` call, or by setting the `retry_mode=adaptive` value in the profile file or by using the `aws.retryMode=ADAPTIVE` system setting.

Customers that need or want the *correct* adaptive mode will need to use instead `RetryMode.ADAPTIVE_V2`. This will reduce the risk of breaking customers that are using the legacy mode.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests to validate that all the current ways of configuring the retry logic in the SDK will create the expected and correct instance that implements the desired logic.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
