### PR TITLE
Re-enable japicmp for utils module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,8 +651,7 @@
                             <includeModule>netty-nio-client</includeModule>
                             <includeModule>url-connection-client</includeModule>
                             <includeModule>cloudwatch-metric-publisher</includeModule>
-                            <!-- TODO revert - Temporarily disable utils to add throws IOException to InputStreamSubscriber.read() -->
-                            <!-- <includeModule>utils</includeModule> -->
+                            <includeModule>utils</includeModule>
                             <includeModule>imds</includeModule>
 
                             <!-- High level libraries -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Re-enable japicmp after temporarily disabling for change in https://github.com/aws/aws-sdk-java-v2/pull/5201
