### PR TITLE
Add ExponentialDelayWithHalfJitter backoff strategy

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-a8d0992.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-a8d0992.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Add a new backoff strategy that reassembles\n`EqualJitterBackoffStrategy` and is used to be behavioral backwards\ncompatible with the way `RetryPolicy` behaves for the `LEGACY` retry\nmode."
+}

--- a/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/BackoffStrategy.java
+++ b/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/BackoffStrategy.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.retries.api.internal.backoff.ExponentialDelayWithHalfJitter;
 import software.amazon.awssdk.retries.api.internal.backoff.ExponentialDelayWithJitter;
 import software.amazon.awssdk.retries.api.internal.backoff.ExponentialDelayWithoutJitter;
 import software.amazon.awssdk.retries.api.internal.backoff.FixedDelayWithJitter;
@@ -70,6 +71,18 @@ public interface BackoffStrategy {
      */
     static BackoffStrategy exponentialDelay(Duration baseDelay, Duration maxDelay) {
         return new ExponentialDelayWithJitter(ThreadLocalRandom::current, baseDelay, maxDelay);
+    }
+
+    /**
+     * Wait for a random period of time with an upper bound of exponentially increasing amount of time between each subsequent
+     * attempt of the same call and a lower bound of half the amount of the computed exponential delay.
+     *
+     * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits between
+     * {@code min(maxDelay, baseDelay * (1 << (attempt - 2))) / 2} and {@code min(maxDelay, baseDelay * (1 << (attempt - 2))) +
+     * 1}.
+     */
+    static BackoffStrategy exponentialDelayHalfJitter(Duration baseDelay, Duration maxDelay) {
+        return new ExponentialDelayWithHalfJitter(ThreadLocalRandom::current, baseDelay, maxDelay);
     }
 
     /**

--- a/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/internal/backoff/ExponentialDelayWithHalfJitter.java
+++ b/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/internal/backoff/ExponentialDelayWithHalfJitter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.api.internal.backoff;
+
+import static software.amazon.awssdk.retries.api.internal.backoff.BackoffStrategiesConstants.calculateExponentialDelay;
+
+import java.time.Duration;
+import java.util.Random;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.utils.NumericUtils;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Strategy that waits for a random period of time between a lower bound x and an exponentially increasing amount of time between
+ * each subsequent attempt of the same call. The lower bound x is half the amount of the computed exponential delay.
+ *
+ * <p>
+ * Specifically, the first attempt waits 0ms, and each subsequent attempt waits between
+ * {@code min(maxDelay, baseDelay * (1 << (attempt - 2))) / 2} and {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+ *
+ * <p>
+ * This is in contrast to {@link ExponentialDelayWithJitter} where the final computed delay before the next retry will be between
+ * 0 and the computed exponential delay.
+ */
+@SdkProtectedApi
+public final class ExponentialDelayWithHalfJitter implements BackoffStrategy {
+    private final Supplier<Random> randomSupplier;
+    private final Duration baseDelay;
+    private final Duration maxDelay;
+
+    public ExponentialDelayWithHalfJitter(Supplier<Random> randomSupplier, Duration baseDelay, Duration maxDelay) {
+        this.randomSupplier = Validate.paramNotNull(randomSupplier, "random");
+        this.baseDelay = NumericUtils.min(Validate.isPositive(baseDelay, "baseDelay"),
+                                          BackoffStrategiesConstants.BASE_DELAY_CEILING);
+        this.maxDelay = NumericUtils.min(Validate.isPositive(maxDelay, "maxDelay"),
+                                         BackoffStrategiesConstants.MAX_BACKOFF_CEILING);
+    }
+
+    @Override
+    public Duration computeDelay(int attempt) {
+        Validate.isPositive(attempt, "attempt");
+        if (attempt == 1) {
+            return Duration.ZERO;
+        }
+        int ceil = calculateExponentialDelay(attempt, baseDelay, maxDelay);
+        return Duration.ofMillis((ceil / 2) + randomSupplier.get().nextInt((ceil / 2) + 1));
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("ExponentialDelayWithHalfJitter")
+                       .add("baseDelay", baseDelay)
+                       .add("maxDelay", maxDelay)
+                       .build();
+    }
+}
+

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
@@ -72,8 +72,9 @@ public final class DefaultRetryStrategy {
         return LegacyRetryStrategy.builder()
                                   .maxAttempts(Legacy.MAX_ATTEMPTS)
                                   .backoffStrategy(BackoffStrategy.exponentialDelay(Legacy.BASE_DELAY, Legacy.MAX_BACKOFF))
-                                  .throttlingBackoffStrategy(BackoffStrategy.exponentialDelay(Legacy.THROTTLED_BASE_DELAY,
-                                                                                              Legacy.MAX_BACKOFF));
+                                  .throttlingBackoffStrategy(BackoffStrategy.exponentialDelayHalfJitter(
+                                      Legacy.THROTTLED_BASE_DELAY,
+                                      Legacy.MAX_BACKOFF));
     }
 
     /**

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/LegacyRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/LegacyRetryStrategy.java
@@ -32,8 +32,9 @@ import software.amazon.awssdk.retries.internal.circuitbreaker.TokenBucketStore;
  *     <li>Retries 3 times (4 total attempts). Adjust with {@link Builder#maxAttempts(int)}
  *     <li>For non-throttling exceptions uses the {@link BackoffStrategy#exponentialDelay} backoff strategy, with a base delay
  *     of 100 milliseconds and max delay of 20 seconds. Adjust with {@link Builder#backoffStrategy}
- *     <li>For throttling exceptions uses the {@link BackoffStrategy#exponentialDelay} backoff strategy, with a base delay of
- *     500 milliseconds  and max delay of 20 seconds. Adjust with {@link LegacyRetryStrategy.Builder#throttlingBackoffStrategy}
+ *     <li>For throttling exceptions uses the {@link BackoffStrategy#exponentialDelayHalfJitter} backoff strategy, with a base
+ *     delay of 500 milliseconds  and max delay of 20 seconds. Adjust with
+ *     {@link LegacyRetryStrategy.Builder#throttlingBackoffStrategy}
  *     <li>Circuit breaking (disabling retries) in the event of high downstream failures across the scope of
  *     the strategy. The circuit breaking will never prevent a successful first attempt. Adjust with
  *     {@link Builder#circuitBreakerEnabled}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.java
@@ -41,7 +41,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  * between 0 and the computed exponential delay.
  *
  * @deprecated Use instead {@link software.amazon.awssdk.retries.api.BackoffStrategy} and
- * {@link software.amazon.awssdk.retries.api.BackoffStrategy#fixedDelayWithoutJitter(Duration)}
+ * {@link software.amazon.awssdk.retries.api.BackoffStrategy#exponentialDelayHalfJitter(Duration, Duration)}
  */
 @SdkPublicApi
 @Deprecated


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Introducing a new backoff strategy that is used in the `LegacyRetryStrategy` for backing off for throttling exceptions.

This change mimics the previous behavior in which the `EqualJitterBackoffStrategy` was used as the throttling backoff strategy for `RetryMode.LEGACY`. See [here](https://github.com/aws/aws-sdk-java-v2/blob/b8f136c7e1bedde1811dc20839ad78ff25b8e0da/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/BackoffStrategy.java#L69) and [here](https://github.com/aws/aws-sdk-java-v2/blob/b8f136c7e1bedde1811dc20839ad78ff25b8e0da/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java#L383).

This backoff strategy differs from the full jitter exponential strategy on a cap used for the minimum delay time. The full jitter exponential backoff strategy waits in the range 

```
[ 0, exponential-delay ]
```

whereas this one waits in the range

```
[ exponential-delay / 2, exponential-delay ]
```

The idea being since we are retrying after a throttling exception we want to wait some amount that is not or close to zero.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
