### PR TITLE
Fix Http2PingHandler to not write to the channel pipeline

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-535defb.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-535defb.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "akidambisrinivasan",
+    "description": "Fix Http2PingHandler to not write to the channel pipeline"
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
@@ -54,7 +54,8 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
             new SdkHttpConfigurationOption<>("ConnectionAcquireTimeout", Duration.class);
 
     /**
-     * Timeout after which an idle connection should be closed.
+     * Timeout after which an idle connection should be closed. For HTTP/2 this only
+     * applies to the connection not streams.
      */
     public static final SdkHttpConfigurationOption<Duration> CONNECTION_MAX_IDLE_TIMEOUT =
             new SdkHttpConfigurationOption<>("ConnectionMaxIdleTimeout", Duration.class);
@@ -86,6 +87,7 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
 
     /**
      * Whether idle connection should be removed after the {@link #CONNECTION_MAX_IDLE_TIMEOUT} has passed.
+     * For HTTP/2, this only applies HTTP/2 connections not streams.
      */
     public static final SdkHttpConfigurationOption<Boolean> REAP_IDLE_CONNECTIONS =
             new SdkHttpConfigurationOption<>("ReapIdleConnections", Boolean.class);

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionReaperHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionReaperHandler.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.http.nio.netty.internal.utils.NettyClientLogger;
 
 /**
  * A handler that closes unused channels that have not had any traffic on them for a configurable amount of time.
+ * For HTTP/2 this is applied to the HTTP/2 connection only not the streams.
  */
 @SdkInternalApi
 public class IdleConnectionReaperHandler extends IdleStateHandler {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionReaperHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionReaperHandler.java
@@ -39,7 +39,8 @@ public class IdleConnectionReaperHandler extends IdleStateHandler {
     protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent event) {
         assert ctx.channel().eventLoop().inEventLoop();
 
-        boolean channelNotInUse = Boolean.FALSE.equals(ctx.channel().attr(ChannelAttributeKey.IN_USE).get());
+        boolean channelNotInUse = ctx.channel().attr(ChannelAttributeKey.IN_USE).get() == null
+            || Boolean.FALSE.equals(ctx.channel().attr(ChannelAttributeKey.IN_USE).get());
 
         if (channelNotInUse && ctx.channel().isOpen()) {
             log.debug(ctx.channel(), () -> "Closing unused connection (" + ctx.channel().id() + ") because it has been idle for "

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -206,10 +206,12 @@ public final class NettyRequestExecutor {
 
         switch (protocol) {
             case HTTP2:
+                // Configure pipeline for the child stream channel
                 pipeline.addLast(new Http2ToHttpInboundAdapter());
                 pipeline.addLast(new HttpToHttp2OutboundAdapter());
                 pipeline.addLast(Http2StreamExceptionHandler.create());
                 requestAdapter = REQUEST_ADAPTER_HTTP2;
+
                 break;
             case HTTP1_1:
                 requestAdapter = REQUEST_ADAPTER_HTTP1_1;

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/PingTimeoutTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/PingTimeoutTest.java
@@ -131,8 +131,12 @@ public class PingTimeoutTest {
 
     private CompletableFuture<Void> makeRequest(Duration healthCheckPingPeriod) {
         netty = NettyNioAsyncHttpClient.builder()
+                 // have a long enough idle timeout so that the connection doesn't timeout from being idle.
+                 // NOTE: Ping traffic will not keep the connection alive from idle timeout.
+                .connectionMaxIdleTime(Duration.ofSeconds(20))
                 .protocol(Protocol.HTTP2)
-                .http2Configuration(Http2Configuration.builder().healthCheckPingPeriod(healthCheckPingPeriod).build())
+                .http2Configuration(Http2Configuration.builder().healthCheckPingPeriod(healthCheckPingPeriod)
+                                                      .build())
                 .build();
 
         SdkHttpFullRequest request = SdkHttpFullRequest.builder()

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionReaperHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionReaperHandlerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http2.DefaultHttp2PingFrame;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.nio.netty.internal.http2.Http2PingHandler;
+import software.amazon.awssdk.http.nio.netty.internal.utils.NettyClientLogger;
+
+public class IdleConnectionReaperHandlerTest {
+    private static final NettyClientLogger log = NettyClientLogger.getLogger(IdleConnectionReaperHandlerTest.class);
+
+    @Test
+    public void channelSwitchFromInUseToNotInUse_shouldCloseOnIdleTimeout_EvenIfPingsAreGoingOn() {
+        // pipelines are in the order of
+        // Transport -> Head -> Handlers -> Tail -> Application
+        IdleConnectionReaperHandler idleHandler = new IdleConnectionReaperHandler(1000); // timeout connection after 1 sec
+        Http2PingHandler pingHandler = new Http2PingHandler(100); // ping every 100 ms.
+
+        // create a channel with the following handlers
+        // Transport -> Head -> pingHandler, idleHandler -> Tail -> Application
+        // Even though pings are going on keeping the channel alive, idleHandler should detect idleness
+        EmbeddedChannel channel = createHttp2Channel(pingHandler, idleHandler);
+        channel.attr(ChannelAttributeKey.IN_USE).set(true);
+
+        // Roughly 20 pings will be sent and acked... channel will be detected as idle but not timeout because it is
+        // in use
+        int count = 0;
+        Instant runEnd = Instant.now().plus(2, SECONDS);
+        while (Instant.now().isBefore(runEnd)) {
+            channel.runPendingTasks();
+            DefaultHttp2PingFrame sentFrame = channel.readOutbound();
+
+            if (sentFrame != null) {
+                assertThat(sentFrame.ack()).isFalse();
+                channel.writeInbound(new DefaultHttp2PingFrame(0, true));
+                count++;
+            }
+        }
+
+        Assert.assertTrue(count >= 20); // atleast 20 must be sent
+        Assert.assertFalse(channel.closeFuture().isDone());
+
+        channel.attr(ChannelAttributeKey.IN_USE).set(false);
+
+        // Roughly 20 more pings will be sent and acked... channel will be detected as idle and timeout and close
+        runEnd = Instant.now().plus(2, SECONDS);
+        while (Instant.now().isBefore(runEnd)) {
+            channel.runPendingTasks();
+            DefaultHttp2PingFrame sentFrame = channel.readOutbound();
+
+            if (sentFrame != null) {
+                assertThat(sentFrame.ack()).isFalse();
+                channel.writeInbound(new DefaultHttp2PingFrame(0, true));
+                count++;
+            }
+        }
+        Assert.assertTrue(channel.closeFuture().isDone());
+    }
+
+
+    @Test
+    public void channelNeverUsed_shouldCloseOnIdleTimeout_EvenIfPingsAreGoingOn() {
+        // pipelines are in the order of
+        // Transport -> Head -> Handlers -> Tail -> Application
+        IdleConnectionReaperHandler idleHandler = new IdleConnectionReaperHandler(1000); // timeout connection after 1 sec
+        Http2PingHandler pingHandler = new Http2PingHandler(100); // ping every 100 ms.
+
+        // create a channel with the following handlers
+        // Transport -> Head -> pingHandler, idleHandler -> Tail -> Application
+        // Even though pings are going on keeping the channel alive, idleHandler should detect idleness
+        EmbeddedChannel channel = createHttp2Channel(pingHandler, idleHandler);
+
+        // Roughly 20 pings will be sent and acked... channel will be detected as idle and timeout and close
+        // in use
+        int count = 0;
+        Instant runEnd = Instant.now().plus(2, SECONDS);
+        while (Instant.now().isBefore(runEnd)) {
+            channel.runPendingTasks();
+            DefaultHttp2PingFrame sentFrame = channel.readOutbound();
+
+            if (sentFrame != null) {
+                assertThat(sentFrame.ack()).isFalse();
+                channel.writeInbound(new DefaultHttp2PingFrame(0, true));
+                count++;
+            }
+        }
+        Assert.assertTrue(count == 10); // because connection closes after 10 pings are sent/rcvd
+        Assert.assertTrue(channel.closeFuture().isDone());
+    }
+
+    private static EmbeddedChannel createChannelWithoutProtocol(ChannelHandler... handlers) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.attr(ChannelAttributeKey.PROTOCOL_FUTURE).set(new CompletableFuture<>());
+        channel.pipeline().addLast(handlers);
+        return channel;
+    }
+
+    private static EmbeddedChannel createHttp2Channel(ChannelHandler... handlers) {
+        EmbeddedChannel channel = createChannelWithoutProtocol(handlers);
+        channel.attr(ChannelAttributeKey.PROTOCOL_FUTURE).get().complete(Protocol.HTTP2);
+        return channel;
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/Http2PingHandlerTest.java
@@ -123,7 +123,7 @@ public class Http2PingHandlerTest {
     public void schedulingDelayDoesNotCausePingTimeout() throws InterruptedException {
         PipelineExceptionCatcher catcher = new PipelineExceptionCatcher();
         PingResponder pingResponder = new PingResponder();
-        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher, pingResponder);
+        EmbeddedChannel channel = createHttp2Channel(pingResponder, fastChecker, catcher);
 
         pingResponder.setCallback(() -> channel.writeInbound(new DefaultHttp2PingFrame(0, true)),
                                   (long)(FAST_CHECKER_DURATION_MILLIS / 10) /* send ack 10ms after getting ping */);
@@ -173,7 +173,7 @@ public class Http2PingHandlerTest {
     @Test
     public void failedWriteResultsInOneChannelException() throws InterruptedException {
         PipelineExceptionCatcher catcher = new PipelineExceptionCatcher();
-        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher, new FailingWriter());
+        EmbeddedChannel channel = createHttp2Channel(new FailingWriter(), fastChecker, catcher);
         channel.runPendingTasks();
         assertThat(catcher.caughtExceptions).hasSize(1);
         assertThat(catcher.caughtExceptions.get(0)).isInstanceOf(IOException.class);
@@ -239,7 +239,7 @@ public class Http2PingHandlerTest {
         PingResponder pingResponder = new PingResponder();
         DelayingWriter delayingWriter = new DelayingWriter((long)(FAST_CHECKER_DURATION_MILLIS * 1.5));
 
-        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher, pingResponder, delayingWriter);
+        EmbeddedChannel channel = createHttp2Channel(pingResponder, delayingWriter, fastChecker, catcher);
 
         pingResponder.setCallback(() -> channel.writeInbound(new DefaultHttp2PingFrame(0, true)),
                                   FAST_CHECKER_DURATION_MILLIS / 10 /* send ack in 10 ms after getting ping*/);
@@ -259,7 +259,7 @@ public class Http2PingHandlerTest {
         PingResponder pingResponder = new PingResponder();
         DelayingWriter delayingWriter = new DelayingWriter((long)(FAST_CHECKER_DURATION_MILLIS * 1.5));
 
-        EmbeddedChannel channel = createHttp2Channel(fastChecker, catcher, pingResponder, delayingWriter);
+        EmbeddedChannel channel = createHttp2Channel(pingResponder, delayingWriter, fastChecker, catcher);
 
         pingResponder.setCallback(() -> channel.writeInbound(new DefaultHttp2PingFrame(0, true)),
                                   (long)(FAST_CHECKER_DURATION_MILLIS * 1.5) /* send a late ack to trigger timeout */);


### PR DESCRIPTION
## Motivation and Context
When Http2PingHandler writes the HTTP/2 PING frames to the pipeline, the writes keep the IdleConnectionReaperHandler from detecting idleness on the connection and reaping it. By writing to handler's context, the IdleConnectionReaperHandler does not see the PING frames and therefore reaps connections with only PING frames.

## Modifications
Use ctx.writeAndFlush instead of channel.writeAndFlush when writing HTTP/2 PING frames
so it doesnt go through the whole pipeline.

## Testing
Added unit test to make sure connections are marked idle correctly and closing connection when
it is just idling with PING traffic on it

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
