### PR TITLE
Fixed an issue in the SDK that caused a generic  to be thrown instead…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-251ce10.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-251ce10.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue in the SDK that caused a generic `RuntimeException` to be thrown instead of `ApiCallTimeoutException`/`ApiCallAttemptTimeoutException` when API call/API call attempt timeout is breached."
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/ChecksumUtil.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/ChecksumUtil.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.Md5Checksu
 import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.SdkChecksum;
 import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.Sha1Checksum;
 import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.Sha256Checksum;
+import software.amazon.awssdk.utils.FunctionalUtils;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 @SdkInternalApi
@@ -85,13 +86,11 @@ public final class ChecksumUtil {
      * when it gets read.
      */
     public static void readAll(InputStream inputStream) {
-        try {
+        FunctionalUtils.invokeSafely(() -> {
             byte[] buffer = new byte[4096];
             while (inputStream.read(buffer) > -1) {
             }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not finish reading stream: ", e);
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
… of / when API call/API call attempt timeout is breached.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I found this issue while investigating a flaky test pasted below. The root cause is that if thread is interrupted while the SDK is reading from the stream in [ChecksumUtil](https://github.com/aws/aws-sdk-java-v2/blob/master/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/ChecksumUtil.java#L92), it will be caught there and a generic RuntimeException will be thrown

```
2024-07-29T21:08:25.1538259Z [INFO] Compiling 743 source files to /codebuild/output/src305860483/src/github.com/aws/aws-sdk-java-v2/services/config/target/classes
2024-07-29T21:08:25.1538675Z [INFO] Running software.amazon.awssdk.protocol.tests.timeout.CrtHttpClientApiCallTimeoutTest
2024-07-29T21:08:25.1539251Z 2024-07-29 21:08:15.956:INFO::main: Logging initialized @8237ms to org.eclipse.jetty.util.log.StdErrLog
2024-07-29T21:08:25.1540179Z [ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.599 s <<< FAILURE! -- in software.amazon.awssdk.protocol.tests.timeout.CrtHttpClientApiCallTimeoutTest
2024-07-29T21:08:25.1541252Z [ERROR] software.amazon.awssdk.protocol.tests.timeout.CrtHttpClientApiCallTimeoutTest.apiCallAttemptExceeded_shouldThrowApiCallAttemptTimeoutException -- Time elapsed: 1.543 s <<< FAILURE!
2024-07-29T21:08:25.1541368Z java.lang.AssertionError:
2024-07-29T21:08:25.1541380Z 
2024-07-29T21:08:25.1541548Z Expecting actual throwable to be an instance of:
2024-07-29T21:08:25.1541848Z   software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException
2024-07-29T21:08:25.1541945Z but was:
2024-07-29T21:08:25.1542171Z   java.lang.RuntimeException: Could not finish reading stream:
2024-07-29T21:08:25.1542645Z 	at software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.readAll(ChecksumUtil.java:93)
2024-07-29T21:08:25.1543170Z 	at software.amazon.awssdk.http.auth.aws.internal.signer.FlexibleChecksummer.checksum(FlexibleChecksummer.java:66)
2024-07-29T21:08:25.1543730Z 	at software.amazon.awssdk.http.auth.aws.internal.signer.DefaultAwsV4HttpSigner.doSign(DefaultAwsV4HttpSigner.java:265)
2024-07-29T21:08:25.1544248Z 	...(120 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
2024-07-29T21:08:25.1545156Z 	at 
```

## Modifications
Use `invokeSafely` to handle the exception

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
