### PR TITLE
Add ConstructorToFluent recipe

### DIFF
--- a/migration-tool/pom.xml
+++ b/migration-tool/pom.xml
@@ -67,6 +67,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <scope>test</scope>
+            <version>1.12.472</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-maven</artifactId>
             <scope>compile</scope>
@@ -87,6 +99,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluent.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluent.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public class ConstructorToFluent extends Recipe {
+    private final String clzzFqcn;
+    private final List<String> parameterTypes;
+    private final List<String> fluentNames;
+
+    @JsonCreator
+    public ConstructorToFluent(@JsonProperty("clzzFqcn") String clzzFqcn,
+                               @JsonProperty("parameterTypes") List<String> parameterTypes,
+                               @JsonProperty("fluentNames") List<String> fluentNames) {
+        this.clzzFqcn = clzzFqcn;
+        this.parameterTypes = parameterTypes;
+        this.fluentNames = fluentNames;
+
+        if (fluentNames.size() != parameterTypes.size()) {
+            throw new IllegalArgumentException("parameterTypes and fluentNames must be the same length.");
+        }
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Moves constructor arguments to fluent setters";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A recipe that takes constructor arguments and moves them to the specified fluent setters on the object.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        List<JavaType.FullyQualified> paramJavaTypes = parameterTypes.stream()
+            .map(JavaType::buildType)
+            .map(TypeUtils::asFullyQualified)
+            .collect(Collectors.toList());
+        return new Visitor(clzzFqcn, paramJavaTypes, fluentNames);
+    }
+
+    private static class Visitor extends JavaVisitor<ExecutionContext> {
+        private final JavaType.FullyQualified clzz;
+        private final List<JavaType.FullyQualified> parameterTypes;
+        private final List<String> fluentNames;
+
+        Visitor(String clzz, List<JavaType.FullyQualified> parameterTypes, List<String> fluentNames) {
+            this.clzz = TypeUtils.asFullyQualified(JavaType.buildType(clzz));
+            this.parameterTypes = parameterTypes;
+            this.fluentNames = fluentNames;
+        }
+
+        @Override
+        public J visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
+            JavaType.Method ctorType = newClass.getMethodType();
+
+            if (ctorType == null) {
+                return newClass;
+            }
+
+            if (!clzz.isAssignableFrom(ctorType.getDeclaringType())) {
+                return newClass;
+            }
+
+            List<JavaType> paramTypes = ctorType.getParameterTypes();
+
+            if (paramTypes.size() != this.parameterTypes.size()) {
+                return newClass;
+            }
+
+            for (int i = 0; i < parameterTypes.size(); ++i) {
+                JavaType.FullyQualified expected = this.parameterTypes.get(i);
+                if (!expected.isAssignableFrom(paramTypes.get(i))) {
+                    return newClass;
+                }
+            }
+
+            // Remove all the arguments from the constructor
+            List<Expression> arguments = newClass.getArguments();
+
+            ctorType = ctorType.withParameterTypes(Collections.emptyList())
+                               .withParameterNames(Collections.emptyList());
+
+            newClass = newClass.withArguments(Collections.emptyList())
+                               .withMethodType(ctorType);
+
+            JavaType.FullyQualified declaringType = ctorType.getDeclaringType();
+            Expression select = newClass;
+            for (int i = 0; i < parameterTypes.size(); ++i) {
+                JavaType.FullyQualified paramType = parameterTypes.get(i);
+                String name = fluentNames.get(i);
+                // Note we don't preserve prefix so we don't end up with
+                // extra spaces after the opening paren like 'withFoo(  arg)'
+                Expression argExpr = arguments.get(i).withPrefix(Space.EMPTY);
+
+                select = addWither(select, name, paramType, argExpr, declaringType);
+            }
+
+            return select;
+        }
+
+        private static J.MethodInvocation addWither(Expression select, String simpleName,
+                                                    JavaType.FullyQualified parameterType,
+                                                    Expression paramExpr,
+                                                    JavaType.FullyQualified declaringType) {
+            JavaType.Method methodType = new JavaType.Method(
+                null,
+                0L,
+                declaringType,
+                simpleName,
+                declaringType,
+                Collections.singletonList(simpleName),
+                Collections.singletonList(parameterType),
+                null,
+                null
+            );
+
+            J.Identifier witherId = new J.Identifier(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                Collections.emptyList(),
+                simpleName,
+                methodType,
+                null
+            );
+
+            return new J.MethodInvocation(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                JRightPadded.build(select),
+                null,
+                witherId,
+                JContainer.build(Collections.singletonList(JRightPadded.build(paramExpr))),
+                methodType
+            );
+        }
+    }
+}

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluent.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluent.java
@@ -66,19 +66,18 @@ public class ConstructorToFluent extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        List<JavaType.FullyQualified> paramJavaTypes = parameterTypes.stream()
+        List<JavaType> paramJavaTypes = parameterTypes.stream()
             .map(JavaType::buildType)
-            .map(TypeUtils::asFullyQualified)
             .collect(Collectors.toList());
         return new Visitor(clzzFqcn, paramJavaTypes, fluentNames);
     }
 
     private static class Visitor extends JavaVisitor<ExecutionContext> {
         private final JavaType.FullyQualified clzz;
-        private final List<JavaType.FullyQualified> parameterTypes;
+        private final List<JavaType> parameterTypes;
         private final List<String> fluentNames;
 
-        Visitor(String clzz, List<JavaType.FullyQualified> parameterTypes, List<String> fluentNames) {
+        Visitor(String clzz, List<JavaType> parameterTypes, List<String> fluentNames) {
             this.clzz = TypeUtils.asFullyQualified(JavaType.buildType(clzz));
             this.parameterTypes = parameterTypes;
             this.fluentNames = fluentNames;
@@ -103,8 +102,8 @@ public class ConstructorToFluent extends Recipe {
             }
 
             for (int i = 0; i < parameterTypes.size(); ++i) {
-                JavaType.FullyQualified expected = this.parameterTypes.get(i);
-                if (!expected.isAssignableFrom(paramTypes.get(i))) {
+                JavaType expected = this.parameterTypes.get(i);
+                if (!TypeUtils.isAssignableTo(expected, paramTypes.get(i))) {
                     return newClass;
                 }
             }
@@ -121,7 +120,7 @@ public class ConstructorToFluent extends Recipe {
             JavaType.FullyQualified declaringType = ctorType.getDeclaringType();
             Expression select = newClass;
             for (int i = 0; i < parameterTypes.size(); ++i) {
-                JavaType.FullyQualified paramType = parameterTypes.get(i);
+                JavaType paramType = parameterTypes.get(i);
                 String name = fluentNames.get(i);
                 // Note we don't preserve prefix so we don't end up with
                 // extra spaces after the opening paren like 'withFoo(  arg)'
@@ -134,7 +133,7 @@ public class ConstructorToFluent extends Recipe {
         }
 
         private static J.MethodInvocation addWither(Expression select, String simpleName,
-                                                    JavaType.FullyQualified parameterType,
+                                                    JavaType parameterType,
                                                     Expression paramExpr,
                                                     JavaType.FullyQualified declaringType) {
             JavaType.Method methodType = new JavaType.Method(

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluentTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluentTest.java
@@ -27,6 +27,10 @@ import org.openrewrite.java.Java8Parser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+/**
+ * Recipe that remaps invocations of model constructors that take some members as constructor parameters, so that the
+ * parameters are specified using the fluent setter for the member instead.
+ */
 public class ConstructorToFluentTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluentTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluentTest.java
@@ -115,4 +115,43 @@ public class ConstructorToFluentTest implements RewriteTest {
             )
         );
     }
+
+    // RequesterPays is a boolean primitive type, test to ensure the type matching can handle this
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    public void getObjectRequest_bucketKeyRequesterPays_convertedToFluent() {
+        rewriteRun(
+            spec -> spec.recipe(new ConstructorToFluent("com.amazonaws.services.s3.model.GetObjectRequest",
+                                                        Arrays.asList("java.lang.String", "java.lang.String", "boolean"),
+                                                        Arrays.asList("withBucketName", "withKey", "withRequesterPays"))),
+            java(
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.GetObjectRequest;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        GetObjectRequest getObject = new GetObjectRequest(\"bucket\", \"key\", false);\n"
+                + "\n"
+                + "        S3Object object = s3.getObject(getObject);\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.GetObjectRequest;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        GetObjectRequest getObject = new GetObjectRequest().withBucketName(\"bucket\").withKey(\"key\").withRequesterPays(false);\n"
+                + "\n"
+                + "        S3Object object = s3.getObject(getObject);\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
 }

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluentTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/ConstructorToFluentTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.openrewrite.java.Assertions.java;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.openrewrite.java.Java8Parser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class ConstructorToFluentTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(Java8Parser.builder().classpath(
+            "aws-java-sdk-s3",
+            "aws-java-sdk-core",
+            "s3",
+            "sdk-core"));
+        spec.recipe(new ConstructorToFluent("com.amazonaws.services.s3.model.GetObjectRequest",
+                                            Arrays.asList("java.lang.String", "java.lang.String"),
+                                            Arrays.asList("withBucketName", "withKey")));
+
+    }
+
+    @Test
+    public void newRecipe_listsNotMatch_throws() {
+        assertThatThrownBy(() -> new ConstructorToFluent("foo",
+                                                         Collections.emptyList(),
+                                                         Collections.singletonList("bar")))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new ConstructorToFluent("foo",
+                                                         Collections.singletonList("bar"),
+                                                         Collections.emptyList()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    public void getObjectRequest_matchingCtorNotFound_doesNotRewrite() {
+        rewriteRun(
+            java("import com.amazonaws.services.s3.AmazonS3;\n"
+                 + "import com.amazonaws.services.s3.model.GetObjectRequest;\n"
+                 + "import com.amazonaws.services.s3.model.S3Object;\n"
+                 + "import com.amazonaws.services.s3.model.S3ObjectInputStream;\n"
+                 + "\n"
+                 + "public class S3Example {\n"
+                 + "    public static void main(String[] args) {\n"
+                 + "        AmazonS3 s3 = null;\n"
+                 + "\n"
+                 + "        GetObjectRequest getObject = new GetObjectRequest(\"bucket\", \"key\", \"version\");\n"
+                 + "\n"
+                 + "        S3Object object = s3.getObject(getObject);\n"
+                 + "\n"
+                 + "        S3ObjectInputStream objectContent = object.getObjectContent();\n"
+                 + "    }\n"
+                 + "}\n",
+                 sourceSpecs -> {}
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    public void getObjectRequest_bucketKeyCtor_convertedToFluent() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.GetObjectRequest;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        GetObjectRequest getObject = new GetObjectRequest(\"bucket\", \"key\");\n"
+                + "\n"
+                + "        S3Object object = s3.getObject(getObject);\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.GetObjectRequest;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        GetObjectRequest getObject = new GetObjectRequest().withBucketName(\"bucket\").withKey(\"key\");\n"
+                + "\n"
+                + "        S3Object object = s3.getObject(getObject);\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The ConstructorToFluent recipe takes a convenience constructor like

new GetObjectRequest(myBucket, myKey)

and transforms it to use the fluent setter style instead:

new GetObjectRequest().withBucketName(myBucket).withKey(myKey)

This allows us to take advantage of other recipes that for example switch from using the fluent setters to using the V2-style builders.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
