### PR TITLE
Fix flaky tests

### DIFF
--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/HttpTestUtils.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/HttpTestUtils.java
@@ -50,6 +50,7 @@ public class HttpTestUtils {
         URL selfSignedJks = SdkHttpClientTestSuite.class.getResource("/selfSigned.jks");
 
         return new WireMockServer(wireMockConfig()
+                                      .dynamicPort()
                                       .dynamicHttpsPort()
                                       .keystorePath(selfSignedJks.toString())
                                       .keystorePassword("changeit")


### PR DESCRIPTION
Fix the following flaky tests.

It doesn't have http port configured, so it will always attempt to use 8080
```
2024-07-31T23:33:09.2801024Z 23:32:38.658 [main] DEBUG software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - Accepting a server certificate: CN=Tom Akehurst, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown
2024-07-31T23:33:09.2802863Z [ERROR] Tests run: 17, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.521 s <<< FAILURE! -- in software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClientWireMockTest
2024-07-31T23:33:09.2804492Z [ERROR] software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClientWireMockTest.testCustomTlsTrustManager -- Time elapsed: 0.030 s <<< ERROR!
2024-07-31T23:33:09.2805927Z com.github.tomakehurst.wiremock.common.FatalStartupException: java.lang.RuntimeException: java.io.IOException: Failed to bind to /0.0.0.0:8080
2024-07-31T23:33:09.2806980Z 	at com.github.tomakehurst.wiremock.WireMockServer.start(WireMockServer.java:157)
2024-07-31T23:33:09.2807944Z 	at software.amazon.awssdk.http.SdkHttpClientTestSuite.testCustomTlsTrustManager(SdkHttpClientTestSuite.java:186)
2024-07-31T23:33:09.2808906Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2024-07-31T23:33:09.2809891Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2024-07-31T23:33:09.2810906Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2024-07-31T23:33:09.2811718Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2024-07-31T23:33:09.2812406Z 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
2024-07-31T23:33:09.2813235Z 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
```