### PR TITLE
Catch UncheckedIOException and throw as IOException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -650,7 +650,8 @@
                             <includeModule>netty-nio-client</includeModule>
                             <includeModule>url-connection-client</includeModule>
                             <includeModule>cloudwatch-metric-publisher</includeModule>
-                            <includeModule>utils</includeModule>
+                            <!-- TODO revert - Temporarily disable utils to add throws IOException to InputStreamSubscriber.read() -->
+                            <!-- <includeModule>utils</includeModule> -->
                             <includeModule>imds</includeModule>
 
                             <!-- High level libraries -->

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTest.java
@@ -45,6 +45,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import software.amazon.awssdk.utils.FunctionalUtils;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 public class InputStreamSubscriberTest {
@@ -240,23 +241,11 @@ public class InputStreamSubscriberTest {
     }
 
     public static Consumer<InputStreamSubscriber> subscriberRead1() {
-        return s -> {
-            try {
-                s.read();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
+        return s -> FunctionalUtils.invokeSafely(() -> s.read());
     }
 
     public static Consumer<InputStreamSubscriber> subscriberReadArray() {
-        return s -> {
-            try {
-                s.read(new byte[4]);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
+        return s -> FunctionalUtils.invokeSafely(() -> s.read(new byte[4]));
     }
 
     public static Consumer<InputStreamSubscriber> subscriberClose() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
IOExceptions such as closed socket are wrapped as [`UncheckedIOException` by the `StoringSubscriber`](https://github.com/aws/aws-sdk-java-v2/blob/master/utils/src/main/java/software/amazon/awssdk/utils/async/StoringSubscriber.java#L181).  They are then [wrapped as `SdkClientException` in the `CombinedResponseHandler`](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/CombinedResponseHandler.java#L110), making them non-retryable. They should be retryable and not wrapped.

This can occur when the socket is closed by the server during a `GetObject` call.

```
software.amazon.awssdk.core.exception.SdkClientException: Unable to unmarshall response (java.io.IOException: software.amazon.awssdk.crt.http.HttpException: socket is closed.). Response Code: 200, Response Text: null
    at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:111) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleSuccessResponse(CombinedResponseHandler.java:110) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleResponse(CombinedResponseHandler.java:75) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handle(CombinedResponseHandler.java:60) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handle(CombinedResponseHandler.java:41) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:50) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:38) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:72) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:55) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:39) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:81) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:56) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:36) ~[AwsJavaSdk-Core-2.0.jar:?]
    ...
Caused by: software.amazon.awssdk.core.exception.NonRetryableException: java.io.IOException: software.amazon.awssdk.crt.http.HttpException: socket is closed.
    at software.amazon.awssdk.core.exception.NonRetryableException$BuilderImpl.build(NonRetryableException.java:109) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler$HttpResponseHandlerAdapter.transformResponse(BaseSyncClientHandler.java:232) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler$HttpResponseHandlerAdapter.handle(BaseSyncClientHandler.java:213) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleSuccessResponse(CombinedResponseHandler.java:99) ~[AwsJavaSdk-Core-2.0.jar:?]
    ... 55 more
Caused by: java.io.UncheckedIOException: java.io.IOException: software.amazon.awssdk.crt.http.HttpException: socket is closed.
    at software.amazon.awssdk.utils.async.StoringSubscriber$Event.runtimeError(StoringSubscriber.java:181) ~[AwsJavaSdk-Core-Utils-2.0.jar:?]
    at software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.transferTo(ByteBufferStoringSubscriber.java:114) ~[AwsJavaSdk-Core-Utils-2.0.jar:?]
    at software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.blockingTransferTo(ByteBufferStoringSubscriber.java:136) ~[AwsJavaSdk-Core-Utils-2.0.jar:?]
    at software.amazon.awssdk.utils.async.InputStreamSubscriber.read(InputStreamSubscriber.java:117) ~[AwsJavaSdk-Core-Utils-2.0.jar:?]
    at software.amazon.awssdk.http.async.AbortableInputStreamSubscriber.read(AbortableInputStreamSubscriber.java:67) ~[AwsJavaSdk-HttpClient-2.0.jar:?]
    at java.io.FilterInputStream.read(FilterInputStream.java:132) ~[?:?]
    at software.amazon.awssdk.services.s3.internal.checksums.S3ChecksumValidatingInputStream.read(S3ChecksumValidatingInputStream.java:112) ~[AwsJavaSdk-S3-2.0.jar:?]
    at java.io.FilterInputStream.read(FilterInputStream.java:132) ~[?:?]
    at software.amazon.awssdk.core.io.SdkFilterInputStream.read(SdkFilterInputStream.java:66) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.metrics.BytesReadTrackingInputStream.read(BytesReadTrackingInputStream.java:49) ~[AwsJavaSdk-Core-2.0.jar:?]
    at java.io.FilterInputStream.read(FilterInputStream.java:132) ~[?:?]
    at java.io.FilterInputStream.read(FilterInputStream.java:106) ~[?:?]
    at software.amazon.awssdk.utils.IoUtils.toByteArray(IoUtils.java:47) ~[AwsJavaSdk-Core-Utils-2.0.jar:?]
    at software.amazon.awssdk.core.sync.ResponseTransformer.lambda$toBytes$3(ResponseTransformer.java:175) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler$HttpResponseHandlerAdapter.transformResponse(BaseSyncClientHandler.java:225) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler$HttpResponseHandlerAdapter.handle(BaseSyncClientHandler.java:213) ~[AwsJavaSdk-Core-2.0.jar:?]
    at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleSuccessResponse(CombinedResponseHandler.java:99) ~[AwsJavaSdk-Core-2.0.jar:?]
    ... 55 more
Caused by: java.io.IOException: software.amazon.awssdk.crt.http.HttpException: socket is closed.
    at software.amazon.awssdk.http.crt.internal.CrtUtils.wrapWithIoExceptionIfRetryable(CrtUtils.java:48) ~[AwsJavaSdk-HttpClient-CrtClient-2.0.jar:?]
    at software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler.onFailedResponseComplete(InputStreamAdaptingHttpStreamResponseHandler.java:139) ~[AwsJavaSdk-HttpClient-CrtClient-2.0.jar:?]
    at software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler.onResponseComplete(InputStreamAdaptingHttpStreamResponseHandler.java:128) ~[AwsJavaSdk-HttpClient-CrtClient-2.0.jar:?]
    at software.amazon.awssdk.crt.http.HttpStreamResponseHandlerNativeAdapter.onResponseComplete(HttpStreamResponseHandlerNativeAdapter.java:66) ~[Aws-crt-java-1.0.x.jar:0.29.14]
Caused by: software.amazon.awssdk.crt.http.HttpException: socket is closed.
    at software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler.onFailedResponseComplete(InputStreamAdaptingHttpStreamResponseHandler.java:138) ~[AwsJavaSdk-HttpClient-CrtClient-2.0.jar:?]
    at software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler.onResponseComplete(InputStreamAdaptingHttpStreamResponseHandler.java:128) ~[AwsJavaSdk-HttpClient-CrtClient-2.0.jar:?]
    at software.amazon.awssdk.crt.http.HttpStreamResponseHandlerNativeAdapter.onResponseComplete(HttpStreamResponseHandlerNativeAdapter.java:66) ~[Aws-crt-java-1.0.x.jar:0.29.14]
```

## Modifications
<!--- Describe your changes in detail -->
Catch `UncheckedIOException` in `InputStreamSubscriber.read()` and throw as `IOException`. This will now be retried since `CombinedResponseHandler` [throws `IOException` as is](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/CombinedResponseHandler.java#L101) and does not wrap as `SdkClientException`.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
