### PR TITLE
Skip downloading S3 folders (0-content-length folders created in the …

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-a0f0de6.json
+++ b/.changes/next-release/bugfix-S3TransferManager-a0f0de6.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Skip downloading S3 folders (0-content-length folders created in the S3 console) in downloadDirectory in the S3 Transfer Manager."
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.transfer.s3.config;
 
 import java.util.function.Predicate;
-import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.transfer.s3.model.DownloadDirectoryRequest;
@@ -28,7 +27,6 @@ import software.amazon.awssdk.transfer.s3.model.DownloadDirectoryRequest;
  * {@link #or(Predicate)} methods.
  */
 @SdkPublicApi
-@SdkPreviewApi
 public interface DownloadFilter extends Predicate<S3Object> {
 
     /**
@@ -41,10 +39,18 @@ public interface DownloadFilter extends Predicate<S3Object> {
     boolean test(S3Object s3Object);
 
     /**
-     * A {@link DownloadFilter} that downloads all objects. This is the default behavior if no filter is provided.
+     * A {@link DownloadFilter} that downloads all non-folder objects. A folder is a 0-byte object created when a customer
+     * uses S3 console to create a folder, and it always ends with "/".
+     *
+     * <p>
+     * This is the default behavior if no filter is provided.
      */
-    @SdkPreviewApi
     static DownloadFilter allObjects() {
-        return ctx -> true;
+        return s3Object -> {
+            boolean isFolder = s3Object.key().endsWith("/") &&
+                               s3Object.size() != null &&
+                               s3Object.size() == 0;
+            return !isFolder;
+        };
     }
 }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/config/DownloadFilterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/config/DownloadFilterTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+public class DownloadFilterTest {
+
+    public static Stream<Arguments> s3Objects() {
+        return Stream.of(
+            Arguments.of(S3Object.builder().key("no-slash-zero-content").size(0L).build(), true),
+            Arguments.of(S3Object.builder().key("slash-zero-content/").size(0L).build(), false),
+            Arguments.of(S3Object.builder().key("key").size(10L).build(), true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("s3Objects")
+    void allObjectsFilter_shouldWork(S3Object s3Object, boolean result) {
+        assertThat(DownloadFilter.allObjects().test(s3Object)).isEqualTo(result);
+    }
+}

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/util/S3ApiCallMockUtils.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/util/S3ApiCallMockUtils.java
@@ -22,6 +22,7 @@ import io.reactivex.Flowable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomStringUtils;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -33,8 +34,14 @@ public class S3ApiCallMockUtils {
     }
 
     public static void stubSuccessfulListObjects(ListObjectsHelper helper, String... keys) {
-        List<S3Object> s3Objects = Arrays.stream(keys).map(k -> S3Object.builder().key(k).build()).collect(Collectors.toList());
+        List<S3Object> s3Objects =
+            Arrays.stream(keys).map(k -> S3Object.builder().key(k).size(100L).build()).collect(Collectors.toList());
         when(helper.listS3ObjectsRecursively(any(ListObjectsV2Request.class))).thenReturn(SdkPublisher.adapt(Flowable.fromIterable(s3Objects)));
+    }
+
+    public static void stubSuccessfulListObjects(ListObjectsHelper helper, S3Object... s3Objects) {
+        when(helper.listS3ObjectsRecursively(any(ListObjectsV2Request.class)))
+            .thenReturn(SdkPublisher.adapt(Flowable.fromIterable(Arrays.asList(s3Objects))));
     }
 
 }


### PR DESCRIPTION
…S3 console) in downloadDirectory in the S3 Transfer Manager.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
 A folder is a 0-byte object created when a customer uses S3 console to create a folder, and it always ends with "/".

Currently, if a user attempts to download a directory that contains a folder object, the request will fail with the following error message:

```
FailedFileDownload(request=DownloadFileRequest(destination=/tmp, getObjectRequest=GetObjectRequest(Bucket=bucket-name, Key=posters/)), exception=software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: java.nio.file.FileSystemException: /tmp: Is a directory)
```

## Modifications
Skip folders in filter. Note that this is not a breaking change per se because the current behavior is failure.

## Testing
Added unit tests, manually created a folder in s3 console and tested it.
Integ tests can't be added since folder objects can only be created from S3 console

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
