### PR TITLE
S3 PutObject String overload

### DIFF
--- a/test/v2-migration-tests/src/test/resources/maven/after/src/main/java/foo/bar/Application.java
+++ b/test/v2-migration-tests/src/test/resources/maven/after/src/main/java/foo/bar/Application.java
@@ -100,4 +100,11 @@ public class Application {
 
         return result;
     }
+
+    private static PutObjectResponse uploadString(S3Client s3, String bucket, String key, String content) {
+        PutObjectResponse result = s3.putObject(PutObjectRequest.builder().bucket(bucket).key(key)
+            .build(), RequestBody.fromString(content));
+
+        return result;
+    }
 }

--- a/test/v2-migration-tests/src/test/resources/maven/before/src/main/java/foo/bar/Application.java
+++ b/test/v2-migration-tests/src/test/resources/maven/before/src/main/java/foo/bar/Application.java
@@ -94,4 +94,10 @@ public class Application {
 
         return result;
     }
+
+    private static PutObjectResult uploadString(AmazonS3 s3, String bucket, String key, String content) {
+        PutObjectResult result = s3.putObject(bucket, key, content);
+
+        return result;
+    }
 }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3StreamingRequestToV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3StreamingRequestToV2.java
@@ -94,6 +94,7 @@ public class S3StreamingRequestToV2 extends Recipe {
             Expression getObjectExpr = bucketAndKeyToPutObject(bucketExpr, keyExpr);
             newArgs.add(getObjectExpr);
 
+            // This is to maintain the formatting/spacing of original code, getPrefix() retrieves the leading whitespace
             Space stringArgPrefix = stringExpr.getPrefix();
             stringExpr = stringToRequestBody(stringExpr.withPrefix(Space.EMPTY)).withPrefix(stringArgPrefix);
             newArgs.add(stringExpr);

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3StreamingRequestToV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3StreamingRequestToV2.java
@@ -39,10 +39,13 @@ import software.amazon.awssdk.v2migration.internal.utils.IdentifierUtils;
 
 @SdkInternalApi
 public class S3StreamingRequestToV2 extends Recipe {
-    private static final MethodMatcher PUT_OBJECT =
+    private static final MethodMatcher PUT_OBJECT_FILE =
         new MethodMatcher("com.amazonaws.services.s3.AmazonS3 "
-                          + "putObject(java.lang.String, java.lang.String, java.io.File)",
-                          true);
+                          + "putObject(java.lang.String, java.lang.String, java.io.File)", true);
+    private static final MethodMatcher PUT_OBJECT_STRING =
+        new MethodMatcher("com.amazonaws.services.s3.AmazonS3 "
+                          + "putObject(java.lang.String, java.lang.String, java.lang.String)", true);
+
     private static final JavaType.FullyQualified V1_PUT_OBJECT_REQUEST =
         TypeUtils.asFullyQualified(JavaType.buildType("com.amazonaws.services.s3.model.PutObjectRequest"));
     private static final JavaType.FullyQualified REQUEST_BODY =
@@ -66,10 +69,76 @@ public class S3StreamingRequestToV2 extends Recipe {
     private static final class Visitor extends JavaIsoVisitor<ExecutionContext> {
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
-            if (PUT_OBJECT.matches(method, false)) {
+            if (PUT_OBJECT_FILE.matches(method, false)) {
                 method = transformPutFileOverload(method);
             }
+            if (PUT_OBJECT_STRING.matches(method, false)) {
+                method = transformPutStringOverload(method);
+            }
             return super.visitMethodInvocation(method, executionContext);
+        }
+
+        private J.MethodInvocation transformPutStringOverload(J.MethodInvocation method) {
+            JavaType.Method methodType = method.getMethodType();
+            if (methodType == null) {
+                return method;
+            }
+
+            List<Expression> originalArgs = method.getArguments();
+
+            Expression bucketExpr = originalArgs.get(0);
+            Expression keyExpr = originalArgs.get(1);
+            Expression stringExpr = originalArgs.get(2);
+
+            List<Expression> newArgs = new ArrayList<>();
+            Expression getObjectExpr = bucketAndKeyToPutObject(bucketExpr, keyExpr);
+            newArgs.add(getObjectExpr);
+
+            Space stringArgPrefix = stringExpr.getPrefix();
+            stringExpr = stringToRequestBody(stringExpr.withPrefix(Space.EMPTY)).withPrefix(stringArgPrefix);
+            newArgs.add(stringExpr);
+
+            List<String> paramNames = Arrays.asList("request", "stringContent");
+            List<JavaType> paramTypes = newArgs.stream()
+                                               .map(Expression::getType)
+                                               .collect(Collectors.toList());
+
+
+            methodType = methodType.withParameterTypes(paramTypes)
+                                   .withParameterNames(paramNames);
+
+            return method.withMethodType(methodType).withArguments(newArgs);
+        }
+
+        private J.MethodInvocation stringToRequestBody(Expression fileExpr) {
+            maybeAddImport(REQUEST_BODY);
+
+            J.Identifier requestBodyId = IdentifierUtils.makeId(REQUEST_BODY.getClassName(), REQUEST_BODY);
+
+            JavaType.Method fromStringType = new JavaType.Method(
+                null,
+                0L,
+                REQUEST_BODY,
+                "fromString",
+                REQUEST_BODY,
+                Collections.singletonList("stringContent"),
+                Collections.singletonList(JavaType.buildType("java.lang.String")),
+                null,
+                null
+            );
+
+            J.Identifier fromFileId = IdentifierUtils.makeId("fromString", fromStringType);
+
+            return new J.MethodInvocation(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                JRightPadded.build(requestBodyId),
+                null,
+                fromFileId,
+                JContainer.build(Collections.singletonList(JRightPadded.build(fileExpr))),
+                fromStringType
+            );
         }
 
         private J.MethodInvocation transformPutFileOverload(J.MethodInvocation method) {

--- a/v2-migration/src/test/java/software/amazon/awssdk/v2migration/S3StreamingRequestToV2Test.java
+++ b/v2-migration/src/test/java/software/amazon/awssdk/v2migration/S3StreamingRequestToV2Test.java
@@ -38,7 +38,7 @@ public class S3StreamingRequestToV2Test implements RewriteTest {
 
     @Test
     @EnabledOnJre({JRE.JAVA_8})
-    public void testS3PutObjectOverrideRewrite() {
+    public void testS3PutObjectOverrideRewrite_file() {
         rewriteRun(
             java(
                 "import com.amazonaws.services.s3.AmazonS3Client;\n"
@@ -73,6 +73,47 @@ public class S3StreamingRequestToV2Test implements RewriteTest {
                 + "        File myFile = new File(\"test.txt\");\n"
                 + "\n"
                 + "        s3.putObject(new PutObjectRequest(BUCKET, KEY), RequestBody.fromFile(myFile));\n"
+                + "    }\n"
+                + "}"
+            )
+        );
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_8})
+    public void testS3PutObjectOverrideRewrite_string() {
+        rewriteRun(
+            java(
+                "import com.amazonaws.services.s3.AmazonS3Client;\n"
+                + "\n"
+                + "import java.io.File;\n"
+                + "\n"
+                + "public class S3PutObjectExample {\n"
+                + "    private static final String BUCKET = \"my-bucket\";\n"
+                + "    private static final String KEY = \"key\";\n"
+                + "    private static final String CONTENT = \"payload\";\n"
+                + "\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3Client s3 = null;\n"
+                + "\n"
+                + "        s3.putObject(BUCKET, KEY, CONTENT);\n"
+                + "    }\n"
+                + "}\n",
+                "import com.amazonaws.services.s3.AmazonS3Client;\n"
+                + "import com.amazonaws.services.s3.model.PutObjectRequest;\n"
+                + "import software.amazon.awssdk.core.sync.RequestBody;\n"
+                + "\n"
+                + "import java.io.File;\n"
+                + "\n"
+                + "public class S3PutObjectExample {\n"
+                + "    private static final String BUCKET = \"my-bucket\";\n"
+                + "    private static final String KEY = \"key\";\n"
+                + "    private static final String CONTENT = \"payload\";\n"
+                + "\n"
+                + "    public static void main(String[] args) {\n"
+                + "        AmazonS3Client s3 = null;\n"
+                + "\n"
+                + "        s3.putObject(new PutObjectRequest(BUCKET, KEY), RequestBody.fromString(CONTENT));\n"
                 + "    }\n"
                 + "}"
             )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Transforming `putObject` overload for String payload:
`putObject(String bucketName, String key, String content)`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit and end-to-end tests
