### PR TITLE
Support for operation without input defined

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddEmptyInputShape.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddEmptyInputShape.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.codegen;
 
-import static software.amazon.awssdk.codegen.internal.Utils.createInputShapeMarshaller;
+import static software.amazon.awssdk.codegen.internal.Utils.createSyntheticInputShapeMarshaller;
 import static software.amazon.awssdk.codegen.internal.Utils.unCapitalize;
 
 import java.util.HashMap;
@@ -75,7 +75,7 @@ final class AddEmptyInputShape implements IntermediateModelShapeProcessor {
                 shape.setVariable(inputVariable);
 
                 shape.setMarshaller(
-                        createInputShapeMarshaller(serviceModel.getMetadata(), operation));
+                        createSyntheticInputShapeMarshaller(serviceModel.getMetadata(), operation));
 
                 emptyInputShapes.put(inputShape, shape);
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DefaultProtocolMetadataConstants.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DefaultProtocolMetadataConstants.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.utils.AttributeMap;
 /**
  * Default implementation of {@link ProtocolMetadataConstants}.
  */
-public class DefaultProtocolMetadataConstants implements ProtocolMetadataConstants {
+public final class DefaultProtocolMetadataConstants implements ProtocolMetadataConstants {
     private final Set<Map.Entry<Class<?>, OperationMetadataAttribute<?>>> knownKeys = new LinkedHashSet<>();
     private final AttributeMap.Builder map = AttributeMap.builder();
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DefaultProtocolMetadataConstants.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DefaultProtocolMetadataConstants.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.internal;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.protocols.core.OperationMetadataAttribute;
+import software.amazon.awssdk.utils.AttributeMap;
+
+/**
+ * Default implementation of {@link ProtocolMetadataConstants}.
+ */
+public class DefaultProtocolMetadataConstants implements ProtocolMetadataConstants {
+    private final Set<Map.Entry<Class<?>, OperationMetadataAttribute<?>>> knownKeys = new LinkedHashSet<>();
+    private final AttributeMap.Builder map = AttributeMap.builder();
+
+    @Override
+    public List<Map.Entry<Class<?>, OperationMetadataAttribute<?>>> keys() {
+        return knownKeys.stream().filter(x -> map.get(x.getValue()) != null).collect(Collectors.toList());
+    }
+
+    @Override
+    public <T> T put(Class<?> containingClass, OperationMetadataAttribute<T> key, T value) {
+        knownKeys.add(new AbstractMap.SimpleEntry<>(containingClass, key));
+        T oldValue = map.get(key);
+        map.put(key, value);
+        return oldValue;
+    }
+
+    @Override
+    public <T> T get(OperationMetadataAttribute<T> key) {
+        return map.get(key);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataConstants.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataConstants.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.internal;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.protocols.core.OperationMetadataAttribute;
+
+/**
+ * Keeps the set of {@link OperationMetadataAttribute} constants attributes per operation/protocol. This is used to codegen
+ * those constant values.
+ */
+public interface ProtocolMetadataConstants {
+
+    /**
+     * Returns the list of keys sets. The {@link Map.Entry} contains as key the class containing the key field and the value
+     * contains the key constant itself. The class is needed to properly codegen a reference to the key.
+     * @return
+     */
+    List<Map.Entry<Class<?>, OperationMetadataAttribute<?>>> keys();
+
+    /**
+     * Adds an operation metadata to the set of constants.
+     */
+    <T> T put(Class<?> containingClass, OperationMetadataAttribute<T> key, T value);
+
+    /**
+     * Adds an operation metadata to the set of constants.
+     */
+    default <T> T put(OperationMetadataAttribute<T> key, T value) {
+        return put(key.getClass(), key, value);
+    }
+
+    /**
+     * Gets the constant value for the operation metadata key.
+     */
+    <T> T get(OperationMetadataAttribute<T> key);
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataDefault.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataDefault.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.internal;
+
+import software.amazon.awssdk.codegen.model.intermediate.Protocol;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeMarshaller;
+import software.amazon.awssdk.protocols.core.OperationMetadataAttribute;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
+import software.amazon.awssdk.utils.MapUtils;
+
+/**
+ * Enum that maps protocol to metadata attribute constants for a given operation.
+ */
+public enum ProtocolMetadataDefault {
+
+    SMITHY_RPC_V2_CBOR(Protocol.SMITHY_RPC_V2_CBOR) {
+        public ProtocolMetadataConstants protocolMetadata(ShapeMarshaller shapeMarshaller) {
+            ProtocolMetadataConstants attributes = new DefaultProtocolMetadataConstants();
+            // Smithy RPCv2 requires the header "smithy-protocol" with value "rpc-v2-cbor"
+            // See https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests.
+            attributes.put(OperationMetadataAttribute.HTTP_EXTRA_HEADERS, MapUtils.of("smithy-protocol",
+                                                                                      "rpc-v2-cbor"));
+            // If the shape is synthetic that means that no-input was defined in the model. For this
+            // case the protocol requires to send an empty body with no content-type. See
+            // https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests.
+            // To accomplish this we use a no-op JSON generator. Otherwise, we serialize the input
+            // even when no members are defined.
+            attributes.put(BaseAwsJsonProtocolFactory.class,
+                           BaseAwsJsonProtocolFactory.USE_NO_OP_GENERATOR,
+                           shapeMarshaller.getIsSynthetic());
+            return attributes;
+        }
+    },
+    DEFAULT(null);
+
+    private final Protocol protocol;
+
+    ProtocolMetadataDefault(Protocol protocol) {
+        this.protocol = protocol;
+    }
+
+    /**
+     * Returns a function that maps from a {@link ShapeMarshaller} to a set of protocol metadata constants that we codegen.
+     */
+    public ProtocolMetadataConstants protocolMetadata(ShapeMarshaller shapeMarshaller) {
+        return new DefaultProtocolMetadataConstants();
+    }
+
+    public static ProtocolMetadataDefault from(Protocol protocol) {
+        for (ProtocolMetadataDefault value : values()) {
+            if (value.protocol == protocol) {
+                return value;
+            }
+        }
+        return DEFAULT;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataDefault.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataDefault.java
@@ -29,10 +29,13 @@ public enum ProtocolMetadataDefault {
     SMITHY_RPC_V2_CBOR(Protocol.SMITHY_RPC_V2_CBOR) {
         public ProtocolMetadataConstants protocolMetadata(ShapeMarshaller shapeMarshaller) {
             ProtocolMetadataConstants attributes = new DefaultProtocolMetadataConstants();
+
             // Smithy RPCv2 requires the header "smithy-protocol" with value "rpc-v2-cbor"
             // See https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests.
-            attributes.put(OperationMetadataAttribute.HTTP_EXTRA_HEADERS, MapUtils.of("smithy-protocol",
-                                                                                      "rpc-v2-cbor"));
+            attributes.put(BaseAwsJsonProtocolFactory.class,
+                           BaseAwsJsonProtocolFactory.HTTP_EXTRA_HEADERS,
+                           MapUtils.of("smithy-protocol", "rpc-v2-cbor"));
+
             // If the shape is synthetic that means that no-input was defined in the model. For this
             // case the protocol requires to send an empty body with no content-type. See
             // https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests.

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataDefault.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ProtocolMetadataDefault.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.codegen.internal;
 
 import software.amazon.awssdk.codegen.model.intermediate.Protocol;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeMarshaller;
-import software.amazon.awssdk.protocols.core.OperationMetadataAttribute;
 import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
 import software.amazon.awssdk.utils.MapUtils;
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Utils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Utils.java
@@ -29,7 +29,6 @@ import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MapModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.Metadata;
-import software.amazon.awssdk.codegen.model.intermediate.Protocol;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeMarshaller;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeType;
@@ -335,7 +334,7 @@ public final class Utils {
                 .withAction(operation.getName())
                 .withVerb(operation.getHttp().getMethod())
                 .withRequestUri(operation.getHttp().getRequestUri())
-                .withSmithyProtocol(getSmithyProtocol(service.getProtocol()));
+                .withProtocol(service.getProtocol());
         Input input = operation.getInput();
         if (input != null) {
             marshaller.setLocationName(input.getLocationName());
@@ -354,12 +353,13 @@ public final class Utils {
 
     }
 
-    private static String getSmithyProtocol(String protocol) {
-        switch (Protocol.fromValue(protocol)) {
-            case SMITHY_RPC_V2_CBOR:
-                return "rpc-v2-cbor";
-            default:
-                return null;
-        }
+    /**
+     * Create the ShapeMarshaller to the input shape from the specified Operation.
+     * The input shape in the operation could be empty.
+     */
+    public static ShapeMarshaller createSyntheticInputShapeMarshaller(ServiceMetadata service, Operation operation) {
+        ShapeMarshaller result = createInputShapeMarshaller(service, operation);
+        result.withIsSynthetic(true);
+        return result;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeMarshaller.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeMarshaller.java
@@ -29,7 +29,9 @@ public class ShapeMarshaller {
 
     private String xmlNameSpaceUri;
 
-    private String smithyProtocol;
+    private Boolean isSynthetic = Boolean.FALSE;
+
+    private String protocol;
 
     public String getAction() {
         return action;
@@ -109,16 +111,29 @@ public class ShapeMarshaller {
         return this;
     }
 
-    public String getSmithyProtocol() {
-        return smithyProtocol;
+    public Boolean getIsSynthetic() {
+        return isSynthetic;
     }
 
-    public void setSmithyProtocol(String smithyProtocol) {
-        this.smithyProtocol = smithyProtocol;
+    public void setIsSynthetic(Boolean isSynthetic) {
+        this.isSynthetic = isSynthetic;
     }
 
-    public ShapeMarshaller withSmithyProtocol(String smithyProtocol) {
-        setSmithyProtocol(smithyProtocol);
+    public ShapeMarshaller withIsSynthetic(Boolean isSynthetic) {
+        setIsSynthetic(isSynthetic);
+        return this;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public ShapeMarshaller withProtocol(String protocol) {
+        setProtocol(protocol);
         return this;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/CodegenSerializer.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/CodegenSerializer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.transform.protocols;
+
+import com.squareup.javapoet.CodeBlock;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.utils.MapUtils;
+
+/**
+ * Encapsulates the codegen serialization logic for the given value.
+ */
+public interface CodegenSerializer<T> {
+    /**
+     * Creates a codegen serialization for the given value using the {@link CodeBlock.Builder}.
+     */
+    void serialize(T value, CodeBlock.Builder builder);
+
+    /**
+     * Codegen for String values.
+     */
+    class CodegenStringSerializer implements CodegenSerializer<String> {
+
+        @Override
+        public void serialize(String value, CodeBlock.Builder builder) {
+            builder.add("$S", value);
+        }
+    }
+
+    /**
+     * Codegen for literal values.
+     */
+    class CodegenLiteralSerializer implements CodegenSerializer<Object> {
+
+        @Override
+        public void serialize(Object value, CodeBlock.Builder builder) {
+            builder.add("$L", value);
+        }
+    }
+
+    /**
+     * Codegen for List values. Serialized as {@code Arrays.asList(v0, ⋯, vn)}.
+     */
+    class CodegenListSerializer implements CodegenSerializer<List<?>> {
+        private final CodegenSerializerResolver resolver;
+
+        public CodegenListSerializer(CodegenSerializerResolver resolver) {
+            this.resolver = resolver;
+        }
+
+        @Override
+        public void serialize(List<?> list, CodeBlock.Builder builder) {
+            builder.add("$T.asList(", Arrays.class);
+            boolean needsComma = false;
+            for (Object value : list) {
+                if (needsComma) {
+                    builder.add(", ");
+                }
+                CodegenSerializer<Object> serializer = resolver.serializerFor(value);
+                serializer.serialize(value, builder);
+                needsComma = true;
+            }
+            builder.add(")");
+        }
+    }
+
+
+    /**
+     * Codegen for Map values. Serialized as {@code MapUtils.of(k0, v0, ⋯, kn, vn)}. This only works for a small amount of
+     * key-value pairs, up to seven.
+     */
+    class CodegenMapSerializer implements CodegenSerializer<Map<?, ?>> {
+        private final CodegenSerializerResolver resolver;
+
+        public CodegenMapSerializer(CodegenSerializerResolver resolver) {
+            this.resolver = resolver;
+        }
+
+        @Override
+        public void serialize(Map<?, ?> map, CodeBlock.Builder builder) {
+            builder.add("$T.of(", MapUtils.class);
+            boolean needsComma = false;
+            for (Map.Entry<?, ?> kvp : map.entrySet()) {
+                if (needsComma) {
+                    builder.add(", ");
+                }
+                Object key = kvp.getKey();
+                CodegenSerializer<Object> keySerializer = resolver.serializerFor(key);
+                keySerializer.serialize(key, builder);
+                builder.add(", ");
+                Object value = kvp.getValue();
+                CodegenSerializer<Object> valueSerializer = resolver.serializerFor(value);
+                valueSerializer.serialize(value, builder);
+                needsComma = true;
+            }
+            builder.add(")");
+        }
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/CodegenSerializerResolver.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/CodegenSerializerResolver.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.transform.protocols;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves {@link CodegenSerializer} for a given instance.
+ */
+public interface CodegenSerializerResolver {
+
+    CodegenSerializerResolver DEFAULT = new CodegenSerializerResolver() {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> CodegenSerializer<T> serializerFor(T value) {
+            if (value == null) {
+                throw new NullPointerException("value");
+            }
+            Class<?> xclass = value.getClass();
+            if (xclass == String.class) {
+                return (CodegenSerializer<T>) new CodegenSerializer.CodegenStringSerializer();
+            }
+            if (List.class.isAssignableFrom(xclass)) {
+                return (CodegenSerializer<T>) new CodegenSerializer.CodegenListSerializer(this);
+            }
+            if (Map.class.isAssignableFrom(xclass)) {
+                return (CodegenSerializer<T>) new CodegenSerializer.CodegenMapSerializer(this);
+            }
+            return (CodegenSerializer<T>) new CodegenSerializer.CodegenLiteralSerializer();
+        }
+    };
+
+    static CodegenSerializerResolver getDefault() {
+        return DEFAULT;
+    }
+
+    /**
+     * Returns a proper codegen serializer for the given value.
+     */
+    <T> CodegenSerializer<T> serializerFor(T value);
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/JsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/JsonMarshallerSpec.java
@@ -24,8 +24,12 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.codegen.internal.ProtocolMetadataConstants;
+import software.amazon.awssdk.codegen.internal.ProtocolMetadataDefault;
+import software.amazon.awssdk.codegen.model.intermediate.Protocol;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
@@ -99,16 +103,24 @@ public class JsonMarshallerSpec implements MarshallerProtocolSpec {
                                       .add(".hasImplicitPayloadMembers($L)", shapeModel.hasImplicitPayloadMembers())
                                       .add(".hasPayloadMembers($L)", shapeModel.hasPayloadMembers());
 
+
         if (StringUtils.isNotBlank(shapeModel.getMarshaller().getTarget())) {
             initializationCodeBlockBuilder.add(".operationIdentifier($S)", shapeModel.getMarshaller().getTarget());
         }
 
-        String smithyProtocol = shapeModel.getMarshaller().getSmithyProtocol();
-        if (StringUtils.isNotBlank(smithyProtocol)) {
-            initializationCodeBlockBuilder.add(".putAdditionalMetadata($T.SMITHY_PROTOCOL, $S)",
-                                               OperationMetadataAttribute.class, smithyProtocol);
+        String protocol = shapeModel.getMarshaller().getProtocol();
+        ProtocolMetadataConstants metadataConstants = ProtocolMetadataDefault.from(Protocol.fromValue(protocol))
+                                                                             .protocolMetadata(shapeModel.getMarshaller());
+        List<Map.Entry<Class<?>, OperationMetadataAttribute<?>>> keys = metadataConstants.keys();
+        for (Map.Entry<Class<?>, OperationMetadataAttribute<?>> kvp : keys) {
+            initializationCodeBlockBuilder.add(".putAdditionalMetadata($T.$L, ",
+                                               ClassName.get(kvp.getKey()),
+                                               fieldName(kvp.getKey(), kvp.getValue()));
+            Object value = metadataConstants.get(kvp.getValue());
+            CodegenSerializer<Object> serializer = CodegenSerializerResolver.getDefault().serializerFor(value);
+            serializer.serialize(value, initializationCodeBlockBuilder);
+            initializationCodeBlockBuilder.add(")");
         }
-
 
         if (shapeModel.isHasStreamingMember()) {
             initializationCodeBlockBuilder.add(".hasStreamingInput(true)");
@@ -124,5 +136,41 @@ public class JsonMarshallerSpec implements MarshallerProtocolSpec {
                         .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
                         .initializer(codeBlock)
                         .build();
+    }
+
+
+    /**
+     * This method resolves a static reference to its name, for instance, when called with
+     * <pre>
+     * fieldName(AwsClientOption.class, AwsClientOption.AWS_REGION)
+     * </pre>
+     * it will return the string "AWS_REGION" that we can use for codegen. Using the value directly avoid typo bugs and allows the
+     * compiler and the IDE to know about this relationship.
+     * <p>
+     * This method uses the fully qualified names in the reflection package to avoid polluting this class imports. Adapted from
+     * https://stackoverflow.com/a/35416606
+     */
+    private static String fieldName(Class<?> containingClass, Object fieldObject) {
+        java.lang.reflect.Field[] allFields = containingClass.getFields();
+        for (java.lang.reflect.Field field : allFields) {
+            int modifiers = field.getModifiers();
+            if (!java.lang.reflect.Modifier.isStatic(modifiers)) {
+                continue;
+            }
+            Object currentFieldObject;
+            try {
+                // For static fields you can pass a null to get back its value.
+                currentFieldObject = field.get(null);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(e);
+            }
+            boolean isWantedField = fieldObject.equals(currentFieldObject);
+            if (isWantedField) {
+                return field.getName();
+            }
+        }
+        throw new java.util.NoSuchElementException(String.format("cannot find constant %s in class %s",
+                                                                 fieldObject,
+                                                                 fieldObject.getClass().getName()));
     }
 }

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
@@ -52,16 +52,15 @@ import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
 
 @SdkProtectedApi
 public abstract class BaseAwsJsonProtocolFactory {
+    /**
+     * Used by operations that do not serialize the input, e.g., when the input is not defined in the model. RPCv2 uses it.
+     */
+    public static final OperationMetadataAttribute<Boolean> USE_NO_OP_GENERATOR = new OperationMetadataAttribute<>(Boolean.class);
 
     /**
      * Content type resolver implementation for plain text AWS_JSON services.
      */
     protected static final JsonContentTypeResolver AWS_JSON = new DefaultJsonContentTypeResolver("application/x-amz-json-");
-
-    /**
-     * Used by operations that do not serialize the input, e.g., when the input is not defined in the model. RPCv2 uses it.
-     */
-    public static final OperationMetadataAttribute<Boolean> USE_NO_OP_GENERATOR = new OperationMetadataAttribute<>(Boolean.class);
 
     private final AwsJsonProtocolMetadata protocolMetadata;
     private final List<ExceptionMetadata> modeledExceptions;

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
@@ -152,7 +152,7 @@ public abstract class BaseAwsJsonProtocolFactory {
         Boolean useNoOp = operationInfo.addtionalMetadata(USE_NO_OP_GENERATOR);
         if (useNoOp == null) {
             AwsJsonProtocol protocol = protocolMetadata.protocol();
-            useNoOp = !(operationInfo.hasPayloadMembers() || protocol == AwsJsonProtocol.AWS_JSON);
+            useNoOp = !operationInfo.hasPayloadMembers() && protocol != AwsJsonProtocol.AWS_JSON;
         }
         if (useNoOp) {
             return StructuredJsonGenerator.NO_OP;

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
@@ -58,6 +58,12 @@ public abstract class BaseAwsJsonProtocolFactory {
     public static final OperationMetadataAttribute<Boolean> USE_NO_OP_GENERATOR = new OperationMetadataAttribute<>(Boolean.class);
 
     /**
+     * Attribute for a protocol to configure extra headers for the operation.
+     */
+    public static final OperationMetadataAttribute<Map<String, String>> HTTP_EXTRA_HEADERS =
+        OperationMetadataAttribute.forUnsafe(Map.class);
+
+    /**
      * Content type resolver implementation for plain text AWS_JSON services.
      */
     protected static final JsonContentTypeResolver AWS_JSON = new DefaultJsonContentTypeResolver("application/x-amz-json-");
@@ -144,8 +150,8 @@ public abstract class BaseAwsJsonProtocolFactory {
 
     private StructuredJsonGenerator createGenerator(OperationInfo operationInfo) {
         Boolean useNoOp = operationInfo.addtionalMetadata(USE_NO_OP_GENERATOR);
-        AwsJsonProtocol protocol = protocolMetadata.protocol();
         if (useNoOp == null) {
+            AwsJsonProtocol protocol = protocolMetadata.protocol();
             useNoOp = !(operationInfo.hasPayloadMembers() || protocol == AwsJsonProtocol.AWS_JSON);
         }
         if (useNoOp) {

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -167,9 +167,9 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
         if (operationIdentifier != null) {
             requestBuilder.putHeader("X-Amz-Target", operationIdentifier);
         }
-        String smithyProtocol = operationInfo.addtionalMetadata(OperationMetadataAttribute.SMITHY_PROTOCOL);
-        if (smithyProtocol != null) {
-            requestBuilder.putHeader("smithy-protocol", smithyProtocol);
+        Map<String, String> extraHeaders = operationInfo.addtionalMetadata(OperationMetadataAttribute.HTTP_EXTRA_HEADERS);
+        if (extraHeaders != null) {
+            extraHeaders.forEach(requestBuilder::putHeader);
         }
         return requestBuilder;
     }

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -39,12 +39,12 @@ import software.amazon.awssdk.core.traits.TimestampFormatTrait;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.protocols.core.InstantToString;
 import software.amazon.awssdk.protocols.core.OperationInfo;
-import software.amazon.awssdk.protocols.core.OperationMetadataAttribute;
 import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
 import software.amazon.awssdk.protocols.core.ProtocolUtils;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter.ValueToString;
 import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
 import software.amazon.awssdk.protocols.json.AwsJsonProtocolMetadata;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.StructuredJsonGenerator;
 
 /**
@@ -167,7 +167,7 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
         if (operationIdentifier != null) {
             requestBuilder.putHeader("X-Amz-Target", operationIdentifier);
         }
-        Map<String, String> extraHeaders = operationInfo.addtionalMetadata(OperationMetadataAttribute.HTTP_EXTRA_HEADERS);
+        Map<String, String> extraHeaders = operationInfo.addtionalMetadata(BaseAwsJsonProtocolFactory.HTTP_EXTRA_HEADERS);
         if (extraHeaders != null) {
             extraHeaders.forEach(requestBuilder::putHeader);
         }

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationMetadataAttribute.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationMetadataAttribute.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.protocols.core;
 
-import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.utils.AttributeMap;
 

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationMetadataAttribute.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationMetadataAttribute.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.protocols.core;
 
+import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -28,12 +29,16 @@ import software.amazon.awssdk.utils.AttributeMap;
 public final class OperationMetadataAttribute<T> extends AttributeMap.Key<T> {
 
     /**
-     * Attribute for configuring the <code>smithy-protocol</code> header.
+     * Attribute for a protocol to configure extra headers for the operation.
      */
-    public static final OperationMetadataAttribute<String> SMITHY_PROTOCOL =
-        new OperationMetadataAttribute<>(String.class);
+    public static final OperationMetadataAttribute<Map<String, String>> HTTP_EXTRA_HEADERS =
+        new OperationMetadataAttribute<>(new UnsafeValueType(Map.class));
 
     public OperationMetadataAttribute(Class<T> valueType) {
         super(valueType);
+    }
+
+    public OperationMetadataAttribute(UnsafeValueType type) {
+        super(type);
     }
 }

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationMetadataAttribute.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationMetadataAttribute.java
@@ -28,17 +28,21 @@ import software.amazon.awssdk.utils.AttributeMap;
 @SdkProtectedApi
 public final class OperationMetadataAttribute<T> extends AttributeMap.Key<T> {
 
-    /**
-     * Attribute for a protocol to configure extra headers for the operation.
-     */
-    public static final OperationMetadataAttribute<Map<String, String>> HTTP_EXTRA_HEADERS =
-        new OperationMetadataAttribute<>(new UnsafeValueType(Map.class));
-
     public OperationMetadataAttribute(Class<T> valueType) {
         super(valueType);
     }
 
-    public OperationMetadataAttribute(UnsafeValueType type) {
+    OperationMetadataAttribute(UnsafeValueType type) {
         super(type);
+    }
+
+    /**
+     * Useful for parameterized types.
+     *
+     * E.g.,
+     * {@code OperationMetadataAttribute<Map<String, String>> KEY = forUnsafe(Map.class)}
+     */
+    public static <T> OperationMetadataAttribute<T> forUnsafe(Class<?> valueClass) {
+        return new OperationMetadataAttribute<>(new UnsafeValueType(valueClass));
     }
 }

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/smithy-rpcv2-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/smithy-rpcv2-input.json
@@ -529,7 +529,10 @@
                     "contains": {
                         "Content-Type": "application/cbor",
                         "smithy-protocol": "rpc-v2-cbor"
-                    }
+                    },
+                    "doesNotContain": [
+                        "X-Amz-Target"
+                    ]
                 }
             }
         }
@@ -552,7 +555,10 @@
                     "contains": {
                         "Content-Type": "application/cbor",
                         "smithy-protocol": "rpc-v2-cbor"
-                    }
+                    },
+                    "doesNotContain": [
+                        "X-Amz-Target"
+                    ]
                 }
             }
         }
@@ -574,7 +580,11 @@
                 "headers": {
                     "contains": {
                         "smithy-protocol": "rpc-v2-cbor"
-                    }
+                    },
+                    "doesNotContain": [
+                        "Content-Type",
+                        "X-Amz-Target"
+                    ]
                 }
             }
         }

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/smithy-rpcv2-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/smithy-rpcv2-input.json
@@ -556,5 +556,27 @@
                 }
             }
         }
+    },
+    {
+        "description": "Body is empty and no Content-Type header if no input",
+        "given": {
+            "input": {}
+        },
+        "when": {
+            "action": "marshall",
+            "operation": "NoInputOutput"
+        },
+        "then": {
+            "serializedAs": {
+                "body": {
+                    "encodedEquals": ""
+                },
+                "headers": {
+                    "contains": {
+                        "smithy-protocol": "rpc-v2-cbor"
+                    }
+                }
+            }
+        }
     }
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

*NOTE* Codgen tests will be added in a follow up PR, this task is already tracked.

## Motivation and Context

Smithy RPCv2 protocol requires a different treatment for operations with empty input and not defined input. For not requests with no defined input types:

> Requests for operations with no defined input type (as in, they target the Unit shape) MUST NOT contain bodies in their HTTP requests. The Content-Type for the serialization format MUST NOT be set.

This change adds support for this requirement. 

1. Creates new `OperationMetadataAttribute` to control when to use a no-op JSON generator. This value can for this attribute key can be codegen per operation.
2. Changes the way we codegen `OperationInfo` to add metadata defaults
3. Reverts previously added, protocol specific, code to support adding the `smithy-header`, this is now implemented with a more generic way of adding extra headers.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications

For an operation without input the codegen marshaller now looks like:

```java
@Generated("software.amazon.awssdk:codegen")
@SdkInternalApi
public class NoInputOutputRequestMarshaller implements Marshaller<NoInputOutputRequest> {
    private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
            .requestUri("/service/RpcV2Protocol/operation/NoInputOutput").httpMethod(SdkHttpMethod.POST)
            .hasExplicitPayloadMember(false).hasImplicitPayloadMembers(false).hasPayloadMembers(false)
            .putAdditionalMetadata(BaseAwsJsonProtocolFactory.HTTP_EXTRA_HEADERS, MapUtils.of("smithy-protocol", "rpc-v2-cbor"))
            .putAdditionalMetadata(BaseAwsJsonProtocolFactory.USE_NO_OP_GENERATOR, true).build();

```

And an operation with defined input but without members, the marshaller gets codegen as

```java
@Generated("software.amazon.awssdk:codegen")
@SdkInternalApi
public class EmptyInputOutputRequestMarshaller implements Marshaller<EmptyInputOutputRequest> {
    private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
            .requestUri("/service/RpcV2Protocol/operation/EmptyInputOutput").httpMethod(SdkHttpMethod.POST)
            .hasExplicitPayloadMember(false).hasImplicitPayloadMembers(false).hasPayloadMembers(false)
            .putAdditionalMetadata(BaseAwsJsonProtocolFactory.HTTP_EXTRA_HEADERS, MapUtils.of("smithy-protocol", "rpc-v2-cbor"))
            .putAdditionalMetadata(BaseAwsJsonProtocolFactory.USE_NO_OP_GENERATOR, false).build();
```

A non-rpcv2 service will get its marshaller published as before, e.g.,

```java
@Generated("software.amazon.awssdk:codegen")
@SdkInternalApi
public class AllTypesRequestMarshaller implements Marshaller<AllTypesRequest> {
    private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().requestUri("/2016-03-11/allTypes")
            .httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false).hasImplicitPayloadMembers(true)
            .hasPayloadMembers(true).build();
```
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
