### PR TITLE
Fixed an issue in the SDK that caused UncheckedIOException to be thrown instead of /when …

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1e8d215.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1e8d215.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue in the SDK that caused `UncheckedIOException` to be thrown instead of `ApiCallTimeoutException`/`ApiCallAttemptTimeoutException` when API call/API call attempt timeout is breached."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptTimeoutTrackingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptTimeoutTrackingStage.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import static software.amazon.awssdk.core.internal.http.timers.TimerUtils.resolveTimeoutInMillis;
 import static software.amazon.awssdk.core.internal.http.timers.TimerUtils.timeSyncTaskIfNeeded;
-import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
@@ -35,12 +35,14 @@ import software.amazon.awssdk.core.internal.http.pipeline.RequestToResponsePipel
 import software.amazon.awssdk.core.internal.http.timers.SyncTimeoutTask;
 import software.amazon.awssdk.core.internal.http.timers.TimeoutTracker;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.utils.Logger;
 
 /**
  * Wrapper around a {@link RequestPipeline} to manage the api call attempt timeout feature.
  */
 @SdkInternalApi
 public final class ApiCallAttemptTimeoutTrackingStage<OutputT> implements RequestToResponsePipeline<OutputT> {
+    private static final Logger log = Logger.loggerFor(ApiCallAttemptTimeoutTrackingStage.class);
 
     private final RequestPipeline<SdkHttpFullRequest, Response<OutputT>> wrapped;
     private final Duration apiCallAttemptTimeout;
@@ -129,7 +131,10 @@ public final class ApiCallAttemptTimeoutTrackingStage<OutputT> implements Reques
      */
     private RuntimeException handleInterruptedException(RequestExecutionContext context, InterruptedException e) {
         if (e instanceof SdkInterruptedException) {
-            ((SdkInterruptedException) e).getResponseStream().ifPresent(r -> invokeSafely(r::close));
+            ((SdkInterruptedException) e).getResponseStream()
+                                         .ifPresent(r -> runAndLogError(log.logger(),
+                                                                        "Failed to close the response stream",
+                                                                        r::close));
         }
         if (context.apiCallAttemptTimeoutTracker().hasExecuted()) {
             // Clear the interrupt status

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptTimeoutTrackingStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptTimeoutTrackingStageTest.java
@@ -16,12 +16,18 @@
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.SCHEDULED_EXECUTOR_SERVICE;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -35,6 +41,9 @@ import software.amazon.awssdk.core.Response;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkRequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.SdkInterruptedException;
 import software.amazon.awssdk.core.http.NoopTestRequest;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
@@ -42,7 +51,10 @@ import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.http.timers.ApiCallTimeoutTracker;
 import software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndRequestTimerTestUtils;
 import software.amazon.awssdk.core.internal.http.timers.NoOpTimeoutTracker;
+import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import utils.ValidSdkObjects;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApiCallAttemptTimeoutTrackingStageTest {
@@ -55,6 +67,9 @@ public class ApiCallAttemptTimeoutTrackingStageTest {
 
     @Mock
     private ScheduledFuture scheduledFuture;
+
+    @Mock
+    private InputStream responseStream;
 
     private ApiCallAttemptTimeoutTrackingStage<Void> stage;
 
@@ -91,6 +106,18 @@ public class ApiCallAttemptTimeoutTrackingStageTest {
         assertThat(context.apiCallAttemptTimeoutTracker().hasExecuted()).isFalse();
     }
 
+    @Test
+    public void interruptedException_streamCloseFailed_shouldNotSurface() throws Exception {
+        SdkHttpFullResponse response = SdkHttpFullResponse.builder().content(AbortableInputStream.create(responseStream,
+                                                                                                         () -> {})).build();
+        when(timeoutExecutor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenReturn(scheduledFuture);
+        when(wrapped.execute(any(), any())).thenThrow(new SdkInterruptedException(response));
+        RequestExecutionContext context = requestContext(1);
+        doThrow(new IOException()).when(responseStream).close();
+        assertThatThrownBy(() -> stage.execute(ValidSdkObjects.sdkHttpFullRequest().build(), context))
+            .isInstanceOfAny(AbortedException.class);
+        verify(responseStream).close();
+    }
 
     private RequestExecutionContext requestContext(long timeout) {
         SdkRequestOverrideConfiguration.Builder configBuilder = SdkRequestOverrideConfiguration.builder();

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallTimeoutTrackingStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallTimeoutTrackingStageTest.java
@@ -19,12 +19,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,19 +44,26 @@ import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.SdkInterruptedException;
 import software.amazon.awssdk.core.http.NoopTestRequest;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndRequestTimerTestUtils;
+import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+import utils.ValidSdkObjects;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApiCallTimeoutTrackingStageTest {
 
     @Mock
     private RequestPipeline<SdkHttpFullRequest, Response<Void>> wrapped;
+
+    @Mock
+    private InputStream responseStream;
 
     private ApiCallTimeoutTrackingStage<Void> stage;
 
@@ -90,6 +104,19 @@ public class ApiCallTimeoutTrackingStageTest {
         stage.execute(mock(SdkHttpFullRequest.class), context);
         assertThat(context.apiCallTimeoutTracker().hasExecuted()).isFalse();
     }
+
+    @Test
+    public void timeoutException_streamCloseFailed_shouldNotSurface() throws Exception {
+        SdkHttpFullResponse response = SdkHttpFullResponse.builder().content(AbortableInputStream.create(responseStream,
+                                                                                                         () -> {})).build();
+        when(wrapped.execute(any(), any())).thenThrow(new SdkInterruptedException(response));
+        RequestExecutionContext context = requestContext(300);
+        doThrow(new IOException()).when(responseStream).close();
+        assertThatThrownBy(() -> stage.execute(ValidSdkObjects.sdkHttpFullRequest().build(), context))
+            .isInstanceOfAny(AbortedException.class);
+        verify(responseStream).close();
+    }
+
 
     @Test(expected = RuntimeException.class)
     public void nonTimerInterruption_RuntimeExceptionThrown_interruptFlagIsPreserved() throws Exception {


### PR DESCRIPTION
…API call/API call attempt timeout is breached

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Currently, if the configured API call attempt timeout is exceeded, the SDK will interrupt the thread and attempt to close the response stream if it's present, and if it fails to close the stream for some reason, `UncheckedIOException` will be surfaced (instead of `ApiCallTimeoutException`), which is a unretryable exception.

## Modifications
Updated the code to not throw exception if closing stream fails.

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
