### PR TITLE
Make sure that override plays well for retry policies and strategies

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1a76a6f.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1a76a6f.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Allows overrides of the retry strategy for Kinesis clients. Kinesis has its own RetryPolicy that would take precedence over any retry strategy making it impossible to override using a retry strategy."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -403,54 +403,55 @@ public class BaseClientBuilderClass implements ClassSpec {
         builder.addStatement("return result.build()")
                .addCode("});");
 
-        builder.addCode("builder.option($1T.EXECUTION_INTERCEPTORS, interceptors)", SdkClientOption.class);
+        builder.addStatement("builder.option($1T.EXECUTION_INTERCEPTORS, interceptors)", SdkClientOption.class);
 
         if (model.getCustomizationConfig().getServiceConfig().hasDualstackProperty()) {
-            builder.addCode(".option($T.DUALSTACK_ENDPOINT_ENABLED, finalServiceConfig.dualstackEnabled())",
+            builder.addStatement("builder.option($T.DUALSTACK_ENDPOINT_ENABLED, finalServiceConfig.dualstackEnabled())",
                             AwsClientOption.class);
         }
 
         if (model.getCustomizationConfig().getServiceConfig().hasFipsProperty()) {
-            builder.addCode(".option($T.FIPS_ENDPOINT_ENABLED, finalServiceConfig.fipsModeEnabled())", AwsClientOption.class);
+            builder.addStatement("builder.option($T.FIPS_ENDPOINT_ENABLED, finalServiceConfig.fipsModeEnabled())",
+                                 AwsClientOption.class);
         }
 
         if (model.getEndpointOperation().isPresent()) {
-            builder.addCode(".option($T.ENDPOINT_DISCOVERY_ENABLED, endpointDiscoveryEnabled)\n",
+            builder.addStatement("builder.option($T.ENDPOINT_DISCOVERY_ENABLED, endpointDiscoveryEnabled)\n",
                             SdkClientOption.class);
         }
 
 
-        if (StringUtils.isNotBlank(model.getCustomizationConfig().getCustomRetryPolicy())) {
-            builder.addCode(".option($1T.RETRY_POLICY, $2T.resolveRetryPolicy(config))",
-                            SdkClientOption.class,
-                            PoetUtils.classNameFromFqcn(model.getCustomizationConfig().getCustomRetryPolicy()));
-        }
-
         if (StringUtils.isNotBlank(model.getCustomizationConfig().getCustomRetryStrategy())) {
-            builder.addCode(".option($1T.RETRY_STRATEGY, $2T.resolveRetryStrategy(config))",
+            builder.addStatement("builder.option($1T.RETRY_STRATEGY, $2T.resolveRetryStrategy(config))",
                             SdkClientOption.class,
                             PoetUtils.classNameFromFqcn(model.getCustomizationConfig().getCustomRetryStrategy()));
         }
 
+        if (StringUtils.isNotBlank(model.getCustomizationConfig().getCustomRetryPolicy())) {
+            builder.beginControlFlow("if (builder.option($T.RETRY_STRATEGY) == null)", SdkClientOption.class);
+            builder.addStatement("builder.option($1T.RETRY_POLICY, $2T.resolveRetryPolicy(config))",
+                                 SdkClientOption.class,
+                                 PoetUtils.classNameFromFqcn(model.getCustomizationConfig().getCustomRetryPolicy()));
+            builder.endControlFlow();
+        }
+
         if (StringUtils.isNotBlank(clientConfigClassName)) {
-            builder.addCode(".option($T.SERVICE_CONFIGURATION, finalServiceConfig)", SdkClientOption.class);
+            builder.addStatement("builder.option($T.SERVICE_CONFIGURATION, finalServiceConfig)", SdkClientOption.class);
         }
 
         if (model.getCustomizationConfig().useGlobalEndpoint()) {
-            builder.addCode(".option($1T.USE_GLOBAL_ENDPOINT, globalEndpointResolver.resolve(config.option($1T.AWS_REGION)))",
-                            AwsClientOption.class);
+            builder.addStatement("builder.option($1T.USE_GLOBAL_ENDPOINT, "
+                                 + "globalEndpointResolver.resolve(config.option($1T.AWS_REGION)))", AwsClientOption.class);
         }
 
         if (hasClientContextParams() || endpointRulesSpecUtils.useS3Express()) {
-            builder.addCode(".option($T.CLIENT_CONTEXT_PARAMS, clientContextParams.build())", SdkClientOption.class);
+            builder.addStatement("builder.option($T.CLIENT_CONTEXT_PARAMS, clientContextParams.build())", SdkClientOption.class);
         }
 
         if (endpointParamsKnowledgeIndex.hasAccountIdEndpointModeBuiltIn()) {
-            builder.addCode(".option($T.$L, resolveAccountIdEndpointMode(config))",
+            builder.addStatement("builder.option($T.$L, resolveAccountIdEndpointMode(config))",
                             AwsClientOption.class, model.getNamingStrategy().getEnumValueName("accountIdEndpointMode"));
         }
-
-        builder.addCode(";\n");
         builder.addStatement("return builder.build()");
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-class.java
@@ -155,12 +155,14 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
-                .option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED, finalServiceConfig.dualstackEnabled())
-                .option(AwsClientOption.FIPS_ENDPOINT_ENABLED, finalServiceConfig.fipsModeEnabled())
-                .option(SdkClientOption.RETRY_POLICY, MyServiceRetryPolicy.resolveRetryPolicy(config))
-                .option(SdkClientOption.RETRY_STRATEGY, MyServiceRetryStrategy.resolveRetryStrategy(config))
-                .option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED, finalServiceConfig.dualstackEnabled());
+        builder.option(AwsClientOption.FIPS_ENDPOINT_ENABLED, finalServiceConfig.fipsModeEnabled());
+        builder.option(SdkClientOption.RETRY_STRATEGY, MyServiceRetryStrategy.resolveRetryStrategy(config));
+        if (builder.option(SdkClientOption.RETRY_STRATEGY) == null) {
+            builder.option(SdkClientOption.RETRY_POLICY, MyServiceRetryPolicy.resolveRetryPolicy(config));
+        }
+        builder.option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
         return builder.build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-endpoints-auth-params.java
@@ -97,9 +97,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
-                .option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build())
-                .option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build());
+        builder.option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
         return builder.build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-composed-sync-default-client-builder.java
@@ -102,8 +102,8 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors).option(SdkClientOption.SERVICE_CONFIGURATION,
-                finalServiceConfig);
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
         return builder.build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-query-client-builder-class.java
@@ -96,9 +96,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
-                .option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build())
-                .option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build());
+        builder.option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
         return builder.build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -148,12 +148,14 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
-                .option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED, finalServiceConfig.dualstackEnabled())
-                .option(AwsClientOption.FIPS_ENDPOINT_ENABLED, finalServiceConfig.fipsModeEnabled())
-                .option(SdkClientOption.RETRY_POLICY, MyServiceRetryPolicy.resolveRetryPolicy(config))
-                .option(SdkClientOption.RETRY_STRATEGY, MyServiceRetryStrategy.resolveRetryStrategy(config))
-                .option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED, finalServiceConfig.dualstackEnabled());
+        builder.option(AwsClientOption.FIPS_ENDPOINT_ENABLED, finalServiceConfig.fipsModeEnabled());
+        builder.option(SdkClientOption.RETRY_STRATEGY, MyServiceRetryStrategy.resolveRetryStrategy(config));
+        if (builder.option(SdkClientOption.RETRY_STRATEGY) == null) {
+            builder.option(SdkClientOption.RETRY_POLICY, MyServiceRetryPolicy.resolveRetryPolicy(config));
+        }
+        builder.option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
         return builder.build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -89,9 +89,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
-                .option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build())
-                .option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build());
+        builder.option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
         return builder.build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
@@ -95,8 +95,8 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors).option(SdkClientOption.SERVICE_CONFIGURATION,
-                finalServiceConfig);
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
         return builder.build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -89,9 +89,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
             }
             return result.build();
         });
-        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
-                .option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build())
-                .option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
+        builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
+        builder.option(SdkClientOption.CLIENT_CONTEXT_PARAMS, clientContextParams.build());
+        builder.option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
         return builder.build();
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -815,6 +815,9 @@ public final class ClientOverrideConfiguration
         @Override
         public Builder retryPolicy(RetryPolicy retryPolicy) {
             config.option(RETRY_POLICY, retryPolicy);
+            config.option(CONFIGURED_RETRY_STRATEGY, null);
+            config.option(CONFIGURED_RETRY_CONFIGURATOR, null);
+            config.option(CONFIGURED_RETRY_MODE, null);
             return this;
         }
 
@@ -833,6 +836,7 @@ public final class ClientOverrideConfiguration
             config.option(CONFIGURED_RETRY_STRATEGY, retryStrategy);
             config.option(CONFIGURED_RETRY_CONFIGURATOR, null);
             config.option(CONFIGURED_RETRY_MODE, null);
+            config.option(RETRY_POLICY, null);
             return this;
         }
 
@@ -842,6 +846,7 @@ public final class ClientOverrideConfiguration
             config.option(CONFIGURED_RETRY_CONFIGURATOR, configurator);
             config.option(CONFIGURED_RETRY_MODE, null);
             config.option(CONFIGURED_RETRY_STRATEGY, null);
+            config.option(RETRY_POLICY, null);
             return this;
         }
 
@@ -851,6 +856,7 @@ public final class ClientOverrideConfiguration
             config.option(CONFIGURED_RETRY_MODE, retryMode);
             config.option(CONFIGURED_RETRY_CONFIGURATOR, null);
             config.option(CONFIGURED_RETRY_STRATEGY, null);
+            config.option(RETRY_POLICY, null);
             return this;
         }
 

--- a/services/kinesis/src/test/java/software/amazon/awssdk/services/kinesis/KinesisClientCanOverrideDefaultRetryPolicy.java
+++ b/services/kinesis/src/test/java/software/amazon/awssdk/services/kinesis/KinesisClientCanOverrideDefaultRetryPolicy.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.kinesis;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEventStream;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardRequest;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler;
+
+public class KinesisClientCanOverrideDefaultRetryPolicy {
+    private WireMockServer wireMock = new WireMockServer(0);
+
+    @Test
+    public void kinesisRetryPolicyIsUsedWhenNotOverridden() {
+        URI endpointOverride = URI.create("http://localhost:" + wireMock.port());
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+
+        KinesisAsyncClient client = KinesisAsyncClient.builder()
+                                                      .credentialsProvider(credentialsProvider)
+                                                      .endpointOverride(endpointOverride)
+                                                      .build();
+        assertThrows(ExecutionException.class, () -> callSubscribeToShard(client));
+        // Standard retry strategy does not retry on subscribeToShard
+        verifyRequestCount(1);
+    }
+
+    @Test
+    public void retryStrategyClientBuilderOverrideIsUsed() {
+        URI endpointOverride = URI.create("http://localhost:" + wireMock.port());
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+
+        KinesisAsyncClient client = KinesisAsyncClient.builder()
+                                                      .credentialsProvider(credentialsProvider)
+                                                      .overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD))
+                                                      .endpointOverride(endpointOverride)
+                                                      .build();
+        assertThrows(ExecutionException.class, () -> callSubscribeToShard(client));
+        // Standard retry strategy does retry on subscribeToShard
+        verifyRequestCount(3);
+    }
+
+    @Test
+    public void retryStrategyPluginOverrideIsUsed() {
+        URI endpointOverride = URI.create("http://localhost:" + wireMock.port());
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+
+        KinesisAsyncClient client = KinesisAsyncClient.builder()
+                                                      .credentialsProvider(credentialsProvider)
+                                                      .endpointOverride(endpointOverride)
+                                                      .addPlugin(c -> c.overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD)))
+                                                      .build();
+        assertThrows(ExecutionException.class, () -> callSubscribeToShard(client));
+        // Standard retry strategy does retry on subscribeToShard
+        verifyRequestCount(3);
+    }
+
+    @Test
+    public void retryStrategyRequestPluginOverrideIsUsed() {
+        URI endpointOverride = URI.create("http://localhost:" + wireMock.port());
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+
+        KinesisAsyncClient client = KinesisAsyncClient.builder()
+                                                      .credentialsProvider(credentialsProvider)
+                                                      .endpointOverride(endpointOverride)
+                                                      .build();
+        SdkPlugin plugin = c -> c.overrideConfiguration(o -> o.retryStrategy(RetryMode.STANDARD));
+        assertThrows(ExecutionException.class, () -> callSubscribeToShard(client, plugin));
+        // Standard retry strategy does retry on subscribeToShard
+        verifyRequestCount(3);
+    }
+
+    private void callSubscribeToShard(KinesisAsyncClient client, SdkPlugin... plugins) throws Exception {
+        List<SubscribeToShardEventStream> events = new ArrayList<>();
+        SubscribeToShardRequest.Builder builder = SubscribeToShardRequest.builder();
+        for (SdkPlugin plugin : plugins) {
+            builder.overrideConfiguration(o -> o.addPlugin(plugin));
+        }
+        client.subscribeToShard(builder.build(),
+                                SubscribeToShardResponseHandler.builder()
+                                                               .subscriber(events::add)
+                                                               .build())
+              .get(10, TimeUnit.SECONDS);
+    }
+
+    private void verifyRequestCount(int count) {
+        wireMock.verify(count, anyRequestedFor(anyUrl()));
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        wireMock.start();
+        wireMock.stubFor(post(anyUrl())
+                             .willReturn(
+                                 aResponse()
+                                     .withStatus(500)));
+
+    }
+
+    @AfterEach
+    private void afterEach() {
+        wireMock.stop();
+    }
+
+}

--- a/services/kinesis/src/test/java/software/amazon/awssdk/services/kinesis/KinesisClientCanOverrideDefaultRetryPolicyTest.java
+++ b/services/kinesis/src/test/java/software/amazon/awssdk/services/kinesis/KinesisClientCanOverrideDefaultRetryPolicyTest.java
@@ -38,7 +38,7 @@ import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEventStream
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardRequest;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler;
 
-public class KinesisClientCanOverrideDefaultRetryPolicy {
+public class KinesisClientCanOverrideDefaultRetryPolicyTest {
     private WireMockServer wireMock = new WireMockServer(0);
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Currently this bug mostly affects Kinesis but might also affect other clients when there's an override for retry policy followed by an override for a retry strategy. 

Kinesis has a custom `RetryPolicy` that was not converted to a `RetryStrategy` due to their use of non-supported features, in particular they need to get from the request the specific operation to avoid retries on `subscribeToShard` calls. This is not supported by `RetryStrategy` that does not know anything about requests. 

To keep backwards compatibility, the retry stages look for a retry policy and if found it takes precedence over retry strategies. This means that if any user overrides a retry policy and then overrides a retry strategy the retry policy will still be used.

For the particular case of Kinesis this happens by default, i.e., the service builders will create the default retry policy which cannot be overridden for anything else but another retry policy. 

This change clears a previously existing retry policy if there's a retry strategy override, thus making the override work as expected.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
