### PR TITLE
Support Customization string array endpoint params for S3 access grants, until all SDKs add support for string array.

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -167,8 +167,19 @@ public class IntermediateModelBuilder {
         setSimpleMethods(trimmedModel);
 
         namingStrategy.validateCustomerVisibleNaming(trimmedModel);
-
+        customizeEndpointParameters(fullModel, endpointRuleSet);
         return trimmedModel;
+    }
+
+    private void customizeEndpointParameters(IntermediateModel fullModel, EndpointRuleSetModel endpointRuleSet) {
+        if (fullModel.getCustomizationConfig().getEndpointParameters() != null) {
+            fullModel.getCustomizationConfig().getEndpointParameters().keySet().forEach(key -> {
+                if (endpointRuleSet.getParameters().containsKey(key)) {
+                    throw new IllegalStateException("Duplicate parameters found in customizationConfig");
+                }
+            });
+            fullModel.getCustomizationConfig().getEndpointParameters().forEach(endpointRuleSet.getParameters()::put);
+        }
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.model.service.ClientContextParam;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.traits.PayloadTrait;
@@ -317,6 +318,12 @@ public class CustomizationConfig {
      * TODO(multi-auth): full multi-auth support is not implemented
      */
     private boolean useMultiAuth;
+
+    /**
+     * Special case for a service where model changes for endpoint params were not updated .
+     * This should be removed once the service updates its models
+     */
+    private Map<String, ParameterModel> endpointParameters;
 
     private CustomizationConfig() {
     }
@@ -842,5 +849,13 @@ public class CustomizationConfig {
 
     public boolean useMultiAuth() {
         return useMultiAuth;
+    }
+
+    public Map<String, ParameterModel> getEndpointParameters() {
+        return endpointParameters;
+    }
+
+    public void setEndpointParameters(Map<String, ParameterModel> endpointParameters) {
+        this.endpointParameters = endpointParameters;
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -175,6 +175,30 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel queryServiceModelWithSpecialCustomization(String specialCustomization) {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/query/service-2.json").getFile());
+        File customizationModel =
+            new File(ClientTestModels.class.getResource("client/c2j/query/"+  specialCustomization).getFile());
+
+
+        File waitersModel = new File(ClientTestModels.class.getResource("client/c2j/query/waiters-2.json").getFile());
+        File endpointRuleSetModel =
+            new File(ClientTestModels.class.getResource("client/c2j/query/endpoint-rule-set.json").getFile());
+        File endpointTestsModel =
+            new File(ClientTestModels.class.getResource("client/c2j/query/endpoint-tests.json").getFile());
+
+        C2jModels models = C2jModels
+            .builder()
+            .serviceModel(getServiceModel(serviceModel))
+            .customizationConfig(getCustomizationConfig(customizationModel))
+            .waitersModel(getWaiters(waitersModel))
+            .endpointRuleSetModel(getEndpointRuleSet(endpointRuleSetModel))
+            .endpointTestSuiteModel(getEndpointTestSuite(endpointTestsModel))
+            .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     public static IntermediateModel granularAuthProvidersServiceModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/fine-grained-auth/service-2.json").getFile());
         File customizationModel =

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderInterfaceSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderInterfaceSpecTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.codegen.poet.rules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
@@ -33,5 +34,13 @@ public class EndpointProviderInterfaceSpecTest {
     public void endpointParameters() {
         ClassSpec endpointParametersClassSpec = new EndpointParametersClassSpec(ClientTestModels.queryServiceModels());
         assertThat(endpointParametersClassSpec, generatesTo("endpoint-parameters.java"));
+    }
+
+    @Test
+    public void endpointParametersWithDuplicatesInCustomizationConfig() {
+        assertThatIllegalStateException()
+            .isThrownBy(() -> new EndpointParametersClassSpec(
+                ClientTestModels.queryServiceModelWithSpecialCustomization("customization-with-duplicate-endpointparameter.config")))
+            .withMessageContaining("Duplicate parameters found in customizationConfig");
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization-with-duplicate-endpointparameter.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization-with-duplicate-endpointparameter.config
@@ -1,0 +1,9 @@
+{
+  "endpointParameters": {
+        "endpointId": {
+            "required": false,
+            "documentation": "Test to make sure exceptiion is thrown when there is already a paramater defined in model.",
+            "type": "String"
+            }
+        }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization-with-duplicate-endpointparameter.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization-with-duplicate-endpointparameter.config
@@ -2,7 +2,7 @@
   "endpointParameters": {
         "endpointId": {
             "required": false,
-            "documentation": "Test to make sure exceptiion is thrown when there is already a paramater defined in model.",
+            "documentation": "Test to make sure exception is thrown when there is already a paramater defined in model.",
             "type": "String"
             }
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/customization.config
@@ -4,5 +4,12 @@
     },
   "skipEndpointTests": {
         "test case 4": "Does not work"
+  },
+  "endpointParameters": {
+    "CustomEndpointArray": {
+      "required": false,
+      "documentation": "Parameter from the customization config",
+      "type": "StringArray"
+    }
   }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -43,6 +43,7 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
 
     private final String operationContextParam;
 
+    private final List<String> customEndpointArray;
     private QueryEndpointParams(BuilderImpl builder) {
         this.region = builder.region;
         this.useDualStackEndpoint = builder.useDualStackEndpoint;
@@ -58,6 +59,7 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
         this.booleanContextParam = builder.booleanContextParam;
         this.stringContextParam = builder.stringContextParam;
         this.operationContextParam = builder.operationContextParam;
+        this.customEndpointArray = builder.customEndpointArray;
     }
 
     public static Builder builder() {
@@ -121,6 +123,10 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
         return operationContextParam;
     }
 
+    public List<String> customEndpointArray() {
+        return customEndpointArray;
+    }
+
     public Builder toBuilder() {
         return new BuilderImpl(this);
     }
@@ -155,6 +161,8 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
 
         Builder operationContextParam(String operationContextParam);
 
+        Builder customEndpointArray(List<String> customEndpointArray);
+
         QueryEndpointParams build();
     }
 
@@ -172,6 +180,7 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
         private List<String> listOfStrings;
 
         private List<String> defaultListOfStrings = Arrays.asList("item1", "item2", "item3");
+
         private String endpointId;
 
         private Boolean defaultTrueParam = true;
@@ -185,6 +194,8 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
         private String stringContextParam;
 
         private String operationContextParam;
+
+        private List<String> customEndpointArray;
 
         private BuilderImpl() {
         }
@@ -204,6 +215,8 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
             this.booleanContextParam = builder.booleanContextParam;
             this.stringContextParam = builder.stringContextParam;
             this.operationContextParam = builder.operationContextParam;
+            this.customEndpointArray = builder.customEndpointArray;
+
         }
 
         @Override
@@ -297,6 +310,12 @@ public final class QueryEndpointParams implements ToCopyableBuilder<QueryEndpoin
         @Override
         public Builder operationContextParam(String operationContextParam) {
             this.operationContextParam = operationContextParam;
+            return this;
+        }
+
+        @Override
+        public Builder customEndpointArray(List<String> customEndpointArray) {
+            this.customEndpointArray = customEndpointArray;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -60,14 +60,12 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         if (params.awsAccountIdEndpointMode() != null) {
             paramsMap.put(Identifier.of("awsAccountIdEndpointMode"), Value.fromStr(params.awsAccountIdEndpointMode()));
         }
-
         if (params.listOfStrings() != null) {
             paramsMap.put(Identifier.of("listOfStrings"), Value.fromArray(params.listOfStrings()));
         }
         if (params.defaultListOfStrings() != null) {
             paramsMap.put(Identifier.of("defaultListOfStrings"), Value.fromArray(params.defaultListOfStrings()));
         }
-
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
         }
@@ -88,6 +86,9 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         }
         if (params.operationContextParam() != null) {
             paramsMap.put(Identifier.of("operationContextParam"), Value.fromStr(params.operationContextParam()));
+        }
+        if (params.customEndpointArray() != null) {
+            paramsMap.put(Identifier.of("CustomEndpointArray"), Value.fromArray(params.customEndpointArray()));
         }
         return paramsMap;
     }
@@ -388,8 +389,13 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                         Parameter.builder().name("stringContextParam").type(ParameterType.fromValue("string"))
                                                 .required(false).build())
                                 .addParameter(
-                                        Parameter.builder().name("operationContextParam").type(ParameterType.fromValue("string"))
-                                                .required(false).build()).build()).addRule(endpointRule_0()).build();
+                                    Parameter.builder().name("operationContextParam").type(ParameterType.fromValue("string"))
+                                             .required(false).build())
+                                .addParameter(
+                                    Parameter.builder().name("CustomEndpointArray")
+                                             .type(ParameterType.fromValue("StringArray")).required(false)
+                                             .documentation("Parameter from the customization config").build()).build())
+                .addRule(endpointRule_0()).build();
     }
 
     @Override


### PR DESCRIPTION
Support Customization string array endpoint params for S3 access grants, until all SDKs add support for string array.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- S3 Access will not do model changes until StringArray is supported for all the SDKs.
- Thus we need to add Customization for S3

## Modifications
<!--- Describe your changes in detail -->
- Customization Config classes .

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
