### PR TITLE
Increase HTTP test suite wiremock rule creation max attempts to fix f…

### DIFF
--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
@@ -363,7 +363,7 @@ public abstract class SdkHttpClientTestSuite {
     }
 
     private WireMockRule createWireMockRule() {
-        int maxAttempts = 5;
+        int maxAttempts = 10;
         for (int i = 0; i < maxAttempts; ++i) {
             try {
                 return new WireMockRule(wireMockConfig().dynamicPort()


### PR DESCRIPTION
…laky tests

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Reduce flakiness by increasing max attempts

```
2024-07-30T22:54:04.1007250Z [ERROR] Tests run: 17, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.536 s <<< FAILURE! -- in software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClientWireMockTest
2024-07-30T22:54:04.1008943Z [ERROR] software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClientWireMockTest.testCustomTlsTrustManager -- Time elapsed: 0.039 s <<< ERROR!
2024-07-30T22:54:04.1010386Z com.github.tomakehurst.wiremock.common.FatalStartupException: java.lang.RuntimeException: java.io.IOException: Failed to bind to /0.0.0.0:8080
2024-07-30T22:54:04.1011438Z 	at com.github.tomakehurst.wiremock.WireMockServer.start(WireMockServer.java:157)
2024-07-30T22:54:04.1012409Z 	at software.amazon.awssdk.http.SdkHttpClientTestSuite.testCustomTlsTrustManager(SdkHttpClientTestSuite.java:186)
2024-07-30T22:54:04.1013501Z 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
2024-07-30T22:54:04.1014301Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
2024-07-30T22:54:04.1015001Z 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(Fr
```
