### PR TITLE
External PR Implement ApiName.equals/.hashCode #5302

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-ffd0ebe.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-ffd0ebe.json
@@ -1,0 +1,6 @@
+{
+  "type": "bugfix",
+  "category": "AWS SDK for Java v2",
+  "contributor": "brettkail-wk",
+  "description": "Implement `ApiName.equals`/`.hashCode`"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/ApiName.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/ApiName.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core;
 
 import static software.amazon.awssdk.utils.Validate.notNull;
 
+import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
@@ -40,6 +41,30 @@ public final class ApiName {
 
     public String version() {
         return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ApiName that = (ApiName) o;
+
+        if (!Objects.equals(name, that.name)) {
+            return false;
+        }
+        return Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        return result;
     }
 
     public static Builder builder() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/ApiNameTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/ApiNameTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class ApiNameTest {
+
+    @Test
+    public void equalsHashCode() {
+        EqualsVerifier.forClass(ApiName.class)
+                      .withNonnullFields("name", "version")
+                      .verify();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes #5292.

## Modifications
<!--- Describe your changes in detail -->
Implements `ApiName.equals` and `.hashCode` in a similar style to `CompressionConfiguration`.

I think this change qualifies as "non-substantial" for CLA purposes.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added `ApiNameTest` in a similar style to `CompressionConfigurationTest`.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
