### PR TITLE
Fix V1GetterToV2 to not change get method

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingUtils.java
@@ -59,6 +59,6 @@ public final class NamingUtils {
     }
 
     public static boolean isGetter(String name) {
-        return !StringUtils.isBlank(name) && name.startsWith("get");
+        return !StringUtils.isBlank(name) && name.startsWith("get") && !name.equals("get");
     }
 }

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingUtilsTest.java
@@ -91,4 +91,20 @@ public class NamingUtilsTest {
     public void removeWith_empty_returnsValue() {
         assertThat(NamingUtils.removeWith("")).isEqualTo("");
     }
+
+    @Test
+    public void isGetter_startsWithGetter_returnsTrue() {
+        assertThat(NamingUtils.isGetter("getFoo")).isTrue();
+    }
+
+    @Test
+    public void isGetter_equalsToGet_returnsFalse() {
+        assertThat(NamingUtils.isGetter("get")).isFalse();
+    }
+
+    @Test
+    public void isGetter_emptyOrNull_returnsFalse() {
+        assertThat(NamingUtils.isGetter("")).isFalse();
+        assertThat(NamingUtils.isGetter(null)).isFalse();
+    }
 }

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/V1GetterToV2Test.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/V1GetterToV2Test.java
@@ -37,6 +37,7 @@ public class V1GetterToV2Test implements RewriteTest {
                 + "        ReceiveMessageRequest request = new ReceiveMessageRequest().withQueueUrl(\"url\");\n"
                 + "        ReceiveMessageResult receiveMessage = sqs.receiveMessage(request);\n"
                 + "        List<Message> messages = receiveMessage.getMessages();\n"
+                + "        Message message = receiveMessage.getMessages().get(0);\n"
                 + "    }\n"
                 + "}\n",
                 "import software.amazon.awssdk.services.sqs.SqsClient;\n"
@@ -50,6 +51,7 @@ public class V1GetterToV2Test implements RewriteTest {
                 + "        ReceiveMessageRequest request = ReceiveMessageRequest.builder().queueUrl(\"url\").build();\n"
                 + "        ReceiveMessageResponse receiveMessage = sqs.receiveMessage(request);\n"
                 + "        List<Message> messages = receiveMessage.messages();\n"
+                + "        Message message = receiveMessage.messages().get(0);\n"
                 + "    }\n"
                 + "}"
             )

--- a/test/migration-tool-tests/src/test/resources/after/src/main/java/foo/bar/Application.java
+++ b/test/migration-tool-tests/src/test/resources/after/src/main/java/foo/bar/Application.java
@@ -48,15 +48,21 @@ public class Application {
             .nextToken("token").build();
 
         try {
+
             ListQueuesResponse listQueuesResult = sqs.listQueues(request);
+            String queueUrl = listQueuesResult.queueUrls().get(0);
             String token = listQueuesResult.nextToken();
-            System.out.println(listQueuesResult);
+            System.out.println(queueUrl);
+            System.out.println(token);
+
         } catch (QueueDoesNotExistException exception) {
+
             String errorCode = exception.awsErrorDetails().errorCode();
             String errorMessage = exception.awsErrorDetails().errorMessage();
             String requestId = exception.requestId();
             byte[] rawResponse = exception.awsErrorDetails().rawResponse().asByteArray();
             System.out.println(String.format("Error code: %s, message: %s, requestId: %s", errorCode, errorMessage, requestId));
+
         } catch (SqsException exception) {
             System.out.println(String.format("Error code: %s. RequestId: %s. Raw response content: %s",
                                              exception.awsErrorDetails().errorCode(), exception.requestId(),

--- a/test/migration-tool-tests/src/test/resources/before/src/main/java/foo/bar/Application.java
+++ b/test/migration-tool-tests/src/test/resources/before/src/main/java/foo/bar/Application.java
@@ -46,15 +46,21 @@ public class Application {
             .withNextToken("token");
 
         try {
+
             ListQueuesResult listQueuesResult = sqs.listQueues(request);
+            String queueUrl = listQueuesResult.getQueueUrls().get(0);
             String token = listQueuesResult.getNextToken();
-            System.out.println(listQueuesResult);
+            System.out.println(queueUrl);
+            System.out.println(token);
+
         } catch (QueueDoesNotExistException exception) {
+
             String errorCode = exception.getErrorCode();
             String errorMessage = exception.getErrorMessage();
             String requestId = exception.getRequestId();
             byte[] rawResponse = exception.getRawResponse();
             System.out.println(String.format("Error code: %s, message: %s, requestId: %s", errorCode, errorMessage, requestId));
+
         } catch (AmazonSQSException exception) {
             System.out.println(String.format("Error code: %s. RequestId: %s. Raw response content: %s",
                                              exception.getErrorCode(), exception.getRequestId(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix V1GetterToV2 to not change get method on a list member

### Current Behavior
`Message message = receiveMessage.getMessages().get(0)` -> `Message message = receiveMessage.message().(0)`

### Expected Behavior

`Message message = receiveMessage.getMessages().get(0)` -> `Message message = receiveMessage.message().get(0)`