### PR TITLE
Supporting wildcard and keys fn in JmesPathRuntime

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -87,13 +87,11 @@ import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.HostnameValidator;
-import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.internal.CodegenNamingUtils;
 
 public class EndpointResolverInterceptorSpec implements ClassSpec {
 
-    private static final String LOGGER_FIELD_NAME = "LOG";
     private final IntermediateModel model;
     private final EndpointRulesSpecUtils endpointRulesSpecUtils;
     private final EndpointParamsKnowledgeIndex endpointParamsKnowledgeIndex;
@@ -127,8 +125,6 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
                                       .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                                       .addAnnotation(SdkInternalApi.class)
                                       .addSuperinterface(ExecutionInterceptor.class);
-
-        b.addField(logger());
 
         if (!useSraAuth) {
             b.addField(endpointAuthSchemeStrategyFieldSpec);
@@ -573,13 +569,7 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
                                               .add(")")
                                               .build();
 
-                b.beginControlFlow("try");
                 b.addStatement(addParam);
-                b.endControlFlow();
-                b.beginControlFlow("catch ($T e)", Exception.class);
-                b.addStatement("$N.warn(() -> \"Error resolving operation context parameter '$L'; will set param to null."
-                               + " \\nError message: \" + e.getMessage())", LOGGER_FIELD_NAME, setterName);
-                b.endControlFlow();
             } else {
                 throw new RuntimeException("Invalid operation context parameter path for " + opModel.getOperationName() +
                                            ". Expected VALUE_STRING, but got " + value.getValue().asToken());
@@ -895,10 +885,4 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         return b.build();
     }
 
-    private FieldSpec logger() {
-        return FieldSpec.builder(Logger.class, LOGGER_FIELD_NAME)
-                        .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                        .initializer("$T.loggerFor($T.class)", Logger.class, className())
-                        .build();
-    }
 }

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/jmespath/JmesPathRuntime.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/jmespath/JmesPathRuntime.java.resource
@@ -188,12 +188,15 @@ public final class JmesPathRuntime {
             if (type == Type.LIST) {
                 List<String> result = new ArrayList<>();
                 for (Object listEntry : listValue) {
-                    Value listValue = new Value(listEntry);
-                    if (listValue.type != Type.STRING) {
-                        throw new IllegalStateException("Expected list elements to be of type String, but were "
-                        + listValue.type);
+                    Value entryAsValue = new Value(listEntry);
+                    if (entryAsValue.type == Type.NULL) {
+                        continue;
                     }
-                    result.add(listValue.stringValue);
+                    if (entryAsValue.type != Type.STRING) {
+                        throw new IllegalStateException("Expected list elements to be of type String, but were "
+                        + entryAsValue.type);
+                    }
+                    result.add(entryAsValue.stringValue);
                 }
                 return result;
             }
@@ -478,6 +481,7 @@ public final class JmesPathRuntime {
                                       .map(Value::new)
                                       .map(functionToApply)
                                       .map(Value::value)
+                                      .filter(Objects::nonNull)
                                       .collect(toList()),
                              true);
         }

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/jmespath/JmesPathRuntime.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/jmespath/JmesPathRuntime.java.resource
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
 
@@ -222,14 +223,16 @@ public final class JmesPathRuntime {
                 return NULL_VALUE;
             }
 
-            if (type != Type.POJO) {
-                throw new IllegalArgumentException("Cannot flatten a " + type);
+            if (type == Value.Type.LIST) {
+                return newProjection(listValue);
             }
 
-            return Value.newProjection(pojoValue.sdkFields().stream()
-                                                .map(f -> f.getValueOrDefault(pojoValue))
-                                                .filter(Objects::nonNull)
-                                                .collect(toList()));
+            if (type == Value.Type.POJO) {
+                return newProjection(pojoValue.sdkFields().stream().map(f -> f.getValueOrDefault(pojoValue))
+                                              .filter(Objects::nonNull).collect(toList()));
+            }
+
+            throw new IllegalArgumentException("Cannot use a wildcard expression on a " + type);
         }
 
         /**
@@ -330,6 +333,18 @@ public final class JmesPathRuntime {
             }
 
             throw new IllegalArgumentException("Unsupported type for length function: " + type);
+        }
+
+        public Value keys() {
+            if (type == Type.NULL) {
+                return new Value(Collections.emptyList(), false);
+            }
+
+            if (type == Type.POJO) {
+                return new Value(pojoValue.sdkFields().stream().map(SdkField::memberName).collect(toList()));
+            }
+
+            throw new IllegalArgumentException("Unsupported type for keys function: " + type);
         }
 
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
@@ -43,11 +43,13 @@ import software.amazon.awssdk.services.query.model.OperationWithCustomizedOperat
 import software.amazon.awssdk.services.query.model.OperationWithOperationContextParamRequest;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
-
+import software.amazon.awssdk.utils.Logger;
 
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
 public final class QueryResolveEndpointInterceptor implements ExecutionInterceptor {
+    private static final Logger LOG = Logger.loggerFor(QueryResolveEndpointInterceptor.class);
+
     private final EndpointAuthSchemeStrategy endpointAuthSchemeStrategy;
 
     public QueryResolveEndpointInterceptor() {
@@ -218,14 +220,25 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithCustomizedOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString").stringValues());
-
+        try {
+            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+                                            .stringValues());
+        } catch (Exception e) {
+            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
+                           + e.getMessage());
+        }
     }
 
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString").stringValues());
+        try {
+            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+                                            .stringValues());
+        } catch (Exception e) {
+            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
+                           + e.getMessage());
+        }
     }
 
     private static Optional<String> hostPrefix(String operationName, SdkRequest request) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
@@ -43,13 +43,10 @@ import software.amazon.awssdk.services.query.model.OperationWithCustomizedOperat
 import software.amazon.awssdk.services.query.model.OperationWithOperationContextParamRequest;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
-import software.amazon.awssdk.utils.Logger;
 
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
 public final class QueryResolveEndpointInterceptor implements ExecutionInterceptor {
-    private static final Logger LOG = Logger.loggerFor(QueryResolveEndpointInterceptor.class);
-
     private final EndpointAuthSchemeStrategy endpointAuthSchemeStrategy;
 
     public QueryResolveEndpointInterceptor() {
@@ -220,25 +217,15 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithCustomizedOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        try {
-            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
                                             .stringValues());
-        } catch (Exception e) {
-            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
-                           + e.getMessage());
-        }
     }
 
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        try {
-            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
                                             .stringValues());
-        } catch (Exception e) {
-            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
-                           + e.getMessage());
-        }
     }
 
     private static Optional<String> hostPrefix(String operationName, SdkRequest request) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -38,10 +38,13 @@ import software.amazon.awssdk.services.query.model.OperationWithCustomizedOperat
 import software.amazon.awssdk.services.query.model.OperationWithOperationContextParamRequest;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Logger;
 
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
 public final class QueryResolveEndpointInterceptor implements ExecutionInterceptor {
+    private static final Logger LOG = Logger.loggerFor(QueryResolveEndpointInterceptor.class);
+
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         SdkRequest result = context.request();
@@ -204,14 +207,25 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithCustomizedOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString").stringValues());
-
+        try {
+            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+                                            .stringValues());
+        } catch (Exception e) {
+            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
+                           + e.getMessage());
+        }
     }
 
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString").stringValues());
+        try {
+            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+                                            .stringValues());
+        } catch (Exception e) {
+            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
+                           + e.getMessage());
+        }
     }
 
     private static Optional<String> hostPrefix(String operationName, SdkRequest request) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -38,12 +38,10 @@ import software.amazon.awssdk.services.query.model.OperationWithCustomizedOperat
 import software.amazon.awssdk.services.query.model.OperationWithOperationContextParamRequest;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
-import software.amazon.awssdk.utils.Logger;
 
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
 public final class QueryResolveEndpointInterceptor implements ExecutionInterceptor {
-    private static final Logger LOG = Logger.loggerFor(QueryResolveEndpointInterceptor.class);
 
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
@@ -207,25 +205,15 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithCustomizedOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        try {
-            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
                                             .stringValues());
-        } catch (Exception e) {
-            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
-                           + e.getMessage());
-        }
     }
 
     private static void setOperationContextParams(QueryEndpointParams.Builder params,
                                                   OperationWithOperationContextParamRequest request) {
         JmesPathRuntime.Value input = new JmesPathRuntime.Value(request);
-        try {
-            params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
+        params.customEndpointArray(input.field("ListMember").field("StringList").wildcard().field("LeafString")
                                             .stringValues());
-        } catch (Exception e) {
-            LOG.warn(() -> "Error resolving operation context parameter 'customEndpointArray'; will set param to null. \nError message: "
-                           + e.getMessage());
-        }
     }
 
     private static Optional<String> hostPrefix(String operationName, SdkRequest request) {

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -296,7 +296,7 @@
       "operationName": "DeleteObjects",
       "operationContextParamsMap": {
         "DeleteObjectKeys": {
-          "value": "Delete.Objects[*].key"
+          "value": "Delete.Objects[*].Key"
         }
       }
     }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
@@ -18,26 +18,16 @@
             "documentation": "A list of string from a wildcard projection",
             "type": "StringArray"
         },
-        "EmptyKeyListOfString": {
+        "KeysListOfString": {
             "required": false,
-            "documentation": "A list of string from a wildcard projection that evaluates to null elements",
+            "documentation": "A list of string that are map keys",
             "type": "StringArray"
         },
          "MissingRequestValuesListOfString": {
              "required": false,
              "documentation": "A list of string from a field that is not populated in the request",
              "type": "StringArray"
-         },
-         "MissingFieldListOfString": {
-             "required": false,
-             "documentation": "A list of string from a field that does not exist. Can only happen with customization config.",
-             "type": "StringArray"
-         },
-        "KeysListOfString": {
-            "required": false,
-            "documentation": "A list of string that are map keys",
-            "type": "StringArray"
-        }
+         }
     },
     "customOperationContextParams": [
         {
@@ -55,14 +45,8 @@
                 "KeysListOfString": {
                     "value": "keys(PojoKeys)"
                 },
-                "EmptyKeyListOfString": {
-                    "value": "Nested.ListOfNested[*].NonExistingMember"
-                },
                 "MissingRequestValuesListOfString": {
                     "value": "Nested.ListOfString"
-                },
-                "MissingFieldListOfString": {
-                    "value": "Nested.NonExistingMember"
                 }
             }
         }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
@@ -4,14 +4,39 @@
     "enableGenerateCompiledEndpointRules": false,
     "endpointParameters": {
         "PojoString": {
-          "required": false,
-          "documentation": "A string",
-          "type": "String"
+            "required": false,
+            "documentation": "A string",
+            "type": "String"
         },
         "BasicListOfString": {
-          "required": false,
-          "documentation": "A list of string keys",
-          "type": "StringArray"
+            "required": false,
+            "documentation": "A list of string keys",
+            "type": "StringArray"
+        },
+        "WildcardKeyListOfString": {
+            "required": false,
+            "documentation": "A list of string from a wildcard projection",
+            "type": "StringArray"
+        },
+        "EmptyKeyListOfString": {
+            "required": false,
+            "documentation": "A list of string from a wildcard projection that evaluates to null elements",
+            "type": "StringArray"
+        },
+         "MissingRequestValuesListOfString": {
+             "required": false,
+             "documentation": "A list of string from a field that is not populated in the request",
+             "type": "StringArray"
+         },
+         "MissingFieldListOfString": {
+             "required": false,
+             "documentation": "A list of string from a field that does not exist. Can only happen with customization config.",
+             "type": "StringArray"
+         },
+        "KeysListOfString": {
+            "required": false,
+            "documentation": "A list of string that are map keys",
+            "type": "StringArray"
         }
     },
     "customOperationContextParams": [
@@ -23,6 +48,21 @@
                 },
                 "BasicListOfString": {
                     "value": "ListOfString"
+                },
+                "WildcardKeyListOfString": {
+                    "value": "Nested.ListOfNested[*].StringMember"
+                },
+                "KeysListOfString": {
+                    "value": "keys(PojoKeys)"
+                },
+                "EmptyKeyListOfString": {
+                    "value": "Nested.ListOfNested[*].NonExistingMember"
+                },
+                "MissingRequestValuesListOfString": {
+                    "value": "Nested.ListOfString"
+                },
+                "MissingFieldListOfString": {
+                    "value": "Nested.NonExistingMember"
                 }
             }
         }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/service-2.json
@@ -386,7 +386,8 @@
       "members":{
         "Nested": {"shape":"NestedContainersStructure"},
         "ListOfString":{"shape":"ListOfStrings"},
-        "ListOfNested":{"shape":"ListOfNested"}
+        "ListOfNested":{"shape":"ListOfNested"},
+        "PojoKeys":{"shape":"PayloadStructType"}
       }
     },
     "GetOperationWithBodyInput":{
@@ -691,6 +692,7 @@
       "type":"structure",
       "members":{
         "ListOfNested":{"shape":"ListOfNested"},
+        "ListOfString":{"shape":"ListOfStrings"},
         "ListOfListsOfStrings":{"shape":"ListOfListsOfStrings"},
         "ListOfListsOfStructs":{"shape":"ListOfListsOfStructs"},
         "ListOfListsOfAllTypesStructs":{"shape":"ListOfListsOfAllTypesStructs"},

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/OperationContextParametersTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/OperationContextParametersTest.java
@@ -22,16 +22,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.logging.impl.Log4JLogger;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,6 +36,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersClient;
 import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJsonEndpointProvidersEndpointParams;
 import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJsonEndpointProvidersEndpointProvider;
+import software.amazon.awssdk.services.restjsonendpointproviders.model.NestedContainersOperationRequest;
 import software.amazon.awssdk.services.restjsonendpointproviders.model.NestedContainersOperationResponse;
 import software.amazon.awssdk.services.restjsonendpointproviders.model.NestedContainersStructure;
 import software.amazon.awssdk.services.restjsonendpointproviders.model.PayloadStructType;
@@ -55,7 +49,6 @@ class OperationContextParametersTest extends LogCaptor.LogCaptorTestBase {
     private static final Region REGION = Region.of("us-east-9000");
 
     private RestJsonEndpointProvidersEndpointProvider mockEndpointProvider;
-    Log4JLogger fooLogger;
 
     @BeforeEach
     public void setup() {
@@ -66,28 +59,22 @@ class OperationContextParametersTest extends LogCaptor.LogCaptorTestBase {
 
     static Stream<Arguments> paramAssertions() {
         return Stream.of(
-            Arguments.of("Single String parameter works as expected", new TestAssertion(
+            Arguments.of("Single String parameter", new TestAssertion(
                 p -> assertThat(p.pojoString()).isEqualTo("StringMemberA"))),
 
-            Arguments.of("List of String parameter works as expected", new TestAssertion(
+            Arguments.of("List of String parameter", new TestAssertion(
                 p -> assertThat(p.basicListOfString()).isNotEmpty().hasSize(2).containsExactly("StringA", "StringB"))),
 
-            Arguments.of("List of String parameter from wildcard works as expected", new TestAssertion(
-                p -> assertThat(p.wildcardKeyListOfString()).isNotEmpty().hasSize(2)
-                                                            .containsExactly("StringMemberS1", "StringMemberS2"))),
+            Arguments.of("List of String parameter from wildcard with null members", new TestAssertion(
+                p -> assertThat(p.wildcardKeyListOfString()).isNotEmpty().hasSize(1)
+                                                            .containsExactly("StringMemberS2"))),
 
-            Arguments.of("List of String parameter from 'keys' function works as expected", new TestAssertion(
+            Arguments.of("List of String parameter from 'keys' function", new TestAssertion(
                 p -> assertThat(p.keysListOfString()).isNotEmpty().hasSize(2)
                                                      .containsExactly("PayloadMemberOne", "PayloadMemberTwo"))),
 
-            Arguments.of("List of String parameter is null if list is empty", new TestAssertion(
-                p -> assertThat(p.emptyKeyListOfString()).isNull())),
-
             Arguments.of("List of String parameter is empty if request does not have list elements", new TestAssertion(
-                p -> assertThat(p.missingRequestValuesListOfString()).isEmpty())),
-
-            Arguments.of("List of String parameter is null if request is missing structure", new TestAssertion(
-                p -> assertThat(p.missingFieldListOfString()).isNull()))
+                p -> assertThat(p.missingRequestValuesListOfString()).isEmpty()))
         );
     }
 
@@ -105,52 +92,33 @@ class OperationContextParametersTest extends LogCaptor.LogCaptorTestBase {
         assertion.verify.accept(params);
     }
 
-    @Test
-    void testErrorsAreEncapsulatedAndLogged() {
-        assertThatThrownBy(this::createClientAndCallApi).isInstanceOf(RuntimeException.class);
-        List<LogEvent> jmesRuntimeEvents = loggedEvents().stream()
-                                                         .filter(e -> e.getLoggerName().contains(
-                                                             "RestJsonEndpointProvidersResolveEndpointInterceptor"))
-                                                         .collect(Collectors.toList());
-        assertThat(jmesRuntimeEvents).hasSize(2);
-        assertThat(jmesRuntimeEvents).extracting("level").containsOnly(Level.WARN);
-        assertThat(jmesRuntimeEvents).extracting("message.formattedMessage")
-                                     .usingElementComparator(stringContains())
-                                     .contains("emptyKeyListOfString", "missingFieldListOfString")
-                                     .contains("No such field: NonExistingMember");
-    }
-
     private NestedContainersOperationResponse createClientAndCallApi() {
         RestJsonEndpointProvidersClient client = RestJsonEndpointProvidersClient.builder()
                                                                                 .region(REGION)
                                                                                 .credentialsProvider(CREDENTIALS)
                                                                                 .endpointProvider(mockEndpointProvider)
                                                                                 .build();
-
-        NestedContainersStructure nestedShallow1 = NestedContainersStructure.builder()
-                                                                            .stringMember("StringMemberS1")
-                                                                            .build();
-        NestedContainersStructure nestedShallow2 = NestedContainersStructure.builder()
-                                                                            .stringMember("StringMemberS2")
-                                                                            .build();
-        NestedContainersStructure nested = NestedContainersStructure.builder()
-                                                                    .stringMember("StringMemberA")
-                                                                    .listOfNested(nestedShallow1, nestedShallow2)
-                                                                    .build();
-        PayloadStructType pojoKeys = PayloadStructType.builder().payloadMemberOne("p1").payloadMemberTwo("p2").build();
-        return client.nestedContainersOperation(r -> r.nested(nested)
-                                                      .listOfString("StringA", "StringB")
-                                                      .listOfNested(nestedShallow1, nestedShallow2)
-                                                      .pojoKeys(pojoKeys));
+        return client.nestedContainersOperation(createRequestObject());
     }
 
-    Comparator<Object> stringContains() {
-        return (t1, t2) -> {
-            if (((String) t1).contains((CharSequence) t2)) {
-                return 0;
-            }
-            return -1;
-        };
+    private static NestedContainersOperationRequest createRequestObject() {
+        NestedContainersStructure pojoInListWithoutProjectionMember = NestedContainersStructure.builder().build();
+        NestedContainersStructure pojoInListWithProjectionMember = NestedContainersStructure.builder()
+                                                                                            .stringMember("StringMemberS2")
+                                                                                            .build();
+        NestedContainersStructure nested = NestedContainersStructure.builder()
+                                                                    .stringMember("StringMemberA")
+                                                                    .listOfNested(pojoInListWithoutProjectionMember,
+                                                                                  pojoInListWithProjectionMember)
+                                                                    .build();
+        PayloadStructType pojoKeys = PayloadStructType.builder().payloadMemberOne("p1").payloadMemberTwo("p2").build();
+
+        return NestedContainersOperationRequest.builder()
+                                               .nested(nested)
+                                               .listOfString("StringA", "StringB")
+                                               .listOfNested(pojoInListWithoutProjectionMember, pojoInListWithProjectionMember)
+                                               .pojoKeys(pojoKeys)
+                                               .build();
     }
 
     private static class TestAssertion {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/OperationContextParametersTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/OperationContextParametersTest.java
@@ -22,13 +22,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.logging.impl.Log4JLogger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -40,14 +45,17 @@ import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJ
 import software.amazon.awssdk.services.restjsonendpointproviders.endpoints.RestJsonEndpointProvidersEndpointProvider;
 import software.amazon.awssdk.services.restjsonendpointproviders.model.NestedContainersOperationResponse;
 import software.amazon.awssdk.services.restjsonendpointproviders.model.NestedContainersStructure;
+import software.amazon.awssdk.services.restjsonendpointproviders.model.PayloadStructType;
+import software.amazon.awssdk.testutils.LogCaptor;
 
-class OperationContextParametersTest {
+class OperationContextParametersTest extends LogCaptor.LogCaptorTestBase {
     private static final AwsCredentialsProvider CREDENTIALS = StaticCredentialsProvider.create(
         AwsBasicCredentials.create("akid", "skid"));
 
     private static final Region REGION = Region.of("us-east-9000");
 
     private RestJsonEndpointProvidersEndpointProvider mockEndpointProvider;
+    Log4JLogger fooLogger;
 
     @BeforeEach
     public void setup() {
@@ -56,9 +64,36 @@ class OperationContextParametersTest {
             .thenThrow(new RuntimeException("boom"));
     }
 
-    @ParameterizedTest
-    @MethodSource("testCases")
-    void operationContextParams_customization_resolvedCorrectly(TestCase tc) {
+    static Stream<Arguments> paramAssertions() {
+        return Stream.of(
+            Arguments.of("Single String parameter works as expected", new TestAssertion(
+                p -> assertThat(p.pojoString()).isEqualTo("StringMemberA"))),
+
+            Arguments.of("List of String parameter works as expected", new TestAssertion(
+                p -> assertThat(p.basicListOfString()).isNotEmpty().hasSize(2).containsExactly("StringA", "StringB"))),
+
+            Arguments.of("List of String parameter from wildcard works as expected", new TestAssertion(
+                p -> assertThat(p.wildcardKeyListOfString()).isNotEmpty().hasSize(2)
+                                                            .containsExactly("StringMemberS1", "StringMemberS2"))),
+
+            Arguments.of("List of String parameter from 'keys' function works as expected", new TestAssertion(
+                p -> assertThat(p.keysListOfString()).isNotEmpty().hasSize(2)
+                                                     .containsExactly("PayloadMemberOne", "PayloadMemberTwo"))),
+
+            Arguments.of("List of String parameter is null if list is empty", new TestAssertion(
+                p -> assertThat(p.emptyKeyListOfString()).isNull())),
+
+            Arguments.of("List of String parameter is empty if request does not have list elements", new TestAssertion(
+                p -> assertThat(p.missingRequestValuesListOfString()).isEmpty())),
+
+            Arguments.of("List of String parameter is null if request is missing structure", new TestAssertion(
+                p -> assertThat(p.missingFieldListOfString()).isNull()))
+        );
+    }
+
+    @ParameterizedTest(name = "{index} - {0}")
+    @MethodSource("paramAssertions")
+    void operationContextParams_customization_resolvedCorrectly(String description, TestAssertion assertion) {
         assertThatThrownBy(this::createClientAndCallApi).isInstanceOf(RuntimeException.class);
 
         ArgumentCaptor<RestJsonEndpointProvidersEndpointParams> paramsCaptor =
@@ -67,23 +102,22 @@ class OperationContextParametersTest {
         verify(mockEndpointProvider).resolveEndpoint(paramsCaptor.capture());
         RestJsonEndpointProvidersEndpointParams params = paramsCaptor.getValue();
 
-        tc.verify.accept(params);
+        assertion.verify.accept(params);
     }
 
-    static List<TestCase> testCases() {
-        List<TestCase> testCases = new ArrayList<>();
-
-        testCases.add(new TestCase(p -> {
-            String listOfPojoKeysArray = p.pojoString();
-            assertThat(listOfPojoKeysArray).isEqualTo("StringMemberA");
-        }));
-
-        testCases.add(new TestCase(p -> {
-            List<String> listOfPojoKeysArray = p.basicListOfString();
-            assertThat(listOfPojoKeysArray).isNotEmpty().hasSize(2).containsExactly("StringA", "StringB");
-        }));
-
-        return testCases;
+    @Test
+    void testErrorsAreEncapsulatedAndLogged() {
+        assertThatThrownBy(this::createClientAndCallApi).isInstanceOf(RuntimeException.class);
+        List<LogEvent> jmesRuntimeEvents = loggedEvents().stream()
+                                                         .filter(e -> e.getLoggerName().contains(
+                                                             "RestJsonEndpointProvidersResolveEndpointInterceptor"))
+                                                         .collect(Collectors.toList());
+        assertThat(jmesRuntimeEvents).hasSize(2);
+        assertThat(jmesRuntimeEvents).extracting("level").containsOnly(Level.WARN);
+        assertThat(jmesRuntimeEvents).extracting("message.formattedMessage")
+                                     .usingElementComparator(stringContains())
+                                     .contains("emptyKeyListOfString", "missingFieldListOfString")
+                                     .contains("No such field: NonExistingMember");
     }
 
     private NestedContainersOperationResponse createClientAndCallApi() {
@@ -103,15 +137,26 @@ class OperationContextParametersTest {
                                                                     .stringMember("StringMemberA")
                                                                     .listOfNested(nestedShallow1, nestedShallow2)
                                                                     .build();
+        PayloadStructType pojoKeys = PayloadStructType.builder().payloadMemberOne("p1").payloadMemberTwo("p2").build();
         return client.nestedContainersOperation(r -> r.nested(nested)
                                                       .listOfString("StringA", "StringB")
-                                                      .listOfNested(nestedShallow1, nestedShallow2));
+                                                      .listOfNested(nestedShallow1, nestedShallow2)
+                                                      .pojoKeys(pojoKeys));
     }
 
-    private static class TestCase {
+    Comparator<Object> stringContains() {
+        return (t1, t2) -> {
+            if (((String) t1).contains((CharSequence) t2)) {
+                return 0;
+            }
+            return -1;
+        };
+    }
+
+    private static class TestAssertion {
         private final Consumer<RestJsonEndpointProvidersEndpointParams> verify;
 
-        TestCase(Consumer<RestJsonEndpointProvidersEndpointParams> verify) {
+        TestAssertion(Consumer<RestJsonEndpointProvidersEndpointParams> verify) {
             this.verify = verify;
         }
     }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/jmespath/JmesPathRuntimeValueTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/jmespath/JmesPathRuntimeValueTest.java
@@ -21,7 +21,6 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,7 @@ import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.services.restjsonwithwaiters.jmespath.internal.JmesPathRuntime.Value;
+import software.amazon.awssdk.services.restjsonwithwaiters.model.PayloadStructType;
 import software.amazon.awssdk.utils.Pair;
 
 class JmesPathRuntimeValueTest {
@@ -53,14 +53,14 @@ class JmesPathRuntimeValueTest {
         assertThat(new Value("").values()).isEqualTo(singletonList(""));
         assertThat(new Value(true).values()).isEqualTo(singletonList(true));
         assertThat(new Value(singletonList("a")).values()).isEqualTo(singletonList("a"));
-        assertThat(new Value(sdkPojo()).values()).isEqualTo(singletonList(sdkPojo()));
+        assertThat(new Value(simpleSdkPojo()).values()).isEqualTo(singletonList(simpleSdkPojo()));
     }
 
     @Test
     void booleanValueReturnsConstructorInput() {
         assertThat(new Value(null).booleanValue()).isEqualTo(null);
-        assertThatThrownBy(() -> new Value(sdkPojo()).booleanValue()).isInstanceOf(IllegalStateException.class)
-                                                                     .hasMessageContaining("Cannot convert type POJO");
+        assertThatThrownBy(() -> new Value(simpleSdkPojo()).booleanValue()).isInstanceOf(IllegalStateException.class)
+                                                                           .hasMessageContaining("Cannot convert type POJO");
         assertThatThrownBy(() -> new Value(5).booleanValue()).isInstanceOf(IllegalStateException.class)
                                                              .hasMessageContaining("Cannot convert type INTEGER");
         assertThat(new Value("").booleanValue()).isEqualTo(false);
@@ -72,8 +72,8 @@ class JmesPathRuntimeValueTest {
     @Test
     void stringValueReturnsConstructorInput() {
         assertThat(new Value(null).stringValue()).isEqualTo(null);
-        assertThatThrownBy(() -> new Value(sdkPojo()).stringValue()).isInstanceOf(IllegalStateException.class)
-                                                                    .hasMessageContaining("Cannot convert type POJO");
+        assertThatThrownBy(() -> new Value(simpleSdkPojo()).stringValue()).isInstanceOf(IllegalStateException.class)
+                                                                          .hasMessageContaining("Cannot convert type POJO");
         assertThat(new Value(5).stringValue()).isEqualTo("5");
         assertThat(new Value("").stringValue()).isEqualTo("");
         assertThat(new Value(true).stringValue()).isEqualTo("true");
@@ -88,8 +88,8 @@ class JmesPathRuntimeValueTest {
         assertThat(new Value("").stringValues()).isEqualTo(singletonList(""));
         assertThat(new Value(true).stringValues()).isEqualTo(singletonList("true"));
         assertThat(new Value(singletonList("a")).stringValues()).isEqualTo(singletonList("a"));
-        assertThatThrownBy(() -> new Value(sdkPojo()).stringValues()).isInstanceOf(IllegalStateException.class)
-                                                                     .hasMessageContaining("Cannot convert type POJO");
+        assertThatThrownBy(() -> new Value(simpleSdkPojo()).stringValues()).isInstanceOf(IllegalStateException.class)
+                                                                           .hasMessageContaining("Cannot convert type POJO");
     }
 
     @Test
@@ -102,10 +102,10 @@ class JmesPathRuntimeValueTest {
 
     @Test
     void andBehavesWithPojos() {
-        Value truePojo1 = sdkPojoValue(Pair.of("foo", "bar"));
-        Value truePojo2 = sdkPojoValue(Pair.of("foo", "bar"));
-        Value falsePojo1 = sdkPojoValue();
-        Value falsePojo2 = sdkPojoValue();
+        Value truePojo1 = simpleSdkPojoValue(Pair.of("foo", "bar"));
+        Value truePojo2 = simpleSdkPojoValue(Pair.of("foo", "bar"));
+        Value falsePojo1 = simpleSdkPojoValue();
+        Value falsePojo2 = simpleSdkPojoValue();
 
         assertThat(truePojo1.and(truePojo2)).isSameAs(truePojo2);
         assertThat(falsePojo1.and(truePojo1)).isSameAs(falsePojo1);
@@ -149,10 +149,10 @@ class JmesPathRuntimeValueTest {
 
     @Test
     void orBehavesWithPojos() {
-        Value truePojo1 = sdkPojoValue(Pair.of("foo", "bar"));
-        Value truePojo2 = sdkPojoValue(Pair.of("foo", "bar"));
-        Value falsePojo1 = sdkPojoValue();
-        Value falsePojo2 = sdkPojoValue();
+        Value truePojo1 = simpleSdkPojoValue(Pair.of("foo", "bar"));
+        Value truePojo2 = simpleSdkPojoValue(Pair.of("foo", "bar"));
+        Value falsePojo1 = simpleSdkPojoValue();
+        Value falsePojo2 = simpleSdkPojoValue();
 
         assertThat(truePojo1.or(truePojo2)).isSameAs(truePojo1);
         assertThat(falsePojo1.or(truePojo1)).isSameAs(truePojo1);
@@ -205,62 +205,27 @@ class JmesPathRuntimeValueTest {
     }
 
     @Test
-    void wildcardBehavesWithPojos() {
-        assertThat(sdkPojoValue(Pair.of("foo", "bar"),
-                                Pair.of("foo2", singletonList("bar")),
-                                Pair.of("foo3", sdkPojo(Pair.of("x", "y"))))
+    void wildcardBehavesWithPojosAndDoesNotFlatten() {
+        assertThat(simpleSdkPojoValue(Pair.of("foo", "bar"),
+                                      Pair.of("foo2", singletonList("bar")),
+                                      Pair.of("foo3", simpleSdkPojo(Pair.of("x", "y"))))
                        .wildcard())
             .isEqualTo(new Value(asList("bar",
                                         singletonList("bar"),
-                                        sdkPojo(Pair.of("x", "y")))));
+                                        simpleSdkPojo(Pair.of("x", "y")))));
     }
 
     @Test
-    void wildcardBehavesWithNested() {
-        assertThat(nestedConstruct().field("foo2").wildcard())
-            .isEqualTo(new Value(asList(sdkPojo(Pair.of("baz", asList(sdkPojo(Pair.of("key", "value1"))))),
-                                        sdkPojo(Pair.of("baz", asList(sdkPojo(Pair.of("key", "value2"))))))));
+    void wildcardBehavesWithLists() {
+        assertThat(nestedConstruct().field("foo2").field("baz").wildcard())
+            .isEqualTo(new Value(asList(PayloadStructType.builder().payloadMemberTwo("2a").build(),
+                                        PayloadStructType.builder().payloadMemberOne("1b").payloadMemberTwo("2b").build())));
     }
 
     @Test
-    void wildcardBehavesWithNested2() {
-        assertThat(nestedConstruct().field("foo2").wildcard().field("baz"))
-            .isEqualTo(new Value(asList(asList(sdkPojo(Pair.of("key", "value1"))),
-                                        asList(sdkPojo(Pair.of("key", "value2"))))));
-    }
-
-    @Test
-    void wildcardBehavesWithNested3() {
-        assertThat(nestedConstruct().field("foo2").wildcard().field("baz").wildcard())
-            .isEqualTo(new Value(asList(asList(sdkPojo(Pair.of("key", "value1"))),
-                                        asList(sdkPojo(Pair.of("key", "value2"))))));
-    }
-
-    @Test
-    void flattenBehavesWithNested() {
-        assertThat(nestedConstruct().field("foo2").flatten())
-            .isEqualTo(new Value(asList(sdkPojo(Pair.of("baz", asList(sdkPojo(Pair.of("key", "value1"))))),
-                                        sdkPojo(Pair.of("baz", asList(sdkPojo(Pair.of("key", "value2"))))))));
-    }
-
-    @Test
-    void flattenBehavesWithNested2() {
-        assertThat(nestedConstruct().field("foo2").flatten().field("baz"))
-            .isEqualTo(new Value(asList(asList(sdkPojo(Pair.of("key", "value1"))),
-                                        asList(sdkPojo(Pair.of("key", "value2"))))));
-    }
-
-    @Test
-    void flattenBehavesWithNested3() {
-        assertThat(nestedConstruct().field("foo2").flatten().field("baz").flatten())
-            .isEqualTo(new Value(asList(sdkPojo(Pair.of("key", "value1")),
-                                        sdkPojo(Pair.of("key", "value2")))));
-    }
-
-    @Test
-    void flattenBehavesWithNested4() {
-        assertThat(nestedConstruct().field("foo2").flatten().field("baz").flatten().field("key"))
-            .isEqualTo(new Value(asList("value1","value2")));
+    void wildcardBehavesWithProjectionAndFiltersNullElements() {
+        assertThat(nestedConstruct().field("foo2").field("baz").wildcard().field("PayloadMemberOne"))
+            .isEqualTo(new Value(asList("1b")));
     }
 
     @Test
@@ -272,17 +237,23 @@ class JmesPathRuntimeValueTest {
     void flattenBehavesWithLists() {
         assertThat(new Value(asList("bar",
                                     singletonList("bar"),
-                                    sdkPojo(Pair.of("x", "y"))))
+                                    simpleSdkPojo(Pair.of("x", "y"))))
                        .flatten())
             .isEqualTo(new Value(asList("bar",
                                         "bar",
-                                        sdkPojo(Pair.of("x", "y")))));
+                                        simpleSdkPojo(Pair.of("x", "y")))));
+    }
+
+    @Test
+    void flattenBehavesWithProjectionAndFiltersNullElements() {
+        assertThat(nestedConstruct().field("foo2").field("baz").flatten().field("PayloadMemberOne"))
+            .isEqualTo(new Value(asList("1b")));
     }
 
     @Test
     void fieldBehaves() {
         assertThat(new Value(null).field("foo")).isEqualTo(new Value(null));
-        assertThat(sdkPojoValue(Pair.of("foo", "bar")).field("foo")).isEqualTo(new Value("bar"));
+        assertThat(simpleSdkPojoValue(Pair.of("foo", "bar")).field("foo")).isEqualTo(new Value("bar"));
     }
 
     @Test
@@ -299,7 +270,7 @@ class JmesPathRuntimeValueTest {
     void lengthBehaves() {
         assertThat(new Value(null).length()).isEqualTo(new Value(null));
         assertThat(new Value("a").length()).isEqualTo(new Value(1));
-        assertThat(sdkPojoValue(Pair.of("a", "b")).length()).isEqualTo(new Value(1));
+        assertThat(simpleSdkPojoValue(Pair.of("a", "b")).length()).isEqualTo(new Value(1));
         assertThat(new Value(singletonList("a")).length()).isEqualTo(new Value(1));
     }
 
@@ -310,7 +281,7 @@ class JmesPathRuntimeValueTest {
                                                        .hasMessageContaining("Unsupported type for keys function");
         assertThatThrownBy(() -> new Value(asList("a", "b")).keys()).isInstanceOf(IllegalArgumentException.class)
                                                                     .hasMessageContaining("Unsupported type for keys function");
-        assertThat(sdkPojoValue(Pair.of("a", "b"), Pair.of("c", "d")).keys()).isEqualTo(new Value(asList("a", "c")));
+        assertThat(simpleSdkPojoValue(Pair.of("a", "b"), Pair.of("c", "d")).keys()).isEqualTo(new Value(asList("a", "c")));
     }
 
 
@@ -354,31 +325,47 @@ class JmesPathRuntimeValueTest {
         return new Value(false);
     }
 
+    //This construct is useful for testing projections as it contains elements with incomplete data
     private Value nestedConstruct() {
-        return sdkPojoValue(Pair.of("foo", "bar"),
-                            Pair.of("foo2", asList(
-                                sdkPojo(Pair.of("baz", asList(sdkPojo(Pair.of("key", "value1"))))),
-                                sdkPojo(Pair.of("baz", asList(sdkPojo(Pair.of("key", "value2")))))
-                            )),
-                            Pair.of("foo3", sdkPojo(Pair.of("x", "y"))));
+        return simpleSdkPojoValue(Pair.of("foo", "bar"),
+                                  Pair.of("foo2", simpleSdkPojo(
+                                      Pair.of("baz", asList(
+                                          PayloadStructType.builder().payloadMemberTwo("2a").build(),
+                                          PayloadStructType.builder().payloadMemberOne("1b").payloadMemberTwo("2b").build()
+                                      )))),
+                                  Pair.of("foo3", simpleSdkPojo(Pair.of("x", "y"))));
     }
 
+    /**
+     * Do not use for projections. See {@code SimpleSdkPojo}.
+     */
     @SafeVarargs
-    private final Value sdkPojoValue(Pair<String, Object>... entry) {
-        return new Value(sdkPojo(entry));
+    private final Value simpleSdkPojoValue(Pair<String, Object>... entry) {
+        return new Value(simpleSdkPojo(entry));
     }
 
+    /**
+     * Do not use for projections. See {@code SimpleSdkPojo}.
+     */
     @SafeVarargs
-    private final SdkPojo sdkPojo(Pair<String, Object>... entry) {
+    private final SdkPojo simpleSdkPojo(Pair<String, Object>... entry) {
         Map<String, Object> result = new HashMap<>();
         Stream.of(entry).forEach(e -> result.put(e.left(), e.right()));
-        return new MockSdkPojo(result);
+        return new SimpleSdkPojo(result);
     }
 
-    private static class MockSdkPojo implements SdkPojo {
+    /**
+     * The SimpleSdkPojo is useful to quickly construct test objects for most test cases.
+     * It is NOT a true SdkPojo because there is no typing and cannot be used to test
+     * complex nesting cases. Consider an SdkPojo that contains a typed list of two
+     * SdkPojo of a different kind - SimpleSdkPojo cannot reliably be used, because if
+     * a field referenced in the expression is null, JmesPathRuntime will assume it doesn't
+     * exist and throw an error.
+     */
+    private static class SimpleSdkPojo implements SdkPojo {
         private final Map<String, Object> map;
 
-        private MockSdkPojo(Map<String, Object> map) {
+        private SimpleSdkPojo(Map<String, Object> map) {
             this.map = map;
         }
 
@@ -405,7 +392,7 @@ class JmesPathRuntimeValueTest {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            MockSdkPojo that = (MockSdkPojo) o;
+            SimpleSdkPojo that = (SimpleSdkPojo) o;
             return Objects.equals(map, that.map);
         }
 


### PR DESCRIPTION
## Motivation and Context

## Modifications
- Modifies the `wildcard` function, which has existed in the runtime but never been used in waiters, to accept lists which is according to specs: https://jmespath.org/specification.html#wildcard-expressions
- Adds a `keys` function which can return the names of `SdkField` members in an `SdkPojo`
- [INCORRECT] Catches errors when evaluating OperationContextParams at runtime and returns null instead, logging errors. It's complex functionality especially when sourcing parameters from a customization config. We can re-evaluate this behavior when model traits are available. 
- Fixes a minor bug in `project` to filter null values from the result. Another alternative would be to just filter nulls when returning `stringValues` but I can't think of a Java use-case where we want to preserve the null when evaluating an expression. 
- Also changed to filter nulls for stringValues, because it is correct.

## Testing
Tested in `codegen-generated-classes-test` 

Testing with incomplete objects where the projected field does not exist in a list projection member didn't work with the approximation of and SdkPojo in the test class. Instead, switched to a modeled pojo that correctly returns null for a field instead of not recognizing field.