### PR TITLE
Retry strategies plugins overrides have to be cleared

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -259,22 +259,25 @@ public final class ClientClassUtils {
         builder.addStatement("$T retryMode = builder.retryMode()", RetryMode.class);
         builder.beginControlFlow("if (retryMode != null)")
                .addStatement("configuration.option($T.RETRY_STRATEGY, $T.forRetryMode(retryMode))", SdkClientOption.class,
-                             AwsRetryStrategy.class)
-               .addStatement("return")
-               .endControlFlow();
+                             AwsRetryStrategy.class);
+        builder.nextControlFlow("else");
         builder.addStatement("$T<$T<?, ?>> configurator = builder.retryStrategyConfigurator()", Consumer.class,
                              RetryStrategy.Builder.class);
         builder.beginControlFlow("if (configurator != null)")
                .addStatement("$T<?, ?>  defaultBuilder = $T.defaultRetryStrategy().toBuilder()", RetryStrategy.Builder.class,
                              AwsRetryStrategy.class)
                .addStatement("configurator.accept(defaultBuilder)")
-               .addStatement("configuration.option($T.RETRY_STRATEGY, defaultBuilder.build())", SdkClientOption.class)
-               .addStatement("return")
-               .endControlFlow();
+               .addStatement("configuration.option($T.RETRY_STRATEGY, defaultBuilder.build())", SdkClientOption.class);
+        builder.nextControlFlow("else");
         builder.addStatement("$T retryStrategy = builder.retryStrategy()", RetryStrategy.class);
         builder.beginControlFlow("if (retryStrategy != null)")
                .addStatement("configuration.option($T.RETRY_STRATEGY, retryStrategy)", SdkClientOption.class)
                .endControlFlow();
+        builder.endControlFlow();
+        builder.endControlFlow();
+        builder.addStatement("configuration.option($T.CONFIGURED_RETRY_MODE, null)", SdkClientOption.class);
+        builder.addStatement("configuration.option($T.CONFIGURED_RETRY_STRATEGY, null)", SdkClientOption.class);
+        builder.addStatement("configuration.option($T.CONFIGURED_RETRY_CONFIGURATOR, null)", SdkClientOption.class);
         return builder.build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-bearer-auth-client-builder-class.java
@@ -152,19 +152,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-class.java
@@ -241,19 +241,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-endpoints-auth-params.java
@@ -182,19 +182,22 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-internal-defaults-class.java
@@ -148,19 +148,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-composed-sync-default-client-builder.java
@@ -183,19 +183,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-no-auth-ops-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-no-auth-ops-client-builder-class.java
@@ -145,19 +145,22 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-no-auth-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-no-auth-service-client-builder-class.java
@@ -133,19 +133,22 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-query-client-builder-class.java
@@ -179,19 +179,22 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -123,19 +123,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -215,19 +215,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -153,19 +153,22 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -120,19 +120,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
@@ -157,19 +157,22 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
@@ -114,19 +114,22 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
@@ -99,19 +99,22 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -153,19 +153,22 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private List<SdkPlugin> internalPlugins(SdkClientConfiguration config) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-aws-json-async-client-class.java
@@ -1177,19 +1177,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-json-async-client-class.java
@@ -1359,19 +1359,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-json-client-class.java
@@ -917,19 +917,22 @@ final class DefaultJsonClient implements JsonClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-query-async-client-class.java
@@ -1114,19 +1114,22 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-query-client-class.java
@@ -946,19 +946,22 @@ final class DefaultQueryClient implements QueryClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-xml-async-client-class.java
@@ -895,19 +895,22 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-xml-client-class.java
@@ -663,19 +663,22 @@ final class DefaultXmlClient implements XmlClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -1207,19 +1207,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
@@ -176,19 +176,22 @@ final class DefaultQueryToJsonCompatibleAsyncClient implements QueryToJsonCompat
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
@@ -150,19 +150,22 @@ final class DefaultQueryToJsonCompatibleClient implements QueryToJsonCompatibleC
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
@@ -160,19 +160,22 @@ final class DefaultProtocolRestJsonWithCustomPackageAsyncClient implements Proto
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
@@ -139,19 +139,22 @@ final class DefaultProtocolRestJsonWithCustomPackageClient implements ProtocolRe
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
@@ -160,19 +160,22 @@ final class DefaultProtocolRestJsonWithCustomContentTypeAsyncClient implements P
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
@@ -139,19 +139,22 @@ final class DefaultProtocolRestJsonWithCustomContentTypeClient implements Protoc
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
@@ -416,19 +416,22 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
@@ -356,19 +356,22 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -1393,19 +1393,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -936,19 +936,22 @@ final class DefaultJsonClient implements JsonClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -1142,19 +1142,22 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -963,19 +963,22 @@ final class DefaultQueryClient implements QueryClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -923,19 +923,22 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -680,19 +680,22 @@ final class DefaultXmlClient implements XmlClient {
         RetryMode retryMode = builder.retryMode();
         if (retryMode != null) {
             configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
-            return;
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
         }
-        Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
-        if (configurator != null) {
-            RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
-            configurator.accept(defaultBuilder);
-            configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
-            return;
-        }
-        RetryStrategy retryStrategy = builder.retryStrategy();
-        if (retryStrategy != null) {
-            configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
-        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
     }
 
     private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/OverridesAreForgotten.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/OverridesAreForgotten.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.net.URI;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+public abstract class OverridesAreForgotten<ClientT, BuilderT extends AwsClientBuilder<BuilderT, ClientT>> {
+
+    protected WireMockServer wireMock = new WireMockServer(0);
+
+    protected abstract BuilderT newClientBuilder();
+
+    protected abstract AllTypesResponse callAllTypes(ClientT client, SdkPlugin... plugins);
+
+    private BuilderT clientBuilder() {
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+        return newClientBuilder()
+            .credentialsProvider(credentialsProvider)
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create("http://localhost:" + wireMock.port()));
+    }
+
+    @Test
+    public void pluginOverridesAreForgottenForSubsequentPlugins() {
+        stubThrottlingResponse();
+        ClientT client = clientBuilder()
+            .addPlugin(c -> c.overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD)))
+            .build();
+
+        // 50 times 2 retries 5 tokens withdrawn for each for a grand total of 500.
+        // Tokens are exhausted, no more retries will be allowed by this strategy.
+        int expected = 0;
+        for (int x = 1; x <= 50; x++) {
+            assertThatThrownBy(() -> callAllTypes(client))
+                .isInstanceOf(SdkException.class);
+            expected += 3;
+            verifyRequestCount(expected);
+        }
+
+        // Override for the request, new strategy should allow the
+        // default 3 attempts (first attempt plus two retries).
+        assertThatThrownBy(() -> callAllTypes(client,
+                                              config -> config.overrideConfiguration(
+                                                  oc -> oc.retryStrategy(RetryMode.STANDARD))))
+            .isInstanceOf(SdkException.class);
+        expected += 3;
+        verifyRequestCount(expected);
+
+        // Call again using a no-op plugin.
+        assertThatThrownBy(() -> callAllTypes(client, config -> {
+        }))
+            .isInstanceOf(SdkException.class);
+        // only one attempt, the original strategy is back in place and has exhausted its tokens.
+        expected += 1;
+        verifyRequestCount(expected);
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        wireMock.start();
+    }
+
+    @AfterEach
+    private void afterEach() {
+        wireMock.stop();
+    }
+
+    private void stubThrottlingResponse() {
+        wireMock.stubFor(post(anyUrl())
+                             .willReturn(aResponse().withStatus(429)));
+    }
+
+    private void verifyRequestCount(int count) {
+        wireMock.verify(count, anyRequestedFor(anyUrl()));
+    }
+
+    static class SyncOverridesAreForgotten extends OverridesAreForgotten<ProtocolRestJsonClient,
+        ProtocolRestJsonClientBuilder> {
+        @Override
+        protected ProtocolRestJsonClientBuilder newClientBuilder() {
+            return ProtocolRestJsonClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonClient client, SdkPlugin... plugins) {
+            AllTypesRequest.Builder requestBuilder = AllTypesRequest.builder();
+            for (SdkPlugin plugin : plugins) {
+                requestBuilder.overrideConfiguration(o -> o.addPlugin(plugin));
+            }
+            return client.allTypes(requestBuilder.build());
+        }
+    }
+
+    static class AsyncOverridesAreForgotten extends OverridesAreForgotten<ProtocolRestJsonAsyncClient,
+        ProtocolRestJsonAsyncClientBuilder> {
+        @Override
+        protected ProtocolRestJsonAsyncClientBuilder newClientBuilder() {
+            return ProtocolRestJsonAsyncClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonAsyncClient client, SdkPlugin... plugins) {
+            try {
+                AllTypesRequest.Builder requestBuilder = AllTypesRequest.builder();
+                for (SdkPlugin plugin : plugins) {
+                    requestBuilder.overrideConfiguration(o -> o.addPlugin(plugin));
+                }
+                return client.allTypes(requestBuilder.build()).join();
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Fix for another bug with retry overrides. If the state is not cleared after running the plugins then it might linger and get picked up by the next plugins execution.

## Modifications

This change modifies the previously added method `updateRetryStrategyClientConfiguration` to clear the state after setting the overrides if any.

## Testing

* Unit tests were added to validate that two consecutive plugin runs do not interfere with each other regarding retry strategies overrides.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
