### PR TITLE
Avoid growing copies of collections of known size

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
@@ -17,7 +17,7 @@ final class BlobMapTypeCopier {
         if (blobMapTypeParam == null || blobMapTypeParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SdkBytes> modifiableMap = new LinkedHashMap<>();
+            Map<String, SdkBytes> modifiableMap = new LinkedHashMap<>(blobMapTypeParam.size());
             blobMapTypeParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofblobstypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofblobstypecopier.java
@@ -18,10 +18,7 @@ final class ListOfBlobsTypeCopier {
         if (listOfBlobsTypeParam == null || listOfBlobsTypeParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<SdkBytes> modifiableList = new ArrayList<>();
-            listOfBlobsTypeParam.forEach(entry -> {
-                modifiableList.add(entry);
-            });
+            List<SdkBytes> modifiableList = new ArrayList<>(listOfBlobsTypeParam);
             list = Collections.unmodifiableList(modifiableList);
         }
         return list;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
@@ -17,7 +17,7 @@ final class ListOfEnumsCopier {
         if (listOfEnumsParam == null || listOfEnumsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<String> modifiableList = new ArrayList<>();
+            List<String> modifiableList = new ArrayList<>(listOfEnumsParam.size());
             listOfEnumsParam.forEach(entry -> {
                 modifiableList.add(entry);
             });
@@ -31,7 +31,7 @@ final class ListOfEnumsCopier {
         if (listOfEnumsParam == null || listOfEnumsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<String> modifiableList = new ArrayList<>();
+            List<String> modifiableList = new ArrayList<>(listOfEnumsParam.size());
             listOfEnumsParam.forEach(entry -> {
                 String result = entry.toString();
                 modifiableList.add(result);
@@ -46,7 +46,7 @@ final class ListOfEnumsCopier {
         if (listOfEnumsParam == null || listOfEnumsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<EnumType> modifiableList = new ArrayList<>();
+            List<EnumType> modifiableList = new ArrayList<>(listOfEnumsParam.size());
             listOfEnumsParam.forEach(entry -> {
                 EnumType result = EnumType.fromValue(entry);
                 modifiableList.add(result);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofintegerscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofintegerscopier.java
@@ -17,10 +17,7 @@ final class ListOfIntegersCopier {
         if (listOfIntegersParam == null || listOfIntegersParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Integer> modifiableList = new ArrayList<>();
-            listOfIntegersParam.forEach(entry -> {
-                modifiableList.add(entry);
-            });
+            List<Integer> modifiableList = new ArrayList<>(listOfIntegersParam);
             list = Collections.unmodifiableList(modifiableList);
         }
         return list;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistoflistofstringscopier.java
@@ -13,27 +13,24 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfListOfListOfStringsCopier {
     static List<List<List<String>>> copy(
-        Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStringsParam) {
+            Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStringsParam) {
         List<List<List<String>>> list;
         if (listOfListOfListOfStringsParam == null || listOfListOfListOfStringsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<List<List<String>>> modifiableList = new ArrayList<>();
+            List<List<List<String>>> modifiableList = new ArrayList<>(listOfListOfListOfStringsParam.size());
             listOfListOfListOfStringsParam.forEach(entry -> {
                 List<List<String>> list1;
                 if (entry == null || entry instanceof SdkAutoConstructList) {
                     list1 = DefaultSdkAutoConstructList.getInstance();
                 } else {
-                    List<List<String>> modifiableList1 = new ArrayList<>();
+                    List<List<String>> modifiableList1 = new ArrayList<>(entry.size());
                     entry.forEach(entry1 -> {
                         List<String> list2;
                         if (entry1 == null || entry1 instanceof SdkAutoConstructList) {
                             list2 = DefaultSdkAutoConstructList.getInstance();
                         } else {
-                            List<String> modifiableList2 = new ArrayList<>();
-                            entry1.forEach(entry2 -> {
-                                modifiableList2.add(entry2);
-                            });
+                            List<String> modifiableList2 = new ArrayList<>(entry1);
                             list2 = Collections.unmodifiableList(modifiableList2);
                         }
                         modifiableList1.add(list2);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistofstringscopier.java
@@ -17,16 +17,13 @@ final class ListOfListOfStringsCopier {
         if (listOfListOfStringsParam == null || listOfListOfStringsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<List<String>> modifiableList = new ArrayList<>();
+            List<List<String>> modifiableList = new ArrayList<>(listOfListOfStringsParam.size());
             listOfListOfStringsParam.forEach(entry -> {
                 List<String> list1;
                 if (entry == null || entry instanceof SdkAutoConstructList) {
                     list1 = DefaultSdkAutoConstructList.getInstance();
                 } else {
-                    List<String> modifiableList1 = new ArrayList<>();
-                    entry.forEach(entry1 -> {
-                        modifiableList1.add(entry1);
-                    });
+                    List<String> modifiableList1 = new ArrayList<>(entry);
                     list1 = Collections.unmodifiableList(modifiableList1);
                 }
                 modifiableList.add(list1);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofenumtostringcopier.java
@@ -21,13 +21,13 @@ final class ListOfMapOfEnumToStringCopier {
         if (listOfMapOfEnumToStringParam == null || listOfMapOfEnumToStringParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Map<String, String>> modifiableList = new ArrayList<>();
+            List<Map<String, String>> modifiableList = new ArrayList<>(listOfMapOfEnumToStringParam.size());
             listOfMapOfEnumToStringParam.forEach(entry -> {
                 Map<String, String> map;
                 if (entry == null || entry instanceof SdkAutoConstructMap) {
                     map = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, String> modifiableMap = new LinkedHashMap<>();
+                    Map<String, String> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
                         modifiableMap.put(key, value);
                     });
@@ -45,13 +45,13 @@ final class ListOfMapOfEnumToStringCopier {
         if (listOfMapOfEnumToStringParam == null || listOfMapOfEnumToStringParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Map<String, String>> modifiableList = new ArrayList<>();
+            List<Map<String, String>> modifiableList = new ArrayList<>(listOfMapOfEnumToStringParam.size());
             listOfMapOfEnumToStringParam.forEach(entry -> {
                 Map<String, String> map;
                 if (entry == null || entry instanceof SdkAutoConstructMap) {
                     map = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, String> modifiableMap = new LinkedHashMap<>();
+                    Map<String, String> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
                         String result = key.toString();
                         modifiableMap.put(result, value);
@@ -70,13 +70,13 @@ final class ListOfMapOfEnumToStringCopier {
         if (listOfMapOfEnumToStringParam == null || listOfMapOfEnumToStringParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Map<EnumType, String>> modifiableList = new ArrayList<>();
+            List<Map<EnumType, String>> modifiableList = new ArrayList<>(listOfMapOfEnumToStringParam.size());
             listOfMapOfEnumToStringParam.forEach(entry -> {
                 Map<EnumType, String> map;
                 if (entry == null || entry instanceof SdkAutoConstructMap) {
                     map = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<EnumType, String> modifiableMap = new LinkedHashMap<>();
+                    Map<EnumType, String> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
                         EnumType result = EnumType.fromValue(key);
                         if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofstringtostructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofstringtostructcopier.java
@@ -17,18 +17,18 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfMapOfStringToStructCopier {
     static List<Map<String, SimpleStruct>> copy(
-        Collection<? extends Map<String, ? extends SimpleStruct>> listOfMapOfStringToStructParam) {
+            Collection<? extends Map<String, ? extends SimpleStruct>> listOfMapOfStringToStructParam) {
         List<Map<String, SimpleStruct>> list;
         if (listOfMapOfStringToStructParam == null || listOfMapOfStringToStructParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Map<String, SimpleStruct>> modifiableList = new ArrayList<>();
+            List<Map<String, SimpleStruct>> modifiableList = new ArrayList<>(listOfMapOfStringToStructParam.size());
             listOfMapOfStringToStructParam.forEach(entry -> {
                 Map<String, SimpleStruct> map;
                 if (entry == null || entry instanceof SdkAutoConstructMap) {
                     map = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+                    Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
                         modifiableMap.put(key, value);
                     });
@@ -42,18 +42,18 @@ final class ListOfMapOfStringToStructCopier {
     }
 
     static List<Map<String, SimpleStruct>> copyFromBuilder(
-        Collection<? extends Map<String, ? extends SimpleStruct.Builder>> listOfMapOfStringToStructParam) {
+            Collection<? extends Map<String, ? extends SimpleStruct.Builder>> listOfMapOfStringToStructParam) {
         List<Map<String, SimpleStruct>> list;
         if (listOfMapOfStringToStructParam == null || listOfMapOfStringToStructParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Map<String, SimpleStruct>> modifiableList = new ArrayList<>();
+            List<Map<String, SimpleStruct>> modifiableList = new ArrayList<>(listOfMapOfStringToStructParam.size());
             listOfMapOfStringToStructParam.forEach(entry -> {
                 Map<String, SimpleStruct> map;
                 if (entry == null || entry instanceof SdkAutoConstructMap) {
                     map = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+                    Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
                         SimpleStruct member = value == null ? null : value.build();
                         modifiableMap.put(key, member);
@@ -68,18 +68,18 @@ final class ListOfMapOfStringToStructCopier {
     }
 
     static List<Map<String, SimpleStruct.Builder>> copyToBuilder(
-        Collection<? extends Map<String, ? extends SimpleStruct>> listOfMapOfStringToStructParam) {
+            Collection<? extends Map<String, ? extends SimpleStruct>> listOfMapOfStringToStructParam) {
         List<Map<String, SimpleStruct.Builder>> list;
         if (listOfMapOfStringToStructParam == null || listOfMapOfStringToStructParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Map<String, SimpleStruct.Builder>> modifiableList = new ArrayList<>();
+            List<Map<String, SimpleStruct.Builder>> modifiableList = new ArrayList<>(listOfMapOfStringToStructParam.size());
             listOfMapOfStringToStructParam.forEach(entry -> {
                 Map<String, SimpleStruct.Builder> map;
                 if (entry == null || entry instanceof SdkAutoConstructMap) {
                     map = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>();
+                    Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
                         SimpleStruct.Builder member = value == null ? null : value.toBuilder();
                         modifiableMap.put(key, member);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapstringtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapstringtostringcopier.java
@@ -21,13 +21,13 @@ final class ListOfMapStringToStringCopier {
         if (listOfMapStringToStringParam == null || listOfMapStringToStringParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<Map<String, String>> modifiableList = new ArrayList<>();
+            List<Map<String, String>> modifiableList = new ArrayList<>(listOfMapStringToStringParam.size());
             listOfMapStringToStringParam.forEach(entry -> {
                 Map<String, String> map;
                 if (entry == null || entry instanceof SdkAutoConstructMap) {
                     map = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, String> modifiableMap = new LinkedHashMap<>();
+                    Map<String, String> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
                         modifiableMap.put(key, value);
                     });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofsimplestructscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofsimplestructscopier.java
@@ -17,7 +17,7 @@ final class ListOfSimpleStructsCopier {
         if (listOfSimpleStructsParam == null || listOfSimpleStructsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<SimpleStruct> modifiableList = new ArrayList<>();
+            List<SimpleStruct> modifiableList = new ArrayList<>(listOfSimpleStructsParam.size());
             listOfSimpleStructsParam.forEach(entry -> {
                 modifiableList.add(entry);
             });
@@ -31,7 +31,7 @@ final class ListOfSimpleStructsCopier {
         if (listOfSimpleStructsParam == null || listOfSimpleStructsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<SimpleStruct> modifiableList = new ArrayList<>();
+            List<SimpleStruct> modifiableList = new ArrayList<>(listOfSimpleStructsParam.size());
             listOfSimpleStructsParam.forEach(entry -> {
                 SimpleStruct member = entry == null ? null : entry.build();
                 modifiableList.add(member);
@@ -46,7 +46,7 @@ final class ListOfSimpleStructsCopier {
         if (listOfSimpleStructsParam == null || listOfSimpleStructsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<SimpleStruct.Builder> modifiableList = new ArrayList<>();
+            List<SimpleStruct.Builder> modifiableList = new ArrayList<>(listOfSimpleStructsParam.size());
             listOfSimpleStructsParam.forEach(entry -> {
                 SimpleStruct.Builder member = entry == null ? null : entry.toBuilder();
                 modifiableList.add(member);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofstringscopier.java
@@ -17,10 +17,7 @@ final class ListOfStringsCopier {
         if (listOfStringsParam == null || listOfStringsParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<String> modifiableList = new ArrayList<>();
-            listOfStringsParam.forEach(entry -> {
-                modifiableList.add(entry);
-            });
+            List<String> modifiableList = new ArrayList<>(listOfStringsParam);
             list = Collections.unmodifiableList(modifiableList);
         }
         return list;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
@@ -16,7 +16,7 @@ final class MapOfEnumToEnumCopier {
         if (mapOfEnumToEnumParam == null || mapOfEnumToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfEnumToEnumParam.size());
             mapOfEnumToEnumParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });
@@ -30,7 +30,7 @@ final class MapOfEnumToEnumCopier {
         if (mapOfEnumToEnumParam == null || mapOfEnumToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfEnumToEnumParam.size());
             mapOfEnumToEnumParam.forEach((key, value) -> {
                 String result = key.toString();
                 String result1 = value.toString();
@@ -46,7 +46,7 @@ final class MapOfEnumToEnumCopier {
         if (mapOfEnumToEnumParam == null || mapOfEnumToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<EnumType, EnumType> modifiableMap = new LinkedHashMap<>();
+            Map<EnumType, EnumType> modifiableMap = new LinkedHashMap<>(mapOfEnumToEnumParam.size());
             mapOfEnumToEnumParam.forEach((key, value) -> {
                 EnumType result = EnumType.fromValue(key);
                 EnumType result1 = EnumType.fromValue(value);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtolistofenumscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtolistofenumscopier.java
@@ -21,13 +21,13 @@ final class MapOfEnumToListOfEnumsCopier {
         if (mapOfEnumToListOfEnumsParam == null || mapOfEnumToListOfEnumsParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, List<String>> modifiableMap = new LinkedHashMap<>();
+            Map<String, List<String>> modifiableMap = new LinkedHashMap<>(mapOfEnumToListOfEnumsParam.size());
             mapOfEnumToListOfEnumsParam.forEach((key, value) -> {
                 List<String> list;
                 if (value == null || value instanceof SdkAutoConstructList) {
                     list = DefaultSdkAutoConstructList.getInstance();
                 } else {
-                    List<String> modifiableList = new ArrayList<>();
+                    List<String> modifiableList = new ArrayList<>(value.size());
                     value.forEach(entry -> {
                         modifiableList.add(entry);
                     });
@@ -45,14 +45,14 @@ final class MapOfEnumToListOfEnumsCopier {
         if (mapOfEnumToListOfEnumsParam == null || mapOfEnumToListOfEnumsParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, List<String>> modifiableMap = new LinkedHashMap<>();
+            Map<String, List<String>> modifiableMap = new LinkedHashMap<>(mapOfEnumToListOfEnumsParam.size());
             mapOfEnumToListOfEnumsParam.forEach((key, value) -> {
                 String result = key.toString();
                 List<String> list;
                 if (value == null || value instanceof SdkAutoConstructList) {
                     list = DefaultSdkAutoConstructList.getInstance();
                 } else {
-                    List<String> modifiableList = new ArrayList<>();
+                    List<String> modifiableList = new ArrayList<>(value.size());
                     value.forEach(entry -> {
                         String result1 = entry.toString();
                         modifiableList.add(result1);
@@ -71,14 +71,14 @@ final class MapOfEnumToListOfEnumsCopier {
         if (mapOfEnumToListOfEnumsParam == null || mapOfEnumToListOfEnumsParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<EnumType, List<EnumType>> modifiableMap = new LinkedHashMap<>();
+            Map<EnumType, List<EnumType>> modifiableMap = new LinkedHashMap<>(mapOfEnumToListOfEnumsParam.size());
             mapOfEnumToListOfEnumsParam.forEach((key, value) -> {
                 EnumType result = EnumType.fromValue(key);
                 List<EnumType> list;
                 if (value == null || value instanceof SdkAutoConstructList) {
                     list = DefaultSdkAutoConstructList.getInstance();
                 } else {
-                    List<EnumType> modifiableList = new ArrayList<>();
+                    List<EnumType> modifiableList = new ArrayList<>(value.size());
                     value.forEach(entry -> {
                         EnumType result1 = EnumType.fromValue(entry);
                         modifiableList.add(result1);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtomapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtomapofstringtoenumcopier.java
@@ -16,13 +16,13 @@ final class MapOfEnumToMapOfStringToEnumCopier {
         if (mapOfEnumToMapOfStringToEnumParam == null || mapOfEnumToMapOfStringToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, Map<String, String>> modifiableMap = new LinkedHashMap<>();
+            Map<String, Map<String, String>> modifiableMap = new LinkedHashMap<>(mapOfEnumToMapOfStringToEnumParam.size());
             mapOfEnumToMapOfStringToEnumParam.forEach((key, value) -> {
                 Map<String, String> map1;
                 if (value == null || value instanceof SdkAutoConstructMap) {
                     map1 = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, String> modifiableMap1 = new LinkedHashMap<>();
+                    Map<String, String> modifiableMap1 = new LinkedHashMap<>(value.size());
                     value.forEach((key1, value1) -> {
                         modifiableMap1.put(key1, value1);
                     });
@@ -36,19 +36,19 @@ final class MapOfEnumToMapOfStringToEnumCopier {
     }
 
     static Map<String, Map<String, String>> copyEnumToString(
-        Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnumParam) {
+            Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnumParam) {
         Map<String, Map<String, String>> map;
         if (mapOfEnumToMapOfStringToEnumParam == null || mapOfEnumToMapOfStringToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, Map<String, String>> modifiableMap = new LinkedHashMap<>();
+            Map<String, Map<String, String>> modifiableMap = new LinkedHashMap<>(mapOfEnumToMapOfStringToEnumParam.size());
             mapOfEnumToMapOfStringToEnumParam.forEach((key, value) -> {
                 String result = key.toString();
                 Map<String, String> map1;
                 if (value == null || value instanceof SdkAutoConstructMap) {
                     map1 = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, String> modifiableMap1 = new LinkedHashMap<>();
+                    Map<String, String> modifiableMap1 = new LinkedHashMap<>(value.size());
                     value.forEach((key1, value1) -> {
                         String result1 = value1.toString();
                         modifiableMap1.put(key1, result1);
@@ -63,19 +63,19 @@ final class MapOfEnumToMapOfStringToEnumCopier {
     }
 
     static Map<EnumType, Map<String, EnumType>> copyStringToEnum(
-        Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnumParam) {
+            Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnumParam) {
         Map<EnumType, Map<String, EnumType>> map;
         if (mapOfEnumToMapOfStringToEnumParam == null || mapOfEnumToMapOfStringToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<EnumType, Map<String, EnumType>> modifiableMap = new LinkedHashMap<>();
+            Map<EnumType, Map<String, EnumType>> modifiableMap = new LinkedHashMap<>(mapOfEnumToMapOfStringToEnumParam.size());
             mapOfEnumToMapOfStringToEnumParam.forEach((key, value) -> {
                 EnumType result = EnumType.fromValue(key);
                 Map<String, EnumType> map1;
                 if (value == null || value instanceof SdkAutoConstructMap) {
                     map1 = DefaultSdkAutoConstructMap.getInstance();
                 } else {
-                    Map<String, EnumType> modifiableMap1 = new LinkedHashMap<>();
+                    Map<String, EnumType> modifiableMap1 = new LinkedHashMap<>(value.size());
                     value.forEach((key1, value1) -> {
                         EnumType result1 = EnumType.fromValue(value1);
                         modifiableMap1.put(key1, result1);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
@@ -16,7 +16,7 @@ final class MapOfEnumToSimpleStructCopier {
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(mapOfEnumToSimpleStructParam.size());
             mapOfEnumToSimpleStructParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });
@@ -30,7 +30,7 @@ final class MapOfEnumToSimpleStructCopier {
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(mapOfEnumToSimpleStructParam.size());
             mapOfEnumToSimpleStructParam.forEach((key, value) -> {
                 SimpleStruct member = value == null ? null : value.build();
                 modifiableMap.put(key, member);
@@ -45,7 +45,7 @@ final class MapOfEnumToSimpleStructCopier {
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>();
+            Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>(mapOfEnumToSimpleStructParam.size());
             mapOfEnumToSimpleStructParam.forEach((key, value) -> {
                 SimpleStruct.Builder member = value == null ? null : value.toBuilder();
                 modifiableMap.put(key, member);
@@ -60,7 +60,7 @@ final class MapOfEnumToSimpleStructCopier {
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(mapOfEnumToSimpleStructParam.size());
             mapOfEnumToSimpleStructParam.forEach((key, value) -> {
                 String result = key.toString();
                 modifiableMap.put(result, value);
@@ -75,7 +75,7 @@ final class MapOfEnumToSimpleStructCopier {
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<EnumType, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            Map<EnumType, SimpleStruct> modifiableMap = new LinkedHashMap<>(mapOfEnumToSimpleStructParam.size());
             mapOfEnumToSimpleStructParam.forEach((key, value) -> {
                 EnumType result = EnumType.fromValue(key);
                 if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
@@ -16,7 +16,7 @@ final class MapOfEnumToStringCopier {
         if (mapOfEnumToStringParam == null || mapOfEnumToStringParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfEnumToStringParam.size());
             mapOfEnumToStringParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });
@@ -30,7 +30,7 @@ final class MapOfEnumToStringCopier {
         if (mapOfEnumToStringParam == null || mapOfEnumToStringParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfEnumToStringParam.size());
             mapOfEnumToStringParam.forEach((key, value) -> {
                 String result = key.toString();
                 modifiableMap.put(result, value);
@@ -45,7 +45,7 @@ final class MapOfEnumToStringCopier {
         if (mapOfEnumToStringParam == null || mapOfEnumToStringParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<EnumType, String> modifiableMap = new LinkedHashMap<>();
+            Map<EnumType, String> modifiableMap = new LinkedHashMap<>(mapOfEnumToStringParam.size());
             mapOfEnumToStringParam.forEach((key, value) -> {
                 EnumType result = EnumType.fromValue(key);
                 if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
@@ -16,7 +16,7 @@ final class MapOfStringToEnumCopier {
         if (mapOfStringToEnumParam == null || mapOfStringToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfStringToEnumParam.size());
             mapOfStringToEnumParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });
@@ -30,7 +30,7 @@ final class MapOfStringToEnumCopier {
         if (mapOfStringToEnumParam == null || mapOfStringToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfStringToEnumParam.size());
             mapOfStringToEnumParam.forEach((key, value) -> {
                 String result = value.toString();
                 modifiableMap.put(key, result);
@@ -45,7 +45,7 @@ final class MapOfStringToEnumCopier {
         if (mapOfStringToEnumParam == null || mapOfStringToEnumParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, EnumType> modifiableMap = new LinkedHashMap<>();
+            Map<String, EnumType> modifiableMap = new LinkedHashMap<>(mapOfStringToEnumParam.size());
             mapOfStringToEnumParam.forEach((key, value) -> {
                 EnumType result = EnumType.fromValue(value);
                 modifiableMap.put(key, result);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
@@ -21,16 +21,13 @@ final class MapOfStringToIntegerListCopier {
         if (mapOfStringToIntegerListParam == null || mapOfStringToIntegerListParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, List<Integer>> modifiableMap = new LinkedHashMap<>();
+            Map<String, List<Integer>> modifiableMap = new LinkedHashMap<>(mapOfStringToIntegerListParam.size());
             mapOfStringToIntegerListParam.forEach((key, value) -> {
                 List<Integer> list;
                 if (value == null || value instanceof SdkAutoConstructList) {
                     list = DefaultSdkAutoConstructList.getInstance();
                 } else {
-                    List<Integer> modifiableList = new ArrayList<>();
-                    value.forEach(entry -> {
-                        modifiableList.add(entry);
-                    });
+                    List<Integer> modifiableList = new ArrayList<>(value);
                     list = Collections.unmodifiableList(modifiableList);
                 }
                 modifiableMap.put(key, list);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
@@ -17,27 +17,24 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToListOfListOfStringsCopier {
     static Map<String, List<List<String>>> copy(
-        Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
         Map<String, List<List<String>>> map;
         if (mapOfStringToListOfListOfStringsParam == null || mapOfStringToListOfListOfStringsParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, List<List<String>>> modifiableMap = new LinkedHashMap<>();
+            Map<String, List<List<String>>> modifiableMap = new LinkedHashMap<>(mapOfStringToListOfListOfStringsParam.size());
             mapOfStringToListOfListOfStringsParam.forEach((key, value) -> {
                 List<List<String>> list;
                 if (value == null || value instanceof SdkAutoConstructList) {
                     list = DefaultSdkAutoConstructList.getInstance();
                 } else {
-                    List<List<String>> modifiableList = new ArrayList<>();
+                    List<List<String>> modifiableList = new ArrayList<>(value.size());
                     value.forEach(entry -> {
                         List<String> list1;
                         if (entry == null || entry instanceof SdkAutoConstructList) {
                             list1 = DefaultSdkAutoConstructList.getInstance();
                         } else {
-                            List<String> modifiableList1 = new ArrayList<>();
-                            entry.forEach(entry1 -> {
-                                modifiableList1.add(entry1);
-                            });
+                            List<String> modifiableList1 = new ArrayList<>(entry);
                             list1 = Collections.unmodifiableList(modifiableList1);
                         }
                         modifiableList.add(list1);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
@@ -16,7 +16,7 @@ final class MapOfStringToSimpleStructCopier {
         if (mapOfStringToSimpleStructParam == null || mapOfStringToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(mapOfStringToSimpleStructParam.size());
             mapOfStringToSimpleStructParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });
@@ -30,7 +30,7 @@ final class MapOfStringToSimpleStructCopier {
         if (mapOfStringToSimpleStructParam == null || mapOfStringToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(mapOfStringToSimpleStructParam.size());
             mapOfStringToSimpleStructParam.forEach((key, value) -> {
                 SimpleStruct member = value == null ? null : value.build();
                 modifiableMap.put(key, member);
@@ -45,7 +45,7 @@ final class MapOfStringToSimpleStructCopier {
         if (mapOfStringToSimpleStructParam == null || mapOfStringToSimpleStructParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>();
+            Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>(mapOfStringToSimpleStructParam.size());
             mapOfStringToSimpleStructParam.forEach((key, value) -> {
                 SimpleStruct.Builder member = value == null ? null : value.toBuilder();
                 modifiableMap.put(key, member);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
@@ -16,7 +16,7 @@ final class MapOfStringToStringCopier {
         if (mapOfStringToStringParam == null || mapOfStringToStringParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfStringToStringParam.size());
             mapOfStringToStringParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivelisttypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivelisttypecopier.java
@@ -17,7 +17,7 @@ final class RecursiveListTypeCopier {
         if (recursiveListTypeParam == null || recursiveListTypeParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<RecursiveStructType> modifiableList = new ArrayList<>();
+            List<RecursiveStructType> modifiableList = new ArrayList<>(recursiveListTypeParam.size());
             recursiveListTypeParam.forEach(entry -> {
                 modifiableList.add(entry);
             });
@@ -31,7 +31,7 @@ final class RecursiveListTypeCopier {
         if (recursiveListTypeParam == null || recursiveListTypeParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<RecursiveStructType> modifiableList = new ArrayList<>();
+            List<RecursiveStructType> modifiableList = new ArrayList<>(recursiveListTypeParam.size());
             recursiveListTypeParam.forEach(entry -> {
                 RecursiveStructType member = entry == null ? null : entry.build();
                 modifiableList.add(member);
@@ -46,7 +46,7 @@ final class RecursiveListTypeCopier {
         if (recursiveListTypeParam == null || recursiveListTypeParam instanceof SdkAutoConstructList) {
             list = DefaultSdkAutoConstructList.getInstance();
         } else {
-            List<RecursiveStructType.Builder> modifiableList = new ArrayList<>();
+            List<RecursiveStructType.Builder> modifiableList = new ArrayList<>(recursiveListTypeParam.size());
             recursiveListTypeParam.forEach(entry -> {
                 RecursiveStructType.Builder member = entry == null ? null : entry.toBuilder();
                 modifiableList.add(member);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
@@ -16,7 +16,7 @@ final class RecursiveMapTypeCopier {
         if (recursiveMapTypeParam == null || recursiveMapTypeParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, RecursiveStructType> modifiableMap = new LinkedHashMap<>();
+            Map<String, RecursiveStructType> modifiableMap = new LinkedHashMap<>(recursiveMapTypeParam.size());
             recursiveMapTypeParam.forEach((key, value) -> {
                 modifiableMap.put(key, value);
             });
@@ -26,12 +26,12 @@ final class RecursiveMapTypeCopier {
     }
 
     static Map<String, RecursiveStructType> copyFromBuilder(
-        Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
+            Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
         Map<String, RecursiveStructType> map;
         if (recursiveMapTypeParam == null || recursiveMapTypeParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, RecursiveStructType> modifiableMap = new LinkedHashMap<>();
+            Map<String, RecursiveStructType> modifiableMap = new LinkedHashMap<>(recursiveMapTypeParam.size());
             recursiveMapTypeParam.forEach((key, value) -> {
                 RecursiveStructType member = value == null ? null : value.build();
                 modifiableMap.put(key, member);
@@ -46,7 +46,7 @@ final class RecursiveMapTypeCopier {
         if (recursiveMapTypeParam == null || recursiveMapTypeParam instanceof SdkAutoConstructMap) {
             map = DefaultSdkAutoConstructMap.getInstance();
         } else {
-            Map<String, RecursiveStructType.Builder> modifiableMap = new LinkedHashMap<>();
+            Map<String, RecursiveStructType.Builder> modifiableMap = new LinkedHashMap<>(recursiveMapTypeParam.size());
             recursiveMapTypeParam.forEach((key, value) -> {
                 RecursiveStructType.Builder member = value == null ? null : value.toBuilder();
                 modifiableMap.put(key, member);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Improves the performance of building collections by allocating the expected size beforehand instead of letting the collection grow as we add elements. This trivial change has small, but noticeable, performance improvements in the benchmarks for RPCv2, but will also benefit other protocols

**Before**

```
Benchmark                              (protocol)  (size)  Mode  Cnt      Score     Error  Units
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2   small  avgt    5   1944.436 ±  21.069  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2  medium  avgt    5   3209.297 ± 259.975  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2     big  avgt    5  11061.383 ± 187.669  ns/op
```
And flamegraph snippet below

<img width="910" alt="before" src="https://github.com/user-attachments/assets/99187c4f-6387-499d-993c-0ad0990ad044">


**After**

```
Benchmark                              (protocol)  (size)  Mode  Cnt      Score     Error  Units
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2   small  avgt    5   1821.490 ±  18.858  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2  medium  avgt    5   3045.257 ± 239.893  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2     big  avgt    5  10593.384 ± 113.698  ns/op
```
And flamegraph snippet below

<img width="909" alt="after" src="https://github.com/user-attachments/assets/1ca8743a-dba0-4496-a996-36b36b126285">


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
