### PR TITLE
Add parentheses to method patterns

### DIFF
--- a/migration-tool/src/main/resources/META-INF/rewrite/change-auth-types.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/change-auth-types.yml
@@ -19,46 +19,46 @@ name: software.amazon.awssdk.ChangeAuthTypes
 displayName: Change auth related classes
 recipeList:
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.DefaultAWSCredentialsProviderChain getInstance
+      methodPattern: com.amazonaws.auth.DefaultAWSCredentialsProviderChain getInstance()
       newMethodName: create
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.AWSCredentialsProviderChain getCredentials
+      methodPattern: com.amazonaws.auth.AWSCredentialsProviderChain getCredentials()
       newMethodName: resolveCredentials
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.DefaultAWSCredentialsProviderChain
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.AWSCredentials getAWSAccessKeyId
+      methodPattern: com.amazonaws.auth.AWSCredentials getAWSAccessKeyId()
       newMethodName: accessKeyId
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.AWSCredentials getAWSSecretKey
+      methodPattern: com.amazonaws.auth.AWSCredentials getAWSSecretKey()
       newMethodName: secretAccessKey
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.AWSSessionCredentials getSessionToken
+      methodPattern: com.amazonaws.auth.AWSSessionCredentials getSessionToken()
       newMethodName: sessionToken
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.AWSCredentials
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.AwsCredentials
 
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.BasicAWSCredentials getAWSAccessKeyId
+      methodPattern: com.amazonaws.auth.BasicAWSCredentials getAWSAccessKeyId()
       newMethodName: accessKeyId
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.BasicAWSCredentials getAWSSecretKey
+      methodPattern: com.amazonaws.auth.BasicAWSCredentials getAWSSecretKey()
       newMethodName: secretAccessKey
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.BasicAWSCredentials
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.BasicSessionCredentials getAWSAccessKeyId
+      methodPattern: com.amazonaws.auth.BasicSessionCredentials getAWSAccessKeyId()
       newMethodName: accessKeyId
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.BasicSessionCredentials getAWSSecretKey
+      methodPattern: com.amazonaws.auth.BasicSessionCredentials getAWSSecretKey()
       newMethodName: secretAccessKey
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.BasicSessionCredentials getSessionToken
+      methodPattern: com.amazonaws.auth.BasicSessionCredentials getSessionToken()
       newMethodName: sessionToken
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.BasicSessionCredentials
@@ -68,18 +68,18 @@ recipeList:
       oldFullyQualifiedTypeName: com.amazonaws.auth.AWSCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.AwsCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.AwsCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
 
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.AWSStaticCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.StaticCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.StaticCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
 
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.EnvironmentVariableCredentialsProvider getCredentials
+      methodPattern: com.amazonaws.auth.EnvironmentVariableCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.EnvironmentVariableCredentialsProvider
@@ -89,53 +89,53 @@ recipeList:
       oldFullyQualifiedTypeName: com.amazonaws.auth.profile.ProfileCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
 
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.ContainerCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.WebIdentityTokenCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider
 
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.auth.InstanceProfileCredentialsProvider getInstance
+      methodPattern: com.amazonaws.auth.InstanceProfileCredentialsProvider getInstance()
       newMethodName: create
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.InstanceProfileCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
 
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.StsAssumeRoleCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.StsAssumeRoleCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
 
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.STSSessionCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.services.sts.auth.EnvironmentVariableCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
 
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.STSAssumeRoleWithWebIdentitySessionCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithWebIdentityCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.StsAssumeRoleWithWebIdentityCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.StsAssumeRoleWithWebIdentityCredentialsProvider getCredentials()
       newMethodName: resolveCredentials
 
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.auth.ProcessCredentialsProvider
       newFullyQualifiedTypeName: software.amazon.awssdk.auth.credentials.ProcessCredentialsProvider
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: software.amazon.awssdk.auth.credentials.ProcessCredentialsProvider getCredentials
+      methodPattern: software.amazon.awssdk.auth.credentials.ProcessCredentialsProvider getCredentials()
       newMethodName: resolveCredentials

--- a/migration-tool/src/main/resources/META-INF/rewrite/change-exception-types.yml
+++ b/migration-tool/src/main/resources/META-INF/rewrite/change-exception-types.yml
@@ -28,35 +28,35 @@ recipeList:
       newFullyQualifiedTypeName: software.amazon.awssdk.core.exception.SdkClientException
 
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getRequestId
+      methodPattern: com.amazonaws.AmazonServiceException getRequestId()
       newMethodName: requestId
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getErrorCode
+      methodPattern: com.amazonaws.AmazonServiceException getErrorCode()
       newMethodName: awsErrorDetails().errorCode
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getServiceName
+      methodPattern: com.amazonaws.AmazonServiceException getServiceName()
       newMethodName: awsErrorDetails().serviceName
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getErrorMessage
+      methodPattern: com.amazonaws.AmazonServiceException getErrorMessage()
       newMethodName: awsErrorDetails().errorMessage
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getStatusCode
+      methodPattern: com.amazonaws.AmazonServiceException getStatusCode()
       newMethodName: awsErrorDetails().sdkHttpResponse().statusCode
   ### TODO: v2 returns Map<String, List<String>>. Convert it to Map<String, String>
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getHttpHeaders
+      methodPattern: com.amazonaws.AmazonServiceException getHttpHeaders()
       newMethodName: awsErrorDetails().sdkHttpResponse().headers
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getRawResponse
+      methodPattern: com.amazonaws.AmazonServiceException getRawResponse()
       newMethodName: awsErrorDetails().rawResponse().asByteArray
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.AmazonServiceException getRawResponseContent
+      methodPattern: com.amazonaws.AmazonServiceException getRawResponseContent()
       newMethodName: awsErrorDetails().rawResponse().asUtf8String
   - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
-      methodPattern: com.amazonaws.AmazonServiceException getErrorType
+      methodPattern: com.amazonaws.AmazonServiceException getErrorType()
       comment: getErrorType is not supported in v2. AwsServiceException is a service error in v2. Consider removing it.
   - software.amazon.awssdk.migration.internal.recipe.AddCommentToMethod:
-      methodPattern: com.amazonaws.AmazonServiceException getProxyHost
+      methodPattern: com.amazonaws.AmazonServiceException getProxyHost()
       comment: getProxyHost is not supported in v2. Please submit a feature request https://github.com/aws/aws-sdk-java-v2/issues
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.amazonaws.AmazonServiceException


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Add `()` to method patterns in recipes to avoid warning logs:
`line 1:65 mismatched input '<EOF>' expecting {'(', '*'}`