### PR TITLE
Handle wildcard imports in ChangeSdkType recipe

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
@@ -46,6 +46,13 @@ public final class NamingConversionUtils {
         return v2PackagePrefix + "." + v2ClassName;
     }
 
+    public static String getV2ModelPackageWildCardEquivalent(String currentFqcn) {
+        int lastIndexOfDot = currentFqcn.lastIndexOf(".");
+        String packagePrefix = currentFqcn.substring(0, lastIndexOfDot);
+        String v2PackagePrefix = packagePrefix.replace(V1_PACKAGE_PREFIX, V2_PACKAGE_PREFIX);
+        return v2PackagePrefix + ".*";
+    }
+
     private static String getV2ClientOrExceptionEquivalent(String className) {
         if (className.startsWith("Abstract")) {
             className = className.substring(8);

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
@@ -78,4 +78,12 @@ public class NamingConversionUtilsTest {
         assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.iot.AmazonIOTException"))
             .isEqualTo("software.amazon.awssdk.services.iot.IotException");
     }
+
+    @Test
+    void v2WildCardImport_shouldConvertToV2() {
+        assertThat(NamingConversionUtils.getV2ModelPackageWildCardEquivalent("com.amazonaws.services.iot.model.*"))
+            .isEqualTo("software.amazon.awssdk.services.iot.model.*");
+        assertThat(NamingConversionUtils.getV2ModelPackageWildCardEquivalent("com.amazonaws.services.iot.*"))
+            .isEqualTo("software.amazon.awssdk.services.iot.*");
+    }
 }

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeSdkTypeTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeSdkTypeTest.java
@@ -74,6 +74,40 @@ public class ChangeSdkTypeTest implements RewriteTest {
 
     @Test
     @EnabledOnJre({JRE.JAVA_8})
+    void wildCardImport_shouldRewrite() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.sqs.model.*;\n" +
+                "import com.amazonaws.services.sqs.*;\n" +
+                "class Test {\n" +
+                "    private DeleteQueueResult deleteQueResult;\n" +
+                "    static void method(CreateQueueResult createQueueResult) {\n" +
+                "        AmazonSQS sqs = null;\n" +
+                "        ListQueuesRequest request = null;\n" +
+                "        ListQueuesResult result = null;\n" +
+                "        InvalidAttributeNameException exception = null;\n" +
+                "        AmazonSQSException baseException = null;\n" +
+                "    }\n" +
+                "}\n",
+                "import software.amazon.awssdk.services.sqs.*;\n"
+                + "import software.amazon.awssdk.services.sqs.model.*;\n"
+                + "\n"
+                + "class Test {\n"
+                + "    private DeleteQueueResponse deleteQueResult;\n"
+                + "    static void method(CreateQueueResponse createQueueResult) {\n"
+                + "        SqsClient sqs = null;\n"
+                + "        ListQueuesRequest request = null;\n"
+                + "        ListQueuesResponse result = null;\n"
+                + "        InvalidAttributeNameException exception = null;\n"
+                + "        SqsException baseException = null;\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
     void shouldChangeFields() {
         rewriteRun(
             java(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Currently, if wildcard imports such as `com.amazonaws.services.sqs.model.*`  and `com.amazonaws.services.sqs.*` are used, v1 types will not get converted to v2 types.
This change fixes wildcard imports in ChangeSdkType recipe