### PR TITLE
Add S3StreamingResponseToV2 Recipe

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/S3StreamingResponseToV2.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/S3StreamingResponseToV2.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.migration.internal.utils.IdentifierUtils;
+
+@SdkInternalApi
+public class S3StreamingResponseToV2 extends Recipe {
+    private static final JavaType.FullyQualified S3_OBJECT_TYPE =
+        TypeUtils.asFullyQualified(JavaType.buildType("com.amazonaws.services.s3.model.S3Object"));
+    private static final JavaType.FullyQualified S3_GET_OBJECT_RESPONSE_TYPE =
+        TypeUtils.asFullyQualified(JavaType.buildType("software.amazon.awssdk.services.s3.model.GetObjectResponse"));
+
+    private static final JavaType.FullyQualified RESPONSE_INPUT_STREAM_TYPE =
+        TypeUtils.asFullyQualified(JavaType.buildType("software.amazon.awssdk.core.ResponseInputStream"));
+
+    private static final MethodMatcher GET_OBJECT_CONTENT =
+        new MethodMatcher("com.amazonaws.services.s3.model.S3Object getObjectContent()");
+
+    private static final MethodMatcher OBJECT_INPUT_STREAM_METHOD =
+        new MethodMatcher("com.amazonaws.services.s3.model.S3ObjectInputStream *(..)");
+
+    @Override
+    public String getDisplayName() {
+        return "V1 S3Object to V2";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transform usage of V1 S3Object to V2.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new Visitor();
+    }
+
+    private static class Visitor extends JavaVisitor<ExecutionContext> {
+
+        // Transform an S3Object myObject = ...
+        // to
+        // ResponseInputStream<GetObjectResponse> myObject = ...
+        @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable,
+                                                                ExecutionContext executionContext) {
+            if (TypeUtils.isAssignableTo(S3_OBJECT_TYPE, multiVariable.getType())) {
+                JavaType.Parameterized newType =
+                    new JavaType.Parameterized(null, RESPONSE_INPUT_STREAM_TYPE,
+                                               Collections.singletonList(S3_GET_OBJECT_RESPONSE_TYPE));
+
+                maybeAddS3ResponseImports();
+
+                multiVariable = multiVariable.withType(newType)
+                                             .withTypeExpression(IdentifierUtils.makeId(IdentifierUtils.simpleName(newType),
+                                                                                        newType));
+
+                List<J.VariableDeclarations.NamedVariable> variables = multiVariable.getVariables().stream()
+                                                                                  .map(nv -> nv.withType(newType))
+                                                                                  .collect(Collectors.toList());
+
+                multiVariable = multiVariable.withVariables(variables);
+            }
+
+            multiVariable = super.visitVariableDeclarations(multiVariable, executionContext).cast();
+
+            return multiVariable;
+        }
+
+        private void maybeAddS3ResponseImports() {
+            maybeAddImport(RESPONSE_INPUT_STREAM_TYPE);
+            // Note: 'onlyIfReferenced' set to false because OpenRewrite does not seem to consider just having the type as a type
+            // parameter as being in use, so will not add the import if set to true.
+            maybeAddImport(S3_GET_OBJECT_RESPONSE_TYPE.getFullyQualifiedName(), null, false);
+        }
+
+        // In v2, the request is inverted. Whereas S3Object contains the response stream, in V2, a response stream object
+        // wraps the response object. so the InputStream methods are directly on the "response" object now, and to access the
+        // non-streaming members, we need to insert a call to response().
+        @Override
+        public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            method = super.visitMethodInvocation(method, executionContext).cast();
+
+            Expression select = method.getSelect();
+
+            if (select == null) {
+                return method;
+            }
+
+            if (GET_OBJECT_CONTENT.matches(method)) {
+                return select;
+            }
+
+            JavaType.Method methodType = method.getMethodType();
+
+            if (methodType == null) {
+                return method;
+            }
+
+            if (!TypeUtils.isAssignableTo(S3_OBJECT_TYPE, methodType.getDeclaringType())) {
+                return method;
+            }
+
+            // Calling a method on the stream, just change the declaring type
+            if (isObjectContentMethod(method)) {
+                method = method.withMethodType(methodType.withDeclaringType(RESPONSE_INPUT_STREAM_TYPE));
+                return method;
+            }
+
+            JavaType.Method responseGetterType = new JavaType.Method(
+                null,
+                0L,
+                RESPONSE_INPUT_STREAM_TYPE,
+                "response",
+                S3_GET_OBJECT_RESPONSE_TYPE,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList()
+            );
+
+            // Calling a method on the response, insert a response() getter
+            J.Identifier responseGetterId = IdentifierUtils.makeId("response", responseGetterType);
+
+            J.MethodInvocation getResponse = new J.MethodInvocation(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                JRightPadded.build(select),
+                null,
+                responseGetterId,
+                JContainer.empty(),
+                responseGetterType
+            );
+
+            methodType = methodType.withDeclaringType(S3_GET_OBJECT_RESPONSE_TYPE);
+            method = method.withSelect(getResponse)
+                           .withName(method.getName().withType(methodType))
+                           .withMethodType(methodType);
+
+            return method;
+        }
+
+        private static boolean isObjectContentMethod(J.MethodInvocation method) {
+            Expression select = method.getSelect();
+            if (select == null || !TypeUtils.isAssignableTo(S3_OBJECT_TYPE, select.getType())) {
+                return false;
+            }
+            return OBJECT_INPUT_STREAM_METHOD.matches(method);
+        }
+    }
+}

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/IdentifierUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/IdentifierUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.utils;
+
+import java.util.Collections;
+import java.util.List;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public final class IdentifierUtils {
+    private IdentifierUtils() {
+    }
+
+    /**
+     * Utility method for creating a {@link J.Identifier}.
+     */
+    public static J.Identifier makeId(String simpleName, JavaType type) {
+        return new J.Identifier(
+            Tree.randomId(),
+            Space.EMPTY,
+            Markers.EMPTY,
+            Collections.emptyList(),
+            simpleName,
+            type,
+            null
+        );
+    }
+
+    /**
+     * Simple method for creating a simple name for a {@link JavaType.Parameterized} instance. This is a naive implementation
+     * that currently requires all type parameters to be {@link JavaType.FullyQualified}, and does not handle nested
+     * parameterized types.
+     */
+    public static String simpleName(JavaType.Parameterized parameterized) {
+        StringBuffer sb = new StringBuffer(parameterized.getClassName())
+            .append('<');
+
+        List<JavaType> typeParams = parameterized.getTypeParameters();
+
+        for (int i = 0; i < typeParams.size(); ++i) {
+            JavaType.FullyQualified fqParamType = TypeUtils.asFullyQualified(typeParams.get(i));
+            if (fqParamType == null) {
+                throw new RuntimeException("Encountered non fully qualified type");
+            }
+            sb.append(fqParamType.getClassName());
+
+            if (i + 1 != typeParams.size()) {
+                sb.append(", ");
+            }
+        }
+
+        return sb.append(">").toString();
+    }
+}

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/IdentifierUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/IdentifierUtils.java
@@ -51,7 +51,7 @@ public final class IdentifierUtils {
      * parameterized types.
      */
     public static String simpleName(JavaType.Parameterized parameterized) {
-        StringBuffer sb = new StringBuffer(parameterized.getClassName())
+        StringBuilder sb = new StringBuilder(parameterized.getClassName())
             .append('<');
 
         List<JavaType> typeParams = parameterized.getTypeParameters();
@@ -68,6 +68,6 @@ public final class IdentifierUtils {
             }
         }
 
-        return sb.append(">").toString();
+        return sb.append('>').toString();
     }
 }

--- a/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
@@ -847,12 +847,6 @@ recipeList:
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
-      oldArtifactId: aws-java-sdk-deadline
-      newGroupId: software.amazon.awssdk
-      newArtifactId: deadline
-      newVersion: 2.23.16-SNAPSHOT
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
-      oldGroupId: com.amazonaws
       oldArtifactId: aws-java-sdk-braket
       newGroupId: software.amazon.awssdk
       newArtifactId: braket
@@ -2176,12 +2170,6 @@ recipeList:
       oldArtifactId: aws-java-sdk-ram
       newGroupId: software.amazon.awssdk
       newArtifactId: ram
-      newVersion: 2.23.16-SNAPSHOT
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
-      oldGroupId: com.amazonaws
-      oldArtifactId: aws-java-sdk-codeconnections
-      newGroupId: software.amazon.awssdk
-      newArtifactId: codeconnections
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/S3StreamingResponseToV2Test.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/S3StreamingResponseToV2Test.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.recipe;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.openrewrite.java.Java8Parser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class S3StreamingResponseToV2Test implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new S3StreamingResponseToV2());
+        spec.parser(Java8Parser.builder().classpath(
+            "aws-java-sdk-s3",
+            "aws-java-sdk-core",
+            "s3",
+            "sdk-core"));
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    public void testS3ObjectRewrite() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        S3Object object = s3.getObject(\"bucket\", \"key\");\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "import software.amazon.awssdk.core.ResponseInputStream;\n"
+                + "import software.amazon.awssdk.services.s3.model.GetObjectResponse;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        ResponseInputStream<GetObjectResponse> object = s3.getObject(\"bucket\", \"key\");\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    public void invocationOnStream() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) throws Exception {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        S3Object object = s3.getObject(\"bucket\", \"key\");\n"
+                + "        object.getObjectContent().close();\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "import software.amazon.awssdk.core.ResponseInputStream;\n"
+                + "import software.amazon.awssdk.services.s3.model.GetObjectResponse;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) throws Exception {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        ResponseInputStream<GetObjectResponse> object = s3.getObject(\"bucket\", \"key\");\n"
+                + "        object.close();\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    public void invocationOnNonStreaming() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) throws Exception {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        S3Object object = s3.getObject(\"bucket\", \"key\");\n"
+                + "        String key = object.getKey();\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.s3.AmazonS3;\n"
+                + "import com.amazonaws.services.s3.model.S3Object;\n"
+                + "import software.amazon.awssdk.core.ResponseInputStream;\n"
+                + "import software.amazon.awssdk.services.s3.model.GetObjectResponse;\n"
+                + "\n"
+                + "public class S3Example {\n"
+                + "    public static void main(String[] args) throws Exception {\n"
+                + "        AmazonS3 s3 = null;\n"
+                + "\n"
+                + "        ResponseInputStream<GetObjectResponse> object = s3.getObject(\"bucket\", \"key\");\n"
+                + "        String key = object.response().getKey();\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+}

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/IdentifierUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/IdentifierUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.internal.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import software.amazon.awssdk.utils.Pair;
+
+public class IdentifierUtilsTest {
+    @Test
+    public void makeId_setsCorrectNameAndType() {
+        String name = "MyId";
+        JavaType.Unknown type = JavaType.Unknown.getInstance();
+
+        J.Identifier identifier = IdentifierUtils.makeId(name, type);
+
+        assertThat(identifier.getSimpleName()).isEqualTo(name);
+        assertThat(identifier.getType()).isSameAs(type);
+    }
+
+    @ParameterizedTest
+    @MethodSource("simpleName_parameterizedTypeCases")
+    public void simpleName_generatesCorrectName(Pair<JavaType.Parameterized, String> testCase) {
+        assertThat(IdentifierUtils.simpleName(testCase.left())).isEqualTo(testCase.right());
+    }
+
+    @Test
+    public void simpleName_typeParamNotFullyQualified_throws() {
+        JavaType.FullyQualified genericType = TypeUtils.asFullyQualified(JavaType.buildType("foo.bar.BazGeneric"));
+        JavaType.Parameterized parameterized =
+            new JavaType.Parameterized(null, genericType,
+                                       Collections.singletonList(JavaType.Unknown.getInstance()));
+        assertThatThrownBy(() -> IdentifierUtils.simpleName(parameterized))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("non fully qualified");
+    }
+
+    private static List<Pair> simpleName_parameterizedTypeCases() {
+        JavaType.FullyQualified genericType = TypeUtils.asFullyQualified(JavaType.buildType("foo.bar.BazGeneric"));
+        JavaType.FullyQualified stringType = TypeUtils.asFullyQualified(JavaType.buildType("java.lang.String"));
+
+        return Arrays.asList(
+            Pair.of(new JavaType.Parameterized(null, genericType, Collections.singletonList(stringType)),
+                    "BazGeneric<String>"),
+            Pair.of(new JavaType.Parameterized(null, genericType, Arrays.asList(stringType, stringType)),
+                    "BazGeneric<String, String>"),
+            Pair.of(new JavaType.Parameterized(null, genericType, Collections.emptyList()), "BazGeneric<>")
+
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This recipe transforms usages of `s3.getObject(..)` such as

```
S3Object myObject = s3.getObject(request);
```

to the equivalent in v2:

```
ResponseInputStream<GetObjectResponse> myObject = s3.getOBject(request);
```

In addition, because of the inversion of streaming and non-streaming members when moving to ResponseInputStream, it further transforms usages of myObject so that calls in v1 that access the stream:

```
myObject.getObjectContent().close()
```

become

```
myObject.close()
```

Likewise, methods that access the non-streaming members

```
myObject.getKey();
```

become

```
myObject.response().getKey();
```

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
