### PR TITLE
Fix a bug that prevents a retry strategy override to get used

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -173,6 +173,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
                 type.addMethod(isSignerOverriddenOnClientMethod());
             }
         }
+        type.addMethod(ClientClassUtils.updateRetryStrategyClientConfigurationMethod());
         type.addMethod(updateSdkClientConfigurationMethod(configurationUtils.serviceClientConfigurationBuilderClassName()));
         protocolSpec.createErrorResponseHandler().ifPresent(type::addMethod);
     }
@@ -313,8 +314,9 @@ public final class AsyncClientClass extends AsyncClientInterface {
                .addStatement("$1T serviceConfigBuilder = new $1T(configuration)", serviceClientConfigurationBuilderClassName)
                .beginControlFlow("for ($T plugin : plugins)", SdkPlugin.class)
                .addStatement("plugin.configureClient(serviceConfigBuilder)")
-               .endControlFlow()
-               .addStatement("return configuration.build()");
+               .endControlFlow();
+        builder.addStatement("updateRetryStrategyClientConfiguration(configuration)");
+        builder.addStatement("return configuration.build()");
 
         return builder.build();
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -32,6 +32,7 @@ import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.auth.signer.EventStreamAws4Signer;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.codegen.model.config.customization.S3ArnableFieldConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
@@ -40,7 +41,12 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.model.service.HostPrefixProcessor;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.utils.HostnameValidator;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.Validate;
@@ -242,5 +248,37 @@ final class ClientClassUtils {
     private static String inputShapeMemberGetter(OperationModel opModel, String c2jName) {
         return opModel.getInput().getVariableName() + "." +
                opModel.getInputShape().getMemberByC2jName(c2jName).getFluentGetterMethodName() + "()";
+    }
+
+    public static MethodSpec updateRetryStrategyClientConfigurationMethod() {
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("updateRetryStrategyClientConfiguration")
+                                               .addModifiers(Modifier.PRIVATE)
+                                               .addParameter(SdkClientConfiguration.Builder.class, "configuration");
+        builder.addStatement("$T builder = configuration.asOverrideConfigurationBuilder()",
+                             ClientOverrideConfiguration.Builder.class);
+        builder.addStatement("$T retryMode = builder.retryMode()", RetryMode.class);
+        builder.beginControlFlow("if (retryMode != null)")
+               .addStatement("configuration.option($T.RETRY_STRATEGY, $T.forRetryMode(retryMode))", SdkClientOption.class,
+                             AwsRetryStrategy.class)
+               .addStatement("return")
+               .endControlFlow();
+        builder.addStatement("$T<$T<?, ?>> configurator = builder.retryStrategyConfigurator()", Consumer.class,
+                             RetryStrategy.Builder.class);
+        builder.beginControlFlow("if (configurator != null)")
+               // RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+               .addStatement("$T<?, ?>  defaultBuilder = $T.defaultRetryStrategy().toBuilder()", RetryStrategy.Builder.class,
+                             AwsRetryStrategy.class)
+               .addStatement("configurator.accept(defaultBuilder)")
+               .addStatement("configuration.option($T.RETRY_STRATEGY, defaultBuilder.build())", SdkClientOption.class)
+               .addStatement("return")
+               .endControlFlow();
+        // This might be just blindly setting the same strategy that was already configured instead of a given override, but we
+        // don't have any means to know if the retryStrategy was overridden, that's OK compared to having to expand the API to
+        // add a method for it, such as overriddenRetryStrategy().
+        builder.addStatement("$T retryStrategy = builder.retryStrategy()", RetryStrategy.class);
+        builder.beginControlFlow("if (retryStrategy != null)")
+               .addStatement("configuration.option($T.RETRY_STRATEGY, retryStrategy)", SdkClientOption.class)
+               .endControlFlow();
+        return builder.build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -152,6 +152,7 @@ public class SyncClientClass extends SyncClientInterface {
             .addMethod(resolveMetricPublishersMethod());
 
         protocolSpec.createErrorResponseHandler().ifPresent(type::addMethod);
+        type.addMethod(ClientClassUtils.updateRetryStrategyClientConfigurationMethod());
         type.addMethod(updateSdkClientConfigurationMethod(configurationUtils.serviceClientConfigurationBuilderClassName()));
         type.addMethod(protocolSpec.initProtocolFactory(model));
     }
@@ -478,6 +479,7 @@ public class SyncClientClass extends SyncClientInterface {
 
         if (model.getCustomizationConfig() == null ||
             CollectionUtils.isNullOrEmpty(model.getCustomizationConfig().getCustomClientContextParams())) {
+            builder.addStatement("updateRetryStrategyClientConfiguration(configuration)");
             builder.addStatement("return configuration.build()");
             return builder.build();
         }
@@ -499,7 +501,7 @@ public class SyncClientClass extends SyncClientInterface {
                                  Validate.class, Objects.class, endpointRulesSpecUtils.clientContextParamsName(), keyName,
                                  keyName + " cannot be modified by request level plugins");
         });
-
+        builder.addStatement("updateRetryStrategyClientConfiguration(configuration)");
         builder.addStatement("return configuration.build()");
         return builder.build();
     }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -350,7 +350,6 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     private void configureRetryStrategy(SdkClientConfiguration.Builder config) {
         RetryStrategy strategy = config.option(SdkClientOption.RETRY_STRATEGY);
         if (strategy != null) {
-            config.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.configureStrategy(strategy.toBuilder()).build());
             return;
         }
         config.lazyOption(SdkClientOption.RETRY_STRATEGY, this::resolveAwsRetryStrategy);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -477,8 +477,14 @@ public final class ClientOverrideConfiguration
          * Configure the retry strategy that should be used when handling failure cases.
          */
         default Builder retryStrategy(Consumer<RetryStrategy.Builder<?, ?>> mutator) {
-            RetryStrategy.Builder<?, ?> builder = SdkDefaultRetryStrategy.forRetryMode(RetryMode.defaultRetryMode())
-                                                                         .toBuilder();
+            RetryStrategy retryStrategy = retryStrategy();
+            RetryStrategy.Builder<?, ?> builder;
+            if (retryStrategy != null) {
+                builder = retryStrategy.toBuilder();
+            } else {
+                builder = SdkDefaultRetryStrategy.forRetryMode(RetryMode.defaultRetryMode())
+                                                 .toBuilder();
+            }
             mutator.accept(builder);
             return retryStrategy(builder.build());
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.ClientType;
@@ -60,8 +61,26 @@ public final class SdkClientOption<T> extends ClientOption<T> {
     /**
      * @see ClientOverrideConfiguration#retryStrategy()
      */
-    @SuppressWarnings("rawtypes")
     public static final SdkClientOption<RetryStrategy> RETRY_STRATEGY = new SdkClientOption<>(RetryStrategy.class);
+
+    /**
+     * XXX add javadocs after testing, see #CONFIGURED_SCHEDULED_EXECUTOR_SERVICE
+     * @see ClientOverrideConfiguration#retryMode()
+     */
+    public static final SdkClientOption<RetryStrategy> CONFIGURED_RETRY_STRATEGY = new SdkClientOption<>(RetryStrategy.class);
+
+    /**
+     * XXX add javadocs after testing, see #CONFIGURED_SCHEDULED_EXECUTOR_SERVICE
+     * @see ClientOverrideConfiguration#retryMode()
+     */
+    public static final SdkClientOption<RetryMode> CONFIGURED_RETRY_MODE = new SdkClientOption<>(RetryMode.class);
+
+    /**
+     * XXX add javadocs after testing, see #CONFIGURED_SCHEDULED_EXECUTOR_SERVICE
+     * @see ClientOverrideConfiguration#retryMode()
+     */
+    public static final SdkClientOption<Consumer<RetryStrategy.Builder<?, ?>>> CONFIGURED_RETRY_CONFIGURATOR =
+        new SdkClientOption<>(new UnsafeValueType(RetryStrategy.Builder.class));
 
     /**
      * @see ClientOverrideConfiguration#executionInterceptors()

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetryStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetryStrategy.java
@@ -15,7 +15,11 @@
 
 package software.amazon.awssdk.core.internal.retry;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.retry.RetryMode;
@@ -32,6 +36,8 @@ import software.amazon.awssdk.retries.api.RetryStrategy;
  */
 @SdkPublicApi
 public final class SdkDefaultRetryStrategy {
+    private static final Function<RetryMode, RetryStrategy> RETRY_MODE_TO_RETRY_STRATEGY = forRetryModeHandler();
+
 
     private SdkDefaultRetryStrategy() {
     }
@@ -52,18 +58,7 @@ public final class SdkDefaultRetryStrategy {
      * @return the appropriate retry strategy for the retry mode with AWS-specific conditions added.
      */
     public static RetryStrategy forRetryMode(RetryMode mode) {
-        switch (mode) {
-            case STANDARD:
-                return standardRetryStrategy();
-            case ADAPTIVE:
-                return legacyAdaptiveRetryStrategy();
-            case ADAPTIVE_V2:
-                return adaptiveRetryStrategy();
-            case LEGACY:
-                return legacyRetryStrategy();
-            default:
-                throw new IllegalStateException("unknown retry mode: " + mode);
-        }
+        return RETRY_MODE_TO_RETRY_STRATEGY.apply(mode);
     }
 
     /**
@@ -209,6 +204,63 @@ public final class SdkDefaultRetryStrategy {
         return RetryPolicyAdapter.builder()
                                  .retryPolicy(RetryPolicy.forRetryMode(RetryMode.ADAPTIVE))
                                  .build();
+    }
+
+    /**
+     * Creating a retry strategy using retry mode needs to be properly configured for the expected retry conditions. If we are
+     * building a retry strategy for an AWS service the SDK retry strategies do not cover all the AWS retryable conditions.
+     * Furthermore, this can be called statically in a non-client specific context, as when calling
+     * {@link ClientOverrideConfiguration#builder()} and then using
+     * {@link ClientOverrideConfiguration.Builder#retryStrategy(RetryMode)}, this means that we need to call an statically defined
+     * method, and by default we call {@link #forRetryMode(RetryMode)} in this class.
+     * <p>
+     * This method attempts to return properly configured retry strategy for AWS services since we cannot adjust it downstream
+     * without risking overwriting customer defined ones. We do that by trying to load the {@code AwsRetryStrategy} from the class
+     * path and, if found, creating a reflective delegate to its method {@link AwsRetryStrategy#forRetryMode(RetryMode)} which
+     * will create proper strategies for AWS services.
+     */
+    private static Function<RetryMode, RetryStrategy> forRetryModeHandler() {
+        try {
+            Class<?> awsRetryStrategy = Class.forName("software.amazon.awssdk.awscore.retry.AwsRetryStrategy");
+            Method method = awsRetryStrategy.getMethod("forRetryMode", RetryMode.class);
+            return new ReflectiveRetryModeToRetryStrategy(method);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            // ignored.
+        }
+        return SdkDefaultRetryStrategy::defaultForRetryMode;
+    }
+
+    static RetryStrategy defaultForRetryMode(RetryMode mode) {
+        switch (mode) {
+            case STANDARD:
+                return standardRetryStrategy();
+            case ADAPTIVE:
+                return legacyAdaptiveRetryStrategy();
+            case ADAPTIVE_V2:
+                return adaptiveRetryStrategy();
+            case LEGACY:
+                return legacyRetryStrategy();
+            default:
+                throw new IllegalStateException("unknown retry mode: " + mode);
+        }
+    }
+
+    static class ReflectiveRetryModeToRetryStrategy implements Function<RetryMode, RetryStrategy> {
+        private final Method method;
+
+        ReflectiveRetryModeToRetryStrategy(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public RetryStrategy apply(RetryMode retryMode) {
+            try {
+                return RetryStrategy.class.cast(method.invoke(null, retryMode));
+            } catch (ClassCastException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                // ignore and fall back.
+            }
+            return defaultForRetryMode(retryMode);
+        }
     }
 }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/CanOverrideRetryStrategy.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/CanOverrideRetryStrategy.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenRequest;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenResponse;
+import software.amazon.awssdk.retries.api.RecordSuccessRequest;
+import software.amazon.awssdk.retries.api.RecordSuccessResponse;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenRequest;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenResponse;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+public abstract class CanOverrideRetryStrategy<ClientT, BuilderT extends AwsClientBuilder<BuilderT, ClientT>> {
+
+    protected WireMockServer wireMock = new WireMockServer(0);
+
+    protected abstract BuilderT newClientBuilder();
+
+    protected abstract AllTypesResponse callAllTypes(ClientT client);
+
+    private BuilderT clientBuilder(RetryStrategy retryStrategy) {
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+        return newClientBuilder()
+            .credentialsProvider(credentialsProvider)
+            .overrideConfiguration(o -> o.retryStrategy(retryStrategy))
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create("http://localhost:" + wireMock.port()));
+    }
+
+    @Test
+    public void overrideConfiguration_RetryStrategyIsOverridden_itGetsUsed() {
+        WrappingRetryStrategy wrappingRetryStrategy = wrappingRetryStrategy();
+        ClientT client = clientBuilder(wrappingRetryStrategy).build();
+        assertThrows(Exception.class, () -> callAllTypes(client));
+        assertEquals(3, wrappingRetryStrategy.failures.size());
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        wireMock.start();
+        wireMock.stubFor(post(anyUrl())
+                             .willReturn(aResponse().withStatus(429)));
+    }
+
+    @AfterEach
+    private void afterEach() {
+        wireMock.stop();
+    }
+
+
+    public WrappingRetryStrategy wrappingRetryStrategy() {
+        RetryStrategy wrapped = AwsRetryStrategy.standardRetryStrategy();
+        return new WrappingRetryStrategy(wrapped);
+    }
+
+    static class WrappingRetryStrategy implements RetryStrategy {
+        private final List<Throwable> failures = new ArrayList<>();
+        private final RetryStrategy wrapped;
+
+        WrappingRetryStrategy(RetryStrategy wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public AcquireInitialTokenResponse acquireInitialToken(AcquireInitialTokenRequest request) {
+            return wrapped.acquireInitialToken(request);
+        }
+
+        @Override
+        public RefreshRetryTokenResponse refreshRetryToken(RefreshRetryTokenRequest request) {
+            failures.add(request.failure());
+            return wrapped.refreshRetryToken(request);
+        }
+
+        @Override
+        public RecordSuccessResponse recordSuccess(RecordSuccessRequest request) {
+            return wrapped.recordSuccess(request);
+        }
+
+        @Override
+        public int maxAttempts() {
+            return wrapped.maxAttempts();
+        }
+
+        @Override
+        public Builder<?, ?> toBuilder() {
+            return wrapped.toBuilder();
+        }
+    }
+
+    static class SyncCanOverrideStrategy extends CanOverrideRetryStrategy<ProtocolRestJsonClient,
+        ProtocolRestJsonClientBuilder> {
+        @Override
+        protected ProtocolRestJsonClientBuilder newClientBuilder() {
+            return ProtocolRestJsonClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonClient client) {
+            return client.allTypes();
+        }
+    }
+
+    static class AsyncCanOverrideStrategy extends CanOverrideRetryStrategy<ProtocolRestJsonAsyncClient,
+        ProtocolRestJsonAsyncClientBuilder> {
+        @Override
+        protected ProtocolRestJsonAsyncClientBuilder newClientBuilder() {
+            return ProtocolRestJsonAsyncClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonAsyncClient client) {
+            try {
+                return client.allTypes().join();
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+
+                throw e;
+            }
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/RetryStrategySetupUsingRetryMode.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/RetryStrategySetupUsingRetryMode.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
+
+public class RetryStrategySetupUsingRetryMode {
+
+    private WireMockServer wireMock = new WireMockServer(0);
+
+    @Test
+    public void sdkRetryStrategyDoesNotRetryOnAWSRetryableErrors() {
+        // Configuring the client to use an non-AWS aware retry strategy won't retry on AWS retryable conditions.
+        ProtocolRestJsonClient client =
+            client(b -> b.overrideConfiguration(o -> o.retryStrategy(SdkDefaultRetryStrategy.standardRetryStrategy())));
+        assertThrows(ProtocolRestJsonException.class, () -> callAllTypes(client));
+        // One request, i.e., no retries.
+        verifyRequestCount(1);
+    }
+
+    @Test
+    public void clientBuilder_settingRetryModeInOverrideConfigurationConsumer() {
+        // Configuring the client using RetryMode should support AWS retryable conditions.
+        ProtocolRestJsonClient client = client(b -> b.overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD)));
+        assertThrows(ProtocolRestJsonException.class, () -> callAllTypes(client));
+        // Three requests, i.e., there were retries.
+        verifyRequestCount(3);
+    }
+
+    @Test
+    public void request_settingRetryModeInOverrideConfigurationConsumer() {
+        // Configuring the client using RetryMode should support AWS retryable conditions.
+        assertThrows(ProtocolRestJsonException.class, () -> callAllTypesWithPlugin(o -> o.retryStrategy(RetryMode.STANDARD)));
+        // Three requests, i.e., there were retries.
+        verifyRequestCount(3);
+    }
+
+    @Test
+    public void clientBuilder_settingRetryModeInOverrideConfigurationAndUsingIt() {
+        // It does not matter if the ClientOverrideConfiguration.Builder is created by the customer or inside the
+        // overrideConfiguration method in the client, using RetryMode should support AWS retryable conditions.
+        ClientOverrideConfiguration.Builder builder = ClientOverrideConfiguration.builder();
+        builder.retryStrategy(RetryMode.STANDARD);
+        ProtocolRestJsonClient client = client(b -> b.overrideConfiguration(builder.build()));
+        assertThrows(ProtocolRestJsonException.class, () -> callAllTypes(client));
+        // Three requests, i.e., there were retries.
+        verifyRequestCount(3);
+    }
+
+
+    @Test
+    public void clientBuilder_settingRetryModeAndRefinementInOverrideConfigurationConsumer() {
+        // Configure standard mode and chain the configured strategy for max attempts of 4 (default is 3).
+        ProtocolRestJsonClient client = client(
+            b -> b.overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD)
+                                               .retryStrategy(rsb -> rsb.maxAttempts(4))));
+        assertThrows(ProtocolRestJsonException.class, () -> callAllTypes(client));
+        // Four requests, i.e., the refinement works
+        verifyRequestCount(4);
+    }
+
+    @Test
+    public void request_settingRetryModeAndRefinementInOverrideConfigurationConsumer() {
+        assertThrows(ProtocolRestJsonException.class, () ->
+            callAllTypesWithPlugin(o -> o.retryStrategy(RetryMode.STANDARD)
+                                         .retryStrategy(rsb -> rsb.maxAttempts(4))));
+        // Four requests, i.e., the refinement works
+        verifyRequestCount(4);
+    }
+
+    private void verifyRequestCount(int count) {
+        wireMock.verify(count, anyRequestedFor(anyUrl()));
+    }
+
+    AllTypesResponse callAllTypesWithPlugin(Consumer<ClientOverrideConfiguration.Builder> configure) {
+        ProtocolRestJsonClient client = client(b -> {
+        });
+
+        SdkPlugin plugin = config -> config.overrideConfiguration(configure);
+        return callAllTypes(client, Collections.singletonList(plugin));
+    }
+
+    AllTypesResponse callAllTypes(ProtocolRestJsonClient client) {
+        return callAllTypes(client, Collections.emptyList());
+    }
+
+    AllTypesResponse callAllTypes(ProtocolRestJsonClient client, List<SdkPlugin> requestPlugins) {
+        return client.allTypes(r -> r.overrideConfiguration(c -> {
+            for (SdkPlugin plugin : requestPlugins) {
+                c.addPlugin(plugin);
+            }
+        }));
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        wireMock.start();
+        wireMock.stubFor(post(anyUrl())
+                             .willReturn(
+                                 aResponse()
+                                     .withStatus(400)
+                                     // This is an AWS retryable error typ but 4xx are not retryable status codes. A normal SDK
+                                     // retry strategy will not retry this response whereas an AWS retry strategy will.
+                                     .withHeader("x-amzn-ErrorType", "PriorRequestNotComplete")
+                                     .withBody("\"{\"__type\":\"PriorRequestNotComplete\",\"message\":\"Blah "
+                                               + "error\"}\"")));
+
+    }
+
+    @AfterEach
+    private void afterEach() {
+        wireMock.stop();
+    }
+
+
+    private ProtocolRestJsonClient client(Consumer<ProtocolRestJsonClientBuilder> configure) {
+        URI endpointOverride = URI.create("http://localhost:" + wireMock.port());
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+        ProtocolRestJsonClientBuilder builder = ProtocolRestJsonClient
+            .builder()
+            .credentialsProvider(credentialsProvider)
+            .region(Region.US_EAST_1)
+            .endpointOverride(endpointOverride);
+        configure.accept(builder);
+        return builder.build();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Fixes a bug that was found that prevents a retry strategy override from being used as it was overwritten once again to configure it for AWS. This is not needed as the `AwsDefaultClientBuilder` takes care of this without resorting on the `SdkDefaultClientBuilder`. Also added tests to verify that this actually works for both sync and async scenarios.

## Modifications

**NOTE** the build will fail since there were changes to the clients codegen. I will update the tests if the approach looks sound.

<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
