### PR TITLE
Update v4 request signer to log AWS4 canonical request if DEBUG level…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-66877e6.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-66877e6.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Log `AWS4 Canonical Request` in signer if DEBUG level is enabled."
+}

--- a/core/http-auth-aws/pom.xml
+++ b/core/http-auth-aws/pom.xml
@@ -125,7 +125,26 @@
             <artifactId>reactive-streams-tck</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultV4RequestSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultV4RequestSigner.java
@@ -52,8 +52,11 @@ public final class DefaultV4RequestSigner implements V4RequestSigner {
         // Step 1: Create a canonical request
         V4CanonicalRequest canonicalRequest = createCanonicalRequest(requestBuilder.build(), contentHash);
 
+        String canonicalRequestString = canonicalRequest.getCanonicalRequestString();
+        LOG.debug(() -> "AWS4 Canonical Request: " + canonicalRequestString);
+
         // Step 2: Create a hash of the canonical request
-        String canonicalRequestHash = hashCanonicalRequest(canonicalRequest.getCanonicalRequestString());
+        String canonicalRequestHash = hashCanonicalRequest(canonicalRequestString);
 
         // Step 2: Create a hash of the canonical request
         String stringToSign = createSignString(canonicalRequestHash);

--- a/core/http-auth-aws/src/test/resources/log4j2.properties
+++ b/core/http-auth-aws/src/test/resources/log4j2.properties
@@ -1,0 +1,38 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+status = warn
+
+appender.console.type = Console
+appender.console.name = ConsoleAppender
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n%throwable
+
+rootLogger.level = error
+rootLogger.appenderRef.stdout.ref = ConsoleAppender
+
+# Uncomment below to enable more specific logging
+#
+#logger.sdk.name = software.amazon.awssdk
+#logger.sdk.level = debug
+#
+#logger.request.name = software.amazon.awssdk.request
+#logger.request.level = debug
+#
+#logger.apache.name = org.apache.http.wire
+#logger.apache.level = debug
+#
+#logger.netty.name = io.netty.handler.logging
+#logger.netty.level = debug


### PR DESCRIPTION
… is enabled

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`AWS4 canonical request` is important for diagnosing SignatureMismatch errors. It's logged in [AbstractAws4Signer](https://github.com/aws/aws-sdk-java-v2/blob/8ee56341bd8905734e54c89eabff553c79187e3e/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java#L266) prior to 2.20.x, but the new signer `DefaultV4RequestSigner` doesn't log it, which makes troubleshooting a lot harder.

https://github.com/aws/aws-sdk-java-v2/blob/8ee56341bd8905734e54c89eabff553c79187e3e/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java#L266

## Modifications
Update v4 request signer to log AWS4 canonical request at DEBUG level

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
