### PR TITLE
Improve diff output when tests fail

### DIFF
--- a/test/migration-tool-tests/src/test/resources/run-test
+++ b/test/migration-tool-tests/src/test/resources/run-test
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
+from difflib import unified_diff
 import subprocess
 import filecmp
 import os
 import shutil, errno
 import argparse
-import difflib
+import sys
 
 RESOURCE_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "resources")
 BEFORE_DIR = os.path.join(RESOURCE_DIR, "before")
@@ -34,14 +35,13 @@ def run_test(version):
 
 def compare_directory(dcmp):
     if dcmp.diff_files or dcmp.left_only or dcmp.right_only:
+        print("Unexpected diffs found!")
         for diff_file in dcmp.diff_files:
-            file1 = open(dcmp.right + "/" + diff_file, 'r')
-            file2 = open(dcmp.left + "/" + diff_file, 'r')
-            diff = difflib.ndiff(file1.readlines(), file2.readlines())
-            changes = [l for l in diff if l.startswith('+ ') or l.startswith('- ')]
-            print("Diff found in file: " + diff_file)
-            for change in changes:
-                print(change)
+            a = dcmp.right + "/" + diff_file
+            a_contents = open(a, 'r').readlines()
+            b = dcmp.left + "/" + diff_file
+            b_contents = open(b, 'r').readlines()
+            sys.stdout.writelines(unified_diff(a_contents, b_contents, fromfile=a, tofile=b))
 
         return False
     for sub_dcmp in dcmp.subdirs.values():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Use difflib's unified_diff to produce a unified diff between the
expected and actual file. This has the benefit of including the files
compared in the output which makes it easier to do further inspection on
them.

## Modifications
<!--- Describe your changes in detail -->

## Testing
Add a bogus change to the expected `Application.java` file and check the output after running `mvn clean install -pl :migration-tool-tests`

Output:

```
Unexpected diffs found!
--- /Users/dongie/workspace/aws-sdk-java-v2/test/migration-tool-tests/src/test/resources/after/src/main/java/software/amazon/awssdk/migration/tool/Application.java
+++ /Users/dongie/workspace/aws-sdk-java-v2/test/migration-tool-tests/target/generated-test-sources/project/src/main/java/software/amazon/awssdk/migration/tool/Application.java
@@ -21,8 +21,6 @@
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.ListQueuesResponse;

-// Some unexpected change
-
 public class Application {

     private Application() {
```
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
