### PR TITLE
Sugmanue/rpcv2 improve cbor performance 04

### DIFF
--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMarshaller.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.JsonValueTrait;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.RequiredTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
 import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.StringUtils;
@@ -35,7 +36,7 @@ import software.amazon.awssdk.utils.StringUtils;
 public final class HeaderMarshaller {
 
     public static final JsonMarshaller<String> STRING = new SimpleHeaderMarshaller<>(
-        (val, field) -> field.containsTrait(JsonValueTrait.class) ?
+        (val, field) -> field.containsTrait(JsonValueTrait.class, TraitType.JSON_VALUE_TRAIT) ?
                         BinaryUtils.toBase64(val.getBytes(StandardCharsets.UTF_8)) : val);
 
     public static final JsonMarshaller<Integer> INTEGER = new SimpleHeaderMarshaller<>(ValueToStringConverter.FROM_INTEGER);
@@ -61,7 +62,7 @@ public final class HeaderMarshaller {
         if (isNullOrEmpty(list)) {
             return;
         }
-        SdkField memberFieldInfo = sdkField.getRequiredTrait(ListTrait.class).memberFieldInfo();
+        SdkField memberFieldInfo = sdkField.getRequiredTrait(ListTrait.class, TraitType.LIST_TRAIT).memberFieldInfo();
         for (Object listValue : list) {
             if (shouldSkipElement(listValue)) {
                 continue;
@@ -72,7 +73,7 @@ public final class HeaderMarshaller {
     };
 
     public static final JsonMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
-        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class)) {
+        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class, TraitType.REQUIRED_TRAIT)) {
             throw new IllegalArgumentException(String.format("Parameter '%s' must not be null", paramName));
         }
     };

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.PayloadTrait;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.protocols.core.InstantToString;
 import software.amazon.awssdk.protocols.core.OperationInfo;
@@ -227,7 +228,7 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
     }
 
     private boolean isExplicitPayloadMember(SdkField<?> field) {
-        return field.containsTrait(PayloadTrait.class);
+        return field.containsTrait(PayloadTrait.class, TraitType.PAYLOAD_TRAIT);
     }
 
     private void marshallExplicitJsonPayload(SdkField<?> field, Object val) {

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/QueryParamMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/QueryParamMarshaller.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.RequiredTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
 
 @SdkInternalApi
@@ -65,7 +66,7 @@ public final class QueryParamMarshaller {
     };
 
     public static final JsonMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
-        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class)) {
+        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class, TraitType.REQUIRED_TRAIT)) {
             throw new IllegalArgumentException(String.format("Parameter '%s' must not be null", paramName));
         }
     };

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.RequiredTrait;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.protocols.json.StructuredJsonGenerator;
@@ -39,7 +40,7 @@ import software.amazon.awssdk.utils.DateUtils;
 public final class SimpleTypeJsonMarshaller {
 
     public static final JsonMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
-        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class)) {
+        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class, TraitType.REQUIRED_TRAIT)) {
             throw new IllegalArgumentException(String.format("Parameter '%s' must not be null",
                                                              Optional.ofNullable(paramName)
                                                                      .orElseGet(() -> "paramName null")));
@@ -122,7 +123,8 @@ public final class SimpleTypeJsonMarshaller {
         if (paramName != null) {
             jsonGenerator.writeFieldName(paramName);
         }
-        TimestampFormatTrait trait = sdkField != null ? sdkField.getTrait(TimestampFormatTrait.class) : null;
+        TimestampFormatTrait trait = sdkField != null ? sdkField.getTrait(TimestampFormatTrait.class,
+                                                                          TraitType.TIMESTAMP_FORMAT_TRAIT) : null;
         if (trait != null) {
             switch (trait.format()) {
                 case UNIX_TIMESTAMP:

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/HeaderUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/HeaderUnmarshaller.java
@@ -21,6 +21,7 @@ import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.traits.JsonValueTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.core.StringToValueConverter;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.utils.BinaryUtils;
@@ -59,7 +60,7 @@ final class HeaderUnmarshaller {
      */
     private static String unmarshallStringHeader(String value,
                                                  SdkField<String> field) {
-        return field.containsTrait(JsonValueTrait.class) ?
+        return field.containsTrait(JsonValueTrait.class, TraitType.JSON_VALUE_TRAIT) ?
                new String(BinaryUtils.fromBase64(value), StandardCharsets.UTF_8) : value;
     }
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.traits.PayloadTrait;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.protocols.core.StringToInstant;
@@ -179,7 +180,7 @@ public class JsonProtocolUnmarshaller {
             return null;
         }
 
-        SdkField<Object> valueInfo = field.getTrait(MapTrait.class).valueFieldInfo();
+        SdkField<Object> valueInfo = field.getTrait(MapTrait.class, TraitType.MAP_TRAIT).valueFieldInfo();
         JsonUnmarshaller<Object> unmarshaller = context.getUnmarshaller(valueInfo.location(), valueInfo.marshallingType());
         Map<String, JsonNode> asObject = jsonContent.asObject();
         Map<String, Object> map = new HashMap<>(asObject.size());
@@ -194,7 +195,7 @@ public class JsonProtocolUnmarshaller {
             return null;
         }
 
-        SdkField<Object> memberInfo = field.getTrait(ListTrait.class).memberFieldInfo();
+        SdkField<Object> memberInfo = field.getTrait(ListTrait.class, TraitType.LIST_TRAIT).memberFieldInfo();
         List<JsonNode> asArray = jsonContent.asArray();
         List<Object> result = new ArrayList<>(asArray.size());
         for (JsonNode node : asArray) {
@@ -249,7 +250,7 @@ public class JsonProtocolUnmarshaller {
     }
 
     private static boolean isExplicitPayloadMember(SdkField<?> f) {
-        return f.containsTrait(PayloadTrait.class);
+        return f.containsTrait(PayloadTrait.class, TraitType.PAYLOAD_TRAIT);
     }
 
     private boolean isPayloadMemberOnUnmarshall(SdkField<?> f) {

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/marshall/ListQueryMarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/marshall/ListQueryMarshaller.java
@@ -19,6 +19,7 @@ import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.traits.ListTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 
 /**
@@ -52,7 +53,7 @@ public class ListQueryMarshaller implements QueryMarshaller<List<?>> {
             return;
         }
         for (int i = 0; i < val.size(); i++) {
-            ListTrait listTrait = sdkField.getTrait(ListTrait.class);
+            ListTrait listTrait = sdkField.getTrait(ListTrait.class, TraitType.LIST_TRAIT);
             String listPath = pathResolver.resolve(path, i, listTrait);
             QueryMarshaller<Object> marshaller = context.marshallerRegistry().getMarshaller(
                 ((SdkField<?>) listTrait.memberFieldInfo()).marshallingType(), val);

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/marshall/MapQueryMarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/marshall/MapQueryMarshaller.java
@@ -20,13 +20,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 
 @SdkInternalApi
 public class MapQueryMarshaller implements QueryMarshaller<Map<String, ?>> {
 
     @Override
     public void marshall(QueryMarshallerContext context, String path, Map<String, ?> val, SdkField<Map<String, ?>> sdkField) {
-        MapTrait mapTrait = sdkField.getTrait(MapTrait.class);
+        MapTrait mapTrait = sdkField.getTrait(MapTrait.class, TraitType.MAP_TRAIT);
         AtomicInteger entryNum = new AtomicInteger(1);
         val.forEach((key, value) -> {
 

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/ListQueryUnmarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/ListQueryUnmarshaller.java
@@ -22,6 +22,7 @@ import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.traits.ListTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.query.unmarshall.XmlElement;
 
 @SdkInternalApi
@@ -29,7 +30,7 @@ public final class ListQueryUnmarshaller implements QueryUnmarshaller<List<?>> {
 
     @Override
     public List<?> unmarshall(QueryUnmarshallerContext context, List<XmlElement> content, SdkField<List<?>> field) {
-        ListTrait listTrait = field.getTrait(ListTrait.class);
+        ListTrait listTrait = field.getTrait(ListTrait.class, TraitType.LIST_TRAIT);
         List<Object> list = new ArrayList<>();
         getMembers(content, listTrait).forEach(member -> {
             QueryUnmarshaller unmarshaller = context.getUnmarshaller(listTrait.memberFieldInfo().location(),

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/MapQueryUnmarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/MapQueryUnmarshaller.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.query.unmarshall.XmlElement;
 
 @SdkInternalApi
@@ -31,7 +32,7 @@ public final class MapQueryUnmarshaller implements QueryUnmarshaller<Map<String,
     @Override
     public Map<String, ?> unmarshall(QueryUnmarshallerContext context, List<XmlElement> content, SdkField<Map<String, ?>> field) {
         Map<String, Object> map = new HashMap<>();
-        MapTrait mapTrait = field.getTrait(MapTrait.class);
+        MapTrait mapTrait = field.getTrait(MapTrait.class, TraitType.MAP_TRAIT);
         SdkField mapValueSdkField = mapTrait.valueFieldInfo();
 
         getEntries(content, mapTrait).forEach(entry -> {

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/QueryProtocolUnmarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/QueryProtocolUnmarshaller.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.PayloadTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.protocols.core.StringToInstant;
 import software.amazon.awssdk.protocols.core.StringToValueConverter;
@@ -90,7 +91,7 @@ public final class QueryProtocolUnmarshaller implements XmlErrorUnmarshaller {
     private boolean responsePayloadIsBlob(SdkPojo sdkPojo) {
         return sdkPojo.sdkFields().stream()
                       .anyMatch(field -> field.marshallingType() == MarshallingType.SDK_BYTES &&
-                                         field.containsTrait(PayloadTrait.class));
+                                         field.containsTrait(PayloadTrait.class, TraitType.PAYLOAD_TRAIT));
     }
 
     /**
@@ -128,7 +129,9 @@ public final class QueryProtocolUnmarshaller implements XmlErrorUnmarshaller {
     private SdkPojo unmarshall(QueryUnmarshallerContext context, SdkPojo sdkPojo, XmlElement root) {
         if (root != null) {
             for (SdkField<?> field : sdkPojo.sdkFields()) {
-                if (field.containsTrait(PayloadTrait.class) && field.marshallingType() == MarshallingType.SDK_BYTES) {
+                if (field.containsTrait(PayloadTrait.class, TraitType.PAYLOAD_TRAIT)
+                    && field.marshallingType() == MarshallingType.SDK_BYTES
+                ) {
                     field.set(sdkPojo, SdkBytes.fromUtf8String(root.textContent()));
                 }
 

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/HeaderMarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/HeaderMarshaller.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.RequiredTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
 import software.amazon.awssdk.utils.StringUtils;
 
@@ -79,7 +80,7 @@ public final class HeaderMarshaller {
             if (!shouldEmit(list)) {
                 return;
             }
-            SdkField memberFieldInfo = sdkField.getRequiredTrait(ListTrait.class).memberFieldInfo();
+            SdkField memberFieldInfo = sdkField.getRequiredTrait(ListTrait.class, TraitType.LIST_TRAIT).memberFieldInfo();
             for (Object listValue : list) {
                 if (shouldSkipElement(listValue)) {
                     continue;
@@ -102,7 +103,7 @@ public final class HeaderMarshaller {
     };
 
     public static final XmlMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
-        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class)) {
+        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class, TraitType.REQUIRED_TRAIT)) {
             throw new IllegalArgumentException(String.format("Parameter '%s' must not be null", paramName));
         }
     };

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/QueryParamMarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/QueryParamMarshaller.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.traits.RequiredTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
 
 @SdkInternalApi
@@ -62,11 +63,11 @@ public final class QueryParamMarshaller {
             return;
         }
 
-        MapTrait mapTrait = sdkField.getRequiredTrait(MapTrait.class);
+        MapTrait mapTrait = sdkField.getRequiredTrait(MapTrait.class, TraitType.MAP_TRAIT);
         SdkField valueField = mapTrait.valueFieldInfo();
 
         for (Map.Entry<String, ?> entry : map.entrySet()) {
-            if (valueField.containsTrait(ListTrait.class)) {
+            if (valueField.containsTrait(ListTrait.class, TraitType.LIST_TRAIT)) {
                 ((List<?>) entry.getValue()).forEach(val -> {
                     context.marshallerRegistry().getMarshaller(MarshallLocation.QUERY_PARAM, val)
                            .marshall(val, context, entry.getKey(), null);
@@ -81,7 +82,7 @@ public final class QueryParamMarshaller {
     };
 
     public static final XmlMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
-        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class)) {
+        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class, TraitType.REQUIRED_TRAIT)) {
             throw new IllegalArgumentException(String.format("Parameter '%s' must not be null", paramName));
         }
     };

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlPayloadMarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlPayloadMarshaller.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.traits.RequiredTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.core.traits.XmlAttributeTrait;
 import software.amazon.awssdk.core.traits.XmlAttributesTrait;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
@@ -83,7 +84,7 @@ public class XmlPayloadMarshaller {
         @Override
         public void marshall(List<?> list, XmlMarshallerContext context, String paramName,
                              SdkField<List<?>> sdkField, ValueToStringConverter.ValueToString<List<?>> converter) {
-            ListTrait listTrait = sdkField.getRequiredTrait(ListTrait.class);
+            ListTrait listTrait = sdkField.getRequiredTrait(ListTrait.class, TraitType.LIST_TRAIT);
 
             if (!listTrait.isFlattened()) {
                 context.xmlGenerator().startElement(paramName);
@@ -125,7 +126,7 @@ public class XmlPayloadMarshaller {
         public void marshall(Map<String, ?> map, XmlMarshallerContext context, String paramName,
                              SdkField<Map<String, ?>> sdkField, ValueToStringConverter.ValueToString<Map<String, ?>> converter) {
 
-            MapTrait mapTrait = sdkField.getRequiredTrait(MapTrait.class);
+            MapTrait mapTrait = sdkField.getRequiredTrait(MapTrait.class, TraitType.MAP_TRAIT);
 
             for (Map.Entry<String, ?> entry : map.entrySet()) {
                 context.xmlGenerator().startElement("entry");
@@ -144,7 +145,7 @@ public class XmlPayloadMarshaller {
     };
 
     public static final XmlMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
-        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class)) {
+        if (Objects.nonNull(sdkField) && sdkField.containsTrait(RequiredTrait.class, TraitType.REQUIRED_TRAIT)) {
             throw new IllegalArgumentException(String.format("Parameter '%s' must not be null", paramName));
         }
     };
@@ -180,8 +181,11 @@ public class XmlPayloadMarshaller {
                 return;
             }
 
-            if (sdkField != null && sdkField.getOptionalTrait(XmlAttributesTrait.class).isPresent()) {
-                XmlAttributesTrait attributeTrait = sdkField.getTrait(XmlAttributesTrait.class);
+            boolean hasXmlAttributesTrait = sdkField != null &&
+                                            sdkField.getOptionalTrait(XmlAttributesTrait.class,
+                                                                      TraitType.XML_ATTRIBUTES_TRAIT).isPresent();
+            if (hasXmlAttributesTrait) {
+                XmlAttributesTrait attributeTrait = sdkField.getTrait(XmlAttributesTrait.class, TraitType.XML_ATTRIBUTES_TRAIT);
                 Map<String, String> attributes = attributeTrait.attributes()
                                                                .entrySet()
                                                                .stream()
@@ -209,7 +213,8 @@ public class XmlPayloadMarshaller {
         }
 
         private boolean isXmlAttribute(SdkField<T> sdkField) {
-            return sdkField != null && sdkField.getOptionalTrait(XmlAttributeTrait.class).isPresent();
+            return sdkField != null && sdkField.getOptionalTrait(XmlAttributeTrait.class,
+                                                                 TraitType.XML_ATTRIBUTE_TRAIT).isPresent();
         }
     }
 

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlProtocolMarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlProtocolMarshaller.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.PayloadTrait;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.protocols.core.InstantToString;
 import software.amazon.awssdk.protocols.core.OperationInfo;
@@ -129,7 +130,7 @@ public final class XmlProtocolMarshaller implements ProtocolMarshaller<SdkHttpFu
     }
 
     private boolean isExplicitPayloadMember(SdkField<?> field) {
-        return field.containsTrait(PayloadTrait.class);
+        return field.containsTrait(PayloadTrait.class, TraitType.PAYLOAD_TRAIT);
     }
 
     private boolean hasPayloadMembers(SdkPojo sdkPojo) {

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/XmlPayloadUnmarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/XmlPayloadUnmarshaller.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.core.StringToValueConverter;
 import software.amazon.awssdk.protocols.query.unmarshall.XmlElement;
 
@@ -57,7 +58,7 @@ public final class XmlPayloadUnmarshaller {
     }
 
     public static List<?> unmarshallList(XmlUnmarshallerContext context, List<XmlElement> content, SdkField<List<?>> field) {
-        ListTrait listTrait = field.getTrait(ListTrait.class);
+        ListTrait listTrait = field.getTrait(ListTrait.class, TraitType.LIST_TRAIT);
         List<Object> list = new ArrayList<>();
 
         getMembers(content, listTrait).forEach(member -> {
@@ -80,7 +81,7 @@ public final class XmlPayloadUnmarshaller {
     public static Map<String, ?> unmarshallMap(XmlUnmarshallerContext context, List<XmlElement> content,
                                                SdkField<Map<String, ?>> field) {
         Map<String, Object> map = new HashMap<>();
-        MapTrait mapTrait = field.getTrait(MapTrait.class);
+        MapTrait mapTrait = field.getTrait(MapTrait.class, TraitType.MAP_TRAIT);
         SdkField mapValueSdkField = mapTrait.valueFieldInfo();
 
         getEntries(content, mapTrait).forEach(entry -> {

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/XmlProtocolUnmarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/XmlProtocolUnmarshaller.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.PayloadTrait;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.core.traits.XmlAttributeTrait;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.protocols.core.StringToInstant;
@@ -168,11 +169,11 @@ public final class XmlProtocolUnmarshaller implements XmlErrorUnmarshaller {
     }
 
     private boolean isAttribute(SdkField<?> field) {
-        return field.containsTrait(XmlAttributeTrait.class);
+        return field.containsTrait(XmlAttributeTrait.class, TraitType.XML_ATTRIBUTE_TRAIT);
     }
 
     private boolean isExplicitPayloadMember(SdkField<?> field) {
-        return field.containsTrait(PayloadTrait.class);
+        return field.containsTrait(PayloadTrait.class, TraitType.PAYLOAD_TRAIT);
     }
 
     private boolean hasXmlPayload(SdkPojo sdkPojo, SdkHttpFullResponse response) {

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/XmlResponseParserUtils.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/XmlResponseParserUtils.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.PayloadTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.protocols.query.unmarshall.XmlDomParser;
@@ -84,7 +85,7 @@ public final class XmlResponseParserUtils {
     }
 
     private static boolean isExplicitPayloadMember(SdkField<?> f) {
-        return f.containsTrait(PayloadTrait.class);
+        return f.containsTrait(PayloadTrait.class, TraitType.PAYLOAD_TRAIT);
     }
 
     private static boolean hasPayloadMembers(SdkPojo sdkPojo) {

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/AbstractMarshallingRegistry.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/AbstractMarshallingRegistry.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingKnownType;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 
 /**
@@ -31,16 +32,14 @@ import software.amazon.awssdk.core.protocol.MarshallingType;
  */
 @SdkProtectedApi
 public abstract class AbstractMarshallingRegistry {
-
-    private final Map<MarshallLocation, Map<MarshallingType, Object>> registry;
+    private final MarshallingLocationRegistry locationRegistry;
     private final Set<MarshallingType<?>> marshallingTypes;
     private final Map<Class<?>, MarshallingType<?>> marshallingTypeCache;
 
     protected AbstractMarshallingRegistry(Builder builder) {
-        this.registry = builder.registry;
+        this.locationRegistry = builder.locationRegistry.build();
         this.marshallingTypes = builder.marshallingTypes;
         this.marshallingTypeCache = new HashMap<>(marshallingTypes.size());
-
     }
 
     /**
@@ -52,17 +51,7 @@ public abstract class AbstractMarshallingRegistry {
      * @throws SdkClientException if no marshaller/unmarshaller is registered for the given location and type.
      */
     protected Object get(MarshallLocation marshallLocation, MarshallingType<?> marshallingType) {
-        Map<MarshallingType, Object> byLocation = registry.get(marshallLocation);
-        if (byLocation == null) {
-            throw SdkClientException.create("No marshaller/unmarshaller registered for location " + marshallLocation.name());
-        }
-        Object registered = byLocation.get(marshallingType);
-        if (registered == null) {
-            throw SdkClientException.create(String.format("No marshaller/unmarshaller of type %s registered for location %s.",
-                                                          marshallingType,
-                                                          marshallLocation.name()));
-        }
-        return registered;
+        return locationRegistry.get(marshallLocation, marshallingType);
     }
 
     @SuppressWarnings("unchecked")
@@ -98,15 +87,15 @@ public abstract class AbstractMarshallingRegistry {
      * Builder for a {@link AbstractMarshallingRegistry}.
      */
     public abstract static class Builder {
-
-        private final Map<MarshallLocation, Map<MarshallingType, Object>> registry = new EnumMap<>(MarshallLocation.class);
+        private final MarshallingLocationRegistry.Builder locationRegistry;
         private final Set<MarshallingType<?>> marshallingTypes = new HashSet<>();
 
         protected Builder() {
+            this.locationRegistry = MarshallingLocationRegistry.builder();
         }
 
         protected Builder(AbstractMarshallingRegistry marshallingRegistry) {
-            deepCopy(this.registry, marshallingRegistry.registry);
+            this.locationRegistry = marshallingRegistry.locationRegistry.toBuilder();
             this.marshallingTypes.addAll(marshallingRegistry.marshallingTypes);
         }
 
@@ -114,21 +103,123 @@ public abstract class AbstractMarshallingRegistry {
                                        MarshallingType<T> marshallingType,
                                        Object marshaller) {
             marshallingTypes.add(marshallingType);
-            registry.computeIfAbsent(marshallLocation, k -> new HashMap<>());
-            registry.get(marshallLocation).put(marshallingType, marshaller);
+            locationRegistry.register(marshallLocation, marshallingType, marshaller);
             return this;
         }
     }
 
     /**
-     * Copies the map values from source to target making sure to create a new copy that can be owned by the source.
+     * A registry of marshaller per marshalling location and marshalling type.
      */
-    private static void deepCopy(
-        Map<MarshallLocation, Map<MarshallingType, Object>> target,
-        Map<MarshallLocation, Map<MarshallingType, Object>> source
-    ) {
-        for (Map.Entry<MarshallLocation, Map<MarshallingType, Object>> sourceKvp : source.entrySet()) {
-            target.computeIfAbsent(sourceKvp.getKey(), (x) -> new HashMap<>()).putAll(sourceKvp.getValue());
+    static class MarshallingLocationRegistry {
+        private final Map<MarshallLocation, MarshallingTypeRegistry> registry;
+
+        private MarshallingLocationRegistry(Builder builder) {
+            this.registry = new EnumMap<>(MarshallLocation.class);
+            builder.registry.forEach((k, v) -> this.registry.put(k, v.build()));
+        }
+
+        public Object get(MarshallLocation location, MarshallingType<?> marshallingType) {
+            MarshallingTypeRegistry byLocation = registry.get(location);
+            if (byLocation != null) {
+                return byLocation.get(marshallingType);
+            }
+            return null;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Builder toBuilder() {
+            return new Builder(this);
+        }
+
+        static class Builder {
+            private Map<MarshallLocation, MarshallingTypeRegistry.Builder> registry = new EnumMap<>(MarshallLocation.class);
+
+            private Builder() {
+            }
+
+            private Builder(MarshallingLocationRegistry marshallingLocationRegistry) {
+                marshallingLocationRegistry.registry.forEach((k, v) -> this.registry.put(k, v.toBuilder()));
+            }
+
+            public <T> Builder register(
+                MarshallLocation location,
+                MarshallingType<T> marshallingType,
+                Object marshaller
+            ) {
+                registry.computeIfAbsent(location, x -> MarshallingTypeRegistry.builder())
+                    .register(marshallingType, marshaller);
+                return this;
+            }
+
+            public MarshallingLocationRegistry build() {
+                return new MarshallingLocationRegistry(this);
+            }
+        }
+    }
+
+    /**
+     * A registry of marshaller per marshalling type. It keeps two maps, the level 1 is faster as it uses
+     * an {@link EnumMap} for the known marshalling types. The level 2 one is slower, but it can be used
+     * for other, not known marshalling types.
+     */
+    static class MarshallingTypeRegistry {
+        private final Map<MarshallingKnownType, Object> l1registry;
+        private final Map<MarshallingType<?>, Object> l2registry;
+
+        private MarshallingTypeRegistry(Builder builder) {
+            this.l1registry = new EnumMap<>(builder.l1registry);
+            this.l2registry = builder.l2registry;
+        }
+
+
+        public Object get(MarshallingType<?> marshallingType) {
+            MarshallingKnownType knownType = marshallingType.getKnownType();
+            if (knownType != null) {
+                return l1registry.get(knownType);
+            }
+            return l2registry.get(marshallingType);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Builder toBuilder() {
+            return new Builder(this);
+        }
+
+        static class Builder {
+            private Map<MarshallingKnownType, Object> l1registry = new EnumMap<>(MarshallingKnownType.class);
+            private Map<MarshallingType<?>, Object> l2registry = new HashMap<>();
+
+            private Builder() {
+            }
+
+            private Builder(MarshallingTypeRegistry marshallingTypeRegistry) {
+                this.l1registry.putAll(marshallingTypeRegistry.l1registry);
+                this.l2registry.putAll(marshallingTypeRegistry.l2registry);
+            }
+
+            public <T> Builder register(
+                MarshallingType<T> marshallingType,
+                Object marshaller
+            ) {
+                MarshallingKnownType knownType = marshallingType.getKnownType();
+                if (knownType != null) {
+                    l1registry.put(knownType, marshaller);
+                } else {
+                    l2registry.put(marshallingType, marshaller);
+                }
+                return this;
+            }
+
+            public MarshallingTypeRegistry build() {
+                return new MarshallingTypeRegistry(this);
+            }
         }
     }
 }

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/InstantToString.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/InstantToString.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter.ValueToString;
 import software.amazon.awssdk.utils.DateUtils;
 
@@ -44,7 +45,7 @@ public final class InstantToString implements ValueToString<Instant> {
             return null;
         }
         TimestampFormatTrait.Format format =
-            sdkField.getOptionalTrait(TimestampFormatTrait.class)
+            sdkField.getOptionalTrait(TimestampFormatTrait.class, TraitType.TIMESTAMP_FORMAT_TRAIT)
                     .map(TimestampFormatTrait::format)
                     .orElseGet(() -> getDefaultTimestampFormat(sdkField.location(), defaultFormats));
         switch (format) {

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/NumberToInstant.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/NumberToInstant.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 
 /**
  * Converts a number value to an {@link Instant} type. Respects the {@link TimestampFormatTrait} if present.
@@ -59,7 +60,7 @@ public final class NumberToInstant {
     }
 
     private TimestampFormatTrait.Format resolveTimestampFormat(SdkField<Instant> field) {
-        TimestampFormatTrait trait = field.getTrait(TimestampFormatTrait.class);
+        TimestampFormatTrait trait = field.getTrait(TimestampFormatTrait.class, TraitType.TIMESTAMP_FORMAT_TRAIT);
         if (trait == null) {
             TimestampFormatTrait.Format format = defaultFormats.get(field.location());
             if (format == null) {

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/StringToInstant.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/StringToInstant.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.utils.DateUtils;
 
 /**
@@ -80,7 +81,7 @@ public final class StringToInstant implements StringToValueConverter.StringToVal
     }
 
     private TimestampFormatTrait.Format resolveTimestampFormat(SdkField<Instant> field) {
-        TimestampFormatTrait trait = field.getTrait(TimestampFormatTrait.class);
+        TimestampFormatTrait trait = field.getTrait(TimestampFormatTrait.class, TraitType.TIMESTAMP_FORMAT_TRAIT);
         if (trait == null) {
             TimestampFormatTrait.Format format = defaultFormats.get(field.location());
             if (format == null) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingKnownType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingKnownType.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.protocol;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.document.Document;
+
+/**
+ * Enum of known types of marshalling types. This enum is used to use EnumMap's for fast lookup of traits.
+ */
+@SdkProtectedApi
+public enum MarshallingKnownType {
+    NULL,
+    STRING,
+    INTEGER,
+    LONG,
+    FLOAT,
+    DOUBLE,
+    BIG_DECIMAL,
+    BOOLEAN,
+    INSTANT,
+    SDK_BYTES,
+    SDK_POJO,
+    LIST,
+    MAP,
+    SHORT,
+    BYTE,
+    DOCUMENT,
+    ;
+
+    public static MarshallingKnownType from(Class<?> clazz) {
+        if (clazz == Void.class) {
+            return NULL;
+        }
+        if (clazz == String.class) {
+            return STRING;
+        }
+        if (clazz == Integer.class) {
+            return INTEGER;
+        }
+        if (clazz == Long.class) {
+            return LONG;
+        }
+        if (clazz == Float.class) {
+            return FLOAT;
+        }
+        if (clazz == Double.class) {
+            return DOUBLE;
+        }
+        if (clazz == BigDecimal.class) {
+            return BIG_DECIMAL;
+        }
+        if (clazz == Boolean.class) {
+            return BOOLEAN;
+        }
+        if (clazz == Instant.class) {
+            return INSTANT;
+        }
+        if (clazz == SdkBytes.class) {
+            return SDK_BYTES;
+        }
+        if (clazz == SdkPojo.class) {
+            return SDK_POJO;
+        }
+        if (clazz == List.class) {
+            return LIST;
+        }
+        if (clazz == Map.class) {
+            return MAP;
+        }
+        if (clazz == Short.class) {
+            return SHORT;
+        }
+        if (clazz == Byte.class) {
+            return BYTE;
+        }
+        if (clazz == Document.class) {
+            return DOCUMENT;
+        }
+        return null;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingType.java
@@ -69,8 +69,13 @@ public interface MarshallingType<T> {
 
     Class<? super T> getTargetClass();
 
+    default MarshallingKnownType getKnownType() {
+        return null;
+    }
+
     static <T> MarshallingType<T> newType(Class<? super T> clzz) {
         return new MarshallingType<T>() {
+            private final MarshallingKnownType knownType = MarshallingKnownType.from(clzz);
 
             @Override
             public Class<? super T> getTargetClass() {
@@ -78,11 +83,14 @@ public interface MarshallingType<T> {
             }
 
             @Override
+            public MarshallingKnownType getKnownType() {
+                return knownType;
+            }
+
+            @Override
             public String toString() {
                 return clzz.getSimpleName();
             }
         };
-
     }
-
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/DataTypeConversionFailureHandlingTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/DataTypeConversionFailureHandlingTrait.java
@@ -19,4 +19,8 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 @SdkProtectedApi
 public class DataTypeConversionFailureHandlingTrait implements Trait {
+    @Override
+    public TraitType type() {
+        return TraitType.DATA_TYPE_CONVERSION_FAILURE_HANDLING_TRAIT;
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/DefaultValueTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/DefaultValueTrait.java
@@ -62,4 +62,9 @@ public final class DefaultValueTrait implements Trait {
     public static DefaultValueTrait idempotencyToken() {
         return new DefaultValueTrait(IdempotentUtils.getGenerator());
     }
+
+    @Override
+    public TraitType type() {
+        return TraitType.DEFAULT_VALUE_TRAIT;
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/JsonValueTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/JsonValueTrait.java
@@ -30,4 +30,9 @@ public final class JsonValueTrait implements Trait {
     public static JsonValueTrait create() {
         return new JsonValueTrait();
     }
+
+    @Override
+    public TraitType type() {
+        return TraitType.JSON_VALUE_TRAIT;
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/ListTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/ListTrait.java
@@ -63,6 +63,11 @@ public final class ListTrait implements Trait {
         return new Builder();
     }
 
+    @Override
+    public TraitType type() {
+        return TraitType.LIST_TRAIT;
+    }
+
     public static final class Builder {
 
         private String memberLocationName;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/LocationTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/LocationTrait.java
@@ -57,6 +57,11 @@ public final class LocationTrait implements Trait {
         return unmarshallLocationName;
     }
 
+    @Override
+    public TraitType type() {
+        return TraitType.LOCATION_TRAIT;
+    }
+
     /**
      * @return Builder instance.
      */

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/MapTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/MapTrait.java
@@ -68,6 +68,11 @@ public final class MapTrait implements Trait {
         return new Builder();
     }
 
+    @Override
+    public TraitType type() {
+        return TraitType.MAP_TRAIT;
+    }
+
     public static final class Builder {
 
         private String keyLocationName;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/PayloadTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/PayloadTrait.java
@@ -29,4 +29,9 @@ public final class PayloadTrait implements Trait {
     public static PayloadTrait create() {
         return new PayloadTrait();
     }
+
+    @Override
+    public TraitType type() {
+        return TraitType.PAYLOAD_TRAIT;
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/RequiredTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/RequiredTrait.java
@@ -29,4 +29,9 @@ public final class RequiredTrait implements Trait {
     public static RequiredTrait create() {
         return new RequiredTrait();
     }
+
+    @Override
+    public TraitType type() {
+        return TraitType.REQUIRED_TRAIT;
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TimestampFormatTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TimestampFormatTrait.java
@@ -43,6 +43,11 @@ public final class TimestampFormatTrait implements Trait {
         return new TimestampFormatTrait(timestampFormat);
     }
 
+    @Override
+    public TraitType type() {
+        return TraitType.TIMESTAMP_FORMAT_TRAIT;
+    }
+
     /**
      * Enum of the timestamp formats we currently support.
      */

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/Trait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/Trait.java
@@ -23,4 +23,12 @@ import software.amazon.awssdk.core.SdkField;
  */
 @SdkProtectedApi
 public interface Trait {
+
+    /**
+     * The known trait type. This is correctly implemented and uniquely mapped to the enum values which allow us to create enum
+     * maps for trait known trait types.
+     */
+    default TraitType type() {
+        return null;
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TraitType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TraitType.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.traits;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * Enumerates all the know traits. This enum is used to use EnumMap's for fast lookup
+ * of traits.
+ */
+@SdkProtectedApi
+public enum TraitType {
+    DATA_TYPE_CONVERSION_FAILURE_HANDLING_TRAIT(DataTypeConversionFailureHandlingTrait.class),
+    DEFAULT_VALUE_TRAIT(DefaultValueTrait.class),
+    JSON_VALUE_TRAIT(JsonValueTrait.class),
+    LIST_TRAIT(ListTrait.class),
+    LOCATION_TRAIT(LocationTrait.class),
+    MAP_TRAIT(MapTrait.class),
+    PAYLOAD_TRAIT(PayloadTrait.class),
+    REQUIRED_TRAIT(RequiredTrait.class),
+    TIMESTAMP_FORMAT_TRAIT(TimestampFormatTrait.class),
+    XML_ATTRIBUTE_TRAIT(XmlAttributeTrait.class),
+    XML_ATTRIBUTES_TRAIT(XmlAttributesTrait.class),
+    ;
+
+    private final Class<? extends Trait> typeClass;
+
+    TraitType(Class<? extends Trait> typeClass) {
+        this.typeClass = typeClass;
+    }
+
+    /**
+     * Returns the type for the given class.
+     */
+    public static TraitType from(Class<?> clazz) {
+        if (clazz == DataTypeConversionFailureHandlingTrait.class) {
+            return DATA_TYPE_CONVERSION_FAILURE_HANDLING_TRAIT;
+        }
+        if (clazz == DefaultValueTrait.class) {
+            return DEFAULT_VALUE_TRAIT;
+        }
+        if (clazz == JsonValueTrait.class) {
+            return JSON_VALUE_TRAIT;
+        }
+        if (clazz == ListTrait.class) {
+            return LIST_TRAIT;
+        }
+        if (clazz == LocationTrait.class) {
+            return LOCATION_TRAIT;
+        }
+        if (clazz == MapTrait.class) {
+            return MAP_TRAIT;
+        }
+        if (clazz == PayloadTrait.class) {
+            return PAYLOAD_TRAIT;
+        }
+        if (clazz == RequiredTrait.class) {
+            return REQUIRED_TRAIT;
+        }
+        if (clazz == TimestampFormatTrait.class) {
+            return TIMESTAMP_FORMAT_TRAIT;
+        }
+        if (clazz == XmlAttributeTrait.class) {
+            return XML_ATTRIBUTE_TRAIT;
+        }
+        if (clazz == XmlAttributesTrait.class) {
+            return XML_ATTRIBUTES_TRAIT;
+        }
+        return null;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/XmlAttributeTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/XmlAttributeTrait.java
@@ -30,4 +30,9 @@ public final class XmlAttributeTrait implements Trait {
         return new XmlAttributeTrait();
 
     }
+
+    @Override
+    public TraitType type() {
+        return TraitType.XML_ATTRIBUTE_TRAIT;
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/XmlAttributesTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/XmlAttributesTrait.java
@@ -45,6 +45,11 @@ public final class XmlAttributesTrait implements Trait {
         return attributes;
     }
 
+    @Override
+    public TraitType type() {
+        return TraitType.XML_ATTRIBUTES_TRAIT;
+    }
+
     public static final class AttributeAccessors {
         private final Function<Object, String> attributeGetter;
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshaller.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/TransferManagerJsonUnmarshaller.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.traits.TraitType;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.DateUtils;
@@ -85,7 +86,7 @@ public interface TransferManagerJsonUnmarshaller<T> {
                 return null;
             }
 
-            SdkField<Object> valueInfo = field.getTrait(MapTrait.class).valueFieldInfo();
+            SdkField<Object> valueInfo = field.getTrait(MapTrait.class, TraitType.MAP_TRAIT).valueFieldInfo();
 
             Map<String, Object> map = new HashMap<>();
             jsonContent.asObject().forEach((fieldName, value) -> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Improvement to the lookup performance of marshallers and traits. 

Both traits and marshalling types are open classes but with well known, finite, and, statically defined instances. We can improve the performance of the lookups of these values by enumerating them using an enum and associating the enum values to the concrete types, and then using a two level lookup: the fast level 1 uses the an enum map and the associate enumeration value as key, while the l2 uses a regular map with the values as keys as they are. This change improves not only RPCv2, but all the other protocols as well.

This change aims to reduce, or remove the hump highlighted in the flamegraph below


<img width="1021" alt="before-highligthed" src="https://github.com/user-attachments/assets/9339ae33-758f-425f-b39b-b7327bdc2853">


**Before**

```
Benchmark                              (protocol)  (size)  Mode  Cnt      Score     Error  Units
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2   small  avgt    5   3415.127 ±  64.585  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2  medium  avgt    5   5668.994 ±  16.272  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2     big  avgt    5  19475.973 ± 133.802  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json   small  avgt    5  10150.744 ±  28.942  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json  medium  avgt    5  21037.573 ± 139.545  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json     big  avgt    5  86466.945 ± 709.876  ns/op
```

And zoomed in flamegraph

![before-enum-map](https://github.com/user-attachments/assets/4e0016e6-0ab7-43a1-a116-999467f0008d)


**After**

```
Benchmark                              (protocol)  (size)  Mode  Cnt      Score      Error  Units
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2   small  avgt    5   3166.243 ±  151.799  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2  medium  avgt    5   5349.115 ±  172.858  ns/op
JsonMarshallerBenchmark.unmarshall  smithy-rpc-v2     big  avgt    5  17517.889 ±   41.898  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json   small  avgt    5  10178.752 ±  167.762  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json  medium  avgt    5  20440.322 ±  223.031  ns/op
JsonMarshallerBenchmark.unmarshall       aws-json     big  avgt    5  83252.862 ± 1159.517  ns/op
```

And zoomed in flamegraph

![after-enum-map](https://github.com/user-attachments/assets/1aa1d297-8905-401f-9dab-e9c00b12fb8f)


Full flamegraph after this change

<img width="1022" alt="after-full" src="https://github.com/user-attachments/assets/7834c674-be27-4568-99d7-590631d88077">


## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
