### PR TITLE
Consume any pending bytes on socket

### DIFF
--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
@@ -54,6 +54,15 @@ public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
     }
 
     @Override
+    public Socket createLayeredSocket(Socket socket, String target, int port, HttpContext context) throws IOException {
+        Socket layeredSocket = super.createLayeredSocket(socket, target, port, context);
+        if (layeredSocket instanceof SSLSocket) {
+            return new InputShutdownCheckingSslSocket(new SdkSslSocket((SSLSocket) layeredSocket), socket);
+        }
+        return layeredSocket;
+    }
+
+    @Override
     public Socket connectSocket(
             final int connectTimeout,
             final Socket socket,
@@ -64,10 +73,6 @@ public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
         log.trace(() -> String.format("Connecting to %s:%s", remoteAddress.getAddress(), remoteAddress.getPort()));
 
         Socket connectedSocket = super.connectSocket(connectTimeout, socket, host, remoteAddress, localAddress, context);
-
-        if (connectedSocket instanceof SSLSocket) {
-            return new InputShutdownCheckingSslSocket(new SdkSslSocket((SSLSocket) connectedSocket));
-        }
 
         return new SdkSocket(connectedSocket);
     }


### PR DESCRIPTION
This update checks the wrapped socket to see if there is any data available on the socket. If this is true, then there is (at least a partial) TLS record that is waiting to be read. Other than application data, this record may contain a close_notify.

If data is available, then we perform a single-byte read on the SSL socket to get the SSLSocket to consume the record.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
