### PR TITLE
FileAsyncResponseTransformer - write to position

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
@@ -53,7 +53,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
             throw new IllegalArgumentException(String.format(
                 "'position' can only be used with 'WRITE_TO_POSITION' file write option, but was used with '%s'",
                 fileWriteOption
-                ));
+            ));
         }
     }
 
@@ -82,10 +82,10 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     }
 
     /**
-     * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the existing
-     * file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is configured,
-     * bytes 0-127 of the existing file will remain untouched and data will be appended starting at byte 128. If not specified,
-     * defaults to 0.
+     * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the
+     * existing file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is
+     * configured, bytes 0-127 of the existing file will remain untouched and data will be appended starting at byte 128. If not
+     * specified, defaults to 0.
      *
      * @return The offset at which to start overwriting data in the file.
      */
@@ -103,8 +103,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     /**
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_NEW}
      * <p>
-     * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown. In the event of an
-     * error, the SDK will attempt to delete the file (whatever has been written to it so far).
+     * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown.
+     * In the event of an error, the SDK will attempt to delete the file (whatever has been written to it so far).
      */
     public static FileTransformerConfiguration defaultCreateNew() {
         return builder().fileWriteOption(FileWriteOption.CREATE_NEW)
@@ -115,8 +115,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     /**
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_OR_REPLACE_EXISTING}
      * <p>
-     * Create a new file if it doesn't exist, otherwise replace the existing file. In the event of an error, the SDK will NOT
-     * attempt to delete the file, leaving it as-is
+     * Create a new file if it doesn't exist, otherwise replace the existing file.
+     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is
      */
     public static FileTransformerConfiguration defaultCreateOrReplaceExisting() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_REPLACE_EXISTING)
@@ -127,8 +127,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     /**
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_OR_APPEND_TO_EXISTING}
      * <p>
-     * Create a new file if it doesn't exist, otherwise append to the existing file. In the event of an error, the SDK will NOT
-     * attempt to delete the file, leaving it as-is
+     * Create a new file if it doesn't exist, otherwise append to the existing file.
+     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is
      */
     public static FileTransformerConfiguration defaultCreateOrAppend() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_APPEND_TO_EXISTING)
@@ -193,10 +193,10 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         CREATE_OR_APPEND_TO_EXISTING,
 
         /**
-         * Write to an existing file at the specified position, defined by the
-         * {@link FileTransformerConfiguration#position()}. If the file does not exist, a
-         * {@link java.nio.file.NoSuchFileException} will be thrown. If {@link FileTransformerConfiguration#position()} is
-         * not configured, start overriding data at the beginning of the file (byte 0).
+         * Write to an existing file at the specified position, defined by the {@link FileTransformerConfiguration#position()}. If
+         * the file does not exist, a {@link java.nio.file.NoSuchFileException} will be thrown. If
+         * {@link FileTransformerConfiguration#position()} is not configured, start overriding data at the beginning of the file
+         * (byte 0).
          */
         WRITE_TO_POSITION
     }
@@ -244,8 +244,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         Builder executorService(ExecutorService executorService);
 
         /**
-         * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the existing
-         * file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is
+         * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the
+         * existing file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is
          * configured, bytes 0-127 of the existing file will remain untouched and data will be appended starting at byte 128. If
          * not specified, defaults to 0.
          *

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -41,11 +42,19 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     private final FileWriteOption fileWriteOption;
     private final FailureBehavior failureBehavior;
     private final ExecutorService executorService;
+    private final Long position;
 
     private FileTransformerConfiguration(DefaultBuilder builder) {
         this.fileWriteOption = Validate.paramNotNull(builder.fileWriteOption, "fileWriteOption");
         this.failureBehavior = Validate.paramNotNull(builder.failureBehavior, "failureBehavior");
         this.executorService = builder.executorService;
+        this.position = builder.position;
+        if (fileWriteOption != FileWriteOption.WRITE_TO_POSITION && position != null) {
+            throw new IllegalArgumentException(String.format(
+                "'position' can only be used with 'WRITE_TO_POSITION' file write option, but was used with '%s'",
+                fileWriteOption
+                ));
+        }
     }
 
     /**
@@ -73,6 +82,18 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     }
 
     /**
+     * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the existing
+     * file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is configured,
+     * bytes 0-127 of the existing file will remain untouched and data will be appended starting at byte 128. If not specified,
+     * defaults to 0.
+     *
+     * @return The offset at which to start overwriting data in the file.
+     */
+    public Long position() {
+        return position;
+    }
+
+    /**
      * Create a {@link Builder}, used to create a {@link FileTransformerConfiguration}.
      */
     public static Builder builder() {
@@ -82,8 +103,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     /**
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_NEW}
      * <p>
-     * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown.
-     * In the event of an error, the SDK will attempt to delete the file (whatever has been written to it so far).
+     * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown. In the event of an
+     * error, the SDK will attempt to delete the file (whatever has been written to it so far).
      */
     public static FileTransformerConfiguration defaultCreateNew() {
         return builder().fileWriteOption(FileWriteOption.CREATE_NEW)
@@ -94,8 +115,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     /**
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_OR_REPLACE_EXISTING}
      * <p>
-     * Create a new file if it doesn't exist, otherwise replace the existing file.
-     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is
+     * Create a new file if it doesn't exist, otherwise replace the existing file. In the event of an error, the SDK will NOT
+     * attempt to delete the file, leaving it as-is
      */
     public static FileTransformerConfiguration defaultCreateOrReplaceExisting() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_REPLACE_EXISTING)
@@ -106,8 +127,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     /**
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_OR_APPEND_TO_EXISTING}
      * <p>
-     * Create a new file if it doesn't exist, otherwise append to the existing file.
-     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is
+     * Create a new file if it doesn't exist, otherwise append to the existing file. In the event of an error, the SDK will NOT
+     * attempt to delete the file, leaving it as-is
      */
     public static FileTransformerConfiguration defaultCreateOrAppend() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_APPEND_TO_EXISTING)
@@ -137,6 +158,9 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         if (failureBehavior != that.failureBehavior) {
             return false;
         }
+        if (!Objects.equals(position, that.position)) {
+            return false;
+        }
         return Objects.equals(executorService, that.executorService);
     }
 
@@ -145,6 +169,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         int result = fileWriteOption != null ? fileWriteOption.hashCode() : 0;
         result = 31 * result + (failureBehavior != null ? failureBehavior.hashCode() : 0);
         result = 31 * result + (executorService != null ? executorService.hashCode() : 0);
+        result = 31 * result + (position != null ? position.hashCode() : 0);
         return result;
     }
 
@@ -165,7 +190,15 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         /**
          * Create a new file if it doesn't exist, otherwise append to the existing file.
          */
-        CREATE_OR_APPEND_TO_EXISTING
+        CREATE_OR_APPEND_TO_EXISTING,
+
+        /**
+         * Write to an existing file at the specified position, defined by the
+         * {@link FileTransformerConfiguration#position()}. If the file does not exist, a
+         * {@link java.nio.file.NoSuchFileException} will be thrown. If {@link FileTransformerConfiguration#position()} is
+         * not configured, start overriding data at the beginning of the file (byte 0).
+         */
+        WRITE_TO_POSITION
     }
 
     /**
@@ -209,12 +242,24 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
          * @return This object for method chaining.
          */
         Builder executorService(ExecutorService executorService);
+
+        /**
+         * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the existing
+         * file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is
+         * configured, bytes 0-127 of the existing file will remain untouched and data will be appended starting at byte 128. If
+         * not specified, defaults to 0.
+         *
+         * @param writePosition the position at where to start writing data to the file.
+         * @return This object for method chaining.
+         */
+        Builder position(Long writePosition);
     }
 
     private static final class DefaultBuilder implements Builder {
         private FileWriteOption fileWriteOption;
         private FailureBehavior failureBehavior;
         private ExecutorService executorService;
+        private Long position;
 
         private DefaultBuilder() {
         }
@@ -223,6 +268,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
             this.fileWriteOption = fileTransformerConfiguration.fileWriteOption;
             this.failureBehavior = fileTransformerConfiguration.failureBehavior;
             this.executorService = fileTransformerConfiguration.executorService;
+            this.position = fileTransformerConfiguration.position;
         }
 
         @Override
@@ -244,9 +290,24 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         }
 
         @Override
+        public Builder position(Long position) {
+            this.position = position;
+            return this;
+        }
+
+        @Override
         public FileTransformerConfiguration build() {
             return new FileTransformerConfiguration(this);
         }
     }
 
+    @Override
+    public String toString() {
+        return ToString.builder("FileTransformerConfiguration")
+                       .add("fileWriteOption", this.fileWriteOption)
+                       .add("failureBehavior", this.failureBehavior)
+                       .add("executorService", this.executorService)
+                       .add("position", this.position)
+                       .build();
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
@@ -84,7 +84,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     /**
      * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the
      * existing file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is
-     * configured, bytes 0-127 of the existing file will remain untouched and data will be appended starting at byte 128. If not
+     * configured, bytes 0-127 of the existing file will remain untouched and data will be written starting at byte 128. If not
      * specified, defaults to 0.
      *
      * @return The offset at which to start overwriting data in the file.
@@ -195,7 +195,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         /**
          * Write to an existing file at the specified position, defined by the {@link FileTransformerConfiguration#position()}. If
          * the file does not exist, a {@link java.nio.file.NoSuchFileException} will be thrown. If
-         * {@link FileTransformerConfiguration#position()} is not configured, start overriding data at the beginning of the file
+         * {@link FileTransformerConfiguration#position()} is not configured, start overwriting data at the beginning of the file
          * (byte 0).
          */
         WRITE_TO_POSITION
@@ -246,7 +246,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
         /**
          * Exclusively used with {@link FileWriteOption#WRITE_TO_POSITION}. Configures the position, where to start writing to the
          * existing file. The location correspond to the first byte where new data will be written. For example, if {@code 128} is
-         * configured, bytes 0-127 of the existing file will remain untouched and data will be appended starting at byte 128. If
+         * configured, bytes 0-127 of the existing file will remain untouched and data will be written starting at byte 128. If
          * not specified, defaults to 0.
          *
          * @param writePosition the position at where to start writing data to the file.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
@@ -60,7 +60,7 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
     private final FileTransformerConfiguration configuration;
 
     public FileAsyncResponseTransformer(Path path) {
-        this(path, FileTransformerConfiguration.defaultCreateNew());
+        this(path, FileTransformerConfiguration.defaultCreateNew(), 0L);
     }
 
     public FileAsyncResponseTransformer(Path path, FileTransformerConfiguration fileConfiguration) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.internal.async;
 
 import static software.amazon.awssdk.core.FileTransformerConfiguration.FileWriteOption.CREATE_OR_APPEND_TO_EXISTING;
+import static software.amazon.awssdk.core.FileTransformerConfiguration.FileWriteOption.WRITE_TO_POSITION;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ import software.amazon.awssdk.core.FileTransformerConfiguration.FailureBehavior;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * {@link AsyncResponseTransformer} that writes the data to the specified file.
@@ -58,19 +60,21 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
     private final FileTransformerConfiguration configuration;
 
     public FileAsyncResponseTransformer(Path path) {
-        this.path = path;
-        this.configuration = FileTransformerConfiguration.defaultCreateNew();
-        this.position = 0L;
+        this(path, FileTransformerConfiguration.defaultCreateNew());
     }
 
     public FileAsyncResponseTransformer(Path path, FileTransformerConfiguration fileConfiguration) {
-        this.path = path;
-        this.configuration = fileConfiguration;
-        this.position = determineFilePositionToWrite(path);
+        this(path, fileConfiguration, determineFilePositionToWrite(path, fileConfiguration));
     }
 
-    private long determineFilePositionToWrite(Path path) {
-        if (configuration.fileWriteOption() == CREATE_OR_APPEND_TO_EXISTING) {
+    private FileAsyncResponseTransformer(Path path, FileTransformerConfiguration fileTransformerConfiguration, long position) {
+        this.path = path;
+        this.configuration = fileTransformerConfiguration;
+        this.position = position;
+    }
+
+    private static long determineFilePositionToWrite(Path path, FileTransformerConfiguration fileConfiguration) {
+        if (fileConfiguration.fileWriteOption() == CREATE_OR_APPEND_TO_EXISTING) {
             try {
                 return Files.size(path);
             } catch (NoSuchFileException e) {
@@ -78,6 +82,9 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
             } catch (IOException exception) {
                 throw SdkClientException.create("Cannot determine the current file size " + path, exception);
             }
+        }
+        if (fileConfiguration.fileWriteOption() == WRITE_TO_POSITION) {
+            return Validate.getOrDefault(fileConfiguration.position(), () -> 0L);
         }
         return  0L;
     }
@@ -94,6 +101,9 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
                 break;
             case CREATE_NEW:
                 Collections.addAll(options, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+                break;
+            case WRITE_TO_POSITION:
+                Collections.addAll(options, StandardOpenOption.WRITE);
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported file write option: " + configuration.fileWriteOption());

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/FileTransformerConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/FileTransformerConfigurationTest.java
@@ -16,13 +16,32 @@
 package software.amazon.awssdk.core;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static software.amazon.awssdk.core.FileTransformerConfiguration.FailureBehavior.DELETE;
 import static software.amazon.awssdk.core.FileTransformerConfiguration.FileWriteOption.CREATE_NEW;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class FileTransformerConfigurationTest {
+
+    @ParameterizedTest
+    @EnumSource(
+        value = FileTransformerConfiguration.FileWriteOption.class,
+        names = {"CREATE_NEW", "CREATE_OR_REPLACE_EXISTING", "CREATE_OR_APPEND_TO_EXISTING"})
+    void position_whenUsedWithNotWriteToPosition_shouldThrowIllegalArgumentException(
+        FileTransformerConfiguration.FileWriteOption fileWriteOption) {
+        FileTransformerConfiguration.Builder builder = FileTransformerConfiguration.builder()
+            .position(123L)
+            .failureBehavior(DELETE)
+            .fileWriteOption(fileWriteOption);
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(fileWriteOption.name());
+    }
 
     @Test
     void equalsHashcode() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -28,9 +28,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -50,6 +50,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.FileTransformerConfiguration;
 import software.amazon.awssdk.core.FileTransformerConfiguration.FileWriteOption;
+import software.amazon.awssdk.core.FileTransformerConfiguration.FailureBehavior;
 import software.amazon.awssdk.core.async.SdkPublisher;
 
 /**
@@ -185,8 +186,11 @@ class FileAsyncResponseTransformerTest {
     @MethodSource("configurations")
     void exceptionOccurred_deleteFileBehavior(FileTransformerConfiguration configuration) throws Exception {
         Path testPath = testFs.getPath("test_file.txt");
-        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath,
-                                                                                              configuration);
+        if (configuration.fileWriteOption() == FileWriteOption.WRITE_TO_POSITION) {
+            // file must exist for WRITE_TO_POSITION
+            Files.write(testPath, "foobar".getBytes(StandardCharsets.UTF_8));
+        }
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath, configuration);
         stubException(RandomStringUtils.random(200), transformer);
         if (configuration.failureBehavior() == LEAVE) {
             assertThat(testPath).exists();
@@ -196,28 +200,19 @@ class FileAsyncResponseTransformerTest {
     }
 
     private static List<FileTransformerConfiguration> configurations() {
-        return Arrays.asList(
-            FileTransformerConfiguration.defaultCreateNew(),
-            FileTransformerConfiguration.defaultCreateOrAppend(),
-            FileTransformerConfiguration.defaultCreateOrReplaceExisting(),
-            FileTransformerConfiguration.builder()
-                                        .fileWriteOption(FileWriteOption.CREATE_NEW)
-                                        .failureBehavior(LEAVE).build(),
-            FileTransformerConfiguration.builder()
-                                        .fileWriteOption(FileWriteOption.CREATE_NEW)
-                                        .failureBehavior(DELETE).build(),
-            FileTransformerConfiguration.builder()
-                                        .fileWriteOption(FileWriteOption.CREATE_OR_APPEND_TO_EXISTING)
-                                        .failureBehavior(DELETE).build(),
-            FileTransformerConfiguration.builder()
-                                        .fileWriteOption(FileWriteOption.CREATE_OR_APPEND_TO_EXISTING)
-                                        .failureBehavior(LEAVE).build(),
-            FileTransformerConfiguration.builder()
-                                        .fileWriteOption(FileWriteOption.CREATE_OR_REPLACE_EXISTING)
-                                        .failureBehavior(DELETE).build(),
-            FileTransformerConfiguration.builder()
-                                        .fileWriteOption(FileWriteOption.CREATE_OR_REPLACE_EXISTING)
-                                        .failureBehavior(LEAVE).build());
+        List<FileTransformerConfiguration> conf = new ArrayList<>();
+        conf.add(FileTransformerConfiguration.defaultCreateNew());
+        conf.add(FileTransformerConfiguration.defaultCreateOrAppend());
+        conf.add(FileTransformerConfiguration.defaultCreateOrReplaceExisting());
+        for (FailureBehavior failureBehavior : FailureBehavior.values()) {
+            for (FileWriteOption fileWriteOption : FileWriteOption.values()) {
+                conf.add(FileTransformerConfiguration.builder()
+                                                     .fileWriteOption(fileWriteOption)
+                                                     .failureBehavior(failureBehavior)
+                                                     .build());
+            }
+        }
+        return conf;
     }
 
     @Test
@@ -244,6 +239,63 @@ class FileAsyncResponseTransformerTest {
             executor.shutdown();
             assertThat(executor.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
         }
+    }
+
+    @Test
+    void writeToPosition_fileExists_shouldAppendFromPosition() throws Exception {
+        int totalSize = 100;
+        long prefixSize = 80L;
+        int newContentLength = 20;
+
+        Path testPath = testFs.getPath("test_file.txt");
+        String contentBeforeRewrite = RandomStringUtils.randomAlphanumeric(totalSize);
+        byte[] existingBytes = contentBeforeRewrite.getBytes(StandardCharsets.UTF_8);
+        Files.write(testPath, existingBytes);
+        String newContent = RandomStringUtils.randomAlphanumeric(newContentLength);
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(
+            testPath,
+            FileTransformerConfiguration.builder()
+                                        .position(prefixSize)
+                                        .failureBehavior(DELETE)
+                                        .fileWriteOption(FileWriteOption.WRITE_TO_POSITION)
+                                        .build());
+
+        stubSuccessfulStreaming(newContent, transformer);
+
+        String expectedContent = contentBeforeRewrite.substring(0, 80) + newContent;
+        assertThat(testPath).hasContent(expectedContent);
+    }
+
+    @Test
+    void writeToPosition_fileDoesNotExists_shouldThrowException() throws Exception {
+        Path path = testFs.getPath("this/file/does/not/exists");
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(path);
+        transformer.prepare();
+        transformer.onResponse("foobar");
+        assertThatThrownBy(() -> transformer.onStream(testPublisher("foo-bar-content")))
+            .hasRootCauseInstanceOf(NoSuchFileException.class);
+
+    }
+
+    @Test
+    void writeToPosition_fileExists_positionNotDefined_shouldRewriteFromStart() throws Exception {
+        int totalSize = 100;
+        Path testPath = testFs.getPath("test_file.txt");
+        String contentBeforeRewrite = RandomStringUtils.randomAlphanumeric(totalSize);
+        byte[] existingBytes = contentBeforeRewrite.getBytes(StandardCharsets.UTF_8);
+        Files.write(testPath, existingBytes);
+        String newContent = RandomStringUtils.randomAlphanumeric(totalSize);
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(
+            testPath,
+            FileTransformerConfiguration.builder()
+                                        .failureBehavior(DELETE)
+                                        .fileWriteOption(FileWriteOption.WRITE_TO_POSITION)
+                                        .build());
+
+        stubSuccessfulStreaming(newContent, transformer);
+
+        assertThat(testPath).hasContent(newContent);
+
     }
 
     private static void stubSuccessfulStreaming(String newContent, FileAsyncResponseTransformer<String> transformer) throws Exception {


### PR DESCRIPTION
Add a new option to `FileTransformerConfiguration` `WRITE_TO_POSITION` that will start writing the incoming data to the file at the specified byte position.

## Motivation and Context
Required to implement the pause and resume logic for multipart download in the java-based s3 async client.

## Modifications
- Add a new Enum value to `FileTransformerConfiguration. FileWriteOption`
- Add a new configuration to FileTransformerConfiguration: `location`

## Testing
Added unit test.