### PR TITLE
add completed to ResumableFileDownload ser/des

### DIFF
--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/ResumableFileDownloadSerializer.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/ResumableFileDownloadSerializer.java
@@ -63,6 +63,7 @@ public final class ResumableFileDownloadSerializer {
                                        "s3ObjectLastModified");
         }
         marshallDownloadFileRequest(download.downloadFileRequest(), jsonGenerator);
+        TransferManagerJsonMarshaller.LIST.marshall(download.completedParts(), jsonGenerator, "completedParts");
         jsonGenerator.writeEndObject();
 
         return jsonGenerator.getBytes();
@@ -138,7 +139,9 @@ public final class ResumableFileDownloadSerializer {
             builder.s3ObjectLastModified(instantUnmarshaller.unmarshall(downloadNodes.get("s3ObjectLastModified")));
         }
         builder.downloadFileRequest(parseDownloadFileRequest(downloadNodes.get("downloadFileRequest")));
-
+        if (downloadNodes.get("completedParts") != null) {
+            builder.completedParts(TransferManagerJsonUnmarshaller.LIST_INT.unmarshall(downloadNodes.get("completedParts")));
+        }
         return builder.build();
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshaller.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshaller.java
@@ -19,9 +19,12 @@ import static software.amazon.awssdk.transfer.s3.internal.serialization.Transfer
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
@@ -95,6 +98,21 @@ public interface TransferManagerJsonUnmarshaller<T> {
 
         @Override
         public Map<String, Object> unmarshall(String content, SdkField<?> field) {
+            return unmarshall(JsonNode.parser().parse(content), field);
+        }
+    };
+
+    TransferManagerJsonUnmarshaller<List<Integer>> LIST_INT = new TransferManagerJsonUnmarshaller<List<Integer>>() {
+        @Override
+        public List<Integer> unmarshall(JsonNode jsonContent, SdkField<?> field) {
+            if (jsonContent == null) {
+                return null;
+            }
+            return jsonContent.asArray().stream().map(INTEGER::unmarshall).collect(Collectors.toList());
+        }
+
+        @Override
+        public List<Integer> unmarshall(String content, SdkField<?> field) {
             return unmarshall(JsonNode.parser().parse(content), field);
         }
     };

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshaller.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshaller.java
@@ -19,7 +19,6 @@ import static software.amazon.awssdk.transfer.s3.internal.serialization.Transfer
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
@@ -174,6 +174,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
                        .add("s3ObjectLastModified", s3ObjectLastModified)
                        .add("totalSizeInBytes", totalSizeInBytes)
                        .add("downloadFileRequest", downloadFileRequest)
+                       .add("completedParts", completedParts)
                        .build();
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
@@ -23,6 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -61,6 +63,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
     private final Instant s3ObjectLastModified;
     private final Long totalSizeInBytes;
     private final Instant fileLastModified;
+    private final List<Integer> completedParts;
 
     private ResumableFileDownload(DefaultBuilder builder) {
         this.downloadFileRequest = Validate.paramNotNull(builder.downloadFileRequest, "downloadFileRequest");
@@ -69,6 +72,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
         this.s3ObjectLastModified = builder.s3ObjectLastModified;
         this.totalSizeInBytes = Validate.isPositiveOrNull(builder.totalSizeInBytes, "totalSizeInBytes");
         this.fileLastModified = builder.fileLastModified;
+        this.completedParts = Validate.getOrDefault(builder.completedParts, Collections::emptyList);
     }
 
     @Override
@@ -94,6 +98,9 @@ public final class ResumableFileDownload implements ResumableTransfer,
         if (!Objects.equals(fileLastModified, that.fileLastModified)) {
             return false;
         }
+        if (!Objects.equals(completedParts, that.completedParts)) {
+            return false;
+        }
         return Objects.equals(totalSizeInBytes, that.totalSizeInBytes);
     }
 
@@ -104,6 +111,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
         result = 31 * result + (s3ObjectLastModified != null ? s3ObjectLastModified.hashCode() : 0);
         result = 31 * result + (fileLastModified != null ? fileLastModified.hashCode() : 0);
         result = 31 * result + (totalSizeInBytes != null ? totalSizeInBytes.hashCode() : 0);
+        result = 31 * result + (completedParts != null ? completedParts.hashCode() : 0);
         return result;
     }
 
@@ -147,6 +155,15 @@ public final class ResumableFileDownload implements ResumableTransfer,
      */
     public OptionalLong totalSizeInBytes() {
         return totalSizeInBytes == null ? OptionalLong.empty() : OptionalLong.of(totalSizeInBytes);
+    }
+
+    /**
+     * The lists of parts that were successfully completed and saved to the file. Non-empty only for multipart downloads.
+     *
+     * @return part numbers of a multipart download that were completed saved to file.
+     */
+    public List<Integer> completedParts() {
+        return Collections.unmodifiableList(completedParts);
     }
 
     @Override
@@ -318,6 +335,14 @@ public final class ResumableFileDownload implements ResumableTransfer,
          * @return a reference to this object so that method calls can be chained together.
          */
         Builder fileLastModified(Instant lastModified);
+
+        /**
+         * For multipart download, set the lists of parts that were successfully completed and saved to the file.
+         *
+         * @param completedParts the list of completed parts saved to file.
+         * @return a reference to this object so that method calls can be chained together.
+         */
+        Builder completedParts(List<Integer> completedParts);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -327,6 +352,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
         private Instant s3ObjectLastModified;
         private Long totalSizeInBytes;
         private Instant fileLastModified;
+        private List<Integer> completedParts;
 
         private DefaultBuilder() {
         }
@@ -337,6 +363,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
             this.totalSizeInBytes = persistableFileDownload.totalSizeInBytes;
             this.fileLastModified = persistableFileDownload.fileLastModified;
             this.s3ObjectLastModified = persistableFileDownload.s3ObjectLastModified;
+            this.completedParts = persistableFileDownload.completedParts;
         }
 
         @Override
@@ -366,6 +393,12 @@ public final class ResumableFileDownload implements ResumableTransfer,
         @Override
         public Builder fileLastModified(Instant fileLastModified) {
             this.fileLastModified = fileLastModified;
+            return this;
+        }
+
+        @Override
+        public Builder completedParts(List<Integer> completedParts) {
+            this.completedParts = Collections.unmodifiableList(completedParts);
             return this;
         }
 

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshallerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshallerTest.java
@@ -19,12 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.ArrayJsonNode;
 import software.amazon.awssdk.protocols.jsoncore.internal.NullJsonNode;
 import software.amazon.awssdk.protocols.jsoncore.internal.NumberJsonNode;
 import software.amazon.awssdk.protocols.jsoncore.internal.StringJsonNode;
@@ -57,7 +59,12 @@ class TransferManagerJsonUnmarshallerTest {
                          Arguments.of(new StringJsonNode(BinaryUtils.toBase64(SdkBytes.fromString("100", StandardCharsets.UTF_8)
                                                                                       .asByteArray())),
                                       SdkBytes.fromString("100", StandardCharsets.UTF_8),
-                                      TransferManagerJsonUnmarshaller.SDK_BYTES)
+                                      TransferManagerJsonUnmarshaller.SDK_BYTES),
+                         Arguments.of(new ArrayJsonNode(Arrays.asList(new NumberJsonNode("1"),
+                                                                      new NumberJsonNode("2"),
+                                                                      new NumberJsonNode("3"))),
+                                      Arrays.asList(1, 2, 3),
+                                      TransferManagerJsonUnmarshaller.LIST_INT)
         );
     }
 

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownloadTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownloadTest.java
@@ -26,13 +26,13 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Arrays;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.testutils.RandomTempFile;
-import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 
 class ResumableFileDownloadTest {
 
@@ -130,6 +130,7 @@ class ResumableFileDownloadTest {
                                     .fileLastModified(DATE1)
                                     .s3ObjectLastModified(DATE2)
                                     .totalSizeInBytes(2000L)
+                                    .completedParts(Arrays.asList(1, 2, 5))
                                     .build();
     }
 }


### PR DESCRIPTION
Add `completedParts` field to `ResumableFileDownload` with required serialization and deserialization.

## Motivation and Context
Needed to Multipart Pause/Resume logic. The `ResumableFileDownload` can be serialized to json and deserialized back into memory to resume a download for it. 

## Modifications
- Add new field to `ResumableFileDownload` + Builder
- Add a new `TransferManagerJsonUnmarshaller` for list of Integer
- Update marshalling/unmarshalling to include `completedParts` list

## Testing
Added unit tests

