### PR TITLE
Add mapping for core exception types and getters

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
@@ -37,7 +37,7 @@ public final class NamingConversionUtils {
         String v2PackagePrefix = packagePrefix.replace(V1_PACKAGE_PREFIX, V2_PACKAGE_PREFIX);
 
         if (Stream.of("Abstract", "Amazon", "AWS").anyMatch(v1ClassName::startsWith)) {
-            v2ClassName = getV2ClientEquivalent(v1ClassName);
+            v2ClassName = getV2ClientOrExceptionEquivalent(v1ClassName);
         } else if (v1ClassName.endsWith("Result")) {
             int lastIndex = v1ClassName.lastIndexOf("Result");
             v2ClassName = v1ClassName.substring(0, lastIndex) + "Response";
@@ -46,7 +46,7 @@ public final class NamingConversionUtils {
         return v2PackagePrefix + "." + v2ClassName;
     }
 
-    private static String getV2ClientEquivalent(String className) {
+    private static String getV2ClientOrExceptionEquivalent(String className) {
         if (className.startsWith("Abstract")) {
             className = className.substring(8);
         }
@@ -57,6 +57,10 @@ public final class NamingConversionUtils {
         }
 
         String v2Style = CodegenNamingUtils.pascalCase(className);
+
+        if (className.endsWith("Exception")) {
+            return v2Style;
+        }
 
         if (!className.endsWith("Client") && !className.endsWith("Builder")) {
             v2Style = v2Style + "Client";

--- a/migration-tool/src/main/resources/META-INF/rewrite/change-exception-types.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/change-exception-types.yml
@@ -1,0 +1,81 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: software.amazon.awssdk.ChangeExceptionTypes
+displayName: Change SDK Exception types from v1 to v2
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.SdkBaseException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.SdkException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.AmazonClientException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.SdkException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.SdkClientException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.SdkClientException
+
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getRequestId
+      newMethodName: requestId
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getErrorCode
+      newMethodName: awsErrorDetails().errorCode
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getServiceName
+      newMethodName: awsErrorDetails().serviceName
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getErrorMessage
+      newMethodName: awsErrorDetails().errorMessage
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getStatusCode
+      newMethodName: awsErrorDetails().sdkHttpResponse().statusCode
+  ### TODO: v2 returns Map<String, List<String>>. Convert it to Map<String, String>
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getHttpHeaders
+      newMethodName: awsErrorDetails().sdkHttpResponse().headers
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getRawResponse
+      newMethodName: awsErrorDetails().rawResponse().asByteArray
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.AmazonServiceException getRawResponseContent
+      newMethodName: awsErrorDetails().rawResponse().asUtf8String
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.AmazonServiceException getErrorType
+      comment: getErrorType is not supported in v2. AwsServiceException is a service error in v2. Consider removing it.
+  - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
+      methodPattern: com.amazonaws.AmazonServiceException getProxyHost
+      comment: getProxyHost is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.AmazonServiceException
+      newFullyQualifiedTypeName: software.amazon.awssdk.awscore.exception.AwsServiceException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.AbortedException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.AbortedException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.http.timers.client.ClientExecutionTimeoutException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.ApiCallTimeoutException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.http.exception.HttpRequestTimeoutException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.http.timers.client.SdkInterruptedException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.SdkInterruptedException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.http.timers.client.SdkInterruptedException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.SdkInterruptedException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.amazonaws.internal.CRC32MismatchException
+      newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.Crc32MismatchException

--- a/migration-tool/src/main/resources/META-INF/rewrite/change-sdk-core-types.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/change-sdk-core-types.yml
@@ -15,8 +15,9 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: software.amazon.awssdk.ChangeSdkCoreTypes
-displayName: Change Maven dependency groupId, artifactId and/or the version example
+displayName: Change SDK core types from v1 to v2
 recipeList:
   - software.amazon.awssdk.ChangeRegionTypes
   - software.amazon.awssdk.ChangeAuthTypes
   - software.amazon.awssdk.ChangeConfigTypes
+  - software.amazon.awssdk.ChangeExceptionTypes

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
@@ -71,4 +71,11 @@ public class NamingConversionUtilsTest {
         assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.iot.AWSIotAsyncClientBuilder"))
             .isEqualTo("software.amazon.awssdk.services.iot.IotAsyncClientBuilder");
     }
+
+    @Test
+    void v1Exception_shouldConvertToV2() {
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.iot.AmazonIOTException"))
+            .isEqualTo("software.amazon.awssdk.services.iot.IotException");
+    }
 }

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeExceptionTypesTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeExceptionTypesTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.migration.recipe;
+
+import static org.openrewrite.java.Assertions.java;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.YamlResourceLoader;
+import org.openrewrite.java.Java8Parser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import software.amazon.awssdk.migration.internal.recipe.HttpSettingsToHttpClient;
+
+public class ChangeExceptionTypesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        try (InputStream stream = getClass().getResourceAsStream("/META-INF/rewrite/change-exception-types.yml")) {
+            spec.recipes(Environment.builder()
+                                    .load(new YamlResourceLoader(stream, URI.create("rewrite.yml"), new Properties()))
+                                    .build()
+                                    .activateRecipes("software.amazon.awssdk.ChangeExceptionTypes"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs","aws-sdk-java", "sdk-core"));
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void exceptionGetter_shouldRewrite() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.AmazonServiceException;\n"
+                + "import java.util.Map;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        AmazonServiceException serviceException = null;\n"
+                + "        String requestId = serviceException.getRequestId();\n"
+                + "        String errorCode = serviceException.getErrorCode();\n"
+                + "        String errorMessage = serviceException.getErrorMessage();\n"
+                + "        String serviceName = serviceException.getServiceName();\n"
+                + "        int statusCode = serviceException.getStatusCode();\n"
+                + "        Map<String, String> httpHeaders = serviceException.getHttpHeaders();\n"
+                + "        byte[] rawResponse = serviceException.getRawResponse();\n"
+                + "        String rawResponseContent = serviceException.getRawResponseContent();\n"
+                + "\n"
+                + "    }\n"
+                + "}",
+                "import software.amazon.awssdk.awscore.exception.AwsServiceException;\n"
+                + "\n"
+                + "import java.util.Map;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        AwsServiceException serviceException = null;\n"
+                + "        String requestId = serviceException.requestId();\n"
+                + "        String errorCode = serviceException.awsErrorDetails().errorCode();\n"
+                + "        String errorMessage = serviceException.awsErrorDetails().errorMessage();\n"
+                + "        String serviceName = serviceException.awsErrorDetails().serviceName();\n"
+                + "        int statusCode = serviceException.awsErrorDetails().sdkHttpResponse().statusCode();\n"
+                + "        Map<String, String> httpHeaders = serviceException.awsErrorDetails().sdkHttpResponse().headers();\n"
+                + "        byte[] rawResponse = serviceException.awsErrorDetails().rawResponse().asByteArray();\n"
+                + "        String rawResponseContent = serviceException.awsErrorDetails().rawResponse().asUtf8String();\n"
+                + "\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void exceptionGetter_NotSupported_shouldAddComment() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.AmazonServiceException;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        AmazonServiceException serviceException = null;\n"
+                + "        String proxyHost = serviceException.getProxyHost();\n"
+                + "        AmazonServiceException.ErrorType errorCode = serviceException.getErrorType();\n"
+                + "    }\n"
+                + "}",
+                "import software.amazon.awssdk.awscore.exception.AwsServiceException;\n"
+                + "\n"
+                + "public class Example {\n"
+                + "\n"
+                + "    void test() {\n"
+                + "        AwsServiceException serviceException = null;\n"
+                + "        String proxyHost = serviceException/*AWS SDK for Java v2 migration: getProxyHost is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues*/.getProxyHost();\n"
+                + "        AwsServiceException.ErrorType errorCode = serviceException/*AWS SDK for Java v2 migration: getErrorType is not supported in v2. AwsServiceException is a service error in v2. Consider removing it.*/.getErrorType();\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+}

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeSdkTypeTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeSdkTypeTest.java
@@ -28,17 +28,18 @@ public class ChangeSdkTypeTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new ChangeSdkType());
+        spec.recipe(new ChangeSdkType()).parser(Java8Parser.builder().classpath("aws-java-sdk-sqs","sqs"));
     }
 
     @Test
     @EnabledOnJre({JRE.JAVA_8})
     void shouldChangeVariables() {
         rewriteRun(
-            spec -> spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs")),
             java(
                 "import com.amazonaws.services.sqs.AmazonSQS;\n" +
                 "import com.amazonaws.services.sqs.AmazonSQSClient;\n" +
+                "import com.amazonaws.services.sqs.model.InvalidAttributeNameException;\n" +
+                "import com.amazonaws.services.sqs.model.AmazonSQSException;\n" +
                 "import com.amazonaws.services.sqs.model.ListQueuesResult;\n" +
                "import com.amazonaws.services.sqs.model.ListQueuesRequest;\n" +
                 "class Test {\n" +
@@ -46,21 +47,27 @@ public class ChangeSdkTypeTest implements RewriteTest {
                 "        AmazonSQS sqs = null;\n" +
                 "        ListQueuesRequest request = null;\n" +
                 "        ListQueuesResult result = null;\n" +
+                "        InvalidAttributeNameException exception = null;\n" +
+                "        AmazonSQSException baseException = null;\n" +
                 "    }\n" +
                 "}\n",
-               "import software.amazon.awssdk.services.sqs.SqsClient;\n" +
-               "import software.amazon.awssdk.services.sqs.model.ListQueuesRequest;\n" +
+               "import software.amazon.awssdk.services.sqs.SqsClient;\n"
                // TODO: duplicate import for some reason, fix this
-               "import software.amazon.awssdk.services.sqs.SqsClient;\n" +
-                "import software.amazon.awssdk.services.sqs.model.ListQueuesResponse;\n" +
-                "\n" +
-                "class Test {\n" +
-               "    static void method() {\n" +
-                "        SqsClient sqs = null;\n" +
-                "        ListQueuesRequest request = null;\n" +
-                "        ListQueuesResponse result = null;\n" +
-                "    }\n" +
-                "}\n"
+               + "import software.amazon.awssdk.services.sqs.SqsClient;\n"
+               + "import software.amazon.awssdk.services.sqs.model.InvalidAttributeNameException;\n"
+               + "import software.amazon.awssdk.services.sqs.model.ListQueuesRequest;\n"
+               + "import software.amazon.awssdk.services.sqs.model.SqsException;\n"
+               + "import software.amazon.awssdk.services.sqs.model.ListQueuesResponse;\n"
+               + "\n"
+               + "class Test {\n"
+               + "    static void method() {\n"
+               + "        SqsClient sqs = null;\n"
+               + "        ListQueuesRequest request = null;\n"
+               + "        ListQueuesResponse result = null;\n"
+               + "        InvalidAttributeNameException exception = null;\n"
+               + "        SqsException baseException = null;\n"
+               + "    }\n"
+               + "}"
             )
         );
     }
@@ -69,7 +76,6 @@ public class ChangeSdkTypeTest implements RewriteTest {
     @EnabledOnJre({JRE.JAVA_8})
     void shouldChangeFields() {
         rewriteRun(
-            spec -> spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs")),
             java(
                 "import com.amazonaws.services.sqs.model.DeleteQueueRequest;\n" +
                 "import com.amazonaws.services.sqs.model.DeleteQueueResult;\n" +
@@ -92,7 +98,6 @@ public class ChangeSdkTypeTest implements RewriteTest {
     @EnabledOnJre({JRE.JAVA_8})
     void shouldChangeFieldsInAList() {
         rewriteRun(
-            spec -> spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs")),
             java(
                 "import com.amazonaws.services.sqs.model.DeleteQueueResult;\n" +
                 "import java.util.List;\n" +
@@ -113,7 +118,6 @@ public class ChangeSdkTypeTest implements RewriteTest {
     @EnabledOnJre({JRE.JAVA_8})
     void shouldChangeMethodParameters() {
         rewriteRun(
-            spec -> spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs")),
             java(
                 "import com.amazonaws.services.sqs.model.CreateQueueRequest;\n" +
                 "class Test {\n" +
@@ -134,7 +138,6 @@ public class ChangeSdkTypeTest implements RewriteTest {
     @EnabledOnJre({JRE.JAVA_8})
     void shouldNotChangeExistingV2Types() {
         rewriteRun(
-            spec -> spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs", "sqs")),
             java(
                 "import com.amazonaws.services.sqs.model.CreateQueueRequest;\n" +
                 "import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;\n" +
@@ -161,7 +164,6 @@ public class ChangeSdkTypeTest implements RewriteTest {
     @EnabledOnJre({JRE.JAVA_8})
     void shouldChangeFieldsInInnerClass() {
         rewriteRun(
-            spec -> spec.parser(Java8Parser.builder().classpath("aws-java-sdk-sqs")),
             java(
                 "import com.amazonaws.services.sqs.model.CreateQueueResult;\n" +
                 "class Test {\n" +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Add mapping for core exception types and getters in exception glasses

For example:
`exception.getRawResponse` -> `exception.rawResponse().asByteArray`
