### PR TITLE
Fixed a bug in AttributeMap, which causes a ConcurrentModificationException…

### DIFF
--- a/utils/src/main/java/software/amazon/awssdk/utils/AttributeMap.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/AttributeMap.java
@@ -319,6 +319,7 @@ public final class AttributeMap implements ToCopyableBuilder<AttributeMap.Builde
             if (oldValue != null) {
                 dependencyGraph.valueUpdated(oldValue, value);
             }
+
         }
 
         /**
@@ -327,17 +328,17 @@ public final class AttributeMap implements ToCopyableBuilder<AttributeMap.Builde
          */
         private Value<?> internalComputeIfAbsent(Key<?> key, Supplier<Value<?>> value) {
             checkCopyOnUpdate();
-            return attributes.compute(key, (k, v) -> {
-                if (v == null || resolveValue(v) == null) {
-                    Value<?> newValue = value.get();
-                    Validate.notNull(newValue, "Supplied value must not be null.");
-                    if (v != null) {
-                        dependencyGraph.valueUpdated(v, newValue);
-                    }
-                    return newValue;
+            Value<?> currentValue = attributes.get(key);
+            if (currentValue == null || resolveValue(currentValue) == null) {
+                Value<?> newValue = value.get();
+                Validate.notNull(newValue, "Supplied value must not be null.");
+                if (currentValue != null) {
+                    dependencyGraph.valueUpdated(currentValue, newValue);
                 }
-                return v;
-            });
+                attributes.put(key, newValue);
+                return newValue;
+            }
+            return currentValue;
         }
 
         private void checkCopyOnUpdate() {

--- a/utils/src/main/java/software/amazon/awssdk/utils/AttributeMap.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/AttributeMap.java
@@ -319,7 +319,6 @@ public final class AttributeMap implements ToCopyableBuilder<AttributeMap.Builde
             if (oldValue != null) {
                 dependencyGraph.valueUpdated(oldValue, value);
             }
-
         }
 
         /**

--- a/utils/src/test/java/software/amazon/awssdk/utils/AttributeMapTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/AttributeMapTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.w3c.dom.Attr;
 
 public class AttributeMapTest {
 
@@ -156,6 +155,20 @@ public class AttributeMapTest {
 
         builtMap.toBuilder().build().toBuilder().build();
         verify(lazyRead, Mockito.times(1)).run();
+    }
+
+    @Test
+    public void lazyAttributes_canUpdateTheMap_andBeUpdatedWithPutLazyIfAbsent() {
+        AttributeMap.Builder map = AttributeMap.builder();
+        map.putLazyIfAbsent(STRING_KEY, c -> {
+            // Force a modification to the underlying map. We wouldn't usually do this so explicitly, but
+            // this can happen internally within AttributeMap when resolving uncached lazy values,
+            // so it needs to be possible.
+            map.put(INTEGER_KEY, 0);
+            return "string";
+        });
+        map.putLazyIfAbsent(STRING_KEY, c -> "string"); // Force the value to be resolved within the putLazyIfAbsent
+        assertThat(map.get(STRING_KEY)).isEqualTo("string");
     }
 
     @Test


### PR DESCRIPTION
… when lazy properties depend on lazy properties that depend on any other property.

This is achieved by changing a `compute` into a `get` followed by a `put`.

This code path was not hit before the endpoint URL changes, which are forthcoming. Those changes also add a path that tests this change.