### PR TITLE
Avoid parsing numbers when using RPCv2 protocol

### DIFF
--- a/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/JsonNodeParser.java
+++ b/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/JsonNodeParser.java
@@ -25,12 +25,8 @@ import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.protocols.jsoncore.internal.ArrayJsonNode;
-import software.amazon.awssdk.protocols.jsoncore.internal.BooleanJsonNode;
 import software.amazon.awssdk.protocols.jsoncore.internal.EmbeddedObjectJsonNode;
-import software.amazon.awssdk.protocols.jsoncore.internal.NullJsonNode;
-import software.amazon.awssdk.protocols.jsoncore.internal.NumberJsonNode;
 import software.amazon.awssdk.protocols.jsoncore.internal.ObjectJsonNode;
-import software.amazon.awssdk.protocols.jsoncore.internal.StringJsonNode;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonFactory;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonParseException;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonParser;
@@ -55,10 +51,12 @@ public final class JsonNodeParser {
 
     private final boolean removeErrorLocations;
     private final JsonFactory jsonFactory;
+    private final JsonValueNodeFactory jsonValueNodeFactory;
 
     private JsonNodeParser(Builder builder) {
         this.removeErrorLocations = builder.removeErrorLocations;
         this.jsonFactory = builder.jsonFactory;
+        this.jsonValueNodeFactory = builder.jsonValueNodeFactory;
     }
 
     /**
@@ -144,16 +142,12 @@ public final class JsonNodeParser {
         }
         switch (token) {
             case VALUE_STRING:
-                return new StringJsonNode(parser.getText());
             case VALUE_FALSE:
-                return new BooleanJsonNode(false);
             case VALUE_TRUE:
-                return new BooleanJsonNode(true);
             case VALUE_NULL:
-                return NullJsonNode.instance();
             case VALUE_NUMBER_FLOAT:
             case VALUE_NUMBER_INT:
-                return new NumberJsonNode(parser.getText());
+                return jsonValueNodeFactory.node(parser, token);
             case START_OBJECT:
                 return parseObject(parser);
             case START_ARRAY:
@@ -191,6 +185,7 @@ public final class JsonNodeParser {
      */
     public static final class Builder {
         private JsonFactory jsonFactory = DEFAULT_JSON_FACTORY;
+        private JsonValueNodeFactory jsonValueNodeFactory = JsonValueNodeFactory.DEFAULT;
         private boolean removeErrorLocations = false;
 
         private Builder() {
@@ -218,6 +213,17 @@ public final class JsonNodeParser {
          */
         public Builder jsonFactory(JsonFactory jsonFactory) {
             this.jsonFactory = jsonFactory;
+            return this;
+        }
+
+        /**
+         * Factory to create JsonNode out of JSON tokens. This allows JSON variants, such as CBOR, to produce actual values
+         * instead of having to parse them out of strings.
+         *
+         * <p>By default, this is {@link JsonValueNodeFactory#DEFAULT}.
+         */
+        public Builder jsonValueNodeFactory(JsonValueNodeFactory jsonValueNodeFactory) {
+            this.jsonValueNodeFactory = jsonValueNodeFactory;
             return this;
         }
 

--- a/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/JsonValueNodeFactory.java
+++ b/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/JsonValueNodeFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.jsoncore;
+
+import java.io.IOException;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.protocols.jsoncore.internal.BooleanJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.EmbeddedObjectJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.NullJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.NumberJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.StringJsonNode;
+import software.amazon.awssdk.thirdparty.jackson.core.JsonParser;
+import software.amazon.awssdk.thirdparty.jackson.core.JsonToken;
+
+/**
+ * Parses JSON tokens into JsonNode's values. Used only for atomic values.
+ */
+@SdkProtectedApi
+public interface JsonValueNodeFactory {
+
+    /**
+     * Default implementation. Takes the tokens and returns JsonNode values based on its string representation.
+     */
+    JsonValueNodeFactory DEFAULT = (parser, token) -> {
+        switch (token) {
+            case VALUE_STRING:
+                return new StringJsonNode(parser.getText());
+            case VALUE_FALSE:
+                return new BooleanJsonNode(false);
+            case VALUE_TRUE:
+                return new BooleanJsonNode(true);
+            case VALUE_NULL:
+                return NullJsonNode.instance();
+            case VALUE_NUMBER_FLOAT:
+            case VALUE_NUMBER_INT:
+                return new NumberJsonNode(parser.getText());
+            case VALUE_EMBEDDED_OBJECT:
+                return new EmbeddedObjectJsonNode(parser.getEmbeddedObject());
+            default:
+                throw new IllegalArgumentException("Unexpected JSON token - " + token);
+        }
+    };
+
+    JsonNode node(JsonParser parser, JsonToken token) throws IOException;
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
@@ -50,6 +50,7 @@ import software.amazon.awssdk.protocols.json.internal.unmarshall.AwsJsonResponse
 import software.amazon.awssdk.protocols.json.internal.unmarshall.JsonProtocolUnmarshaller;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.JsonResponseHandler;
 import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
+import software.amazon.awssdk.protocols.jsoncore.JsonValueNodeFactory;
 
 @SdkProtectedApi
 public abstract class BaseAwsJsonProtocolFactory {
@@ -88,6 +89,7 @@ public abstract class BaseAwsJsonProtocolFactory {
             .builder()
             .parser(JsonNodeParser.builder()
                                   .jsonFactory(getSdkFactory().getJsonFactory())
+                                  .jsonValueNodeFactory(getJsonValueNodeFactory())
                                   .build())
             .defaultTimestampFormats(getDefaultTimestampFormats())
             .build();
@@ -177,6 +179,13 @@ public abstract class BaseAwsJsonProtocolFactory {
      */
     protected JsonContentTypeResolver getContentTypeResolver() {
         return AWS_JSON;
+    }
+
+    /**
+     * @return Default JsonNode value factory.
+     */
+    protected JsonValueNodeFactory getJsonValueNodeFactory() {
+        return JsonValueNodeFactory.DEFAULT;
     }
 
     /**

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/NumberToInstant.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/NumberToInstant.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.core;
+
+import java.time.Instant;
+import java.util.Map;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+
+/**
+ * Converts a number value to an {@link Instant} type. Respects the {@link TimestampFormatTrait} if present.
+ */
+@SdkProtectedApi
+public final class NumberToInstant {
+
+    /**
+     * Default formats for the given location.
+     */
+    private final Map<MarshallLocation, TimestampFormatTrait.Format> defaultFormats;
+    private final StringToInstant stringToInstant;
+
+    private NumberToInstant(Map<MarshallLocation, TimestampFormatTrait.Format> defaultFormats) {
+        this.stringToInstant = StringToInstant.create(defaultFormats);
+        this.defaultFormats = defaultFormats;
+    }
+
+    public Instant convert(Number value, SdkField<Instant> field) {
+        if (value == null) {
+            return null;
+        }
+        if (field.location() != MarshallLocation.PAYLOAD) {
+            return stringToInstant.convert(value.toString(), field);
+        }
+        TimestampFormatTrait.Format format = resolveTimestampFormat(field);
+        switch (format) {
+            case UNIX_TIMESTAMP:
+                return Instant.ofEpochMilli((long) (value.doubleValue() * 1_000d));
+            case UNIX_TIMESTAMP_MILLIS:
+                return Instant.ofEpochMilli(value.longValue());
+            default:
+                return stringToInstant.convert(value.toString(), field);
+        }
+    }
+
+    private TimestampFormatTrait.Format resolveTimestampFormat(SdkField<Instant> field) {
+        TimestampFormatTrait trait = field.getTrait(TimestampFormatTrait.class);
+        if (trait == null) {
+            TimestampFormatTrait.Format format = defaultFormats.get(field.location());
+            if (format == null) {
+                throw SdkClientException.create(
+                    String.format("Timestamps are not supported for this location (%s)", field.location()));
+            }
+            return format;
+        } else {
+            return trait.format();
+        }
+    }
+
+    /**
+     * @param defaultFormats Default formats for each {@link MarshallLocation} as defined by the protocol.
+     * @return New {@link StringToValueConverter.StringToValue} for {@link Instant} types.
+     */
+    public static NumberToInstant create(Map<MarshallLocation, TimestampFormatTrait.Format> defaultFormats) {
+        return new NumberToInstant(defaultFormats);
+    }
+}

--- a/core/protocols/smithy-rpcv2-protocol/pom.xml
+++ b/core/protocols/smithy-rpcv2-protocol/pom.xml
@@ -57,6 +57,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>json-utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/core/protocols/smithy-rpcv2-protocol/src/main/java/software/amazon/awssdk/protocols/rpcv2/SmithyRpcV2CborProtocolFactory.java
+++ b/core/protocols/smithy-rpcv2-protocol/src/main/java/software/amazon/awssdk/protocols/rpcv2/SmithyRpcV2CborProtocolFactory.java
@@ -24,6 +24,8 @@ import software.amazon.awssdk.core.traits.TimestampFormatTrait;
 import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.JsonContentTypeResolver;
 import software.amazon.awssdk.protocols.json.StructuredJsonFactory;
+import software.amazon.awssdk.protocols.jsoncore.JsonValueNodeFactory;
+import software.amazon.awssdk.protocols.rpcv2.internal.SdkRpcV2CborValueNodeFactory;
 import software.amazon.awssdk.protocols.rpcv2.internal.SdkStructuredRpcV2CborFactory;
 
 /**
@@ -63,6 +65,11 @@ public final class SmithyRpcV2CborProtocolFactory extends BaseAwsJsonProtocolFac
     @Override
     protected Map<MarshallLocation, TimestampFormatTrait.Format> getDefaultTimestampFormats() {
         return LazyHolder.DEFAULT_TIMESTAMP_FORMATS;
+    }
+
+    @Override
+    public JsonValueNodeFactory getJsonValueNodeFactory() {
+        return SdkRpcV2CborValueNodeFactory.INSTANCE;
     }
 
     public static Builder builder() {

--- a/core/protocols/smithy-rpcv2-protocol/src/main/java/software/amazon/awssdk/protocols/rpcv2/internal/SdkRpcV2CborValueNodeFactory.java
+++ b/core/protocols/smithy-rpcv2-protocol/src/main/java/software/amazon/awssdk/protocols/rpcv2/internal/SdkRpcV2CborValueNodeFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.rpcv2.internal;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.protocols.jsoncore.JsonValueNodeFactory;
+import software.amazon.awssdk.protocols.jsoncore.internal.EmbeddedObjectJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.NullJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.NumberJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.StringJsonNode;
+import software.amazon.awssdk.thirdparty.jackson.core.JsonParser;
+import software.amazon.awssdk.thirdparty.jackson.core.JsonToken;
+import software.amazon.awssdk.thirdparty.jackson.dataformat.cbor.CBORParser;
+
+/**
+ * Factory to create JsonNode that can embedded values from the CBOR parser.
+ */
+@SdkInternalApi
+public final class SdkRpcV2CborValueNodeFactory implements JsonValueNodeFactory {
+    public static final JsonValueNodeFactory INSTANCE = new SdkRpcV2CborValueNodeFactory();
+
+    private SdkRpcV2CborValueNodeFactory() {
+    }
+
+    @Override
+    public JsonNode node(JsonParser parser, JsonToken token) throws IOException {
+        if (!(parser instanceof CBORParser)) {
+            return DEFAULT.node(parser, token);
+        }
+
+        switch (token) {
+            case VALUE_STRING:
+                return new StringJsonNode(parser.getText());
+            case VALUE_FALSE:
+                return new EmbeddedObjectJsonNode(false);
+            case VALUE_TRUE:
+                return new EmbeddedObjectJsonNode(true);
+            case VALUE_NULL:
+                return NullJsonNode.instance();
+            case VALUE_NUMBER_FLOAT:
+            case VALUE_NUMBER_INT:
+                return nodeForNumber(parser, token);
+            case VALUE_EMBEDDED_OBJECT:
+                return new EmbeddedObjectJsonNode(parser.getEmbeddedObject());
+            default:
+                throw new IllegalArgumentException("Unexpected JSON token - " + token);
+        }
+    }
+
+    private JsonNode nodeForNumber(JsonParser parser, JsonToken token) throws IOException {
+        JsonParser.NumberType numberType = parser.getNumberType();
+        switch (numberType) {
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+                try {
+                    Number javaNumber = parser.getNumberValue();
+                    return new EmbeddedObjectJsonNode(javaNumber);
+                } catch (Exception e) {
+                    // ignored
+                }
+                break;
+            case BIG_DECIMAL:
+                try {
+                    BigDecimal bigDecimal = parser.getDecimalValue();
+                    return new EmbeddedObjectJsonNode(bigDecimal);
+                } catch (Exception e) {
+                    // ignored
+                }
+                break;
+            case BIG_INTEGER:
+                try {
+                    BigInteger bigInteger = parser.getBigIntegerValue();
+                    return new EmbeddedObjectJsonNode(bigInteger);
+                } catch (Exception e) {
+                    // ignored
+                }
+                break;
+            default:
+        }
+        return new NumberJsonNode(parser.getText());
+    }
+}
+

--- a/core/protocols/smithy-rpcv2-protocol/src/main/java/software/amazon/awssdk/protocols/rpcv2/internal/SdkRpcV2CborValueNodeFactory.java
+++ b/core/protocols/smithy-rpcv2-protocol/src/main/java/software/amazon/awssdk/protocols/rpcv2/internal/SdkRpcV2CborValueNodeFactory.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.thirdparty.jackson.core.JsonToken;
 import software.amazon.awssdk.thirdparty.jackson.dataformat.cbor.CBORParser;
 
 /**
- * Factory to create JsonNode that can embedded values from the CBOR parser.
+ * Factory to create JsonNodes that can embed values from the CBOR parser.
  */
 @SdkInternalApi
 public final class SdkRpcV2CborValueNodeFactory implements JsonValueNodeFactory {

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/protocol/JsonCodec.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/protocol/JsonCodec.java
@@ -42,7 +42,9 @@ import software.amazon.awssdk.protocols.json.StructuredJsonFactory;
 import software.amazon.awssdk.protocols.json.internal.marshall.JsonProtocolMarshallerBuilder;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.JsonProtocolUnmarshaller;
 import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
+import software.amazon.awssdk.protocols.jsoncore.JsonValueNodeFactory;
 import software.amazon.awssdk.protocols.rpcv2.SmithyRpcV2CborProtocolFactory;
+import software.amazon.awssdk.protocols.rpcv2.internal.SdkRpcV2CborValueNodeFactory;
 import software.amazon.awssdk.utils.IoUtils;
 
 /**
@@ -70,6 +72,7 @@ public final class JsonCodec {
                     .builder()
                     .parser(JsonNodeParser.builder()
                                           .jsonFactory(behavior.structuredJsonFactory().getJsonFactory())
+                                          .jsonValueNodeFactory(behavior.jsonValueNodeFactory())
                                           .build())
                     .defaultTimestampFormats(behavior.timestampFormats())
                     .build();
@@ -151,6 +154,11 @@ public final class JsonCodec {
             }
 
             @Override
+            public JsonValueNodeFactory jsonValueNodeFactory() {
+                return SdkRpcV2CborValueNodeFactory.INSTANCE;
+            }
+
+            @Override
             public String contentType() {
                 return "application/cbor";
             }
@@ -161,7 +169,6 @@ public final class JsonCodec {
                                                                       .protocol(AwsJsonProtocol.AWS_JSON)
                                                                       .contentType("application/json")
                                                                       .build();
-            
             BaseAwsJsonProtocolFactory factory = AwsJsonProtocolFactory.builder()
                                                                        .protocol(AwsJsonProtocol.AWS_JSON)
                                                                        .clientConfiguration(EMPTY_CLIENT_CONFIGURATION)
@@ -193,6 +200,10 @@ public final class JsonCodec {
 
         public StructuredJsonFactory structuredJsonFactory() {
             throw new UnsupportedOperationException();
+        }
+
+        public JsonValueNodeFactory jsonValueNodeFactory() {
+            return JsonValueNodeFactory.DEFAULT;
         }
 
         public Map<MarshallLocation, TimestampFormatTrait.Format> timestampFormats() {

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/protocol/JsonMarshallerBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/protocol/JsonMarshallerBenchmark.java
@@ -51,10 +51,10 @@ public class JsonMarshallerBenchmark {
 
     @State(Scope.Thread)
     public static class MarshallingState {
-        @Param( {"small", "medium", "big"})
+        @Param({"small", "medium", "big"})
         public String size;
 
-        @Param( {"smithy-rpc-v2", "aws-json"})
+        @Param({"smithy-rpc-v2", "aws-json"})
         public String protocol;
 
         GetMetricDataResponse data;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

The current unmarshalling process is split into two phases. During the first phase the input is parsed into a `JsonNode` instance that represents the whole JSON input. The second phase uses this `JsonNode` to unmarshall the nodes into SDK pojos.

For a regular JSON input the input, numeric values are represented as strings (e.g., `3.14`, `"17"`), therefore we need to parse the strings to convert them into a numeric type. For Smithy RPCv2 we don't need this, the values in the CBOR payload are already encoded in a way that's a lot cheaper to convert than parsing the string.

This change makes it possible to read from the CBOR input the encoded values without having to convert them into strings and back into numbers. For that it changes the two phases of the unmarshalling process:

1. During parsing, instead of creating a regular `JsonNode`, we create a `EmbeddedObjectJsonNode` which can carry any `Object` with the numeric value. For that, we introduce a new abstraction `JsonValueNodeFactory` which is used to create nodes for simple types which creates plain `JsonNode` by default but a different implementation creates `EmbeddedObjectJsonNode` for CBOR payloads.
2. During unmarshalling we detect those values and use them directly instead of parsing their string values.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Benchmarks

The benchmarks results show below are from unmarshalling a single value of a shape similar to `GetMetricData` (see [here](https://github.com/aws/aws-sdk-java-v2/blob/feature/master/rpcv2-cbor/test/protocol-tests/src/main/resources/codegen-resources/sdkrpcv2/service-2.json#L109-L128)), similar to getting a set of datapoints from a time series (each datapoint is a pair of the time and a floating point value). For the test we labeled 3 samples with "small", "medium", and, "big", and those vary by the amount of datapoints. The labeled "small" has 17, the one labeled "medium" has 37, and, finally the one labeled "big" has 157 datapoints.

The full benchmark results are shown below (showing only for unmarshall, no changes in the marshall results). The summary of how Smithy RPCv2 implementation compares with AWS-JSON is:

*After*

* *small* **2.5x** faster than json
* *medium* **2.8x** faster than json
* *big* **3.7x** faster than json

*Before*

* *small* **1.23x** *slower*  than json
* *medium* **1.05x** *slower* than json
* *big* **1.22x** *slower* than json



### After this change

```
Benchmark                              (protocol)  (size)  Mode  Cnt       Score     Error  Units
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2   small  avgt    5    8,021.875 ± 199.474  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json   small  avgt    5   15,630.801 ± 113.576  ns/op

JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2  medium  avgt    5   12,655.069 ± 122.454  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json  medium  avgt    5   29,624.410 ± 913.256  ns/op

JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2     big  avgt    5   37,135.590 ± 531.297  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json     big  avgt    5  110,714.788 ± 389.752  ns/op
```

### Before this change

```
Benchmark                              (protocol)  (size)  Mode  Cnt       Score     Error  Units
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2   small  avgt    5   20,204.149 ±  152.628  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json   small  avgt    5   16,424.807 ±  378.576  ns/op

JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2  medium  avgt    5   35,466.582 ±  172.311  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json  medium  avgt    5   33,548.364 ±  799.947  ns/op

JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2     big  avgt    5  137,709.264 ± 1920.922  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json     big  avgt    5  112,142.916 ±  306.063  ns/op
```



## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
