### PR TITLE
Change package name for migration tool and update dependencies

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -43,7 +43,7 @@
 
         "dynamodb": { "packageName": "AwsJavaSdk-DynamoDb" },
         "waf": { "packageName": "AwsJavaSdk-Waf" },
-        "migration-tool": { "packageName":  "AwsJavaSdk-MigrationTool"},
+        "migration-tool": { "packageName":  "AwsJavaSdk-Tooling-MigrationTool"},
 
         "third-party-jackson-core": {
             "packageName": "AwsJavaSdk-ThirdParty-JacksonCore",
@@ -102,7 +102,8 @@
         "test-utils": { "skipImport": true },
         "tests-coverage-reporting": { "skipImport": true },
         "third-party": { "skipImport": true },
-        "third-party-slf4j-api": { "skipImport": true }
+        "third-party-slf4j-api": { "skipImport": true },
+        "migration-tool-tests": {"migration-tool-tests":  true}
     },
 
     "dependencies": {
@@ -141,6 +142,8 @@
         "org.junit.jupiter:junit-jupiter": { "packageName": "JUnit5", "packageVersion": "5.x" },
         "org.mockito:mockito-core": { "packageName": "Mockito", "packageVersion": "3.x" },
         "io.reactivex.rxjava3:rxjava": { "packageName": "RxJava", "packageVersion": "3.x" },
-        "org.assertj:assertj-core": { "packageName": "AssertJ", "packageVersion": "3.22.x" }
+        "org.assertj:assertj-core": { "packageName": "AssertJ", "packageVersion": "3.22.x" },
+        "org.openrewrite:rewrite-java-8": {"packageName": "Maven-org-openrewrite_rewrite-java-8", "packageVersion": "8.x"},
+        "org.openrewrite:rewrite-java": {"packageName": "Maven-org-openrewrite_rewrite-java", "packageVersion": "8.x"}
     }
 }

--- a/.brazil.json
+++ b/.brazil.json
@@ -103,7 +103,7 @@
         "tests-coverage-reporting": { "skipImport": true },
         "third-party": { "skipImport": true },
         "third-party-slf4j-api": { "skipImport": true },
-        "migration-tool-tests": {"migration-tool-tests":  true}
+        "migration-tool-tests": {"skipImport":  true}
     },
 
     "dependencies": {

--- a/buildspecs/release-javadoc.yml
+++ b/buildspecs/release-javadoc.yml
@@ -18,7 +18,7 @@ phases:
     commands:
     - python ./scripts/doc_crosslinks/generate_cross_link_data.py --apiDefinitionsBasePath ./services/ --apiDefinitionsRelativeFilePath src/main/resources/codegen-resources/service-2.json  --templateFilePath ./scripts/doc_crosslinks/crosslink_redirect.html --outputFilePath ./scripts/crosslink_redirect.html
     - mvn install -P quick -T1C
-    - mvn clean install javadoc:aggregate -B -Ppublic-javadoc -Dcheckstyle.skip -Dspotbugs.skip -DskipTests -Ddoclint=none -pl '!:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:s3-benchmarks,!:module-path-tests,!:test-utils,!:http-client-tests,!:tests-coverage-reporting,!:sdk-native-image-test,!:ruleset-testing-core,!:old-client-version-compatibility-test,!:migration-tool'
+    - mvn clean install javadoc:aggregate -B -Ppublic-javadoc -Dcheckstyle.skip -Dspotbugs.skip -DskipTests -Ddoclint=none -pl '!:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:s3-benchmarks,!:module-path-tests,!:test-utils,!:http-client-tests,!:tests-coverage-reporting,!:sdk-native-image-test,!:ruleset-testing-core,!:old-client-version-compatibility-test,!:migration-tool,!:migration-tool-tests'
     - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
     -
     - aws s3 sync target/site/apidocs/ $DOC_PATH/$RELEASE_VERSION/ --acl="public-read"

--- a/buildspecs/release-to-maven.yml
+++ b/buildspecs/release-to-maven.yml
@@ -34,7 +34,7 @@ phases:
             awk 'BEGIN { var=ENVIRON["SDK_SIGNING_GPG_KEYNAME"] } { gsub("\\$SDK_SIGNING_GPG_KEYNAME", var, $0); print }' > \
             $SETTINGS_XML
 
-          mvn clean deploy -B -s $SETTINGS_XML -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests,!:sdk-native-image-test,!:auth-tests,!:s3-benchmarks,!:region-testing,!:old-client-version-compatibility-test -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+          mvn clean deploy -B -s $SETTINGS_XML -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests,!:sdk-native-image-test,!:auth-tests,!:s3-benchmarks,!:region-testing,!:old-client-version-compatibility-test,!:migration-tool-tests -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
         else
           echo "This version was already released."
         fi

--- a/migration-tool/pom.xml
+++ b/migration-tool/pom.xml
@@ -46,12 +46,31 @@
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java-8</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -81,14 +100,8 @@
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-maven</artifactId>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.openrewrite.recipe</groupId>
-            <artifactId>rewrite-migrate-java</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-test</artifactId>
@@ -112,26 +125,6 @@
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>utils</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sdk-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>auth</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sts</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         <!-- Used in UpgradeSdkDependenciesTest -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -145,11 +138,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>utils</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -158,7 +146,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <failOnWarning>false</failOnWarning>
+                    <ignoreNonCompile>false</ignoreNonCompile>
                 </configuration>
             </plugin>
             <plugin>

--- a/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
@@ -187,6 +187,12 @@ recipeList:
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
+      oldArtifactId: aws-java-sdk-timestreaminfluxdb
+      newGroupId: software.amazon.awssdk
+      newArtifactId: timestreaminfluxdb
+      newVersion: 2.23.16-SNAPSHOT
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.amazonaws
       oldArtifactId: aws-java-sdk-lakeformation
       newGroupId: software.amazon.awssdk
       newArtifactId: lakeformation
@@ -589,6 +595,12 @@ recipeList:
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
+      oldArtifactId: aws-java-sdk-chatbot
+      newGroupId: software.amazon.awssdk
+      newArtifactId: chatbot
+      newVersion: 2.23.16-SNAPSHOT
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.amazonaws
       oldArtifactId: aws-java-sdk-fms
       newGroupId: software.amazon.awssdk
       newArtifactId: fms
@@ -727,6 +739,12 @@ recipeList:
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
+      oldArtifactId: aws-java-sdk-route53profiles
+      newGroupId: software.amazon.awssdk
+      newArtifactId: route53profiles
+      newVersion: 2.23.16-SNAPSHOT
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.amazonaws
       oldArtifactId: aws-java-sdk-bcmdataexports
       newGroupId: software.amazon.awssdk
       newArtifactId: bcmdataexports
@@ -832,6 +850,12 @@ recipeList:
       oldArtifactId: aws-java-sdk-transfer
       newGroupId: software.amazon.awssdk
       newArtifactId: transfer
+      newVersion: 2.23.16-SNAPSHOT
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.amazonaws
+      oldArtifactId: aws-java-sdk-deadline
+      newGroupId: software.amazon.awssdk
+      newArtifactId: deadline
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
@@ -1693,6 +1717,12 @@ recipeList:
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
+      oldArtifactId: aws-java-sdk-artifact
+      newGroupId: software.amazon.awssdk
+      newArtifactId: artifact
+      newVersion: 2.23.16-SNAPSHOT
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.amazonaws
       oldArtifactId: aws-java-sdk-iotsitewise
       newGroupId: software.amazon.awssdk
       newArtifactId: iotsitewise
@@ -1900,6 +1930,12 @@ recipeList:
       oldArtifactId: aws-java-sdk-appconfigdata
       newGroupId: software.amazon.awssdk
       newArtifactId: appconfigdata
+      newVersion: 2.23.16-SNAPSHOT
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.amazonaws
+      oldArtifactId: aws-java-sdk-controlcatalog
+      newGroupId: software.amazon.awssdk
+      newArtifactId: controlcatalog
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
@@ -2152,6 +2188,12 @@ recipeList:
       oldArtifactId: aws-java-sdk-ram
       newGroupId: software.amazon.awssdk
       newArtifactId: ram
+      newVersion: 2.23.16-SNAPSHOT
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.amazonaws
+      oldArtifactId: aws-java-sdk-codeconnections
+      newGroupId: software.amazon.awssdk
+      newArtifactId: codeconnections
       newVersion: 2.23.16-SNAPSHOT
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws

--- a/test/migration-tool-tests/pom.xml
+++ b/test/migration-tool-tests/pom.xml
@@ -55,6 +55,12 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>migration-tool</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/test/migration-tool-tests/src/test/resources/run-test
+++ b/test/migration-tool-tests/src/test/resources/run-test
@@ -32,7 +32,7 @@ def run_test(version):
     is_same = compare_directory(filecmp.dircmp(TARGET_DIR, AFTER_DIR))
     if not is_same:
         raise Exception("The transformed directory('target/generated-test-sources/project') does not match with the expected one('src/test/resources/after')")
-    result = subprocess.run(["mvn", "clean", "package"], cwd=TARGET_DIR, capture_output=True)
+    result = subprocess.run(["mvn", "package"], cwd=TARGET_DIR, capture_output=True, check=True)
     print(result)
 
 def compare_directory(dcmp):

--- a/test/migration-tool-tests/src/test/resources/run-test
+++ b/test/migration-tool-tests/src/test/resources/run-test
@@ -32,7 +32,8 @@ def run_test(version):
     is_same = compare_directory(filecmp.dircmp(TARGET_DIR, AFTER_DIR))
     if not is_same:
         raise Exception("The transformed directory('target/generated-test-sources/project') does not match with the expected one('src/test/resources/after')")
-    result = subprocess.run(["mvn", "package"], cwd=TARGET_DIR, check=True, stdout = subprocess.DEVNULL)
+    result = subprocess.run(["mvn", "clean", "package"], cwd=TARGET_DIR, capture_output=True)
+    print(result)
 
 def compare_directory(dcmp):
     if dcmp.diff_files or dcmp.left_only or dcmp.right_only:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Change package name for migration tool `AwsJavaSdk-MigrationTool` -> `AwsJavaSdk-Tooling-MigrationTool` to not cause potential naming conflicts in the future.
- Update dependencies
- Exclude `migration-tool-tests` from javadoc and deployment