### PR TITLE
Fix POJO class naming mapping

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
@@ -33,13 +33,14 @@ public final class NamingConversionUtils {
         String v1ClassName = currentFqcn.substring(lastIndexOfDot + 1, currentFqcn.length());
         String packagePrefix = currentFqcn.substring(0, lastIndexOfDot);
 
-        String v2ClassName;
+        String v2ClassName = CodegenNamingUtils.pascalCase(v1ClassName);
         String v2PackagePrefix = packagePrefix.replace(V1_PACKAGE_PREFIX, V2_PACKAGE_PREFIX);
 
         if (Stream.of("Abstract", "Amazon", "AWS").anyMatch(v1ClassName::startsWith)) {
             v2ClassName = getV2ClientEquivalent(v1ClassName);
-        } else {
-            v2ClassName = v1ClassName.replace("Result", "Response");
+        } else if (v1ClassName.endsWith("Result")) {
+            int lastIndex = v1ClassName.lastIndexOf("Result");
+            v2ClassName = v1ClassName.substring(0, lastIndex) + "Response";
         }
 
         return v2PackagePrefix + "." + v2ClassName;

--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/SdkTypeUtils.java
@@ -137,7 +137,8 @@ public final class SdkTypeUtils {
     }
 
     public static boolean isEligibleToConvertToBuilder(JavaType.FullyQualified type) {
-        return type != null && (isV2ModelClass(type) || isV2ClientClass(type) || isV2CoreClassesWithBuilder(type.getFullyQualifiedName()));
+        return type != null && (isV2ModelClass(type) || isV2ClientClass(type) ||
+                                isV2CoreClassesWithBuilder(type.getFullyQualifiedName()));
     }
 
     public static boolean isEligibleToConvertToStaticFactory(JavaType.FullyQualified type) {

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
@@ -31,6 +31,15 @@ public class NamingConversionUtilsTest {
 
         assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.iot.model.AuditFinding"))
             .isEqualTo("software.amazon.awssdk.services.iot.model.AuditFinding");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.iot.ResultConfiguration"))
+            .isEqualTo("software.amazon.awssdk.services.iot.ResultConfiguration");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.iot.ResultConfigurationResult"))
+            .isEqualTo("software.amazon.awssdk.services.iot.ResultConfigurationResponse");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.iot.ListCACertificatesRequest"))
+            .isEqualTo("software.amazon.awssdk.services.iot.ListCaCertificatesRequest");
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Current behavior:
v1 `ResultConfiguration` -> v2 `ResponseConfiguration`
v1 `ResultConfigurationResult` -> v2 `ResponseConfigurationResponse`

Expected behavior:
v1 `ResultConfiguration` -> v2 `ResultConfiguration`
v1 `ResultConfigurationResult` -> v2 `ResultConfigurationResponse`


## Testing
Added tests
