### PR TITLE
Disallow no-op retry strategies

### DIFF
--- a/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
@@ -35,6 +35,7 @@ public final class DefaultRetryStrategy {
     public static StandardRetryStrategy doNotRetry() {
         return standardStrategyBuilder()
             .maxAttempts(1)
+            .retryOnException(t -> false)
             .build();
     }
 

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -45,7 +45,11 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkInternalApi
 public abstract class BaseRetryStrategy implements RetryStrategy {
-
+    private static final String EMPTY_RETRY_PREDICATES_ERROR = "The retry predicates are empty, this means that this retry "
+                                                               + "strategy will not retry ever. Please consider adding at least "
+                                                               + "one retry predicate, or using the preconfigured retry "
+                                                               + "strategies in the AwsRetryStrategy package, or add just one "
+                                                               + "predicate `t -> false` if you want to disable retries.";
     protected final Logger log;
     protected final List<Predicate<Throwable>> retryPredicates;
     protected final int maxAttempts;
@@ -58,7 +62,8 @@ public abstract class BaseRetryStrategy implements RetryStrategy {
 
     BaseRetryStrategy(Logger log, Builder builder) {
         this.log = log;
-        this.retryPredicates = Collections.unmodifiableList(Validate.paramNotNull(builder.retryPredicates, "retryPredicates"));
+        this.retryPredicates = Collections.unmodifiableList(Validate.notEmpty(builder.retryPredicates,
+                                                                              EMPTY_RETRY_PREDICATES_ERROR));
         this.maxAttempts = Validate.isPositive(builder.maxAttempts, "maxAttempts");
         this.circuitBreakerEnabled = builder.circuitBreakerEnabled == null || builder.circuitBreakerEnabled;
         this.backoffStrategy = Validate.paramNotNull(builder.backoffStrategy, "backoffStrategy");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This change disallows building retry strategies that does not have any retry predicate configured. This prevents people from using retry strategies that will not retry assuming that `StandardRetryStrategy.builder()` will create a preconfigured one.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
