### PR TITLE
Add a client config to the client that is now needed

### DIFF
--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/marshaller/dynamodb/V2DynamoDbAttributeValue.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/marshaller/dynamodb/V2DynamoDbAttributeValue.java
@@ -20,12 +20,20 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.http.AbortableInputStream;
@@ -61,11 +69,17 @@ import software.amazon.awssdk.services.dynamodb.model.TableInUseException;
 import software.amazon.awssdk.services.dynamodb.model.TableNotFoundException;
 import software.amazon.awssdk.services.dynamodb.transform.PutItemRequestMarshaller;
 
-
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
 public class V2DynamoDbAttributeValue {
 
     private static final AwsJsonProtocolFactory JSON_PROTOCOL_FACTORY = AwsJsonProtocolFactory
         .builder()
+        .clientConfiguration(SdkClientConfiguration
+                                 .builder()
+                                 .option(SdkClientOption.ENDPOINT, URI.create("https://localhost"))
+                                 .build())
         .defaultServiceExceptionSupplier(DynamoDbException::builder)
         .protocol(AwsJsonProtocol.AWS_JSON)
         .protocolVersion("1.0")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

The `V2DynamoDbAttributeValue` benchmark currently fail with a NPE since the client configuration is missing. This change adds the client configuration to be fix this issue.



```
software.amazon.awssdk.core.exception.SdkClientException: Unable to marshall request to JSON: Cannot invoke "software.amazon.awssdk.core.client.config.SdkClientConfiguration.option(software.amazon.awssdk.core.client.config.ClientOption)" because "this.clientConfiguration" is null
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:111)
	at software.amazon.awssdk.services.dynamodb.transform.PutItemRequestMarshaller.marshall(PutItemRequestMarshaller.java:52)
	at software.amazon.awssdk.benchmark.marshaller.dynamodb.V2DynamoDbAttributeValue.putItem(V2DynamoDbAttributeValue.java:147)
	at software.amazon.awssdk.benchmark.marshaller.dynamodb.jmh_generated.V2DynamoDbAttributeValue_putItem_jmhTest.putItem_thrpt_jmhStub(V2DynamoDbAttributeValue_putItem_jmhTest.java:147)
	at software.amazon.awssdk.benchmark.marshaller.dynamodb.jmh_generated.V2DynamoDbAttributeValue_putItem_jmhTest.putItem_Throughput(V2DynamoDbAttributeValue_putItem_jmhTest.java:86)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:527)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:504)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.NullPointerException: Cannot invoke "software.amazon.awssdk.core.client.config.SdkClientConfiguration.option(software.amazon.awssdk.core.client.config.ClientOption)" because "this.clientConfiguration" is null
	at software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory.createProtocolMarshaller(BaseAwsJsonProtocolFactory.java:186)
	at software.amazon.awssdk.services.dynamodb.transform.PutItemRequestMarshaller.marshall(PutItemRequestMarshaller.java:49)
	... 15 more
```
## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
