### PR TITLE
Add User Agent for Sqs Calls made using Automatic Batching Manager 

### DIFF
--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/ChangeMessageVisibilityBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/ChangeMessageVisibilityBatchManager.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsMessageDefault.USER_AGENT_APPLIER;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -51,26 +53,34 @@ public class ChangeMessageVisibilityBatchManager extends RequestBatchManager<Cha
 
     private static ChangeMessageVisibilityBatchRequest createChangeMessageVisibilityBatchRequest(
         List<IdentifiableMessage<ChangeMessageVisibilityRequest>> identifiedRequests, String batchKey) {
-        List<ChangeMessageVisibilityBatchRequestEntry> entries = identifiedRequests
-            .stream()
-            .map(identifiedRequest -> createChangeMessageVisibilityBatchRequestEntry(identifiedRequest.id(),
-                                                                                     identifiedRequest.message()))
-            .collect(Collectors.toList());
-        // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration,
-        // all requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first
-        // request.
-        Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0).message()
+
+        List<ChangeMessageVisibilityBatchRequestEntry> entries =
+            identifiedRequests.stream()
+                              .map(identifiedRequest -> createChangeMessageVisibilityBatchRequestEntry(
+                                  identifiedRequest.id(),
+                                  identifiedRequest.message()))
+                              .collect(Collectors.toList());
+
+        // All requests have the same overrideConfiguration, so it's sufficient to retrieve it from the first request.
+        Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
+                                                                                            .message()
                                                                                             .overrideConfiguration();
-        return overrideConfiguration.map(
-                                        config -> ChangeMessageVisibilityBatchRequest.builder()
-                                                                                     .queueUrl(batchKey)
-                                                                                     .overrideConfiguration(config)
-                                                                                     .entries(entries)
-                                                                                     .build())
-                                    .orElseGet(() -> ChangeMessageVisibilityBatchRequest.builder()
-                                                                                        .queueUrl(batchKey)
-                                                                                        .entries(entries)
-                                                                                        .build());
+
+        return overrideConfiguration
+            .map(config -> ChangeMessageVisibilityBatchRequest.builder()
+                                                              .queueUrl(batchKey)
+                                                              .overrideConfiguration(config.toBuilder()
+                                                                                           .applyMutation(USER_AGENT_APPLIER)
+                                                                                           .build())
+                                                              .entries(entries)
+                                                              .build())
+            .orElseGet(() -> ChangeMessageVisibilityBatchRequest.builder()
+                                                                .queueUrl(batchKey)
+                                                                .overrideConfiguration(o -> o
+                                                                    .applyMutation(USER_AGENT_APPLIER)
+                                                                    .build())
+                                                                .entries(entries)
+                                                                .build());
     }
 
     private static ChangeMessageVisibilityBatchRequestEntry createChangeMessageVisibilityBatchRequestEntry(

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DeleteMessageBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DeleteMessageBatchManager.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsMessageDefault.USER_AGENT_APPLIER;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -50,20 +52,38 @@ public class DeleteMessageBatchManager extends RequestBatchManager<DeleteMessage
 
     private static DeleteMessageBatchRequest createDeleteMessageBatchRequest(
         List<IdentifiableMessage<DeleteMessageRequest>> identifiedRequests, String batchKey) {
+
         List<DeleteMessageBatchRequestEntry> entries = identifiedRequests
             .stream()
-            .map(identifiedRequest -> createDeleteMessageBatchRequestEntry(identifiedRequest.id(),
-                                                                           identifiedRequest.message()))
+            .map(identifiedRequest -> createDeleteMessageBatchRequestEntry(
+                identifiedRequest.id(), identifiedRequest.message()
+            ))
             .collect(Collectors.toList());
+
         // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration,
-        // all requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first
-        // request.
+        // all requests must have the same overrideConfiguration, so it is sufficient to retrieve it from the first request.
         Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0).message()
                                                                                             .overrideConfiguration();
+
         return overrideConfiguration.map(
-            overrideConfig -> DeleteMessageBatchRequest.builder().queueUrl(batchKey).overrideConfiguration(overrideConfig)
-                                                       .entries(entries).build()).orElse(
-            DeleteMessageBatchRequest.builder().queueUrl(batchKey).entries(entries).build());
+            overrideConfig -> DeleteMessageBatchRequest.builder()
+                                                       .queueUrl(batchKey)
+                                                       .overrideConfiguration(
+                                                           overrideConfig.toBuilder()
+                                                                         .applyMutation(USER_AGENT_APPLIER)
+                                                                         .build()
+                                                       )
+                                                       .entries(entries)
+                                                       .build()
+        ).orElseGet(
+            () -> DeleteMessageBatchRequest.builder()
+                                           .queueUrl(batchKey)
+                                           .overrideConfiguration(o ->
+                                                                      o.applyMutation(USER_AGENT_APPLIER).build()
+                                           )
+                                           .entries(entries)
+                                           .build()
+        );
     }
 
     private static DeleteMessageBatchRequestEntry createDeleteMessageBatchRequestEntry(String id, DeleteMessageRequest request) {

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/QueueAttributesManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/QueueAttributesManager.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsMessageDefault.USER_AGENT_APPLIER;
+
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -138,22 +140,21 @@ public final class QueueAttributesManager {
         GetQueueAttributesRequest request = GetQueueAttributesRequest.builder()
                                                                      .queueUrl(queueUrl)
                                                                      .attributeNames(QUEUE_ATTRIBUTE_NAMES)
+                                                                     .overrideConfiguration(o -> o
+                                                                         .applyMutation(USER_AGENT_APPLIER))
                                                                      .build();
 
-        CompletableFuture<Map<QueueAttributeName, String>> future =
-            sqsClient.getQueueAttributes(request)
-                     .thenApply(response -> {
-                         Map<QueueAttributeName, String> attributes = response.attributes();
-                         Validate.notNull(attributes.get(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS),
-                                          QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS
-                                          + " attribute is null in SQS.");
-                         Validate.notNull(attributes.get(QueueAttributeName.VISIBILITY_TIMEOUT),
-                                          QueueAttributeName.VISIBILITY_TIMEOUT + " attribute is null in SQS.");
-                         return attributes.entrySet().stream()
-                                          .filter(entry -> QUEUE_ATTRIBUTE_NAMES.contains(entry.getKey()))
-                                          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                     });
-
-        return future;
+        return sqsClient.getQueueAttributes(request)
+                        .thenApply(response -> {
+                            Map<QueueAttributeName, String> attributes = response.attributes();
+                            Validate.notNull(attributes.get(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS),
+                                             QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS
+                                             + " attribute is null in SQS.");
+                            Validate.notNull(attributes.get(QueueAttributeName.VISIBILITY_TIMEOUT),
+                                             QueueAttributeName.VISIBILITY_TIMEOUT + " attribute is null in SQS.");
+                            return attributes.entrySet().stream()
+                                             .filter(entry -> QUEUE_ATTRIBUTE_NAMES.contains(entry.getKey()))
+                                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                        });
     }
 }

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/ReceiveSqsMessageHelper.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/ReceiveSqsMessageHelper.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
 
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsMessageDefault.USER_AGENT_APPLIER;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -72,7 +74,8 @@ public class ReceiveSqsMessageHelper {
         ReceiveMessageRequest.Builder request =
             ReceiveMessageRequest.builder()
                                  .queueUrl(queueUrl)
-                                 .maxNumberOfMessages(config.maxBatchItems());
+                                 .maxNumberOfMessages(config.maxBatchItems())
+                .overrideConfiguration(o -> o.applyMutation(USER_AGENT_APPLIER));
 
         if (!CollectionUtils.isNullOrEmpty(config.messageSystemAttributeNames())) {
             request.messageSystemAttributeNames(config.messageSystemAttributeNames());
@@ -158,10 +161,12 @@ public class ReceiveSqsMessageHelper {
                                                                             .build())
                      .collect(Collectors.toList());
 
-        ChangeMessageVisibilityBatchRequest batchRequest = ChangeMessageVisibilityBatchRequest.builder()
-                                                                                              .queueUrl(queueUrl)
-                                                                                              .entries(entries)
-                                                                                              .build();
+        ChangeMessageVisibilityBatchRequest batchRequest =
+            ChangeMessageVisibilityBatchRequest.builder()
+                                               .queueUrl(queueUrl)
+                                               .entries(entries)
+                                               .overrideConfiguration(o -> o.applyMutation(USER_AGENT_APPLIER))
+                                               .build();
 
         return asyncClient.changeMessageVisibilityBatch(batchRequest);
     }

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/ReceiveSqsMessageHelper.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/ReceiveSqsMessageHelper.java
@@ -75,7 +75,7 @@ public class ReceiveSqsMessageHelper {
             ReceiveMessageRequest.builder()
                                  .queueUrl(queueUrl)
                                  .maxNumberOfMessages(config.maxBatchItems())
-                .overrideConfiguration(o -> o.applyMutation(USER_AGENT_APPLIER));
+                                 .overrideConfiguration(o -> o.applyMutation(USER_AGENT_APPLIER));
 
         if (!CollectionUtils.isNullOrEmpty(config.messageSystemAttributeNames())) {
             request.messageSystemAttributeNames(config.messageSystemAttributeNames());

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsMessageDefault.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsMessageDefault.java
@@ -15,7 +15,10 @@
 
 package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.ApiName;
 
 @SdkInternalApi
 public final class SqsMessageDefault {
@@ -23,6 +26,11 @@ public final class SqsMessageDefault {
     public static final int MAX_SUPPORTED_SQS_RECEIVE_MSG = 10;
 
     public static final int MAX_SEND_MESSAGE_PAYLOAD_SIZE_BYTES = 262_144; // 256 KiB
+
+    // abm stands for Automatic Batching Manager
+    public static final Consumer<AwsRequestOverrideConfiguration.Builder> USER_AGENT_APPLIER =
+        b -> b.addApiName(ApiName.builder().version("abm").name("hll").build());
+
 
     /**
      * <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes">

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/ReceiveSqsMessageHelperTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/ReceiveSqsMessageHelperTest.java
@@ -48,6 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.internal.batchmanager.ReceiveSqsMessageHelper;
 import software.amazon.awssdk.services.sqs.internal.batchmanager.ResponseBatchConfiguration;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.SqsMessageDefault;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -291,6 +292,7 @@ class ReceiveSqsMessageHelperTest {
                                                                      .messageAttributeNames("custom1", "custom2")
                                                                      .visibilityTimeout(9)
                                                                      .waitTimeSeconds(15)
+            .overrideConfiguration(o -> o.applyMutation(SqsMessageDefault.USER_AGENT_APPLIER))
                                                                      .build();
 
         verify(sqsClient, times(1)).receiveMessage(eq(expectedRequest));

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/ReceiveSqsMessageHelperTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/ReceiveSqsMessageHelperTest.java
@@ -286,14 +286,15 @@ class ReceiveSqsMessageHelperTest {
         batch.asyncReceiveMessage().get(3, TimeUnit.SECONDS);
 
         // Verify that receiveMessage was called with the correct arguments
-        ReceiveMessageRequest expectedRequest = ReceiveMessageRequest.builder()
-                                                                     .queueUrl(queueUrl)
-                                                                     .maxNumberOfMessages(10)
-                                                                     .messageAttributeNames("custom1", "custom2")
-                                                                     .visibilityTimeout(9)
-                                                                     .waitTimeSeconds(15)
-            .overrideConfiguration(o -> o.applyMutation(SqsMessageDefault.USER_AGENT_APPLIER))
-                                                                     .build();
+        ReceiveMessageRequest expectedRequest =
+            ReceiveMessageRequest.builder()
+                                 .queueUrl(queueUrl)
+                                 .maxNumberOfMessages(10)
+                                 .messageAttributeNames("custom1", "custom2")
+                                 .visibilityTimeout(9)
+                                 .waitTimeSeconds(15)
+                                 .overrideConfiguration(o -> o.applyMutation(SqsMessageDefault.USER_AGENT_APPLIER))
+                                 .build();
 
         verify(sqsClient, times(1)).receiveMessage(eq(expectedRequest));
     }

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManagerTest.java
@@ -30,12 +30,11 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
-import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
-import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 
@@ -44,7 +43,6 @@ public class SqsAsyncBatchManagerTest extends BaseSqsBatchManagerTest {
 
     private static SqsAsyncClient client;
     private SqsAsyncBatchManager batchManager;
-
 
 
     private static SqsAsyncClientBuilder getAsyncClientBuilder(URI httpLocalhostUri) {
@@ -82,6 +80,11 @@ public class SqsAsyncBatchManagerTest extends BaseSqsBatchManagerTest {
         responses.add(batchManager.sendMessage(builder -> builder.queueUrl(DEFAULT_QUEUE_URL).messageBody(message1)));
         responses.add(batchManager.sendMessage(builder -> builder.queueUrl(DEFAULT_QUEUE_URL).messageBody(message2)));
         return responses;
+    }
+
+    @Override
+    public CompletableFuture<ReceiveMessageResponse> createAndReceiveMessage(ReceiveMessageRequest request) {
+        return batchManager.receiveMessage(request);
     }
 
     @Override


### PR DESCRIPTION


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Calls made using High Level library should be identified as `hll/faturename`

## Modifications
<!--- Describe your changes in detail -->
- Update override configuration of request to send `hll/abm` in the request

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Junits for validate the header of user-agent

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
