### PR TITLE
Skip transformation for S3 Transfer Manager and DynamoDB mapper

### DIFF
--- a/migration-tool/pom.xml
+++ b/migration-tool/pom.xml
@@ -39,6 +39,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>1.12.472</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -87,7 +94,17 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
             <scope>test</scope>
-            <version>1.12.472</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson</groupId>
@@ -99,7 +116,6 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <scope>test</scope>
-            <version>1.12.472</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson</groupId>

--- a/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/upgrade-sdk-dependencies.yml
@@ -21,10 +21,12 @@ recipeList:
       groupId: software.amazon.awssdk
       artifactId: apache-client
       version: 2.23.16-SNAPSHOT
+      onlyIfUsing: com.amazonaws.ClientConfiguration
   - org.openrewrite.maven.AddDependency:
       groupId: software.amazon.awssdk
       artifactId: netty-nio-client
       version: 2.23.16-SNAPSHOT
+      onlyIfUsing: com.amazonaws.ClientConfiguration
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: com.amazonaws
       oldArtifactId: aws-java-sdk-core

--- a/migration-tool/src/main/resources/scripts/generate_upgrade_sdk_dependencies_recipe.py
+++ b/migration-tool/src/main/resources/scripts/generate_upgrade_sdk_dependencies_recipe.py
@@ -59,16 +59,19 @@ def write_bom_recipe(f, version):
       newVersion: {0}'''
     f.write(change_bom.format(version))
 
-def add_dependencies(f, version):
+# Only add apache-client and netty-nio-client if ClientConfiguration is used
+def add_http_client_dependencies_if_needed(f, version):
     add_dependencies_str = '''
   - org.openrewrite.maven.AddDependency:
       groupId: software.amazon.awssdk
       artifactId: apache-client
       version: {0}
+      onlyIfUsing: com.amazonaws.ClientConfiguration
   - org.openrewrite.maven.AddDependency:
       groupId: software.amazon.awssdk
       artifactId: netty-nio-client
-      version: {0}'''
+      version: {0}
+      onlyIfUsing: com.amazonaws.ClientConfiguration'''
     f.write(add_dependencies_str.format(version))
 
 def replace_core_dependencies(f, version):
@@ -98,7 +101,7 @@ def write_recipe_yml_file(service_mapping):
     with open(filename, 'w') as f:
         write_copy_right_header(f)
         write_recipe_metadata(f, version)
-        add_dependencies(f, version)
+        add_http_client_dependencies_if_needed(f, version)
         replace_core_dependencies(f, version)
         write_bom_recipe(f, version)
         for s in service_mapping:

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeSdkTypeTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/ChangeSdkTypeTest.java
@@ -28,7 +28,8 @@ public class ChangeSdkTypeTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new ChangeSdkType()).parser(Java8Parser.builder().classpath("aws-java-sdk-sqs","sqs"));
+        spec.recipe(new ChangeSdkType()).parser(Java8Parser.builder().classpath("aws-java-sdk-sqs","sqs", "aws-java-sdk-s3",
+                                                                                "aws-java-sdk-dynamodb"));
     }
 
     @Test
@@ -212,6 +213,32 @@ public class ChangeSdkTypeTest implements RewriteTest {
                 "       private CreateQueueResponse createQueue;\n" +
                 "    }\n" +
                 "}\n"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    void hasUnsupportedFeature_shouldSkip() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.s3.transfer.TransferManager;\n" +
+                "import com.amazonaws.services.sqs.model.DeleteQueueRequest;\n" +
+                "import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;\n" +
+                "class Test {\n" +
+                "    private TransferManager transferManager;\n" +
+                "    private DeleteQueueRequest deleteQueue;\n" +
+                "    private DynamoDBMapper ddbMapper;\n" +
+                "}\n",
+                "import com.amazonaws.services.s3.transfer.TransferManager;\n"
+                + "import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;\n"
+                + "import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;\n"
+                + "\n"
+                + "class Test {\n"
+                + "    private TransferManager transferManager;\n"
+                + "    private DeleteQueueRequest deleteQueue;\n"
+                + "    private DynamoDBMapper ddbMapper;\n"
+                + "}"
             )
         );
     }

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/UpgradeSdkDependenciesTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/UpgradeSdkDependenciesTest.java
@@ -28,6 +28,8 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.openrewrite.java.Java8Parser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -81,6 +83,7 @@ public class UpgradeSdkDependenciesTest implements RewriteTest {
     }
 
     @Test
+    @EnabledOnJre({JRE.JAVA_8})
     void standardClient_shouldChangeDependencyGroupIdAndArtifactId() throws IOException {
         String currentVersion = getVersion();
         rewriteRun(
@@ -125,6 +128,7 @@ public class UpgradeSdkDependenciesTest implements RewriteTest {
     }
 
     @Test
+    @EnabledOnJre({JRE.JAVA_8})
     void useClientConfiguration_shouldAddHttpDependencies() throws IOException {
         String currentVersion = getVersion();
         rewriteRun(

--- a/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/UpgradeSdkDependenciesTest.java
+++ b/migration-tool/src/test/java/software/amazon/awssdk/migration/recipe/UpgradeSdkDependenciesTest.java
@@ -15,6 +15,9 @@
 
 package software.amazon.awssdk.migration.recipe;
 
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.java.Assertions.srcMainJava;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import java.io.IOException;
@@ -25,12 +28,25 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.Java8Parser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 public class UpgradeSdkDependenciesTest implements RewriteTest {
 
     private static String sdkVersion;
+
+    private final String useClientConfiguration = "    import com.amazonaws.services.sqs.AmazonSQSClient;\n"
+                                                  + "    import com.amazonaws.ClientConfiguration;\n"
+                                                  + "          public class Test {\n"
+                                                  + "              private ClientConfiguration configuration;\n"
+                                                  + "              private AmazonSQSClient sqsClient;\n"
+                                                  + "          }";
+
+    private final String noClientConfiguration = "    import com.amazonaws.services.sqs.AmazonSQSClient;\n"
+                                                  + "          public class Test {\n"
+                                                  + "              private AmazonSQSClient sqsClient;\n"
+                                                  + "          }";
 
     @BeforeAll
     static void setUp() throws IOException {
@@ -40,7 +56,9 @@ public class UpgradeSdkDependenciesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         try (InputStream stream = getClass().getResourceAsStream("/META-INF/rewrite/upgrade-sdk-dependencies.yml")) {
-            spec.recipe(stream, "software.amazon.awssdk.UpgradeSdkDependencies");
+            spec.recipe(stream, "software.amazon.awssdk.UpgradeSdkDependencies")
+                .parser(Java8Parser.builder().classpath(
+                "aws-java-sdk-sqs", "aws-java-sdk-core"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -64,9 +82,9 @@ public class UpgradeSdkDependenciesTest implements RewriteTest {
 
     @Test
     void standardClient_shouldChangeDependencyGroupIdAndArtifactId() throws IOException {
-        getVersion();
         String currentVersion = getVersion();
         rewriteRun(
+            mavenProject("project", srcMainJava(java(noClientConfiguration)),
             pomXml(
                 "                  <project>\n"
                 + "                      <groupId>com.test.app</groupId>\n"
@@ -100,20 +118,64 @@ public class UpgradeSdkDependenciesTest implements RewriteTest {
                               + "            <artifactId>sqs</artifactId>\n"
                               + "            <version>2.23.16-SNAPSHOT</version>\n"
                               + "        </dependency>\n"
-                              + "        <dependency>\n"
-                              + "            <groupId>software.amazon.awssdk</groupId>\n"
-                              + "            <artifactId>apache-client</artifactId>\n"
-                              + "            <version>2.23.16-SNAPSHOT</version>\n"
-                              + "        </dependency>\n"
-                              + "        <dependency>\n"
-                              + "            <groupId>software.amazon.awssdk</groupId>\n"
-                              + "            <artifactId>netty-nio-client</artifactId>\n"
-                              + "            <version>2.23.16-SNAPSHOT</version>\n"
-                              + "        </dependency>\n"
                               + "    </dependencies>\n"
                               + "</project>", currentVersion)
 
-            )
-        );
+            )));
     }
+
+    @Test
+    void useClientConfiguration_shouldAddHttpDependencies() throws IOException {
+        String currentVersion = getVersion();
+        rewriteRun(
+            mavenProject("project", srcMainJava(java(useClientConfiguration)),
+                         pomXml(
+                             "                  <project>\n"
+                             + "                      <groupId>com.test.app</groupId>\n"
+                             + "                      <artifactId>my-app</artifactId>\n"
+                             + "                      <version>1</version>\n"
+                             + "                      <dependencies>\n"
+                             + "                          <dependency>\n"
+                             + "                              <groupId>com.amazonaws</groupId>\n"
+                             + "                              <artifactId>aws-java-sdk-core</artifactId>\n"
+                             + "                              <version>1.12.100</version>\n"
+                             + "                          </dependency>\n"
+                             + "                          <dependency>\n"
+                             + "                              <groupId>com.amazonaws</groupId>\n"
+                             + "                              <artifactId>aws-java-sdk-sqs</artifactId>\n"
+                             + "                              <version>1.12.100</version>\n"
+                             + "                          </dependency>\n"
+                             + "                      </dependencies>\n"
+                             + "                  </project>",
+                             String.format("<project>\n"
+                                           + "    <groupId>com.test.app</groupId>\n"
+                                           + "    <artifactId>my-app</artifactId>\n"
+                                           + "    <version>1</version>\n"
+                                           + "    <dependencies>\n"
+                                           + "        <dependency>\n"
+                                           + "            <groupId>software.amazon.awssdk</groupId>\n"
+                                           + "            <artifactId>aws-core</artifactId>\n"
+                                           + "            <version>2.23.16-SNAPSHOT</version>\n"
+                                           + "        </dependency>\n"
+                                           + "        <dependency>\n"
+                                           + "            <groupId>software.amazon.awssdk</groupId>\n"
+                                           + "            <artifactId>sqs</artifactId>\n"
+                                           + "            <version>2.23.16-SNAPSHOT</version>\n"
+                                           + "        </dependency>\n"
+                                           + "        <dependency>\n"
+                                           + "            <groupId>software.amazon.awssdk</groupId>\n"
+                                           + "            <artifactId>apache-client</artifactId>\n"
+                                           + "            <version>2.23.16-SNAPSHOT</version>\n"
+                                           + "        </dependency>\n"
+                                           + "        <dependency>\n"
+                                           + "            <groupId>software.amazon.awssdk</groupId>\n"
+                                           + "            <artifactId>netty-nio-client</artifactId>\n"
+                                           + "            <version>2.23.16-SNAPSHOT</version>\n"
+                                           + "        </dependency>\n"
+                                           + "    </dependencies>\n"
+                                           + "</project>", currentVersion)
+
+                         )));
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Skip transformation for S3 Transfer Manager and DynamoDB mapper since they are not supported in the initial release.
- Only add HTTP client dependencies if `ClientConfiguration` is directly being used (http settings)