### PR TITLE
Fix for multipart integ test failure

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.core.internal.async;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
@@ -70,7 +70,7 @@ public class SplittingTransformer<ResponseT, ResultT> implements SdkPublisher<As
     private final AtomicBoolean onStreamCalled = new AtomicBoolean(false);
 
     /**
-     * Set to true once {@code .concel()} is called in the subscription of the downstream subscriber, or if the
+     * Set to true once {@code .cancel()} is called in the subscription of the downstream subscriber, or if the
      * {@code resultFuture} is cancelled.
      */
     private final AtomicBoolean isCancelled = new AtomicBoolean(false);

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerCopyIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerCopyIntegrationTest.java
@@ -57,8 +57,12 @@ public class S3TransferManagerCopyIntegrationTest extends S3IntegrationTestBase 
         JAVA, CRT
     }
 
+    private static Stream<Arguments> transferManagerTypes() {
+        return Stream.of(Arguments.of(TmType.JAVA), Arguments.of(TmType.CRT));
+    }
+
     @ParameterizedTest
-    @MethodSource("transferManagers")
+    @MethodSource("transferManagerTypes")
     void copy_copiedObject_hasSameContent(TmType tmType) throws Exception {
         CaptureTransferListener transferListener = new CaptureTransferListener();
         byte[] originalContent = randomBytes(OBJ_SIZE);
@@ -68,7 +72,7 @@ public class S3TransferManagerCopyIntegrationTest extends S3IntegrationTestBase 
     }
 
     @ParameterizedTest
-    @MethodSource("transferManagers")
+    @MethodSource("transferManagerTypes")
     void copy_specialCharacters_hasSameContent(TmType tmType) throws Exception {
         CaptureTransferListener transferListener = new CaptureTransferListener();
         byte[] originalContent = randomBytes(OBJ_SIZE);

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadDirectoryIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadDirectoryIntegrationTest.java
@@ -117,7 +117,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
      *   }
      * </pre>
      */
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     public void downloadDirectory(S3TransferManager tm) throws Exception {
         DirectoryDownload downloadDirectory = tm.downloadDirectory(u -> u.destination(directory)
@@ -127,7 +127,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
         assertTwoDirectoriesHaveSameStructure(sourceDirectory, directory);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("prefixTestArguments")
     void downloadDirectory_withPrefix(S3TransferManager tm, String prefix) throws Exception {
         DirectoryDownload downloadDirectory =
@@ -155,7 +155,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
      *   }
      * </pre>
      */
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     void downloadDirectory_containsObjectWithPrefixInTheKey_shouldResolveCorrectly(S3TransferManager tm)
         throws Exception {
@@ -187,7 +187,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
      *   }
      * </pre>
      */
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     public void downloadDirectory_withPrefixAndDelimiter(S3TransferManager tm) throws Exception {
         String prefix = "notes-2021";
@@ -212,7 +212,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
      *   }
      * </pre>
      */
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     public void downloadDirectory_withFilter(S3TransferManager tm) throws Exception {
         DirectoryDownload downloadDirectory = tm.downloadDirectory(u -> u

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryIntegrationTest.java
@@ -76,7 +76,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     void uploadDirectory_filesSentCorrectly(S3TransferManager tm) {
         String prefix = "yolo";
@@ -95,7 +95,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
         keys.forEach(k -> verifyContent(k, k.substring(prefix.length() + 1) + randomString));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     void uploadDirectory_nonExistsBucket_shouldAddFailedRequest(S3TransferManager tm) {
         String prefix = "yolo";
@@ -107,7 +107,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
                                                                                          assertThat(f.exception()).isInstanceOf(NoSuchBucketException.class));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     void uploadDirectory_withDelimiter_filesSentCorrectly(S3TransferManager tm) {
         String prefix = "hello";
@@ -130,7 +130,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
         });
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("transferManagers")
     void uploadDirectory_withRequestTransformer_usesRequestTransformer(S3TransferManager tm) throws Exception {
         String prefix = "requestTransformerTest";
@@ -169,7 +169,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
      * Tests the behavior of traversing local directories with special Unicode characters in their path name. These characters
      * have known to be problematic when using Java's old File API or with Windows (which uses UTF-16 for file-name encoding).
      */
-    @ParameterizedTest
+    @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("prefix")
     void uploadDirectory_fileNameWithUnicode_traversedCorrectly(String directoryPrefix, S3TransferManager tm)
         throws IOException {

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -324,7 +324,8 @@ class GenericS3TransferManager implements S3TransferManager {
         TransferProgressUpdater progressUpdater = new TransferProgressUpdater(downloadRequest, null);
         progressUpdater.transferInitiated();
         responseTransformer = isS3ClientMultipartEnabled()
-                              ? progressUpdater.wrapResponseTransformerForMultipartDownload(responseTransformer)
+                              ? progressUpdater.wrapResponseTransformerForMultipartDownload(
+                                  responseTransformer, downloadRequest.getObjectRequest())
                               : progressUpdater.wrapResponseTransformer(responseTransformer);
         progressUpdater.registerCompletion(returnFuture);
 
@@ -369,7 +370,8 @@ class GenericS3TransferManager implements S3TransferManager {
         try {
             progressUpdater.transferInitiated();
             responseTransformer = isS3ClientMultipartEnabled()
-                                  ? progressUpdater.wrapResponseTransformerForMultipartDownload(responseTransformer)
+                                  ? progressUpdater.wrapResponseTransformerForMultipartDownload(
+                                      responseTransformer, downloadRequest.getObjectRequest())
                                   : progressUpdater.wrapResponseTransformer(responseTransformer);
             progressUpdater.registerCompletion(returnFuture);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloaderSubscriberWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloaderSubscriberWiremockTest.java
@@ -74,7 +74,7 @@ class MultipartDownloaderSubscriberWiremockTest {
 
     @ParameterizedTest
     @MethodSource("argumentsProvider")
-    <T> void happyPath_shouldReceiveAllBodyPArtInCorrectOrder(AsyncResponseTransformerTestSupplier<T> supplier,
+    <T> void happyPath_shouldReceiveAllBodyPartInCorrectOrder(AsyncResponseTransformerTestSupplier<T> supplier,
                                                               int amountOfPartToTest,
                                                               int partSize) {
         byte[] expectedBody = util.stubAllParts(testBucket, testKey, amountOfPartToTest, partSize);


### PR DESCRIPTION
The `S3TransferManagerDownloadPauseResumeIntegrationTest` was failing with S3 Multipart client for 2 reasons.
1. The downloads were not immediately stopped when calling `.pause()`
2. When resuming, the range get would have the whole object size as its content-length, making the TransferProgressUpdater report the wrong number of bytes.

This PR is to fix both of those issues.

## Motivation and Context
Errors were raised during integration test execution.

## Modifications
Fix for the errors consist in 
- Forward cancellation from returnFuture in SplittingTransformer
- Use content-length for range-get in TransferProgressUpdater, when multipart is enabled. 

## Testing
Failing integration test run locally.
Added unit test.