### PR TITLE
Skip brazil import of bundle-shading-tests module

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -103,7 +103,8 @@
         "tests-coverage-reporting": { "skipImport": true },
         "third-party": { "skipImport": true },
         "third-party-slf4j-api": { "skipImport": true },
-        "crt-unavailable-tests": { "skipImport": true }
+        "crt-unavailable-tests": { "skipImport": true },
+        "bundle-shading-tests": { "skipImport": true }
     },
 
     "dependencies": {


### PR DESCRIPTION
Adds the `bundle-shading-tests` module to the excluded module in `.brazil.json`