### PR TITLE
Fix NumberToDuraion recipe to handle variable

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/NumberToDuration.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/recipe/NumberToDuration.java
@@ -87,7 +87,7 @@ public class NumberToDuration extends Recipe {
             String durationStr = durationCreationStr();
 
             JavaTemplate template = JavaTemplate
-                .builder(durationStr + "(#{})")
+                .builder(durationStr + "(#{any()})")
                 .contextSensitive()
                 .imports("java.time.Duration")
                 .build();

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/NumberToDurationTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/recipe/NumberToDurationTest.java
@@ -87,4 +87,37 @@ public class NumberToDurationTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void variableProvided_shouldRewrite() {
+        rewriteRun(
+            spec -> spec.recipe(new NumberToDuration("com.amazonaws.ClientConfiguration setRequestTimeout(int)",
+                                                     TimeUnit.SECONDS))
+                        .parser(Java8Parser.builder().classpath("sqs", "aws-core", "sdk-core", "aws-java-sdk-sqs")),
+            java(
+                "import com.amazonaws.ClientConfiguration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        int timeout = 1000;\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
+                + "        clientConfiguration.setRequestTimeout(timeout);\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.ClientConfiguration;\n\n"
+                + "import java.time.Duration;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "    \n"
+                + "    void test() {\n"
+                + "        int timeout = 1000;\n"
+                + "        ClientConfiguration clientConfiguration = new ClientConfiguration();\n"
+                + "        clientConfiguration.setRequestTimeout(Duration.ofSeconds(timeout));\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix NumberToDuraion recipe to handle variable, currently, the following exception will be thrown if the input is not a literal.

```
Caused by: java.lang.IllegalArgumentException: Template parameter 0 cannot be used in an untyped template substitution. Instead of "#{}", indicate the template parameter's type with "#{any(int)}".
```