### PR TITLE
Codegenerate BatchManager API under AsyncClient and Initail Interfaces for BatchManager

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
@@ -60,6 +60,7 @@ final class AddMetadata {
                 .withBaseBuilder(String.format(Constant.BASE_BUILDER_CLASS_NAME_PATTERN, serviceName))
                 .withDocumentation(serviceModel.getDocumentation())
                 .withServiceAbbreviation(serviceMetadata.getServiceAbbreviation())
+                .withBatchmanagerPackageName(namingStrategy.getBatchManagerPackageName(serviceName))
                 .withServiceFullName(serviceMetadata.getServiceFullName())
                 .withServiceName(serviceName)
                 .withSyncClient(String.format(Constant.SYNC_CLIENT_CLASS_NAME_PATTERN, serviceName))

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Constant.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Constant.java
@@ -76,6 +76,8 @@ public final class Constant {
 
     public static final String PACKAGE_NAME_SMOKE_TEST_PATTERN = "%s.smoketests";
 
+    public static final String PACKAGE_NAME_BATCHMANAGER_PATTERN = "%s.batchmanager";
+
     public static final String PACKAGE_NAME_CUSTOM_AUTH_PATTERN = "%s.auth";
 
     public static final String AUTH_POLICY_ENUM_CLASS_DIR = "software/amazon/awssdk/auth/policy/actions";

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -342,6 +342,11 @@ public class CustomizationConfig {
      */
     private Map<String, PreClientExecutionRequestCustomizer> preClientExecutionRequestCustomizer;
 
+    /**
+     * A boolean flag to indicate if Automatic Batch Request is supported.
+     */
+    private boolean batchManagerSupported;
+
     private CustomizationConfig() {
     }
 
@@ -899,6 +904,14 @@ public class CustomizationConfig {
     public void setPreClientExecutionRequestCustomizer(Map<String, PreClientExecutionRequestCustomizer>
                                                            preClientExecutionRequestCustomizer) {
         this.preClientExecutionRequestCustomizer = preClientExecutionRequestCustomizer;
+    }
+
+    public boolean getBatchManagerSupported() {
+        return batchManagerSupported;
+    }
+
+    public void setBatchManagerSupported(boolean batchManagerSupported) {
+        this.batchManagerSupported = batchManagerSupported;
     }
 
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
@@ -71,6 +71,8 @@ public class Metadata {
 
     private String waitersPackageName;
 
+    private String batchManagerPackageName;
+
     private String endpointRulesPackageName;
 
     private String authSchemePackageName;
@@ -787,6 +789,24 @@ public class Metadata {
 
     public String getFullInternalJmesPathPackageName() {
         return joinPackageNames(getFullJmesPathPackageName(), "internal");
+    }
+
+    public Metadata withBatchmanagerPackageName(String batchmanagerPackageName) {
+        setBatchManagerPackageName(batchmanagerPackageName);
+        return this;
+    }
+
+
+    public String getBatchManagerPackageName() {
+        return batchManagerPackageName;
+    }
+
+    public void setBatchManagerPackageName(String batchManagerPackageName) {
+        this.batchManagerPackageName = batchManagerPackageName;
+    }
+
+    public String getFullBatchManagerPackageName() {
+        return joinPackageNames(rootPackageName, getBatchManagerPackageName());
     }
 
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -190,6 +190,11 @@ public class DefaultNamingStrategy implements NamingStrategy {
     }
 
     @Override
+    public String getBatchManagerPackageName(String serviceName) {
+        return getCustomizedPackageName(concatServiceNameIfShareModel(serviceName), Constant.PACKAGE_NAME_BATCHMANAGER_PATTERN);
+    }
+
+    @Override
     public String getSmokeTestPackageName(String serviceName) {
 
         return getCustomizedPackageName(concatServiceNameIfShareModel(serviceName),

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/NamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/NamingStrategy.java
@@ -75,6 +75,11 @@ public interface NamingStrategy {
     String getJmesPathPackageName(String serviceName);
 
     /**
+     * Retrieve the batchManager package name that should be used based on the service name.
+     */
+    String getBatchManagerPackageName(String serviceName);
+
+    /**
      * Retrieve the smote test package name that should be used based on the service name.
      */
     String getSmokeTestPackageName(String serviceName);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtension.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtension.java
@@ -196,4 +196,9 @@ public class PoetExtension {
     public boolean isRequest(ShapeModel shapeModel) {
         return shapeModel.getShapeType() == ShapeType.Request;
     }
+
+    public ClassName getBatchManagerAsyncInterface() {
+        return ClassName.get(model.getMetadata().getFullBatchManagerPackageName(),
+                             model.getMetadata().getServiceName() + "AsyncBatchManager");
+    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.codegen.poet.client;
 
+import static com.squareup.javapoet.TypeSpec.Builder;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static javax.lang.model.element.Modifier.FINAL;
@@ -104,6 +105,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
     private final ClassName serviceClientConfigurationClassName;
     private final ServiceClientConfigurationUtils configurationUtils;
     private final boolean useSraAuth;
+    private boolean hasScheduledExecutor;
 
     public AsyncClientClass(GeneratorTaskParams dependencies) {
         super(dependencies.getModel());
@@ -139,7 +141,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
     }
 
     @Override
-    protected void addFields(TypeSpec.Builder type) {
+    protected void addFields(Builder type) {
         type.addField(FieldSpec.builder(ClassName.get(Logger.class), "log")
                                .addModifiers(PRIVATE, STATIC, FINAL)
                                .initializer("$T.getLogger($T.class)", LoggerFactory.class,
@@ -153,6 +155,10 @@ public final class AsyncClientClass extends AsyncClientInterface {
         // Kinesis doesn't support CBOR for STS yet so need another protocol factory for JSON
         if (model.getMetadata().isCborProtocol()) {
             type.addField(AwsJsonProtocolFactory.class, "jsonProtocolFactory", PRIVATE, FINAL);
+        }
+
+        if (model.getCustomizationConfig().getBatchManagerSupported() || model.hasWaiters()) {
+            addScheduledExecutorIfNeeded(type);
         }
 
         model.getEndpointOperation().ifPresent(
@@ -180,9 +186,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
 
     @Override
     protected void addWaiterMethod(TypeSpec.Builder type) {
-        type.addField(FieldSpec.builder(ClassName.get(ScheduledExecutorService.class), "executorService")
-                                       .addModifiers(PRIVATE, FINAL)
-                                       .build());
 
         MethodSpec waiter = MethodSpec.methodBuilder("waiter")
                                       .addModifiers(PUBLIC)
@@ -263,7 +266,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
             builder.endControlFlow();
         }
 
-        if (model.hasWaiters()) {
+        if (model.hasWaiters() || model.getCustomizationConfig().getBatchManagerSupported()) {
             builder.addStatement("this.executorService = clientConfiguration.option($T.SCHEDULED_EXECUTOR_SERVICE)",
                                  SdkClientOption.class);
         }
@@ -547,6 +550,26 @@ public final class AsyncClientClass extends AsyncClientInterface {
                          .build();
     }
 
+    @Override
+    protected void addBatchManagerMethod(Builder type) {
+
+        String scheduledExecutor = "executorService";
+        ClassName returnType;
+
+        returnType = poetExtensions.getBatchManagerAsyncInterface();
+
+        MethodSpec batchManager = MethodSpec.methodBuilder("batchManager")
+                                            .addModifiers(PUBLIC)
+                                            .addAnnotation(Override.class)
+                                            .returns(returnType)
+                                            .addStatement("return $T.builder().client(this).scheduledExecutor($N).build()",
+                                                          returnType, scheduledExecutor)
+                                            .build();
+
+
+        type.addMethod(batchManager);
+    }
+
     private MethodSpec resolveMetricPublishersMethod() {
         String clientConfigName = "clientConfiguration";
         String requestOverrideConfigName = "requestOverrideConfiguration";
@@ -620,5 +643,14 @@ public final class AsyncClientClass extends AsyncClientInterface {
     private boolean hasStreamingV4AuthOperations() {
         return model.getOperations().values().stream()
                 .anyMatch(this::shouldUseAsyncWithBodySigner);
+    }
+
+    private void addScheduledExecutorIfNeeded(Builder classBuilder) {
+        if (!hasScheduledExecutor) {
+            classBuilder.addField(FieldSpec.builder(ClassName.get(ScheduledExecutorService.class), "executorService")
+                                           .addModifiers(PRIVATE, FINAL)
+                                           .build());
+            hasScheduledExecutor = true;
+        }
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -157,7 +157,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
             type.addField(AwsJsonProtocolFactory.class, "jsonProtocolFactory", PRIVATE, FINAL);
         }
 
-        if (model.getCustomizationConfig().getBatchManagerSupported() || model.hasWaiters()) {
+        if (shouldAddScheduledExecutor()) {
             addScheduledExecutorIfNeeded(type);
         }
 
@@ -266,12 +266,16 @@ public final class AsyncClientClass extends AsyncClientInterface {
             builder.endControlFlow();
         }
 
-        if (model.hasWaiters() || model.getCustomizationConfig().getBatchManagerSupported()) {
+        if (shouldAddScheduledExecutor()) {
             builder.addStatement("this.executorService = clientConfiguration.option($T.SCHEDULED_EXECUTOR_SERVICE)",
                                  SdkClientOption.class);
         }
 
         return builder.build();
+    }
+
+    private boolean shouldAddScheduledExecutor() {
+        return model.hasWaiters() || model.getCustomizationConfig().getBatchManagerSupported();
     }
 
     private boolean hasOperationWithEventStreamOutput() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
@@ -96,6 +96,9 @@ public class AsyncClientInterface implements ClassSpec {
         if (model.hasWaiters()) {
             addWaiterMethod(result);
         }
+        if (model.getCustomizationConfig().getBatchManagerSupported()) {
+            addBatchManagerMethod(result);
+        }
         result.addMethod(serviceClientConfigMethod());
         addAdditionalMethods(result);
         addCloseMethod(result);
@@ -160,6 +163,16 @@ public class AsyncClientInterface implements ClassSpec {
                                                    poetExtensions.getAsyncWaiterInterface()));
         
         type.addMethod(waiterOperationBody(builder).build());
+    }
+
+    protected void addBatchManagerMethod(TypeSpec.Builder type) {
+        ClassName returnType = poetExtensions.getBatchManagerAsyncInterface();
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("batchManager")
+                                               .addModifiers(PUBLIC)
+                                               .returns(returnType)
+                                               .addJavadoc("Creates an instance of {@link $T} object with the "
+                                                           + "configuration set on this client.", returnType);
+        type.addMethod(batchManagerOperationBody(builder).build());
     }
 
     @Override
@@ -532,4 +545,10 @@ public class AsyncClientInterface implements ClassSpec {
         return builder.addModifiers(DEFAULT, PUBLIC)
                       .addStatement("throw new $T()", UnsupportedOperationException.class);
     }
+
+    protected MethodSpec.Builder batchManagerOperationBody(MethodSpec.Builder builder) {
+        return builder.addModifiers(DEFAULT, PUBLIC)
+                      .addStatement("throw new $T()", UnsupportedOperationException.class);
+    }
+
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
@@ -217,4 +217,9 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
     protected MethodSpec.Builder waiterOperationBody(MethodSpec.Builder builder) {
         return builder.addAnnotation(Override.class).addStatement("return delegate.waiter()");
     }
+
+    @Override
+    protected MethodSpec.Builder batchManagerOperationBody(MethodSpec.Builder builder) {
+        return builder.addAnnotation(Override.class).addStatement("return delegate.batchManager()");
+    }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -380,6 +380,18 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel batchManagerModels() {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/batchmanager/service-2.json").getFile());
+        File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/batchmanager/customization.config").getFile());
+
+        C2jModels models = C2jModels.builder()
+                                    .serviceModel(getServiceModel(serviceModel))
+                                    .customizationConfig(getCustomizationConfig(customizationModel))
+                                    .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     private static ServiceModel getServiceModel(File file) {
         return ModelLoaderUtils.loadModel(ServiceModel.class, file);
     }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.codegen.poet.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.awsJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.awsQueryCompatibleJsonServiceModels;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.batchManagerModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.customContentTypeModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.customPackageModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.endpointDiscoveryModels;
@@ -90,6 +91,12 @@ public class AsyncClientClassTest {
     public void asyncClientCustomPackageName() {
         ClassSpec syncClientCustomServiceMetaData = createAsyncClientClass(customPackageModels());
         assertThat(syncClientCustomServiceMetaData, generatesTo("test-custompackage-async.java"));
+    }
+
+    @Test
+    public void asyncClientBatchManager() {
+        ClassSpec syncClientCustomServiceMetaData = createAsyncClientClass(batchManagerModels());
+        assertThat(syncClientCustomServiceMetaData, generatesTo("test-batchmanager-async.java"));
     }
 
     private AsyncClientClass createAsyncClientClass(IntermediateModel model) {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
@@ -95,8 +95,8 @@ public class AsyncClientClassTest {
 
     @Test
     public void asyncClientBatchManager() {
-        ClassSpec syncClientCustomServiceMetaData = createAsyncClientClass(batchManagerModels());
-        assertThat(syncClientCustomServiceMetaData, generatesTo("test-batchmanager-async.java"));
+        ClassSpec aSyncClientBatchManager = createAsyncClientClass(batchManagerModels());
+        assertThat(aSyncClientBatchManager, generatesTo("test-batchmanager-async.java"));
     }
 
     private AsyncClientClass createAsyncClientClass(IntermediateModel model) {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterfaceTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterfaceTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.codegen.poet.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.batchManagerModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.restJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
@@ -27,5 +28,11 @@ public class AsyncClientInterfaceTest {
     public void asyncClientInterface() {
         ClassSpec asyncClientInterface = new AsyncClientInterface(restJsonServiceModels());
         assertThat(asyncClientInterface, generatesTo("test-json-async-client-interface.java"));
+    }
+
+    @Test
+    public void asyncClientInterfaceWithBatchManager() {
+        ClassSpec asyncClientInterface = new AsyncClientInterface(batchManagerModels());
+        assertThat(asyncClientInterface, generatesTo("test-json-async-client-interface-batchmanager.java"));
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/customization.config
@@ -1,0 +1,3 @@
+{
+    "batchManagerSupported": true
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/service-2.json
@@ -1,0 +1,84 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"batchmanagertest",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "serviceAbbreviation":"BatchManagerTest",
+    "serviceFullName":"BatchManagerTest",
+    "serviceId":"BatchManagerTest",
+    "signatureVersion":"v4",
+    "uid":"batchmanagertest-2016-03-11"
+  },
+  "operations":{
+    "SendRequest":{
+      "name":"SendMessage",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"SendRequestRequest"},
+      "output":{
+        "shape":"SendRequestResult",
+        "resultWrapper":"SendRequestResult"
+      }
+    }
+  },
+  "shapes": {
+    "String": {
+      "type": "string"
+    },
+    "Integer": {
+      "type": "integer"
+    },
+    "Boolean": {
+      "type": "boolean"
+    },
+    "SendRequestRequest": {
+      "type": "structure",
+      "required": [
+        "QueueUrl",
+        "MessageBody"
+      ],
+      "members": {
+        "QueueUrl": {
+          "shape": "String"
+        },
+        "MessageBody": {
+          "shape": "String"
+        },
+        "DelaySeconds": {
+          "shape": "Integer"
+        },
+        "MessageDeduplicationId": {
+          "shape": "String"
+        },
+        "MessageGroupId": {
+          "shape": "String"
+        }
+      }
+    },
+    "SendRequestResult":{
+      "type":"structure",
+      "members":{
+        "MD5OfMessageBody":{
+          "shape":"String"
+        },
+        "MD5OfMessageAttributes":{
+          "shape":"String"
+        },
+        "MD5OfMessageSystemAttributes":{
+          "shape":"String"
+        },
+        "MessageId":{
+          "shape":"String"
+        },
+        "SequenceNumber":{
+          "shape":"String"
+        }
+      }
+    }
+  },
+  "documentation": "A service that implements the batchManager() method"
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
@@ -65,5 +65,6 @@
     "EventStream": ["EventOne", "event-two", "eventThree"]
   },
   "asyncClientDecoratorClass": true,
-  "syncClientDecoratorClass": true
+  "syncClientDecoratorClass": true,
+  "batchManagerSupported": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-aws-json-async-client-class.java
@@ -134,7 +134,6 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private final SdkClientConfiguration clientConfiguration;
 
-
     private final Executor executor;
 
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-aws-json-async-client-class.java
@@ -134,6 +134,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private final SdkClientConfiguration clientConfiguration;
 
+
     private final Executor executor;
 
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/sra/test-json-async-client-class.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -58,6 +59,7 @@ import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.services.json.batchmanager.JsonAsyncBatchManager;
 import software.amazon.awssdk.services.json.internal.JsonServiceClientConfigurationBuilder;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
@@ -142,6 +144,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private final SdkClientConfiguration clientConfiguration;
 
+    private final ScheduledExecutorService executorService;
+
     private final Executor executor;
 
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {
@@ -149,6 +153,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         this.clientConfiguration = clientConfiguration.toBuilder().option(SdkClientOption.SDK_CLIENT, this).build();
         this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
         this.executor = clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
+        this.executorService = clientConfiguration.option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
     }
 
     @Override
@@ -1316,6 +1321,11 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
+    }
+
+    @Override
+    public JsonAsyncBatchManager batchManager() {
+        return JsonAsyncBatchManager.builder().client(this).scheduledExecutor(executorService).build();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.json.batchmanager.JsonAsyncBatchManager;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
 import software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest;
@@ -546,6 +547,14 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
         AsyncResponseTransformer<StreamingOutputOperationResponse, ReturnT> asyncResponseTransformer) {
         return invokeOperation(streamingOutputOperationRequest,
                                request -> delegate.streamingOutputOperation(request, asyncResponseTransformer));
+    }
+
+    /**
+     * Creates an instance of {@link JsonAsyncBatchManager} object with the configuration set on this client.
+     */
+    @Override
+    public JsonAsyncBatchManager batchManager() {
+        return delegate.batchManager();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
@@ -1,0 +1,214 @@
+package software.amazon.awssdk.services.batchmanagertest;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.awscore.internal.AwsProtocolMetadata;
+import software.amazon.awssdk.awscore.internal.AwsServiceProtocol;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.services.batchmanagertest.batchmanager.BatchManagerTestAsyncBatchManager;
+import software.amazon.awssdk.services.batchmanagertest.internal.BatchManagerTestServiceClientConfigurationBuilder;
+import software.amazon.awssdk.services.batchmanagertest.model.BatchManagerTestException;
+import software.amazon.awssdk.services.batchmanagertest.model.SendRequestRequest;
+import software.amazon.awssdk.services.batchmanagertest.model.SendRequestResponse;
+import software.amazon.awssdk.services.batchmanagertest.transform.SendRequestRequestMarshaller;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+
+/**
+ * Internal implementation of {@link BatchManagerTestAsyncClient}.
+ *
+ * @see BatchManagerTestAsyncClient#builder()
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+final class DefaultBatchManagerTestAsyncClient implements BatchManagerTestAsyncClient {
+    private static final Logger log = LoggerFactory.getLogger(DefaultBatchManagerTestAsyncClient.class);
+
+    private static final AwsProtocolMetadata protocolMetadata = AwsProtocolMetadata.builder()
+                                                                                   .serviceProtocol(AwsServiceProtocol.REST_JSON).build();
+
+    private final AsyncClientHandler clientHandler;
+
+    private final AwsJsonProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    private final ScheduledExecutorService executorService;
+
+    protected DefaultBatchManagerTestAsyncClient(SdkClientConfiguration clientConfiguration) {
+        this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
+        this.clientConfiguration = clientConfiguration.toBuilder().option(SdkClientOption.SDK_CLIENT, this).build();
+        this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
+        this.executorService = clientConfiguration.option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
+    }
+
+    /**
+     * Invokes the SendRequest operation asynchronously.
+     *
+     * @param sendRequestRequest
+     * @return A Java Future containing the result of the SendRequest operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions. The exception returned is wrapped with CompletionException, so you need to invoke
+     *         {@link Throwable#getCause} to retrieve the underlying exception.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>BatchManagerTestException Base class for all service exceptions. Unknown exceptions will be thrown as
+     *         an instance of this type.</li>
+     *         </ul>
+     * @sample BatchManagerTestAsyncClient.SendRequest
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/batchmanagertest-2016-03-11/SendRequest" target="_top">AWS
+     *      API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<SendRequestResponse> sendRequest(SendRequestRequest sendRequestRequest) {
+        SdkClientConfiguration clientConfiguration = updateSdkClientConfiguration(sendRequestRequest, this.clientConfiguration);
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, sendRequestRequest
+            .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "BatchManagerTest");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "SendRequest");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                                                                           .isPayloadJson(true).build();
+
+            HttpResponseHandler<SendRequestResponse> responseHandler = protocolFactory.createResponseHandler(operationMetadata,
+                                                                                                             SendRequestResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                                                                                                       operationMetadata);
+
+            CompletableFuture<SendRequestResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<SendRequestRequest, SendRequestResponse>()
+                             .withOperationName("SendRequest").withProtocolMetadata(protocolMetadata)
+                             .withMarshaller(new SendRequestRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                             .withRequestConfiguration(clientConfiguration).withMetricCollector(apiCallMetricCollector)
+                             .withInput(sendRequestRequest));
+            CompletableFuture<SendRequestResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    @Override
+    public BatchManagerTestAsyncBatchManager batchManager() {
+        return BatchManagerTestAsyncBatchManager.builder().client(this).scheduledExecutor(executorService).build();
+    }
+
+    @Override
+    public final BatchManagerTestServiceClientConfiguration serviceClientConfiguration() {
+        return new BatchManagerTestServiceClientConfigurationBuilder(this.clientConfiguration.toBuilder()).build();
+    }
+
+    @Override
+    public final String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
+        return builder.clientConfiguration(clientConfiguration)
+                      .defaultServiceExceptionSupplier(BatchManagerTestException::builder).protocol(AwsJsonProtocol.REST_JSON)
+                      .protocolVersion("1.1");
+    }
+
+    private static List<MetricPublisher> resolveMetricPublishers(SdkClientConfiguration clientConfiguration,
+                                                                 RequestOverrideConfiguration requestOverrideConfiguration) {
+        List<MetricPublisher> publishers = null;
+        if (requestOverrideConfiguration != null) {
+            publishers = requestOverrideConfiguration.metricPublishers();
+        }
+        if (publishers == null || publishers.isEmpty()) {
+            publishers = clientConfiguration.option(SdkClientOption.METRIC_PUBLISHERS);
+        }
+        if (publishers == null) {
+            publishers = Collections.emptyList();
+        }
+        return publishers;
+    }
+
+    private void updateRetryStrategyClientConfiguration(SdkClientConfiguration.Builder configuration) {
+        ClientOverrideConfiguration.Builder builder = configuration.asOverrideConfigurationBuilder();
+        RetryMode retryMode = builder.retryMode();
+        if (retryMode != null) {
+            configuration.option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.forRetryMode(retryMode));
+        } else {
+            Consumer<RetryStrategy.Builder<?, ?>> configurator = builder.retryStrategyConfigurator();
+            if (configurator != null) {
+                RetryStrategy.Builder<?, ?> defaultBuilder = AwsRetryStrategy.defaultRetryStrategy().toBuilder();
+                configurator.accept(defaultBuilder);
+                configuration.option(SdkClientOption.RETRY_STRATEGY, defaultBuilder.build());
+            } else {
+                RetryStrategy retryStrategy = builder.retryStrategy();
+                if (retryStrategy != null) {
+                    configuration.option(SdkClientOption.RETRY_STRATEGY, retryStrategy);
+                }
+            }
+        }
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_MODE, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_STRATEGY, null);
+        configuration.option(SdkClientOption.CONFIGURED_RETRY_CONFIGURATOR, null);
+    }
+
+    private SdkClientConfiguration updateSdkClientConfiguration(SdkRequest request, SdkClientConfiguration clientConfiguration) {
+        List<SdkPlugin> plugins = request.overrideConfiguration().map(c -> c.plugins()).orElse(Collections.emptyList());
+        SdkClientConfiguration.Builder configuration = clientConfiguration.toBuilder();
+        if (plugins.isEmpty()) {
+            return configuration.build();
+        }
+        BatchManagerTestServiceClientConfigurationBuilder serviceConfigBuilder = new BatchManagerTestServiceClientConfigurationBuilder(
+            configuration);
+        for (SdkPlugin plugin : plugins) {
+            plugin.configureClient(serviceConfigBuilder);
+        }
+        updateRetryStrategyClientConfiguration(configuration);
+        return configuration.build();
+    }
+
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
+                                                                                JsonOperationMetadata operationMetadata) {
+        return protocolFactory.createErrorResponseHandler(operationMetadata);
+    }
+
+    @Override
+    public void close() {
+        clientHandler.close();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface-batchmanager.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface-batchmanager.java
@@ -1,0 +1,116 @@
+package software.amazon.awssdk.services.batchmanagertest;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.services.batchmanagertest.batchmanager.BatchManagerTestAsyncBatchManager;
+import software.amazon.awssdk.services.batchmanagertest.model.SendRequestRequest;
+import software.amazon.awssdk.services.batchmanagertest.model.SendRequestResponse;
+
+/**
+ * Service client for accessing BatchManagerTest asynchronously. This can be created using the static {@link #builder()}
+ * method.The asynchronous client performs non-blocking I/O when configured with any {@code SdkAsyncHttpClient}
+ * supported in the SDK. However, full non-blocking is not guaranteed as the async client may perform blocking calls in
+ * some cases such as credentials retrieval and endpoint discovery as part of the async API call.
+ *
+ * A service that implements the batchManager() method
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+@ThreadSafe
+public interface BatchManagerTestAsyncClient extends AwsClient {
+    String SERVICE_NAME = "batchmanagertest";
+
+    /**
+     * Value for looking up the service's metadata from the
+     * {@link software.amazon.awssdk.regions.ServiceMetadataProvider}.
+     */
+    String SERVICE_METADATA_ID = "batchmanagertest";
+
+    /**
+     * Invokes the SendRequest operation asynchronously.
+     *
+     * @param sendRequestRequest
+     * @return A Java Future containing the result of the SendRequest operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions. The exception returned is wrapped with CompletionException, so you need to invoke
+     *         {@link Throwable#getCause} to retrieve the underlying exception.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>BatchManagerTestException Base class for all service exceptions. Unknown exceptions will be thrown as
+     *         an instance of this type.</li>
+     *         </ul>
+     * @sample BatchManagerTestAsyncClient.SendRequest
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/batchmanagertest-2016-03-11/SendRequest" target="_top">AWS
+     *      API Documentation</a>
+     */
+    default CompletableFuture<SendRequestResponse> sendRequest(SendRequestRequest sendRequestRequest) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Invokes the SendRequest operation asynchronously.<br/>
+     * <p>
+     * This is a convenience which creates an instance of the {@link SendRequestRequest.Builder} avoiding the need to
+     * create one manually via {@link SendRequestRequest#builder()}
+     * </p>
+     *
+     * @param sendRequestRequest
+     *        A {@link Consumer} that will call methods on
+     *        {@link software.amazon.awssdk.services.batchmanagertest.model.SendRequestRequest.Builder} to create a
+     *        request.
+     * @return A Java Future containing the result of the SendRequest operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions. The exception returned is wrapped with CompletionException, so you need to invoke
+     *         {@link Throwable#getCause} to retrieve the underlying exception.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>BatchManagerTestException Base class for all service exceptions. Unknown exceptions will be thrown as
+     *         an instance of this type.</li>
+     *         </ul>
+     * @sample BatchManagerTestAsyncClient.SendRequest
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/batchmanagertest-2016-03-11/SendRequest" target="_top">AWS
+     *      API Documentation</a>
+     */
+    default CompletableFuture<SendRequestResponse> sendRequest(Consumer<SendRequestRequest.Builder> sendRequestRequest) {
+        return sendRequest(SendRequestRequest.builder().applyMutation(sendRequestRequest).build());
+    }
+
+    /**
+     * Creates an instance of {@link BatchManagerTestAsyncBatchManager} object with the configuration set on this
+     * client.
+     */
+    default BatchManagerTestAsyncBatchManager batchManager() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default BatchManagerTestServiceClientConfiguration serviceClientConfiguration() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a {@link BatchManagerTestAsyncClient} with the region loaded from the
+     * {@link software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain} and credentials loaded from the
+     * {@link software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider}.
+     */
+    static BatchManagerTestAsyncClient create() {
+        return builder().build();
+    }
+
+    /**
+     * Create a builder that can be used to configure and create a {@link BatchManagerTestAsyncClient}.
+     */
+    static BatchManagerTestAsyncClientBuilder builder() {
+        return new DefaultBatchManagerTestAsyncClientBuilder();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.builder.Builder;
 import software.amazon.awssdk.services.builder.CustomBuilder;
 import software.amazon.awssdk.services.builder.DefaultBuilder;
 import software.amazon.awssdk.services.builder.DefaultBuilderTwo;
+import software.amazon.awssdk.services.json.batchmanager.JsonAsyncBatchManager;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
 import software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest;
@@ -1866,6 +1867,13 @@ public interface JsonAsyncClient extends AwsClient {
         Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest, Path destinationPath) {
         return streamingOutputOperation(StreamingOutputOperationRequest.builder().applyMutation(streamingOutputOperationRequest)
                                                                        .build(), destinationPath);
+    }
+
+    /**
+     * Creates an instance of {@link JsonAsyncBatchManager} object with the configuration set on this client.
+     */
+    default JsonAsyncBatchManager batchManager() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/BatchOverrideConfiguration.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/BatchOverrideConfiguration.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.services.sqs.internal.batchmanager;
+package software.amazon.awssdk.services.sqs.batchmanager;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -37,6 +37,7 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
     private final Duration maxBatchOpenInMs;
 
     public BatchOverrideConfiguration(Builder builder) {
+        //TODO : Add defaults based on QueueBufferConfig.java of V1 Default values.
         this.maxBatchItems = Validate.isPositiveOrNull(builder.maxBatchItems, "maxBatchItems");
         this.maxBatchOpenInMs = Validate.isPositiveOrNull(builder.maxBatchOpenInMs, "maxBachOpenInMs");
         this.maxBatchKeys = Validate.isPositiveOrNull(builder.maxBatchKeys, "maxBatchKeys");
@@ -137,7 +138,8 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
         }
 
         /**
-         * Define the the maximum number of messages that are batched together in a single request.
+         * Define the maximum number of messages that are batched together in a single request.
+         * //TODO : QueueBufferConfig.java Default value of 10.
          *
          * @param maxBatchItems The new maxBatchItems value.
          * @return This object for method chaining.
@@ -176,7 +178,7 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
         /**
          * The maximum amount of time (in milliseconds) that an outgoing call waits for other requests before sending out a batch
          * request.
-         *
+         * TODO : Decide if Ms needs to be added to the name in surface API review meeting
          * @param maxBatchOpenInMs The new maxBatchOpenInMs value.
          * @return This object for method chaining.
          */

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.internal.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsAsyncBatchManager;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
@@ -36,6 +35,7 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
  * <p>
  * This manager buffers client requests and sends them in batches to the service, enhancing efficiency by reducing the number of
  * API requests. Requests are buffered until they reach a specified limit or a timeout occurs.
+ * TODO : add consumer builder overloads for requests for all the methods.
  */
 @SdkPublicApi
 public interface SqsAsyncBatchManager extends SdkAutoCloseable {
@@ -112,6 +112,7 @@ public interface SqsAsyncBatchManager extends SdkAutoCloseable {
          *
          * @param client The SqsAsyncClient to use.
          * @return This builder for method chaining.
+         * @throws NullPointerException If client is null.
          */
         Builder client(SqsAsyncClient client);
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.batchmanager;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.BatchOverrideConfiguration;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
+/**
+ * Batch manager for implementing automatic batching with an SQS async client. Create an instance using {@link #builder()}.
+ * <p>
+ * This manager buffers client requests and sends them in batches to the service, enhancing efficiency by reducing the number of
+ * API requests. Requests are buffered until they reach a specified limit or a timeout occurs.
+ */
+@SdkPublicApi
+public interface SqsAsyncBatchManager extends SdkAutoCloseable {
+
+    /**
+     * Creates a builder for configuring and creating an {@link SqsAsyncBatchManager}.
+     *
+     * @return A new builder.
+     */
+    static Builder builder() {
+        return DefaultSqsAsyncBatchManager.builder();
+    }
+
+    /**
+     * Buffers and batches {@link SendMessageRequest}s, sending them as a
+     * {@link software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest}. Requests are grouped by queue URL and override
+     * configuration, and sent when the batch size or timeout is reached.
+     *
+     * @param request The SendMessageRequest to be buffered.
+     * @return CompletableFuture of the corresponding {@link SendMessageResponse}.
+     */
+    default CompletableFuture<SendMessageResponse> sendMessage(SendMessageRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Buffers and batches {@link DeleteMessageRequest}s, sending them as a
+     * {@link software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest}. Requests are grouped by queue URL and override
+     * configuration, and sent when the batch size or timeout is reached.
+     *
+     * @param request The DeleteMessageRequest to be buffered.
+     * @return CompletableFuture of the corresponding {@link DeleteMessageResponse}.
+     */
+    default CompletableFuture<DeleteMessageResponse> deleteMessage(DeleteMessageRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Buffers and batches {@link ChangeMessageVisibilityRequest}s, sending them as a
+     * {@link software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest}. Requests are grouped by queue URL
+     * and override configuration, and sent when the batch size or timeout is reached.
+     *
+     * @param request The ChangeMessageVisibilityRequest to be buffered.
+     * @return CompletableFuture of the corresponding {@link ChangeMessageVisibilityResponse}.
+     */
+    default CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(ChangeMessageVisibilityRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Buffers and retrieves messages with {@link ReceiveMessageRequest}, with a maximum of 10 messages per request. Returns an
+     * empty message if no messages are available in SQS.
+     *
+     * @param request The ReceiveMessageRequest.
+     * @return CompletableFuture of the corresponding {@link ReceiveMessageResponse}.
+     */
+    default CompletableFuture<ReceiveMessageResponse> receiveMessage(ReceiveMessageRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    interface Builder {
+
+        /**
+         * Sets custom overrides for the BatchManager configuration.
+         *
+         * @param overrideConfiguration The configuration overrides.
+         * @return This builder for method chaining.
+         */
+        Builder overrideConfiguration(BatchOverrideConfiguration overrideConfiguration);
+
+        /**
+         * Sets a custom {@link software.amazon.awssdk.services.sqs.SqsClient} for polling resources. This client must be closed
+         * by the caller.
+         *
+         * @param client The SqsAsyncClient to use.
+         * @return This builder for method chaining.
+         */
+        Builder client(SqsAsyncClient client);
+
+        /**
+         * Sets a custom {@link ScheduledExecutorService} for periodic buffer flushes. This executor must be closed by the
+         * caller.
+         *
+         * @param scheduledExecutor The executor to use.
+         * @return This builder for method chaining.
+         */
+        Builder scheduledExecutor(ScheduledExecutorService scheduledExecutor);
+
+        /**
+         * Builds an instance of {@link SqsAsyncBatchManager} based on the supplied configurations.
+         *
+         * @return An initialized SqsAsyncBatchManager.
+         */
+        SqsAsyncBatchManager build();
+    }
+}

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/BatchOverrideConfiguration.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/BatchOverrideConfiguration.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.internal.batchmanager;
+
+import java.time.Duration;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * Configuration values for the BatchManager Implementation.  All values are optional, and the default values will be used
+ * if they are not specified.
+ */
+@SdkPublicApi
+public final class BatchOverrideConfiguration implements ToCopyableBuilder<BatchOverrideConfiguration.Builder,
+    BatchOverrideConfiguration> {
+
+    private final Integer maxBatchItems;
+    private final Integer maxBatchKeys;
+    private final Integer maxBufferSize;
+    private final Duration maxBatchOpenInMs;
+
+    public BatchOverrideConfiguration(Builder builder) {
+        this.maxBatchItems = Validate.isPositiveOrNull(builder.maxBatchItems, "maxBatchItems");
+        this.maxBatchOpenInMs = Validate.isPositiveOrNull(builder.maxBatchOpenInMs, "maxBachOpenInMs");
+        this.maxBatchKeys = Validate.isPositiveOrNull(builder.maxBatchKeys, "maxBatchKeys");
+        this.maxBufferSize = Validate.isPositiveOrNull(builder.maxBufferSize, "maxBufferSize");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * @return the optional maximum number of messages that are batched together in a single request.
+     */
+    public Optional<Integer> maxBatchItems() {
+        return Optional.ofNullable(maxBatchItems);
+    }
+
+    /**
+     * @return the optional maximum number of batchKeys to keep track of.
+     */
+    public Optional<Integer> maxBatchKeys() {
+        return Optional.ofNullable(maxBatchKeys);
+    }
+
+    /**
+     * @return the maximum number of items to allow to be buffered for each batchKey.
+     */
+    public Optional<Integer> maxBufferSize() {
+        return Optional.ofNullable(maxBufferSize);
+    }
+
+    /**
+     * @return the optional maximum amount of time (in milliseconds) that an outgoing call waits to be batched with messages of
+     * the same type.
+     */
+    public Optional<Duration> maxBatchOpenInMs() {
+        return Optional.ofNullable(maxBatchOpenInMs);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new Builder().maxBatchItems(maxBatchItems)
+                            .maxBatchKeys(maxBatchKeys)
+                            .maxBufferSize(maxBufferSize)
+                            .maxBatchOpenInMs(maxBatchOpenInMs);
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("BatchOverrideConfiguration")
+                       .add("maxBatchItems", maxBatchItems)
+                       .add("maxBatchKeys", maxBatchKeys)
+                       .add("maxBufferSize", maxBufferSize)
+                       .add("maxBatchOpenInMs", maxBatchOpenInMs.toMillis())
+                       .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BatchOverrideConfiguration that = (BatchOverrideConfiguration) o;
+
+        if (maxBatchItems != null ? !maxBatchItems.equals(that.maxBatchItems) : that.maxBatchItems != null) {
+            return false;
+        }
+        if (maxBatchKeys != null ? !maxBatchKeys.equals(that.maxBatchKeys) : that.maxBatchKeys != null) {
+            return false;
+        }
+        if (maxBufferSize != null ? !maxBufferSize.equals(that.maxBufferSize) : that.maxBufferSize != null) {
+            return false;
+        }
+        return maxBatchOpenInMs != null ? maxBatchOpenInMs.equals(that.maxBatchOpenInMs) : that.maxBatchOpenInMs == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = maxBatchItems != null ? maxBatchItems.hashCode() : 0;
+        result = 31 * result + (maxBatchKeys != null ? maxBatchKeys.hashCode() : 0);
+        result = 31 * result + (maxBufferSize != null ? maxBufferSize.hashCode() : 0);
+        result = 31 * result + (maxBatchOpenInMs != null ? maxBatchOpenInMs.hashCode() : 0);
+        return result;
+    }
+
+    public static final class Builder implements CopyableBuilder<Builder, BatchOverrideConfiguration> {
+
+        private Integer maxBatchItems;
+        private Integer maxBatchKeys;
+        private Integer maxBufferSize;
+        private Duration maxBatchOpenInMs;
+
+        private Builder() {
+        }
+
+        /**
+         * Define the the maximum number of messages that are batched together in a single request.
+         *
+         * @param maxBatchItems The new maxBatchItems value.
+         * @return This object for method chaining.
+         */
+        public Builder maxBatchItems(Integer maxBatchItems) {
+            this.maxBatchItems = maxBatchItems;
+            return this;
+        }
+
+        /**
+         * Define the maximum number of batchKeys to keep track of. A batchKey determines which requests are batched together
+         * and is calculated by the client based on the information in a request.
+         * <p>
+         * Ex. SQS determines a batchKey based on a request's queueUrl in combination with its overrideConfiguration, so
+         * requests with the same queueUrl and overrideConfiguration will have the same batchKey and be batched together.
+         *
+         * @param maxBatchKeys the new maxBatchKeys value.
+         * @return This object for method chaining.
+         */
+        public Builder maxBatchKeys(Integer maxBatchKeys) {
+            this.maxBatchKeys = maxBatchKeys;
+            return this;
+        }
+
+        /**
+         * Define the maximum number of items to allow to be buffered for each batchKey.
+         *
+         * @param maxBufferSize the new maxBufferSize value.
+         * @return This object for method chaining.
+         */
+        public Builder maxBufferSize(Integer maxBufferSize) {
+            this.maxBufferSize = maxBufferSize;
+            return this;
+        }
+
+        /**
+         * The maximum amount of time (in milliseconds) that an outgoing call waits for other requests before sending out a batch
+         * request.
+         *
+         * @param maxBatchOpenInMs The new maxBatchOpenInMs value.
+         * @return This object for method chaining.
+         */
+        public Builder maxBatchOpenInMs(Duration maxBatchOpenInMs) {
+            this.maxBatchOpenInMs = maxBatchOpenInMs;
+            return this;
+        }
+
+        public BatchOverrideConfiguration build() {
+            return new BatchOverrideConfiguration(this);
+        }
+    }
+}

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.internal.batchmanager;
+
+import java.util.concurrent.ScheduledExecutorService;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.BatchOverrideConfiguration;
+
+@SdkInternalApi
+public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
+    private final SqsAsyncClient client;
+
+    private DefaultSqsAsyncBatchManager(DefaultBuilder builder) {
+        this.client = builder.client;
+    }
+
+    public static SqsAsyncBatchManager.Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    public static final class DefaultBuilder implements SqsAsyncBatchManager.Builder {
+        private SqsAsyncClient client;
+        private BatchOverrideConfiguration overrideConfiguration;
+        private ScheduledExecutorService scheduledExecutor;
+
+        private DefaultBuilder() {
+        }
+
+        @Override
+        public SqsAsyncBatchManager.Builder overrideConfiguration(BatchOverrideConfiguration overrideConfiguration) {
+            this.overrideConfiguration = overrideConfiguration;
+            return this;
+        }
+
+        @Override
+        public SqsAsyncBatchManager.Builder client(SqsAsyncClient client) {
+            this.client = client;
+            return this;
+        }
+
+        @Override
+        public SqsAsyncBatchManager.Builder scheduledExecutor(ScheduledExecutorService scheduledExecutor) {
+            this.scheduledExecutor = scheduledExecutor;
+            return this;
+        }
+
+        @Override
+        public SqsAsyncBatchManager build() {
+            return new DefaultSqsAsyncBatchManager(this);
+        }
+    }
+}

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
@@ -18,15 +18,22 @@ package software.amazon.awssdk.services.sqs.internal.batchmanager;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
-import software.amazon.awssdk.services.sqs.internal.batchmanager.BatchOverrideConfiguration;
+import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
+    // TODO : update the validation here while implementing this class in next PR
     private final SqsAsyncClient client;
+    private final  ScheduledExecutorService scheduledExecutor;
+    private final  BatchOverrideConfiguration overrideConfiguration;
 
     private DefaultSqsAsyncBatchManager(DefaultBuilder builder) {
-        this.client = builder.client;
+        this.client = Validate.notNull(builder.client, "client cannot be null");
+        this.scheduledExecutor = Validate.notNull(builder.scheduledExecutor, "scheduledExecutor cannot be null");
+        // TODO : create overrideConfiguration with Default values if null
+        this.overrideConfiguration = builder.overrideConfiguration;
     }
 
     public static SqsAsyncBatchManager.Builder builder() {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

PR similar to https://github.com/aws/aws-sdk-java-v2/pull/2666. But following are considered after design reviews
1. The BatchManager Implementation will be hand written , thus we donot need codegenrated BatchFunctions and code generated Default batch Manager.
2.  We will proivide batchManager() api only to AsyncClient , since returning  completable future for sync Api doesnot make sense for Sync API  , instead sync API can directly call send/recieve with custom BatchedRequest in its request.



## Modifications
<!--- Describe your changes in detail -->

Customization 
```json
  "batchManagerSupported": true
```

Will result in code
1. Addition of scheduledExecutor similar to that of waiters()
2.  Java code as below

```java
    @Override
    public BatchManagerTestAsyncBatchManager batchManager() {
        return BatchManagerTestAsyncBatchManager.builder().client(this).scheduledExecutor(executorService).build();
    }
```


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Added Junits
2. Also tested with SQS , made sure other service not impacted


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
