### PR TITLE
Check if input is shut down before writing

### DIFF
--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
@@ -26,6 +26,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.protocol.HttpContext;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.apache.internal.net.InputShutdownCheckingSslSocket;
 import software.amazon.awssdk.http.apache.internal.net.SdkSocket;
 import software.amazon.awssdk.http.apache.internal.net.SdkSslSocket;
 import software.amazon.awssdk.utils.Logger;
@@ -65,7 +66,7 @@ public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
         Socket connectedSocket = super.connectSocket(connectTimeout, socket, host, remoteAddress, localAddress, context);
 
         if (connectedSocket instanceof SSLSocket) {
-            return new SdkSslSocket((SSLSocket) connectedSocket);
+            return new InputShutdownCheckingSslSocket(new SdkSslSocket((SSLSocket) connectedSocket));
         }
 
         return new SdkSocket(connectedSocket);

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/net/InputShutdownCheckingSslSocket.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/net/InputShutdownCheckingSslSocket.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache.internal.net;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.net.ssl.SSLSocket;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Wrapper socket that ensures the read end of the socket is still open before performing a {@code write()}. In TLS 1.3, it is
+ * permitted for the connection to be in a half-closed state, which is dangerous for the Apache client because it can get stuck in
+ * a state where it continues to write to the socket and potentially end up a blocked state writing to the socket indefinitely.
+ */
+@SdkInternalApi
+public final class InputShutdownCheckingSslSocket extends DelegateSslSocket {
+
+    public InputShutdownCheckingSslSocket(SSLSocket sock) {
+        super(sock);
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return new InputShutdownCheckingOutputStream(sock.getOutputStream(), sock);
+    }
+
+    private static class InputShutdownCheckingOutputStream extends FilterOutputStream {
+        private final SSLSocket sock;
+
+        InputShutdownCheckingOutputStream(OutputStream out, SSLSocket sock) {
+            super(out);
+            this.sock = sock;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            checkInputShutdown();
+            super.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            checkInputShutdown();
+            super.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            checkInputShutdown();
+            super.write(b, off, len);
+        }
+
+        private void checkInputShutdown() throws IOException {
+            if (sock.isInputShutdown()) {
+                throw new IOException("Remote end is closed.");
+            }
+
+            try {
+                sock.getInputStream();
+            } catch (IOException inputStreamException) {
+                IOException e = new IOException("Remote end is closed.");
+                e.addSuppressed(inputStreamException);
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a wrapper socket that ensures the read end of the socket is still open before performing a {@code write()}. In TLS 1.3, it is permitted for the connection to be in a half-closed state, which is dangerous for the Apache client because it can get stuck in a state where it continues to write to the socket and potentially end up a blocked state writing to the socket indefinitely.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
