### PR TITLE
Integeration tests for SQS Automatic Request Batching

### DIFF
--- a/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/RequestBatchManagerSqsIntegrationTest.java
+++ b/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/RequestBatchManagerSqsIntegrationTest.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Md5Utils;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RequestBatchManagerSqsIntegrationTest extends IntegrationTestBase {
+
+    private static final int DEFAULT_MAX_BATCH_OPEN = 200;
+    private static final String TEST_QUEUE_PREFIX = "myTestQueue";
+    private static final Logger log = Logger.loggerFor(RequestBatchManagerSqsIntegrationTest.class);
+    private static SqsAsyncClient client;
+    private static String defaultQueueUrl;
+    private SqsAsyncBatchManager batchManager;
+
+    @BeforeAll
+    public static void setUpBeforeClass() throws Exception {
+        client = createSqsAyncClient();
+
+
+        defaultQueueUrl = client.createQueue(CreateQueueRequest.builder()
+                                                               .queueName(TEST_QUEUE_PREFIX + "0")
+                                                               .build())
+                                .get(3, TimeUnit.SECONDS)
+                                .queueUrl();
+    }
+
+    @AfterAll
+    public static void tearDownAfterClass() {
+        purgeQueue(defaultQueueUrl);
+        client.close();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        batchManager = client.batchManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        batchManager.close();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideQueueUrls")
+    public void sendTenMessages(String queueUrl) {
+        executeSendMessagesTest(10, queueUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideQueueUrls")
+    public void sendTwentyMessages(String queueUrl) {
+        executeSendMessagesTest(20, queueUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideQueueUrls")
+    public void scheduleSendFiveMessages(String queueUrl) {
+        long startTime = System.nanoTime();
+        Map<String, SendMessageRequest> requests = createSendMessageRequests(5, queueUrl);
+        Map<String, CompletableFuture<SendMessageResponse>> responses = sendMessages(requests);
+        waitForAllResponses(responses);
+        long endTime = System.nanoTime();
+
+        assertThat(Duration.ofNanos(endTime - startTime).toMillis()).isGreaterThan(DEFAULT_MAX_BATCH_OPEN);
+        verifyResponses(requests, responses);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideQueueUrls")
+    public void scheduleTwoSendMessageBatches(String queueUrl) {
+        long startTime = System.nanoTime();
+        Map<String, SendMessageRequest> requests = createSendMessageRequests(10, queueUrl);
+        Map<String, CompletableFuture<SendMessageResponse>> responses = sendMessages(0, 5, requests);
+        waitFor(DEFAULT_MAX_BATCH_OPEN + 10);
+        responses.putAll(sendMessages(5, 5, requests));
+        waitForAllResponses(responses);
+        long endTime = System.nanoTime();
+
+        assertThat(responses).hasSize(10);
+        assertThat(Duration.ofNanos(endTime - startTime).toMillis()).isGreaterThan(DEFAULT_MAX_BATCH_OPEN + 100);
+        verifyResponses(requests, responses);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMessageAndThreadCounts")
+    public void sendMultipleMessagesWithMultiThread(int numMessages, int numThreads, String queueUrl) {
+        executeConcurrentSendMessagesTest(numThreads, numMessages, queueUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideQueueUrls")
+    public void scheduleFiveMessagesWithEachThreadToDifferentLocations(String queueUrl) throws Exception {
+        int numThreads = 10;
+        int numMessages = 5;
+
+        Map<String, SendMessageRequest> requests = createSendMessageRequestsForDifferentDestinations(numThreads, numMessages);
+        ConcurrentHashMap<String, CompletableFuture<SendMessageResponse>> responses = new ConcurrentHashMap<>();
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+        List<CompletableFuture<Map<String, CompletableFuture<SendMessageResponse>>>> sendRequestFutures =
+            createThreadsAndSendMessages(numThreads, numMessages, requests, responses, executorService);
+
+        checkThreadedResponses(requests, responses, sendRequestFutures);
+
+        cleanupQueues(numThreads);
+    }
+
+    @ParameterizedTest
+    @MethodSource("messageAndQueueProvider")
+    public void deleteMessages(int numMessages, String queueUrl) throws Exception {
+        executeDeleteMessagesTest(numMessages, queueUrl);
+    }
+
+    @ParameterizedTest
+    @MethodSource("messageAndQueueProvider")
+    public void changeVisibilityMessages(int numMessages, String queueUrl) throws Exception {
+        executeChangeVisibilityTest(numMessages, queueUrl);
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("provideQueueUrls")
+    void sendMessagesWhichCanExceed256KiBCollectively(String queueUrl) {
+
+        String largeMessageBody = createLargeString('a', 256_000);
+
+        List<CompletableFuture<SendMessageResponse>> futures = new ArrayList<>();
+
+        // Send the large message 10 times and collect the futures
+        for (int i = 0; i < 10; i++) {
+            CompletableFuture<SendMessageResponse> future =
+                batchManager.sendMessage(r -> r.queueUrl(queueUrl).messageBody(largeMessageBody));
+            futures.add(future);
+        }
+
+        // Wait for all sendMessage futures to complete
+        CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        allFutures.join();
+
+        // Validate that all responses have a non-null messageId
+        futures.forEach(future -> {
+            SendMessageResponse response = future.join();
+            assertThat(response.messageId()).isNotNull();
+            assertThat(response.md5OfMessageBody()).isNotNull();
+        });
+    }
+
+
+    private String createLargeString(char ch, int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(ch);
+        }
+        return sb.toString();
+    }
+
+
+    private static Stream<Arguments> provideQueueUrls() {
+        return Stream.of(
+            Arguments.of(defaultQueueUrl)
+        );
+    }
+
+    private static Stream<Arguments> messageAndQueueProvider() {
+        return Stream.of(
+            Arguments.of(1, defaultQueueUrl),
+            Arguments.of(5, defaultQueueUrl),
+            Arguments.of(10, defaultQueueUrl)
+        );
+    }
+
+    private static Stream<Arguments> provideMessageAndThreadCounts() {
+        return Stream.of(
+            Arguments.of(1, 1, defaultQueueUrl),
+            Arguments.of(10, 1, defaultQueueUrl),
+            Arguments.of(1, 10, defaultQueueUrl),
+            Arguments.of(10, 10, defaultQueueUrl)
+        );
+    }
+
+    private void executeSendMessagesTest(int numMessages, String queueUrl) {
+        Map<String, SendMessageRequest> requests = createSendMessageRequests(numMessages, queueUrl);
+        Map<String, CompletableFuture<SendMessageResponse>> responses = sendMessages(requests);
+        verifyResponses(requests, responses);
+    }
+
+    private void executeConcurrentSendMessagesTest(int numThreads, int numMessages, String queueUrl) {
+        Map<String, SendMessageRequest> requests = createSendMessageRequests(numThreads * numMessages, queueUrl);
+        ConcurrentHashMap<String, CompletableFuture<SendMessageResponse>> responses = new ConcurrentHashMap<>();
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+        List<CompletableFuture<Map<String, CompletableFuture<SendMessageResponse>>>> sendRequestFutures =
+            createThreadsAndSendMessages(numThreads, numMessages, requests, responses, executorService);
+
+        checkThreadedResponses(requests, responses, sendRequestFutures);
+    }
+
+    private void executeDeleteMessagesTest(int numMessages, String queueUrl) throws Exception {
+        Map<String, SendMessageRequest> requests = createSendMessageRequestsForDestination(numMessages, queueUrl);
+        Map<String, CompletableFuture<SendMessageResponse>> responses = sendMessages(requests);
+        waitForAllResponses(responses);
+
+        List<Message> messages = receiveMessages(queueUrl, numMessages);
+        deleteMessagesInBatches(messages, queueUrl);
+        purgeQueue(queueUrl);
+
+        assertThat(responses).hasSize(numMessages);
+    }
+
+    private void executeChangeVisibilityTest(int numMessages, String queueUrl) throws Exception {
+        Map<String, SendMessageRequest> requests = createSendMessageRequestsForDestination(numMessages, queueUrl);
+        Map<String, CompletableFuture<SendMessageResponse>> responses = sendMessages(requests);
+        waitForAllResponses(responses);
+
+        List<Message> messages = receiveMessages(queueUrl, numMessages);
+        changeVisibilityForMessages(messages, queueUrl);
+        assertThat(responses).hasSize(numMessages);
+    }
+
+    private Map<String, SendMessageRequest> createSendMessageRequests(int size, String queueUrl) {
+        return createSendMessageRequestsForDestination(size, queueUrl);
+    }
+
+    private Map<String, SendMessageRequest> createSendMessageRequestsForDestination(int size, String queueUrl) {
+        Map<String, SendMessageRequest> requests = new HashMap<>();
+        for (int i = 0; i < size; i++) {
+            String key = Integer.toString(i);
+            requests.put(key, createSendMessageRequestToDestination(key, queueUrl));
+        }
+        return requests;
+    }
+
+    private SendMessageRequest createSendMessageRequestToDestination(String messageBody, String queueUrl) {
+        SendMessageRequest.Builder requestBuilder = SendMessageRequest.builder()
+                                                                      .messageBody(messageBody)
+                                                                      .queueUrl(queueUrl);
+        // Check if the queue URL corresponds to a FIFO queue
+        if (queueUrl.endsWith(".fifo")) {
+            // Include a MessageGroupId for FIFO queues
+            requestBuilder.messageGroupId("default-group");  // Use a consistent or meaningful group ID
+        }
+        return requestBuilder.build();
+    }
+
+    private Map<String, CompletableFuture<SendMessageResponse>> sendMessages(Map<String, SendMessageRequest> requests) {
+        return sendMessages(0, requests.size(), requests);
+    }
+
+    private Map<String, CompletableFuture<SendMessageResponse>> sendMessages(int start, int size, Map<String, SendMessageRequest> requests) {
+        Map<String, CompletableFuture<SendMessageResponse>> responses = new HashMap<>();
+        for (int i = start; i < start + size; i++) {
+            String key = Integer.toString(i);
+            SendMessageRequest request = requests.get(key);
+            responses.put(key, batchManager.sendMessage(request));
+        }
+        return responses;
+    }
+
+    private List<CompletableFuture<Map<String, CompletableFuture<SendMessageResponse>>>> createThreadsAndSendMessages(
+        int numThreads, int numMessages, Map<String, SendMessageRequest> requests,
+        ConcurrentHashMap<String, CompletableFuture<SendMessageResponse>> responses, ExecutorService executorService) {
+        List<CompletableFuture<Map<String, CompletableFuture<SendMessageResponse>>>> executions = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            executions.add(sendMessagesToDestination(i * numMessages, numMessages, requests, responses, executorService));
+        }
+        return executions;
+    }
+
+    private CompletableFuture<Map<String, CompletableFuture<SendMessageResponse>>> sendMessagesToDestination(
+        int start, int size, Map<String, SendMessageRequest> requests,
+        ConcurrentHashMap<String, CompletableFuture<SendMessageResponse>> responses, ExecutorService executorService) {
+        return CompletableFuture.supplyAsync(() -> {
+            Map<String, CompletableFuture<SendMessageResponse>> newResponses = sendMessages(start, size, requests);
+            responses.putAll(newResponses);
+            return newResponses;
+        }, executorService);
+    }
+
+    private void checkThreadedResponses(Map<String, SendMessageRequest> requests,
+                                        ConcurrentHashMap<String, CompletableFuture<SendMessageResponse>> responses,
+                                        List<CompletableFuture<Map<String, CompletableFuture<SendMessageResponse>>>> sendRequestFutures) {
+        for (CompletableFuture<Map<String, CompletableFuture<SendMessageResponse>>> sendRequestFuture : sendRequestFutures) {
+            try {
+                waitForAllResponses(sendRequestFuture.get(300, TimeUnit.MILLISECONDS));
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                log.error(() -> String.valueOf(e));
+            }
+        }
+        verifyResponses(requests, responses);
+    }
+
+    private void verifyResponses(Map<String, SendMessageRequest> requests, Map<String, CompletableFuture<SendMessageResponse>> responses) {
+        assertThat(responses).hasSameSizeAs(requests);
+        responses.forEach((key, future) -> {
+            String expectedMd5 = BinaryUtils.toHex(Md5Utils.computeMD5Hash(requests.get(key).messageBody().getBytes(StandardCharsets.UTF_8)));
+            assertThat(future.join().md5OfMessageBody()).isEqualTo(expectedMd5);
+        });
+    }
+
+    private void waitForAllResponses(Map<String, CompletableFuture<SendMessageResponse>> responses) {
+        CompletableFuture.allOf(responses.values().toArray(new CompletableFuture[0])).join();
+    }
+
+    private List<Message> receiveMessages(String queueUrl, int numMessages) throws Exception {
+        return client.receiveMessage(ReceiveMessageRequest.builder()
+                                                          .queueUrl(queueUrl)
+                                                          .maxNumberOfMessages(numMessages)
+                                                          .build())
+                     .get(3, TimeUnit.SECONDS)
+                     .messages();
+    }
+
+    private void deleteMessagesInBatches(List<Message> messages, String queueUrl) throws Exception {
+        while (!messages.isEmpty()) {
+            Map<String, DeleteMessageRequest> deleteRequests = createDeleteRequests(messages, queueUrl);
+            sendDeleteMessages(deleteRequests);
+            messages = receiveMessages(queueUrl, messages.size());
+        }
+    }
+
+    private void changeVisibilityForMessages(List<Message> messages, String queueUrl) throws Exception {
+        while (!messages.isEmpty()) {
+            Map<String, ChangeMessageVisibilityRequest> visibilityRequests = createChangeVisibilityRequests(messages, queueUrl);
+            sendChangeVisibilityRequests(visibilityRequests);
+            messages = receiveMessages(queueUrl, messages.size());
+        }
+    }
+
+    private Map<String, DeleteMessageRequest> createDeleteRequests(List<Message> messages, String queueUrl) {
+        Map<String, DeleteMessageRequest> requests = new HashMap<>();
+        for (int i = 0; i < messages.size(); i++) {
+            requests.put(Integer.toString(i), DeleteMessageRequest.builder()
+                                                                  .receiptHandle(messages.get(i).receiptHandle())
+                                                                  .queueUrl(queueUrl)
+                                                                  .build());
+        }
+        return requests;
+    }
+
+    private void sendDeleteMessages(Map<String, DeleteMessageRequest> deleteRequests) {
+        deleteRequests.forEach((key, request) -> batchManager.deleteMessage(request));
+    }
+
+    private Map<String, ChangeMessageVisibilityRequest> createChangeVisibilityRequests(List<Message> messages, String queueUrl) {
+        Map<String, ChangeMessageVisibilityRequest> requests = new HashMap<>();
+        for (int i = 0; i < messages.size(); i++) {
+            requests.put(Integer.toString(i), ChangeMessageVisibilityRequest.builder()
+                                                                            .receiptHandle(messages.get(i).receiptHandle())
+                                                                            .queueUrl(queueUrl)
+                                                                            .build());
+        }
+        return requests;
+    }
+
+    private void sendChangeVisibilityRequests(Map<String, ChangeMessageVisibilityRequest> visibilityRequests) {
+        visibilityRequests.forEach((key, request) -> batchManager.changeMessageVisibility(request));
+    }
+
+    private String createQueue(String queueName) throws Exception {
+        return client.createQueue(CreateQueueRequest.builder()
+                                                    .queueName(queueName)
+                                                    .build())
+                     .get(3, TimeUnit.SECONDS)
+                     .queueUrl();
+    }
+
+    private void cleanupQueues(int numThreads) throws Exception {
+        for (int i = 1; i < numThreads; i++) {
+            String queueUrl = client.getQueueUrl(GetQueueUrlRequest.builder().queueName(TEST_QUEUE_PREFIX + i).build())
+                                    .get(3, TimeUnit.SECONDS)
+                                    .queueUrl();
+            purgeQueue(queueUrl);
+        }
+    }
+
+    private static void purgeQueue(String queueUrl) {
+        client.purgeQueue(PurgeQueueRequest.builder()
+                                           .queueUrl(queueUrl)
+                                           .build());
+    }
+
+    private void waitFor(int milliseconds) {
+        CountDownLatch latch = new CountDownLatch(1);
+        try {
+            latch.await(milliseconds, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private Map<String, SendMessageRequest> createSendMessageRequestsForDifferentDestinations(int numDestinations, int destinationSize) throws Exception {
+        Map<String, SendMessageRequest> requests = new HashMap<>();
+        for (int i = 0; i < numDestinations; i++) {
+            // Create a new queue for each destination
+            String queueUrl = createQueue(TEST_QUEUE_PREFIX + i);
+
+            for (int j = 0; j < destinationSize; j++) {
+                // Generate a unique key for each message
+                String key = Integer.toString(i * destinationSize + j);
+                // Create a SendMessageRequest for the specific destination (queue)
+                requests.put(key, createSendMessageRequestToDestination(key, queueUrl));
+            }
+        }
+        return requests;
+    }
+}

--- a/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/ResponseBatchManagerSqsIntegrationTest.java
+++ b/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/ResponseBatchManagerSqsIntegrationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ResponseBatchManagerSqsIntegrationTest extends IntegrationTestBase {
+    private static final String TEST_QUEUE_PREFIX = "ResponseBatchManagerSqsIntegrationTest-";
+    private static SqsAsyncClient client;
+    private static String defaultQueueUrl;
+    private static SqsAsyncBatchManager batchManager;
+
+    @BeforeAll
+    public static void setUpBeforeClass() throws Exception {
+        client = SqsAsyncClient.builder()
+                               .credentialsProvider(getCredentialsProvider())
+                               .build();
+        defaultQueueUrl = client.createQueue(CreateQueueRequest.builder()
+                                                               .queueName(TEST_QUEUE_PREFIX + UUID.randomUUID().toString())
+                                                               .build())
+                                .get(3, TimeUnit.SECONDS)
+                                .queueUrl();
+    }
+
+    @AfterAll
+    public static void tearDownAfterClass() {
+        purgeQueue(defaultQueueUrl);
+        client.deleteQueue(d -> d.queueUrl(defaultQueueUrl)).join();
+        if(batchManager != null){
+            batchManager.close();
+        }
+        client.close();
+    }
+
+    private static void purgeQueue(String queueUrl) {
+        client.purgeQueue(PurgeQueueRequest.builder()
+                                           .queueUrl(queueUrl)
+                                           .build())
+              .join();
+    }
+
+    private static void deleteMessages(ReceiveMessageResponse receiveMessageResponse, SqsAsyncBatchManager batchManager) {
+        List<CompletableFuture<DeleteMessageResponse>> deleteFutures =
+            receiveMessageResponse.messages().stream()
+                                  .map(message -> batchManager.deleteMessage(r -> r.queueUrl(defaultQueueUrl)
+                                                                                   .receiptHandle(message.receiptHandle())))
+                                  .collect(Collectors.toList());
+        CompletableFuture.allOf(deleteFutures.toArray(new CompletableFuture[0])).join();
+    }
+
+    private static void sendMessages(SqsAsyncBatchManager batchManager, String queueUrl, int numOfMessages) throws Exception {
+        List<CompletableFuture<Void>> futures = IntStream.rangeClosed(1, numOfMessages)
+                                                         .mapToObj(i -> batchManager.sendMessage(s -> s.queueUrl(queueUrl)
+                                                                                                       .messageBody("Message " + i)
+                                                                                                       .messageAttributes(messageAttributeValueMap()))
+                                                                                    .thenAccept(response -> {
+                                                                                    }))  // Removed logging
+                                                         .collect(Collectors.toList());
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+    }
+
+    private static Map<String, MessageAttributeValue> messageAttributeValueMap() {
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
+        attributes.put("keyOne", MessageAttributeValue.builder().stringValue("4").dataType("String").build());
+        attributes.put("keyTwo", MessageAttributeValue.builder().stringValue("2").dataType("String").build());
+        attributes.put("keyThree", MessageAttributeValue.builder().stringValue("3").dataType("String").build());
+        attributes.put("keyFour", MessageAttributeValue.builder().stringValue("5").dataType("String").build());
+        return attributes;
+    }
+
+    private void assertMessagesReceived(SqsAsyncBatchManager batchManager, int expectedMessageCount) throws Exception {
+        List<Message> allMessages = new ArrayList<>();
+        while (allMessages.size() < expectedMessageCount) {
+            CompletableFuture<ReceiveMessageResponse> receiveMessageFuture =
+                batchManager.receiveMessage(r -> r.queueUrl(defaultQueueUrl));
+            ReceiveMessageResponse receiveMessageResponse = receiveMessageFuture.get(5, TimeUnit.SECONDS);
+            if (!receiveMessageResponse.messages().isEmpty()) {
+                allMessages.addAll(receiveMessageResponse.messages());
+                deleteMessages(receiveMessageResponse, batchManager);
+            }
+        }
+        assertThat(allMessages.size()).isEqualTo(expectedMessageCount);
+    }
+
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    @Test
+    void simpleReceiveMessagesWithDefaultConfiguration() throws Exception {
+        batchManager = client.batchManager();
+        sendMessages(batchManager, defaultQueueUrl, 10);
+        assertMessagesReceived(batchManager, 10);
+
+        List<Message> allMessages = batchManager.receiveMessage(r -> r.queueUrl(defaultQueueUrl))
+                                                .get(5, TimeUnit.SECONDS)
+                                                .messages();
+        assertTrue(allMessages.stream().allMatch(m -> m.messageAttributes().isEmpty()), "Expected no message attributes.");
+        assertTrue(allMessages.stream().allMatch(m -> m.attributes().isEmpty()), "Expected no system attributes.");
+    }
+
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    @Test
+    void simpleReceiveMessagesWithCustomConfigurations() throws Exception {
+        batchManager = SqsAsyncBatchManager.builder()
+                                           .client(client)
+                                           .scheduledExecutor(Executors.newScheduledThreadPool(5))
+                                           .overrideConfiguration(b -> b
+                                               .receiveMessageMinWaitDuration(Duration.ofSeconds(10))
+                                               .receiveMessageVisibilityTimeout(Duration.ofSeconds(1))
+                                               .receiveMessageAttributeNames(Collections.singletonList("*"))
+                                               .receiveMessageSystemAttributeNames(Collections.singletonList(MessageSystemAttributeName.ALL)))
+                                           .build();
+
+        sendMessages(batchManager, defaultQueueUrl, 10);
+        assertMessagesReceived(batchManager, 10);
+
+        List<Message> allMessages = batchManager.receiveMessage(r -> r.queueUrl(defaultQueueUrl))
+                                                .get(5, TimeUnit.SECONDS)
+                                                .messages();
+
+        Map<String, MessageAttributeValue> expectedMessageAttributes = messageAttributeValueMap();
+        allMessages.forEach(m -> {
+            assertFalse(m.messageAttributes().isEmpty(), "Expected message attributes, but found none.");
+            assertThat(m.messageAttributes()).isEqualTo(expectedMessageAttributes);
+            assertFalse(m.attributes().isEmpty(), "Expected system attributes, but found none.");
+            assertTrue(m.attributes().containsKey(MessageSystemAttributeName.SENDER_ID), "Expected SenderId, but missing.");
+            assertTrue(m.attributes().containsKey(MessageSystemAttributeName.APPROXIMATE_FIRST_RECEIVE_TIMESTAMP), "Expected "
+                                                                                                                   +
+                                                                                                                   "ApproximateFirstReceiveTimestamp, but missing.");
+        });
+    }
+
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    @Test
+    void requestLevelMaxMessageAndWaitTimeIsHonoured() throws Exception {
+        batchManager = client.batchManager();
+
+        sendMessages(batchManager, defaultQueueUrl, 10);
+
+        List<Message> allMessages = new ArrayList<>();
+        List<CompletableFuture<DeleteMessageResponse>> deleteFutures = new ArrayList<>();
+        int expectedMessageCount = 10;
+
+        while (allMessages.size() < expectedMessageCount) {
+            CompletableFuture<ReceiveMessageResponse> future =
+                batchManager.receiveMessage(r -> r.queueUrl(defaultQueueUrl)
+                                                  .maxNumberOfMessages(1)
+                                                  .waitTimeSeconds(2));
+
+            // Process the received message and delete if non-empty
+            future.whenComplete((response, throwable) -> {
+                if (response != null && !response.messages().isEmpty()) {
+                    allMessages.addAll(response.messages());
+                    assertThat(response.messages().size()).isEqualTo(1);
+
+                    // Collect deleteMessage futures for each message
+                    response.messages().forEach(message -> {
+                        CompletableFuture<DeleteMessageResponse> deleteFuture = batchManager.deleteMessage(d -> d.queueUrl(defaultQueueUrl)
+                                                                                                                 .receiptHandle(message.receiptHandle()));
+                        deleteFutures.add(deleteFuture);
+                    });
+                }
+            }).join();  // Wait for each receiveMessage future to complete before continuing
+        }
+
+        // Wait for all deleteMessage futures to complete
+        CompletableFuture<Void> allDeleteFutures = CompletableFuture.allOf(deleteFutures.toArray(new CompletableFuture[0]));
+        allDeleteFutures.join();
+
+        assertThat(allMessages.size()).isEqualTo(expectedMessageCount);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Integ test for Automatic Request Batching
- Integ test is needed to make sure Batching feature is able to handle SQS service real time behaviour when it comes to sending and receieing message


### Summary of Testing in `RequestBatchManagerSqsIntegrationTest`

This test class performs integration testing for AWS SQS batch manager, covering various message sending, receiving, and management scenarios using SQS.

### Scenarios Covered:

1. **Basic Message Sending:**
   - **`sendTenMessages`**: Sends 10 messages to a queue.
   - **`sendTwentyMessages`**: Sends 20 messages to a queue.

2. **Batching and Scheduling:**
   - **`scheduleSendFiveMessages`**: Sends 5 messages in a batch and checks batch processing time.
   - **`scheduleTwoSendMessageBatches`**: Sends 10 messages in two batches and checks batch behavior.

3. **Multi-threaded Message Sending:**
   - **`sendMultipleMessagesWithMultiThread`**: Sends messages using multiple threads and verifies concurrency.

4. **Messages to Different Queues:**
   - **`scheduleFiveMessagesWithEachThreadToDifferentLocations`**: Sends messages to different queues from multiple threads.

5. **Message Deletion:**
   - **`deleteMessages`**: Sends and deletes messages, ensuring batch deletion works.

6. **Visibility Timeout Change:**
   - **`changeVisibilityMessages`**: Changes visibility timeout of messages after sending.

7. **Large Message Handling:**
   - **`sendMessagesWhichCanExceed256KiBCollectively`**: Sends large messages (256 KiB) and verifies correct handling.

8. **Queue Management:**
   - **`createSendMessageRequestsForDifferentDestinations`**: Creates multiple queues and sends messages to them.

### Key Features:
- **Multi-threading**: Concurrent message sending and management.
- **Batching**: Focus on batch processing for sending, receiving, and deleting messages.
- **Message Size Limit**: Tests sending large messages near the 256 KiB limit.
- **Custom Configurations**: Tests custom attributes and system attributes for messages.

### Summary of Testing in `ResponseBatchManagerSqsIntegrationTest`

This test class performs integration testing for AWS SQS response batch manager, focusing on message sending, receiving, and processing via SQS.

### Scenarios Covered:

1. **Basic Message Receiving:**
   - **`simpleReceiveMessagesWithDefaultConfiguration`**: Sends 10 messages and receives them with default batch manager settings. Ensures no message attributes or system attributes are present.

2. **Custom Configuration for Message Receiving:**
   - **`simpleReceiveMessagesWithCustomConfigurations`**: Tests receiving messages with custom configurations (e.g., wait time, message attributes). Ensures message attributes and system attributes are correctly processed.

3. **Request-Level Max Message and Wait Time Handling:**
   - **`requestLevelMaxMessageAndWaitTimeIsHonoured`**: Ensures the request-level configurations like `maxNumberOfMessages` and `waitTimeSeconds` are respected when receiving and processing messages. Verifies message deletion after receiving each message.

### Key Features:
- **Batch Processing**: Tests the behavior of batch manager while sending, receiving, and deleting messages.
- **Custom Configurations**: Tests custom configurations for receiving messages (e.g., attribute names, system attribute names, wait times).
- **Message Deletion**: Ensures proper message deletion after processing.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
