### PR TITLE
Fix 4990, allow null values in S3 object metadata

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-d82f8b1.json
+++ b/.changes/next-release/bugfix-AmazonS3-d82f8b1.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "dropofwill",
+    "description": "Fixes issue 4990 allowing null values in S3 object metadata"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ObjectMetadataInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ObjectMetadataInterceptor.java
@@ -15,8 +15,8 @@
 
 package software.amazon.awssdk.services.s3.internal.handlers;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -69,6 +69,6 @@ public final class ObjectMetadataInterceptor implements ExecutionInterceptor {
 
     private Map<String, String> trimKeys(Map<String, String> map) {
         return map.entrySet().stream()
-            .collect(Collectors.toMap(e -> StringUtils.trim(e.getKey()), Map.Entry::getValue));
+            .collect(HashMap::new, (hm, entry) -> hm.put(StringUtils.trim(entry.getKey()), entry.getValue()), HashMap::putAll);
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/ObjectMetadataInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/ObjectMetadataInterceptorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,15 +38,20 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 public class ObjectMetadataInterceptorTest {
     private static final ObjectMetadataInterceptor INTERCEPTOR = new ObjectMetadataInterceptor();
 
-
-
     public static List<TestCase> testCases() {
+        List<String> listWithNulls = new ArrayList<>();
+        listWithNulls.add("\tc\r\n");
+        listWithNulls.add(null);
+
+        List<String> listWithNullsTrimmed = new ArrayList<>();
+        listWithNullsTrimmed.add("c");
+        listWithNullsTrimmed.add(null);
         return asList(
             tc(asList("a", "b", "c"), asList("a", "b", "c")),
             tc(asList(" a ", "b", "c"), asList("a", "b", "c")),
             tc(asList("   a", "\tb", "\tc"), asList("a", "b", "c")),
-            tc(asList("a\n", "\tb", "\tc\r\n"), asList("a", "b", "c"))
-
+            tc(asList("a\n", "\tb", "\tc\r\n"), asList("a", "b", "c")),
+            tc(listWithNulls, listWithNullsTrimmed)
         );
     }
 
@@ -68,7 +74,7 @@ public class ObjectMetadataInterceptorTest {
 
         PutObjectRequest modified = (PutObjectRequest) INTERCEPTOR.modifyRequest(ctx, attrs);
 
-        assertThat(modified.metadata().keySet()).containsExactlyElementsOf(tc.expectedKeys);
+        assertThat(modified.metadata().keySet()).containsOnlyOnceElementsOf(tc.expectedKeys);
     }
 
     @ParameterizedTest
@@ -90,7 +96,7 @@ public class ObjectMetadataInterceptorTest {
 
         CreateMultipartUploadRequest modified = (CreateMultipartUploadRequest) INTERCEPTOR.modifyRequest(ctx, attrs);
 
-        assertThat(modified.metadata().keySet()).containsExactlyElementsOf(tc.expectedKeys);
+        assertThat(modified.metadata().keySet()).containsOnlyOnceElementsOf(tc.expectedKeys);
     }
 
     @Test


### PR DESCRIPTION
Change tests to check keys in any order instead of relying on keySets implicit ordering.

## Motivation and Context
Fixes #4990 

## Modifications
Collect with HashMap instead of built in Java collector which [cannot handle nulls.](https://bugs.openjdk.org/browse/JDK-8148463)

## Testing
Added a test with null keys, fails without my change, passes with it.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
