### PR TITLE
Update docs for EqualJitterBackoffStrategy

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.java
@@ -41,7 +41,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  * between 0 and the computed exponential delay.
  *
  * @deprecated Use instead {@link software.amazon.awssdk.retries.api.BackoffStrategy} and
- * {@link software.amazon.awssdk.retries.api.BackoffStrategy#fixedDelayWithoutJitter(Duration)}
+ * {@link software.amazon.awssdk.retries.api.BackoffStrategy#exponentialDelay(Duration, Duration)}
  */
 @SdkPublicApi
 @Deprecated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Update javadocs to refer to `BackoffStrategy.exponentialDelay()` instead of `BackoffStrategy.fixedDelayWithoutJitter()`, as replacement for deprecated `EqualJitterBackoffStrategy`