### PR TITLE
Converts endpoint param list of string to list of value

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderSpec.java
@@ -324,6 +324,7 @@ public class EndpointProviderSpec implements ClassSpec {
             } else {
                 coerce = CodeBlock.builder().build();
             }
+
             CodeBlock valueExpr = endpointRulesSpecUtils.valueCreationCode(
                 model.getType(),
                 CodeBlock.builder()

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -147,7 +147,7 @@ public class EndpointRulesSpecUtils {
                 break;
             case "stringarray":
                 methodName = "fromArray";
-                param = CodeBlock.of("$L.stream().map($T::fromStr).collect($T.toList())",
+                param = CodeBlock.of("$N.stream().map($T::fromStr).collect($T.toList())",
                                      param,
                                      rulesRuntimeClassName("Value"),
                                      Collectors.class);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -147,6 +147,10 @@ public class EndpointRulesSpecUtils {
                 break;
             case "stringarray":
                 methodName = "fromArray";
+                param = CodeBlock.of("$L.stream().map($T::fromStr).collect($T.toList())",
+                                     param,
+                                     rulesRuntimeClassName("Value"),
+                                     Collectors.class);
                 break;
             default:
                 throw new RuntimeException("Don't know how to create a Value instance from type " + type);

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/ParameterType.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/ParameterType.java.resource
@@ -7,6 +7,7 @@ import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 public enum ParameterType {
     STRING("String"),
     BOOLEAN("Boolean"),
+    STRING_ARRAY("StringArray"),
     ;
 
     private final String name;
@@ -30,6 +31,8 @@ public enum ParameterType {
                 return STRING;
             case "boolean":
                 return BOOLEAN;
+            case "stringarray":
+                return STRING_ARRAY;
             default:
                 throw SdkClientException.create("Unknown parameter type: " + value);
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
@@ -61,10 +62,12 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             paramsMap.put(Identifier.of("awsAccountIdEndpointMode"), Value.fromStr(params.awsAccountIdEndpointMode()));
         }
         if (params.listOfStrings() != null) {
-            paramsMap.put(Identifier.of("listOfStrings"), Value.fromArray(params.listOfStrings()));
+            paramsMap.put(Identifier.of("listOfStrings"),
+                          Value.fromArray(params.listOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.defaultListOfStrings() != null) {
-            paramsMap.put(Identifier.of("defaultListOfStrings"), Value.fromArray(params.defaultListOfStrings()));
+            paramsMap.put(Identifier.of("defaultListOfStrings"),
+                          Value.fromArray(params.defaultListOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
@@ -88,7 +91,8 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             paramsMap.put(Identifier.of("operationContextParam"), Value.fromStr(params.operationContextParam()));
         }
         if (params.customEndpointArray() != null) {
-            paramsMap.put(Identifier.of("CustomEndpointArray"), Value.fromArray(params.customEndpointArray()));
+            paramsMap.put(Identifier.of("CustomEndpointArray"),
+                          Value.fromArray(params.customEndpointArray().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         return paramsMap;
     }
@@ -365,9 +369,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                     Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
                                              .required(false).build())
                                 .addParameter(
-                                    Parameter.builder().name("defaultListOfStrings")
-                                             .type(ParameterType.fromValue("stringarray")).required(false)
-                                             .defaultValue(Value.fromArray(Arrays.asList("item1", "item2", "item3"))).build())
+                                    Parameter
+                                        .builder()
+                                        .name("defaultListOfStrings")
+                                        .type(ParameterType.fromValue("stringarray"))
+                                        .required(false)
+                                        .defaultValue(
+                                            Value.fromArray(Arrays.asList("item1", "item2", "item3").stream()
+                                                                  .map(Value::fromStr).collect(Collectors.toList()))).build())
                                 .addParameter(
                                         Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
                                                 .required(false).build())

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -60,10 +61,12 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             paramsMap.put(Identifier.of("awsAccountIdEndpointMode"), Value.fromStr(params.awsAccountIdEndpointMode()));
         }
         if (params.listOfStrings() != null) {
-            paramsMap.put(Identifier.of("listOfStrings"), Value.fromArray(params.listOfStrings()));
+            paramsMap.put(Identifier.of("listOfStrings"),
+                          Value.fromArray(params.listOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.defaultListOfStrings() != null) {
-            paramsMap.put(Identifier.of("defaultListOfStrings"), Value.fromArray(params.defaultListOfStrings()));
+            paramsMap.put(Identifier.of("defaultListOfStrings"),
+                          Value.fromArray(params.defaultListOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
@@ -361,9 +364,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                     Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
                                              .required(false).build())
                                 .addParameter(
-                                    Parameter.builder().name("defaultListOfStrings")
-                                             .type(ParameterType.fromValue("stringarray")).required(false)
-                                             .defaultValue(Value.fromArray(Arrays.asList("item1", "item2", "item3"))).build())
+                                    Parameter
+                                        .builder()
+                                        .name("defaultListOfStrings")
+                                        .type(ParameterType.fromValue("stringarray"))
+                                        .required(false)
+                                        .defaultValue(
+                                            Value.fromArray(Arrays.asList("item1", "item2", "item3").stream()
+                                                                  .map(Value::fromStr).collect(Collectors.toList()))).build())
                                 .addParameter(
                                         Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
                                                 .required(false).build())

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
@@ -1,5 +1,22 @@
 {
     "skipEndpointTestGeneration": true,
     "useSraAuth": true,
-    "enableGenerateCompiledEndpointRules": false
+    "enableGenerateCompiledEndpointRules": false,
+    "endpointParameters": {
+        "ListOfKeysArray": {
+          "required": false,
+          "documentation": "A list of nested objects",
+          "type": "StringArray"
+        }
+      },
+      "customOperationContextParams": [
+        {
+          "operationName": "FurtherNestedContainers",
+          "operationContextParamsMap": {
+            "ListOfKeysArray": {
+              "value": "ListOfNested.NestedContainersStructure[*].StringMember"
+            }
+          }
+        }
+      ]
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/OperationContextParametersTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/OperationContextParametersTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.endpointproviders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersClient;
+import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJsonEndpointProvidersEndpointParams;
+import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJsonEndpointProvidersEndpointProvider;
+
+class OperationContextParametersTest {
+    private static final AwsCredentialsProvider CREDENTIALS = StaticCredentialsProvider.create(
+        AwsBasicCredentials.create("akid", "skid"));
+
+    private static final Region REGION = Region.of("us-east-9000");
+
+    private RestJsonEndpointProvidersEndpointProvider mockEndpointProvider;
+
+    @BeforeEach
+    public void setup() {
+        mockEndpointProvider = mock(RestJsonEndpointProvidersEndpointProvider.class);
+        when(mockEndpointProvider.resolveEndpoint(any(RestJsonEndpointProvidersEndpointParams.class)))
+            .thenThrow(new RuntimeException("boom"));
+    }
+
+    @Test
+    void operationContextParams_customization_resolvedCorrectly() {
+        RestJsonEndpointProvidersClient client = RestJsonEndpointProvidersClient.builder()
+                                                                                .region(REGION)
+                                                                                .credentialsProvider(CREDENTIALS)
+                                                                                .endpointProvider(mockEndpointProvider)
+                                                                                .build();
+
+        assertThatThrownBy(() -> client.furtherNestedContainers(r -> {
+        }));
+
+        ArgumentCaptor<RestJsonEndpointProvidersEndpointParams> paramsCaptor =
+            ArgumentCaptor.forClass(RestJsonEndpointProvidersEndpointParams.class);
+
+        verify(mockEndpointProvider).resolveEndpoint(paramsCaptor.capture());
+
+        RestJsonEndpointProvidersEndpointParams params = paramsCaptor.getValue();
+
+        List<String> listOfKeysArray = params.listOfKeysArray();
+        assertThat(listOfKeysArray).isEmpty();
+    }
+}


### PR DESCRIPTION
## Motivation and Context
The type of the endpoint param, `List<String>`, and the type required by the rules engine, `List<Value>`, are incompatible. Codegen Generated Classes Test cannot compile. 

## Modifications
- Changed the parameter assignment in the rules engine to a list of Value by streaming the endpoint parameter contents and converting each `String` using `Value.fromStr`
- Also added `stringarray` to `ParameterType` - required for Codegen Generated Classes Test tests to compile
