### PR TITLE
Codegen: Fix flipped conditional for the simple method warning log

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -291,7 +291,7 @@ public class IntermediateModelBuilder {
                                               config.getExcludedSimpleMethods().stream().noneMatch(m -> m.equals("*")) ||
                                               !config.getBlacklistedSimpleMethods().contains(methodName) ||
                                               config.getBlacklistedSimpleMethods().stream().noneMatch(m -> m.equals("*"));
-                boolean methodHasNoRequiredMembers = !CollectionUtils.isNullOrEmpty(inputShape.getRequired());
+                boolean methodHasNoRequiredMembers = CollectionUtils.isNullOrEmpty(inputShape.getRequired());
                 boolean methodIsNotStreaming = !operation.isStreaming();
                 boolean methodHasSimpleMethodVerb = methodName.matches(Constant.APPROVED_SIMPLE_METHOD_VERBS);
 


### PR DESCRIPTION
## Motivation and Context
Noticed during code generation there are warnings about not allowlisting certain operations as simple methods, but the warning doesn't actually apply because the methods *do* have required arguments.  

## Modifications
* Fixed an improperly negated conditional -- implementation of the conditional didn't match the variable name stating what it should have been.

## Testing
* Unable to implement new testing due to the behavior being a logging-only behavior.  
  * The modified code does not affect anything at runtime

## Screenshots (if appropriate)
Logged output

```
A potential simple method exists that isn't explicitly excluded or included: getThread
```

Applicable model snippet:
```
        "GetThreadInput": {
            "type": "structure",
            "required": [
                "threadId"
            ],
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
  - Had environmental issues that prevented me from running successfully (running locally on a Mac laptop and running on a AL2 EC2 instance that has the IMDS port blocked in a weird way)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
  - I don't think this change necessitates a changelog entry
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
