### PR TITLE
Account for v1 package service name differences

### DIFF
--- a/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
+++ b/migration-tool/src/main/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtils.java
@@ -35,6 +35,7 @@ public final class NamingConversionUtils {
 
         String v2ClassName = CodegenNamingUtils.pascalCase(v1ClassName);
         String v2PackagePrefix = packagePrefix.replace(V1_PACKAGE_PREFIX, V2_PACKAGE_PREFIX);
+        v2PackagePrefix = checkPackageServiceNameForV2Suffix(v2PackagePrefix);
 
         if (Stream.of("Abstract", "Amazon", "AWS").anyMatch(v1ClassName::startsWith)) {
             v2ClassName = getV2ClientOrExceptionEquivalent(v1ClassName);
@@ -44,6 +45,19 @@ public final class NamingConversionUtils {
         }
 
         return v2PackagePrefix + "." + v2ClassName;
+    }
+
+    /**
+     * Edge cases in v1 package names
+     */
+    private static String checkPackageServiceNameForV2Suffix(String v2PackagePrefix) {
+        if (v2PackagePrefix.contains("dynamodbv2")) {
+            return v2PackagePrefix.replace("dynamodbv2", "dynamodb");
+        }
+        if (v2PackagePrefix.contains("cloudsearchv2")) {
+            return v2PackagePrefix.replace("cloudsearchv2", "cloudsearch");
+        }
+        return v2PackagePrefix;
     }
 
     public static String getV2ModelPackageWildCardEquivalent(String currentFqcn) {

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/internal/utils/NamingConversionUtilsTest.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.migration.internal.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.migration.internal.utils.NamingConversionUtils;
 
 public class NamingConversionUtilsTest {
     @Test
@@ -85,5 +84,13 @@ public class NamingConversionUtilsTest {
             .isEqualTo("software.amazon.awssdk.services.iot.model.*");
         assertThat(NamingConversionUtils.getV2ModelPackageWildCardEquivalent("com.amazonaws.services.iot.*"))
             .isEqualTo("software.amazon.awssdk.services.iot.*");
+    }
+
+    @Test
+    void packageNameV2Suffix_shouldBeRemoved() {
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.cloudsearchv2.AmazonCloudSearchClient"))
+                       .isEqualTo("software.amazon.awssdk.services.cloudsearch.CloudSearchClient");
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.dynamodbv2.AmazonDynamoDB"))
+            .isEqualTo("software.amazon.awssdk.services.dynamodb.DynamoDbClient");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Remove `v2` from `dynamodbv2` and `cloudsearchv2` imports
