### PR TITLE
Adding guidance to MD5 calculation exception message

### DIFF
--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/MessageMD5ChecksumInterceptor.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/MessageMD5ChecksumInterceptor.java
@@ -218,7 +218,10 @@ public final class MessageMD5ChecksumInterceptor implements ExecutionInterceptor
             expectedMd5 = Md5Utils.computeMD5Hash(messageBody.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             throw SdkClientException.builder()
-                                    .message("Unable to calculate the MD5 hash of the message body. " + e.getMessage())
+                                    .message("Unable to calculate the MD5 hash of the message body. "
+                                             + "Potential reasons include JVM configuration or FIPS compliance issues. "
+                                             + "To disable message MD5 validation, you can set checksumValidationEnabled "
+                                             + "to false when instantiating the client." + e.getMessage())
                                     .cause(e)
                                     .build();
         }
@@ -271,7 +274,10 @@ public final class MessageMD5ChecksumInterceptor implements ExecutionInterceptor
             }
         } catch (Exception e) {
             throw SdkClientException.builder()
-                                    .message("Unable to calculate the MD5 hash of the message attributes. " + e.getMessage())
+                                    .message("Unable to calculate the MD5 hash of the message attributes. "
+                                             + "Potential reasons include JVM configuration or FIPS compliance issues. "
+                                             + "To disable message MD5 validation, you can set checksumValidationEnabled "
+                                             + "to false when instantiating the client." + e.getMessage())
                                     .cause(e)
                                     .build();
         }


### PR DESCRIPTION
## Motivation and Context
If MD5 calculation fails because there is no available algorithm in the underlying JVM, this could be because the SDK is executing in a FIPS environment, where MD5 is no longer allowed due to compliance reasons. 

In addition to disabling MD5 checks on SQS message responses if the flag `checksumValidationEnabled` flag is set to false (PR #4729), this PR informs users with failing calculations that the flag exists by extending the exception message. 
