### PR TITLE
Allow slow recovery of tokens in the token bucket

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-ead1561.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-ead1561.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix a bug on the token bucket, after success we need to deposit back one token to allow it to slowly recover and allow more retries after seeing several successful responses."
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -196,8 +196,10 @@ public abstract class BaseRetryStrategy implements RetryStrategy {
 
     private ReleaseResponse releaseTokenBucketCapacity(DefaultRetryToken token) {
         TokenBucket bucket = tokenBucketStore.tokenBucketForScope(token.scope());
-        int capacityReleased = token.capacityAcquired();
-        return bucket.release(Math.max(capacityReleased, 1));
+        // Make sure that we release at least one token to allow the token bucket
+        // to replenish its tokens.
+        int capacityReleased = Math.max(token.capacityAcquired(), 1);
+        return bucket.release(capacityReleased);
     }
 
     private DefaultRetryToken refreshRetryTokenAfterSuccess(DefaultRetryToken token, ReleaseResponse releaseResponse) {

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -197,7 +197,7 @@ public abstract class BaseRetryStrategy implements RetryStrategy {
     private ReleaseResponse releaseTokenBucketCapacity(DefaultRetryToken token) {
         TokenBucket bucket = tokenBucketStore.tokenBucketForScope(token.scope());
         int capacityReleased = token.capacityAcquired();
-        return bucket.release(capacityReleased);
+        return bucket.release(Math.max(capacityReleased, 1));
     }
 
     private DefaultRetryToken refreshRetryTokenAfterSuccess(DefaultRetryToken token, ReleaseResponse releaseResponse) {

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/circuitbreaker/TokenBucket.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/circuitbreaker/TokenBucket.java
@@ -89,8 +89,7 @@ public final class TokenBucket {
                            .maxCapacity(maxCapacity);
 
         if (amountToRelease == 0) {
-            return builder.currentCapacity(capacity.get())
-                          .build();
+            amountToRelease = 1;
         }
 
         int currentCapacity;

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/circuitbreaker/TokenBucket.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/circuitbreaker/TokenBucket.java
@@ -89,7 +89,8 @@ public final class TokenBucket {
                            .maxCapacity(maxCapacity);
 
         if (amountToRelease == 0) {
-            amountToRelease = 1;
+            return builder.currentCapacity(capacity.get())
+                          .build();
         }
 
         int currentCapacity;

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/TokenBucketRecoversTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/TokenBucketRecoversTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import java.net.URI;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+@SuppressWarnings("deprecation")
+public abstract class TokenBucketRecoversTest<ClientT, BuilderT extends AwsClientBuilder<BuilderT, ClientT>> {
+
+    protected WireMockServer wireMock;
+
+    protected abstract BuilderT newClientBuilder();
+
+    protected abstract AllTypesResponse callAllTypes(ClientT client, SdkPlugin... plugins);
+
+    private BuilderT clientBuilder() {
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+        return newClientBuilder()
+            .credentialsProvider(credentialsProvider)
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create("http://localhost:" + wireMock.port()));
+    }
+
+    @Test
+    public void retryPolicyTokenBucketRecovers() {
+        RetryPolicy retryPolicy = RetryPolicy.forRetryMode(RetryMode.STANDARD)
+                                             .toBuilder()
+                                             .throttlingBackoffStrategy(BackoffStrategy.none())
+                                             .backoffStrategy(BackoffStrategy.none())
+                                             .build();
+        ClientT client = clientBuilder()
+            .overrideConfiguration(o -> o.retryPolicy(retryPolicy))
+            .build();
+        int exceptions = 0;
+        for (int x = 0; x < 60; x++) {
+            try {
+                callAllTypes(client);
+            } catch (Exception e) {
+                exceptions += 1;
+            }
+        }
+        verifyRequestCount(161);
+    }
+
+    @Test
+    public void retryStrategyTokenBucketRecovers() {
+        RetryStrategy retryStrategy = SdkDefaultRetryStrategy
+            .forRetryMode(RetryMode.STANDARD)
+            .toBuilder()
+            .backoffStrategy(software.amazon.awssdk.retries.api.BackoffStrategy.retryImmediately())
+            .build();
+        ClientT client = clientBuilder()
+            .overrideConfiguration(o -> o.retryStrategy(retryStrategy))
+            .build();
+        int exceptions = 0;
+        for (int x = 0; x < 60; x++) {
+            try {
+                callAllTypes(client);
+            } catch (Exception e) {
+                exceptions += 1;
+            }
+        }
+        verifyRequestCount(161);
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        wireMock = new WireMockServer(wireMockConfig()
+                                          .extensions(ErrorSimulationResponseTransformer.class));
+        wireMock.start();
+        wireMock.stubFor(post(anyUrl())
+                             .willReturn(aResponse()
+                                             .withTransformers("error-simulation-transformer")));
+    }
+
+    @AfterEach
+    private void afterEach() {
+        wireMock.stop();
+    }
+
+    private void verifyRequestCount(int count) {
+        wireMock.verify(count, anyRequestedFor(anyUrl()));
+    }
+
+    static class SyncCanOverrideStrategy extends TokenBucketRecoversTest<ProtocolRestJsonClient,
+        ProtocolRestJsonClientBuilder> {
+        @Override
+        protected ProtocolRestJsonClientBuilder newClientBuilder() {
+            return ProtocolRestJsonClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonClient client, SdkPlugin... plugins) {
+            AllTypesRequest.Builder requestBuilder = AllTypesRequest.builder();
+            for (SdkPlugin plugin : plugins) {
+                requestBuilder.overrideConfiguration(o -> o.addPlugin(plugin));
+            }
+            return client.allTypes(requestBuilder.build());
+        }
+    }
+
+    static class AsyncCanOverrideStrategy extends TokenBucketRecoversTest<ProtocolRestJsonAsyncClient,
+        ProtocolRestJsonAsyncClientBuilder> {
+        @Override
+        protected ProtocolRestJsonAsyncClientBuilder newClientBuilder() {
+            return ProtocolRestJsonAsyncClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonAsyncClient client, SdkPlugin... plugins) {
+            try {
+                AllTypesRequest.Builder requestBuilder = AllTypesRequest.builder();
+                for (SdkPlugin plugin : plugins) {
+                    requestBuilder.overrideConfiguration(o -> o.addPlugin(plugin));
+                }
+                return client.allTypes(requestBuilder.build()).join();
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+                throw e;
+            }
+        }
+    }
+
+    public static class ErrorSimulationResponseTransformer extends ResponseTransformer {
+        private AtomicInteger requestCount = new AtomicInteger(0);
+
+        @Override
+        public String getName() {
+            return "error-simulation-transformer";
+        }
+
+        @Override
+        public Response transform(Request request, Response response, FileSource files, Parameters parameters) {
+            if (shouldSucceed()) {
+                return Response.Builder.like(response)
+                                       .but().body("{}")
+                                       .status(200)
+                                       .build();
+            }
+            return Response.Builder.like(response)
+                                   .but().body("{}")
+                                   .status(429)
+                                   .build();
+        }
+
+        private boolean shouldSucceed() {
+            int currentCount = requestCount.getAndIncrement();
+            if (currentCount < 150 || currentCount >= 155) {
+                // in between 5 successful calls will allow an additional retry as 5 tokens will be deposited to the store.
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

The original implementation of the token bucket logic did not deposit back for successful invocations which means that once the buckets were exhausted it will no allow any more retries since there's no mechanism to recover from that state.

Customers using custom **`RetryPolicy`** instances or **Kinesis** are NOT affected by this bug.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
