### PR TITLE
Add mappping for non-HTTP config settings

### DIFF
--- a/migration-tool/pom.xml
+++ b/migration-tool/pom.xml
@@ -85,6 +85,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-migrate-java</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-test</artifactId>
             <scope>test</scope>
@@ -110,6 +115,21 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- Used in UpgradeSdkDependenciesTest -->

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/AddCommentToMethod.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/AddCommentToMethod.java
@@ -72,7 +72,7 @@ public class AddCommentToMethod extends Recipe {
 
         Visitor(String methodPattern, String comment) {
             this.methodMatcher = new MethodMatcher(methodPattern, false);
-            this.comment = COMMENT_PREFIX + comment;
+            this.comment = COMMENT_PREFIX + comment + "\n";
         }
 
         @Override

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtils.java
@@ -23,6 +23,19 @@ import java.util.regex.Pattern;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProcessCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithWebIdentityCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 /**
@@ -35,11 +48,11 @@ public final class SdkTypeUtils {
      */
     public static final Map<String, Integer> V2_CORE_CLASSES_WITH_STATIC_FACTORY =
         ImmutableMap.<String, Integer>builder()
-                    .put("software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider", 0)
-                    .put("software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider", 0)
-                    .put("software.amazon.awssdk.auth.credentials.AwsBasicCredentials", 2)
-                    .put("software.amazon.awssdk.auth.credentials.AwsSessionCredentials", 3)
-                    .put("software.amazon.awssdk.auth.credentials.StaticCredentialsProvider", 1)
+                    .put(EnvironmentVariableCredentialsProvider.class.getCanonicalName(), 0)
+                    .put(InstanceProfileCredentialsProvider.class.getCanonicalName(), 0)
+                    .put(AwsBasicCredentials.class.getCanonicalName(), 2)
+                    .put(AwsSessionCredentials.class.getCanonicalName(), 3)
+                    .put(StaticCredentialsProvider.class.getCanonicalName(), 1)
                     .build();
 
     private static final Pattern V1_SERVICE_CLASS_PATTERN =
@@ -66,15 +79,15 @@ public final class SdkTypeUtils {
      * V2 core classes with a builder
      */
     private static final Set<String> V2_CORE_CLASSES_WITH_BUILDER =
-        new HashSet<>(Arrays.asList("software.amazon.awssdk.core.client.ClientOverrideConfiguration",
-                                    "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider",
-                                    "software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider",
-                                    "software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider",
-                                    "software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider",
-                                    "software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider",
-                                    "software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider",
-                                    "software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithWebIdentityCredentialsProvider",
-                                    "software.amazon.awssdk.auth.credentials.ProcessCredentialsProvider"));
+        new HashSet<>(Arrays.asList(ClientOverrideConfiguration.class.getCanonicalName(),
+                                    DefaultCredentialsProvider.class.getCanonicalName(),
+                                    ProfileCredentialsProvider.class.getCanonicalName(),
+                                    ContainerCredentialsProvider.class.getCanonicalName(),
+                                    InstanceProfileCredentialsProvider.class.getCanonicalName(),
+                                    StsAssumeRoleCredentialsProvider.class.getCanonicalName(),
+                                    StsGetSessionTokenCredentialsProvider.class.getCanonicalName(),
+                                    StsAssumeRoleWithWebIdentityCredentialsProvider.class.getCanonicalName(),
+                                    ProcessCredentialsProvider.class.getCanonicalName()));
 
     private static final Pattern V2_CLIENT_BUILDER_PATTERN = Pattern.compile(
         "software\\.amazon\\.awssdk\\.services\\.[a-zA-Z0-9]+\\.[a-zA-Z0-9]+Builder");

--- a/migration-tool/src/main/resources/META-INF/rewrite/change-config-types.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/change-config-types.yml
@@ -1,0 +1,132 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+## TODO: support retry policy, signer and throttledRetries
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: software.amazon.awssdk.ChangeConfigTypes
+displayName: Change region related classes
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration withRequestTimeout(int)
+      newMethodName: withApiCallAttemptTimeout
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration setRequestTimeout(int)
+      newMethodName: withApiCallAttemptTimeout
+  - software.amazon.awssdk.migration.internal.recipe.NumberToDuration:
+      methodPattern: com.amazonaws.ClientConfiguration withApiCallAttemptTimeout(int)
+
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration withClientExecutionTimeout(int)
+      newMethodName: withApiCallTimeout
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration setClientExecutionTimeout(int)
+      newMethodName: withApiCallTimeout
+  - software.amazon.awssdk.migration.internal.recipe.NumberToDuration:
+      methodPattern: com.amazonaws.ClientConfiguration withApiCallTimeout(int)
+
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration withRetryMode(..)
+      newMethodName: withRetryPolicy
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration setRetryMode(..)
+      newMethodName: withRetryPolicy
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration withHeader(String, String)
+      newMethodName: withPutHeader
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.ClientConfiguration setHeader(String, String)
+      newMethodName: withPutHeader
+
+  ## Add comment to unsupported options
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setMaxConsecutiveRetriesBeforeThrottling(int)
+      comment: maxConsecutiveRetriesBeforeThrottling is deprecated and not supported in v2. Consider removing it or using a custom RetryPolicy.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withMaxConsecutiveRetriesBeforeThrottling(int)
+      comment: maxConsecutiveRetriesBeforeThrottling is deprecated and not supported in v2. Consider removing it or using a custom RetryPolicy.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setCacheResponseMetadata(boolean)
+      comment: cacheResponseMetadata is deprecated and not supported in v2. Consider removing it.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withCacheResponseMetadata(boolean)
+      comment: cacheResponseMetadata is deprecated and not supported in v2. Consider removing it.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withDisableHostPrefixInjection(boolean)
+      comment: disableHostPrefixInjection is deprecated and not supported removed in v2. Consider removing it.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setDisableHostPrefixInjection(boolean)
+      comment: disableHostPrefixInjection is deprecated and not supported in v2. Consider removing it.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setDnsResolver(..)
+      comment: dnsResolver is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withDnsResolver(..)
+      comment: dnsResolver is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setGzip(boolean)
+      comment: gzip is not supported in v2 tracking in https://github.com/aws/aws-sdk-java-v2/issues/866. Consider removing it.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withGzip(boolean)
+      comment: gzip is not supported in v2 tracking in https://github.com/aws/aws-sdk-java-v2/issues/866. Consider removing it.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setLocalAddress(..)
+      comment: localAddress is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withLocalAddress(..)
+      comment: localAddress is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setSecureRandom(.*)
+      comment: secureRandom is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withSecureRandom(.*)
+      comment: secureRandom is supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setUseExpectContinue(boolean)
+      comment: useExpectContinue is removed in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withUseExpectContinue(boolean)
+      comment: useExpectContinue is removed in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withProtocol(.*)
+      comment: protocol is deprecated and not supported in v2. Consider using endpointOverride to specify HTTP scheme.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setProtocol(.*)
+      comment: protocol is deprecated and not supported in v2. Consider using endpointOverride to specify HTTP scheme.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withUserAgent(String)
+      comment: userAgent override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setUserAgent(String)
+      comment: userAgent override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withUserAgentPrefix(String)
+      comment: userAgentPrefix override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setUserAgentPrefix(String)
+      comment: userAgentPrefix override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration withUserAgentSuffix(String)
+      comment: userAgentSuffix override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.ClientConfiguration setUserAgentSuffix(String)
+      comment: userAgentSuffix override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).
+
+  ## The following change needs to be the last step
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.ClientConfiguration
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.retry.RetryMode
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.retry.RetryMode

--- a/migration-tool/src/main/resources/META-INF/rewrite/change-sdk-core-types.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/change-sdk-core-types.yml
@@ -19,3 +19,4 @@ displayName: Change Maven dependency groupId, artifactId and/or the version exam
 recipeList:
   - software.amazon.awssdk.ChangeRegionTypes
   - software.amazon.awssdk.ChangeAuthTypes
+  - software.amazon.awssdk.ChangeConfigTypes

--- a/migration-tool/src/main/resources/META-INF/rewrite/java-sdk-v1-to-v2.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/java-sdk-v1-to-v2.yml
@@ -25,6 +25,7 @@ recipeList:
   - software.amazon.awssdk.UpgradeSdkDependencies
   - software.amazon.awssdk.migration.recipe.ChangeSdkType
   - software.amazon.awssdk.ChangeSdkCoreTypes
+  # At this point, all classes should be changed to v2 equivalents
   - software.amazon.awssdk.migration.recipe.V1BuilderVariationsToV2Builder
   - software.amazon.awssdk.migration.recipe.NewClassToBuilderPattern
   - software.amazon.awssdk.migration.recipe.NewClassToStaticFactory

--- a/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
@@ -187,12 +187,6 @@ recipeList:
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
-      oldArtifactId: aws-java-sdk-timestreaminfluxdb
-      newGroupId: software.amazon.awssdk
-      newArtifactId: timestreaminfluxdb
-      newVersion: 2.23.16-SNAPSHOT
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
-      oldGroupId: com.amazonaws
       oldArtifactId: aws-java-sdk-lakeformation
       newGroupId: software.amazon.awssdk
       newArtifactId: lakeformation
@@ -592,12 +586,6 @@ recipeList:
       oldArtifactId: aws-java-sdk-paymentcryptography
       newGroupId: software.amazon.awssdk
       newArtifactId: paymentcryptography
-      newVersion: 2.23.16-SNAPSHOT
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
-      oldGroupId: com.amazonaws
-      oldArtifactId: aws-java-sdk-chatbot
-      newGroupId: software.amazon.awssdk
-      newArtifactId: chatbot
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
@@ -1702,12 +1690,6 @@ recipeList:
       oldArtifactId: aws-java-sdk-internetmonitor
       newGroupId: software.amazon.awssdk
       newArtifactId: internetmonitor
-      newVersion: 2.23.16-SNAPSHOT
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
-      oldGroupId: com.amazonaws
-      oldArtifactId: aws-java-sdk-artifact
-      newGroupId: software.amazon.awssdk
-      newArtifactId: artifact
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/AddCommentToMethodTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/AddCommentToMethodTest.java
@@ -49,8 +49,8 @@ public class AddCommentToMethodTest implements RewriteTest {
                 + "    \n"
                 + "    void test() {\n"
                 + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
-                + "        /*~~(AWS SDK for Java v2 migration: a comment)~~>*/clientConfiguration.setCacheResponseMetadata"
-                + "(false);\n"
+                + "        /*~~(AWS SDK for Java v2 migration: a comment\n"
+                + ")~~>*/clientConfiguration.setCacheResponseMetadata(false);\n"
                 + "    }\n"
                 + "}"
             )
@@ -82,8 +82,8 @@ public class AddCommentToMethodTest implements RewriteTest {
                 + "    void test() {\n"
                 + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
                 + "        // Existing comment \n"
-                + "        /*existing comment*/ /*~~(AWS SDK for Java v2 migration: a comment)~~>*/clientConfiguration"
-                + ".setCacheResponseMetadata(false);\n"
+                + "        /*existing comment*/ /*~~(AWS SDK for Java v2 migration: a comment\n"
+                + ")~~>*/clientConfiguration.setCacheResponseMetadata(false);\n"
                 + "    }\n"
                 + "}"
             )

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeConfigTypesTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeConfigTypesTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.recipe;
+
+import static org.openrewrite.java.Assertions.java;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.YamlResourceLoader;
+import org.openrewrite.java.Java8Parser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class ChangeConfigTypesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        try (InputStream stream = getClass().getResourceAsStream("/META-INF/rewrite/change-config-types.yml")) {
+            spec.recipes(Environment.builder()
+                                    .load(new YamlResourceLoader(stream, URI.create("rewrite.yml"), new Properties()))
+                                    .build()
+                                    .activateRecipes("software.amazon.awssdk.ChangeConfigTypes"),
+                         new NewClassToBuilderPattern());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs","aws-sdk-java", "sdk-core"));
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void defaultConfiguration_shouldConvert() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.ClientConfiguration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
+                + "    }\n"
+                + "}\n",
+                "import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        ClientOverrideConfiguration clientConfiguration = ClientOverrideConfiguration.builder().build();\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void defaultConfigurationWithSupportedNonConnectionSettings_shouldConvert() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.ClientConfiguration;\n"
+                + "import com.amazonaws.retry.RetryMode;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration()\n"
+                + "            .withRetryMode(RetryMode.STANDARD)\n"
+                + "            .withClientExecutionTimeout(5000)\n"
+                + "            .withRequestTimeout(1000)\n"
+                + "            .withHeader(\"foo\", \"bar\");\n"
+                + "    }\n"
+                + "}",
+                "import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;\n"
+                + "import software.amazon.awssdk.core.retry.RetryMode;\n"
+                + "\n"
+                + "import java.time.Duration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        ClientOverrideConfiguration clientConfiguration = ClientOverrideConfiguration.builder()\n"
+                + "            .retryPolicy(RetryMode.STANDARD)\n"
+                + "            .apiCallTimeout(Duration.ofMillis(5000))\n"
+                + "            .apiCallAttemptTimeout(Duration.ofMillis(1000))\n"
+                + "            .putHeader(\"foo\", \"bar\").build();\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void defaultConfigurationWithUnsupportedSettings_shouldAddComment() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.ClientConfiguration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration()\n"
+                + "            .withCacheResponseMetadata(false)\n"
+                + "            .withDisableHostPrefixInjection(true)\n"
+                + "            .withDisableSocketProxy(true)\n"
+                + "            .withDnsResolver(null)\n"
+                + "            .withGzip(true)\n"
+                + "            .withLocalAddress(null)\n"
+                + "            .withSecureRandom(null)\n"
+                + "            .withThrottledRetries(true)\n"
+                + "            .withProtocol(null)\n"
+                + "            .withUserAgent(\"test\")\n"
+                + "            .withUserAgentPrefix(\"test\")\n"
+                + "            .withUserAgentSuffix(\"test\")\n"
+                + "            .withUseExpectContinue(false);\n"
+                + "    }\n"
+                + "}\n",
+                "import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        ClientOverrideConfiguration clientConfiguration = /*~~(AWS SDK for Java v2 migration: useExpectContinue is removed in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: userAgentSuffix override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: userAgentPrefix override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: userAgent override is a request-level config in v2. See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/RequestOverrideConfiguration.Builder.html#addApiName(software.amazon.awssdk.core.ApiName).\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: localAddress is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: gzip is not supported in v2 tracking in https://github.com/aws/aws-sdk-java-v2/issues/866. Consider removing it.\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: dnsResolver is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: disableHostPrefixInjection is deprecated and not supported removed in v2. Consider removing it.\n"
+                + ")~~>*//*~~(AWS SDK for Java v2 migration: cacheResponseMetadata is deprecated and not supported in v2. Consider removing it.\n"
+                + ")~~>*/ClientOverrideConfiguration.builder()\n"
+                + "            .cacheResponseMetadata(false)\n"
+                + "            .disableHostPrefixInjection(true)\n"
+                + "            .disableSocketProxy(true)\n"
+                + "            .dnsResolver(null)\n"
+                + "            .gzip(true)\n"
+                + "            .localAddress(null)\n"
+                + "            .secureRandom(null)\n"
+                + "            .throttledRetries(true)\n"
+                + "            .protocol(null)\n"
+                + "            .userAgent(\"test\")\n"
+                + "            .userAgentPrefix(\"test\")\n"
+                + "            .userAgentSuffix(\"test\")\n"
+                + "            .useExpectContinue(false).build();\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+}

--- a/test/migration-tool-tests/src/test/resources/after/src/main/java/foo/bar/SdkClientsDependencyFactory.java
+++ b/test/migration-tool-tests/src/test/resources/after/src/main/java/foo/bar/SdkClientsDependencyFactory.java
@@ -15,9 +15,13 @@
 
 package foo.bar;
 
-import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import java.time.Duration;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 public final class SdkClientsDependencyFactory {
@@ -30,8 +34,15 @@ public final class SdkClientsDependencyFactory {
     }
 
     public static SqsClient sqsClientWithAllSettings() {
+        ClientOverrideConfiguration clientConfiguration = ClientOverrideConfiguration.builder()
+            .retryPolicy(RetryMode.STANDARD)
+            .apiCallTimeout(Duration.ofMillis(5000))
+            .apiCallAttemptTimeout(Duration.ofMillis(1000))
+            .putHeader("foo", "bar").build();
+
         return SqsClient.builder()
                               .region(Region.US_WEST_2)
+                              .overrideConfiguration(clientConfiguration)
                               .credentialsProvider(CredentialsDependencyFactory.defaultCredentialsProviderChain())
                               .build();
     }

--- a/test/migration-tool-tests/src/test/resources/before/src/main/java/foo/bar/SdkClientsDependencyFactory.java
+++ b/test/migration-tool-tests/src/test/resources/before/src/main/java/foo/bar/SdkClientsDependencyFactory.java
@@ -16,6 +16,8 @@
 package foo.bar;
 
 import com.amazonaws.regions.Regions;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.retry.RetryMode;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
@@ -31,8 +33,15 @@ public final class SdkClientsDependencyFactory {
     }
 
     public static AmazonSQS sqsClientWithAllSettings() {
+        ClientConfiguration clientConfiguration = new ClientConfiguration()
+            .withRetryMode(RetryMode.STANDARD)
+            .withClientExecutionTimeout(5000)
+            .withRequestTimeout(1000)
+            .withHeader("foo", "bar");
+
         return AmazonSQSClient.builder()
                               .withRegion(Regions.US_WEST_2)
+                              .withClientConfiguration(clientConfiguration)
                               .withCredentials(CredentialsDependencyFactory.defaultCredentialsProviderChain())
                               .build();
     }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
- Add mapping for non-HTTP config settings
- For settings that are not supported in v2, we will add comments providing guidance


Supported non-HTTP settings:
```
        ClientConfiguration clientConfiguration = new ClientConfiguration()
            .withRetryMode(RetryMode.STANDARD)
            .withClientExecutionTimeout(5000)
            .withRequestTimeout(1000)
            .with
            .withHeader("foo", "bar");
```

to
```
        ClientOverrideConfiguration clientConfiguration = ClientOverrideConfiguration.builder()
            .retryPolicy(RetryMode.STANDARD)
            .apiCallTimeout(Duration.ofMillis(5000))
            .apiCallAttemptTimeout(Duration.ofMillis(1000))
            .putHeader("foo", "bar").build();
```

Unsupported settings:

```
              ClientConfiguration clientConfiguration = new ClientConfiguration()"
                .withCacheResponseMetadata(false);
```

```
        ClientOverrideConfiguration clientConfiguration = /*~~(AWS SDK for Java v2 migration: cacheResponseMetadata is deprecated and not supported in v2. Consider removing it.
)~~>*/ClientOverrideConfiguration.builder()
            .cacheResponseMetadata(false).build();
```


## Testing
Added tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
