### PR TITLE
External names used for retry modes only support 'adaptive'

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryStrategy.java
@@ -79,7 +79,7 @@ public final class AwsRetryStrategy {
     }
 
     /**
-     * Returns a retry strategy that do not retry.
+     * Returns a retry strategy that does not retry.
      *
      * @return A retry strategy that do not retry.
      */

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
@@ -30,7 +30,7 @@ public final class DefaultRetryStrategy {
     }
 
     /**
-     * Returns a retry strategy that do not retry.
+     * Returns a retry strategy that does not retry.
      */
     public static StandardRetryStrategy doNotRetry() {
         return standardStrategyBuilder()

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryMode.java
@@ -197,8 +197,6 @@ public enum RetryMode {
                 case "standard":
                     return Optional.of(STANDARD);
                 case "adaptive":
-                    return Optional.of(ADAPTIVE);
-                case "adaptive_v2":
                     return Optional.of(ADAPTIVE_V2);
                 default:
                     throw new IllegalStateException("Unsupported retry policy mode configured: " + string);

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/BaseRetrySetupTest.java
@@ -94,7 +94,7 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
         RetryModeSetup setup = scenario.setup();
         switch (setup) {
             case PROFILE_USING_MODE:
-                setupProfile(builder, scenario.mode());
+                setupProfile(builder, scenario);
                 break;
             case CLIENT_OVERRIDE_USING_MODE:
                 builder.overrideConfiguration(o -> o.retryPolicy(mode));
@@ -115,7 +115,7 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
         // client.
         switch (scenario.setup()) {
             case PROFILE_USING_MODE:
-                setupProfile(builder, scenario.mode());
+                setupProfile(builder, scenario);
                 break;
             case CLIENT_OVERRIDE_USING_MODE:
                 builder.overrideConfiguration(o -> o.retryStrategy(mode));
@@ -130,8 +130,8 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
         }
     }
 
-    private void setupProfile(BuilderT builder, RetryMode mode) {
-        String modeName = mode.toString().toLowerCase(Locale.ROOT);
+    private void setupProfile(BuilderT builder, RetryScenario scenario) {
+        String modeName = scenario.modeExternalName();
         ProfileFile profileFile = ProfileFile.builder()
                                              .content(new StringInputStream("[profile retry_test]\n" +
                                                                             "retry_mode = " + modeName))
@@ -165,7 +165,7 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
 
     private void setupScenarioBefore(RetryScenario scenario) {
         if (scenario.setup() == RetryModeSetup.SYSTEM_PROPERTY_USING_MODE) {
-            System.setProperty("aws.retryMode", scenario.mode().name().toLowerCase(Locale.ROOT));
+            System.setProperty("aws.retryMode", scenario.modeExternalName());
         }
     }
 
@@ -233,6 +233,16 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
         // which an adapter is used. That case is tested using RetryImplementation.STRATEGY.
         if (scenario.retryImplementation() == RetryImplementation.POLICY
             && scenario.setup() == RetryModeSetup.SYSTEM_PROPERTY_USING_MODE) {
+            return false;
+        }
+
+        // System property or profile do not support the internal "adaptive_v2" name, only adaptive,
+        // and it's mapped to adaptive_v2. We mark here adaptive using profile or system property
+        // and map in te tests "adaptive_v2" to "adaptive" such that everything comes together at
+        // the end.
+        if (scenario.mode() == RetryMode.ADAPTIVE
+            && (scenario.setup() == RetryModeSetup.PROFILE_USING_MODE
+                || scenario.setup() == RetryModeSetup.SYSTEM_PROPERTY_USING_MODE)) {
             return false;
         }
 
@@ -321,6 +331,25 @@ public abstract class BaseRetrySetupTest<ClientT, BuilderT extends AwsClientBuil
 
         public Builder toBuilder() {
             return new Builder(this);
+        }
+
+        /**
+         * Returns the name used externally of the given mode. This name is used in the profile `retry_mode` setting or in the
+         * system property. Externally, "adaptive" gets mapped to RetryMode.ADAPTIVE_V2, and "adaptive_v2" an internal name
+         * only and not supported externally.
+         */
+        public String modeExternalName() {
+            switch (mode) {
+                case ADAPTIVE:
+                case ADAPTIVE_V2:
+                    return "adaptive";
+                case LEGACY:
+                    return "legacy";
+                case STANDARD:
+                    return "standard";
+                default:
+                    throw new RuntimeException("Unsupported mode: " + mode);
+            }
         }
 
         @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

As discussed in the API review meeting, we need to keep the names in the profile and environment variables SDKs compatible, therefore we removed the resolution of the `adaptive_v2` name and the `adaptive` name now resolves to new retry mode `ADAPTIVE_V2`, meaning, users that have set this up to `adaptive` via either the profile or system setting or an environment variable will see a behavior change since they will get the "correct" adaptive behavior.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
