### PR TITLE
Set expirationTime when building AwsSessionCredentials in HttpCredent…

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/HttpCredentialsLoader.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/HttpCredentialsLoader.java
@@ -104,6 +104,7 @@ public final class HttpCredentialsLoader {
                                         .accessKeyId(accessKeyId)
                                         .secretAccessKey(secretKey)
                                         .sessionToken(token)
+                                        .expirationTime(expiration)
                                         .providerName(providerName)
                                         .build() :
                    AwsBasicCredentials.builder()


### PR DESCRIPTION
Set expirationTime when building AwsSessionCredentials in HttpCredentialsLoader.getAwsCredentials

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When resolving credentials using ContainerCredentialsProvider, expirationTime has always no value.
This change ensure that the value is properly set.

## Modifications
Setting expirationTime

## Testing
Ran the already existing test suites.

Build :auth module and used it in my application. Logged and verified that expirationTime is not null

This change does not affects other areas of the code. It simply set a property that should have been set and makes the behaviour consistent with documentation

## Screenshots (if appropriate)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
