### PR TITLE
Prevent multipart download from hanging

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
@@ -123,12 +123,10 @@ public class SplittingTransformer<ResponseT, ResultT> implements SdkPublisher<As
             maximumBufferSizeInBytes, "maximumBufferSizeInBytes");
 
         this.resultFuture.whenComplete((r, e) -> {
-            log.trace(() -> "result future whenComplete");
             if (e == null) {
                 return;
             }
             if (isCancelled.compareAndSet(false, true)) {
-                log.trace(() -> "result future whenComplete with isCancelled=true");
                 handleFutureCancel(e);
             }
         });
@@ -171,7 +169,6 @@ public class SplittingTransformer<ResponseT, ResultT> implements SdkPublisher<As
         public void cancel() {
             log.trace(() -> String.format("received cancel signal. Current cancel state is 'isCancelled=%s'", isCancelled.get()));
             if (isCancelled.compareAndSet(false, true)) {
-                log.trace(() -> "Cancelling splitting transformer");
                 handleSubscriptionCancel();
             }
         }
@@ -221,20 +218,17 @@ public class SplittingTransformer<ResponseT, ResultT> implements SdkPublisher<As
             }
             if (!onStreamCalled.get()) {
                 // we never subscribe publisherToUpstream to the upstream, it would not complete
-                log.trace(() -> "publisherToUpstream never subscribed, skipping downstreamSubscriber.onComplete()");
                 downstreamSubscriber = null;
                 return;
             }
-            log.trace(() -> "publisherToUpstream.complete()");
             publisherToUpstream.complete().whenComplete((v, t) -> {
                 if (downstreamSubscriber == null) {
-                    log.trace(() -> "[in future] downstreamSubscriber already null, skipping downstreamSubscriber.onComplete()");
                     return;
                 }
                 if (t != null) {
                     downstreamSubscriber.onError(t);
                 } else {
-                    log.trace(() -> "[in future] calling downstreamSubscriber.onComplete");
+                    log.trace(() -> "calling downstreamSubscriber.onComplete()");
                     downstreamSubscriber.onComplete();
                 }
                 downstreamSubscriber = null;
@@ -289,7 +283,6 @@ public class SplittingTransformer<ResponseT, ResultT> implements SdkPublisher<As
             });
             individualFuture.whenComplete((r, e) -> {
                 if (isCancelled.get()) {
-                    log.trace(() -> "Individual future completed .");
                     handleSubscriptionCancel();
                 }
             });

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloaderSubscriber.java
@@ -69,8 +69,6 @@ public class MultipartDownloaderSubscriber implements Subscriber<AsyncResponseTr
      */
     private final CompletableFuture<Void> future = new CompletableFuture<>();
 
-    private final Object lock = new Object();
-
     /**
      * The etag of the object being downloaded.
      */
@@ -88,7 +86,6 @@ public class MultipartDownloaderSubscriber implements Subscriber<AsyncResponseTr
 
     @Override
     public void onSubscribe(Subscription s) {
-        log.trace(() -> "onSubscribe");
         if (this.subscription != null) {
             s.cancel();
             return;
@@ -99,7 +96,6 @@ public class MultipartDownloaderSubscriber implements Subscriber<AsyncResponseTr
 
     @Override
     public void onNext(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> asyncResponseTransformer) {
-        log.trace(() -> String.format("onNext, completed part = %d", completedParts.get()));
         if (asyncResponseTransformer == null) {
             subscription.cancel();
             throw new NullPointerException("onNext must not be called with null asyncResponseTransformer");
@@ -110,7 +106,6 @@ public class MultipartDownloaderSubscriber implements Subscriber<AsyncResponseTr
         if (totalParts != null && nextPartToGet > totalParts) {
             log.debug(() -> String.format("Completing multipart download after a total of %d parts downloaded.", totalParts));
             subscription.cancel();
-            log.trace(() -> "Cancel complete");
             return;
         }
 
@@ -153,12 +148,10 @@ public class MultipartDownloaderSubscriber implements Subscriber<AsyncResponseTr
         }
 
         if (totalParts != null && totalParts > 1 && totalComplete < totalParts) {
-            log.trace(() -> "requesting more because totalParts=" + totalParts + " and totalComplete=" + totalComplete);
             subscription.request(1);
         } else {
             log.debug(() -> String.format("Completing multipart download after a total of %d parts downloaded.", totalParts));
             subscription.cancel();
-            log.trace(() -> "Cancel complete");
         }
     }
 


### PR DESCRIPTION
On single part download, s3 multipart client could hang and never terminates. This is the fix for that issue.

The culprit was the call to `logMulitpartComplete()`, when calling this method inside a synchronized block, the call to `log.debug()` within it would hang. The exact reason for the debug log call method to block is still uncertain. 

To prevent this issue, the synchronized block was remove as it was redundant. The call to `cancel()` is already synchronized in the publisher the multipart Subscriber subscribes to, and the call to `request()` already enforce mutual exclusion in the publisher through atomic booleans.