### PR TITLE
Add NumberToDuration recipe to convert numeric type to Duration

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/NumberToDuration.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/NumberToDuration.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Convert the method parameter from numeric types to duration.
+ */
+@SdkInternalApi
+public class NumberToDuration extends Recipe {
+    @Option(displayName = "Method pattern",
+        description = "A method pattern that is used to find matching method invocations.",
+        example = "com.amazonaws.ClientConfiguration setRequestTimeout(int)")
+    private final String methodPattern;
+
+    @Option(displayName = "Time Unit",
+        description = "The TimeUnit enum value to convert. Defaults to `MILLISECONDS`.",
+        example = "MILLISECONDS",
+        required = false)
+    private final TimeUnit timeUnit;
+
+    @JsonCreator
+    public NumberToDuration(@JsonProperty("methodPattern") String methodPattern,
+                            @JsonProperty("timeUnit") TimeUnit timeUnit) {
+        this.methodPattern = methodPattern;
+        this.timeUnit = timeUnit == null ? TimeUnit.MILLISECONDS : timeUnit;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Convert the method parameter from numeric type to duration";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Convert the method parameter from numeric types to duration.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new Visitor(methodPattern, timeUnit);
+    }
+
+    private static final class Visitor extends JavaIsoVisitor<ExecutionContext> {
+        private final MethodMatcher methodMatcher;
+        private final TimeUnit timeUnit;
+
+        Visitor(String methodPattern, TimeUnit timeUnit) {
+            this.methodMatcher = new MethodMatcher(methodPattern, false);
+            this.timeUnit = timeUnit;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation methodInvocation = super.visitMethodInvocation(method, ctx);
+            if (!methodMatcher.matches(methodInvocation)) {
+                return methodInvocation;
+            }
+
+            String durationStr = durationCreationStr();
+
+            JavaTemplate template = JavaTemplate
+                .builder(durationStr + "(#{})")
+                .contextSensitive()
+                .imports("java.time.Duration")
+                .build();
+
+            List<Object> arguments = new ArrayList<>(methodInvocation.getArguments());
+
+            methodInvocation = template.apply(
+                updateCursor(methodInvocation),
+                methodInvocation.getCoordinates().replaceArguments(),
+                arguments.toArray(new Object[0])
+            );
+            maybeAddImport("java.time.Duration");
+            return methodInvocation;
+        }
+
+        private String durationCreationStr() {
+            String durationStr;
+            switch (timeUnit) {
+                case MILLISECONDS:
+                    durationStr = "Duration.ofMillis";
+                    break;
+                case SECONDS:
+                    durationStr = "Duration.ofSeconds";
+                    break;
+                case MINUTES:
+                    durationStr = "Duration.ofMinutes";
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported time unit: " + timeUnit);
+            }
+            return durationStr;
+        }
+    }
+}

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/NumberToDurationTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/NumberToDurationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import static org.openrewrite.java.Assertions.java;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.openrewrite.java.Java8Parser;
+import org.openrewrite.test.RewriteTest;
+
+public class NumberToDurationTest implements RewriteTest {
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void timeUnitNotSpecified_shouldUseMilliSeconds() {
+        rewriteRun(
+            spec -> spec.recipe(new NumberToDuration("com.amazonaws.ClientConfiguration setRequestTimeout(int)",
+                                                     TimeUnit.MILLISECONDS))
+                        .parser(Java8Parser.builder().classpath("sqs", "aws-core", "sdk-core", "aws-java-sdk-sqs")),
+            java(
+                "import com.amazonaws.ClientConfiguration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
+                + "        clientConfiguration.setRequestTimeout(1000);\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.ClientConfiguration;\n\n"
+                + "import java.time.Duration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
+                + "        clientConfiguration.setRequestTimeout(Duration.ofMillis(1000));\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void timeUnitSpecified_shouldHonor() {
+        rewriteRun(
+            spec -> spec.recipe(new NumberToDuration("com.amazonaws.ClientConfiguration setRequestTimeout(int)",
+                                                     TimeUnit.SECONDS))
+                        .parser(Java8Parser.builder().classpath("sqs", "aws-core", "sdk-core", "aws-java-sdk-sqs")),
+            java(
+                "import com.amazonaws.ClientConfiguration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
+                + "        clientConfiguration.setRequestTimeout(1000);\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.ClientConfiguration;\n\n"
+                + "import java.time.Duration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
+                + "        clientConfiguration.setRequestTimeout(Duration.ofSeconds(1000));\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+}

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/NumberToDurationTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/NumberToDurationTest.java
@@ -31,7 +31,7 @@ public class NumberToDurationTest implements RewriteTest {
     void timeUnitNotSpecified_shouldUseMilliSeconds() {
         rewriteRun(
             spec -> spec.recipe(new NumberToDuration("com.amazonaws.ClientConfiguration setRequestTimeout(int)",
-                                                     TimeUnit.MILLISECONDS))
+                                                     null))
                         .parser(Java8Parser.builder().classpath("sqs", "aws-core", "sdk-core", "aws-java-sdk-sqs")),
             java(
                 "import com.amazonaws.ClientConfiguration;\n"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In v1, request timeout and client execution timeout config take a integer and in v2, they take Duration, so we need to convert numeric type to wrap with Duration when we convert to v2 code. 

## Modifications
This change added `NumberToDuration` recipe to convert numeric type to Duration. The use of it will be in a separate PR.

```
clientConfiguration.setRequestTimeout(1000);
```

to

```
clientConfiguration.setRequestTimeout(Duration.ofMillis(1000));
```

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
