### PR TITLE
Align behaviour of default table creation between sync and async table

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDB-d32dcc5.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-d32dcc5.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced",
+    "description": "This bugfix ensures that when using DynamoDbAsyncTable.createTable with no arguments any secondary indices defined in your TableSchema are also created. This behaviour was already present in the synchronous DynamoDbTable",
+    "contributor": "zakerf"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
@@ -16,12 +16,18 @@
 package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.createKeyFromItem;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.client.DynamoDbTableUtils.extractGlobalSecondaryIndices;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.client.DynamoDbTableUtils.extractLocalSecondaryIndices;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.client.DynamoDbTableUtils.splitSecondaryIndicesToLocalAndGlobalOnes;
 
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.IndexMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -114,7 +120,11 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
 
     @Override
     public CompletableFuture<Void> createTable() {
-        return createTable(CreateTableEnhancedRequest.builder().build());
+        Map<IndexType, List<IndexMetadata>> indexGroups = splitSecondaryIndicesToLocalAndGlobalOnes(tableSchema);
+        return createTable(CreateTableEnhancedRequest.builder()
+                                              .localSecondaryIndices(extractLocalSecondaryIndices(indexGroups))
+                                              .globalSecondaryIndices(extractGlobalSecondaryIndices(indexGroups))
+                                              .build());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
@@ -15,20 +15,19 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 
-import static java.util.Collections.emptyList;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.createKeyFromItem;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.client.DynamoDbTableUtils.extractGlobalSecondaryIndices;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.client.DynamoDbTableUtils.extractLocalSecondaryIndices;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.client.DynamoDbTableUtils.splitSecondaryIndicesToLocalAndGlobalOnes;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.IndexMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
-import software.amazon.awssdk.enhanced.dynamodb.KeyAttributeMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.CreateTableOperation;
@@ -46,8 +45,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest
 import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedResponse;
 import software.amazon.awssdk.enhanced.dynamodb.model.DescribeTableEnhancedResponse;
-import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
-import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedLocalSecondaryIndex;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedResponse;
 import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
@@ -61,7 +58,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedResponse
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
-import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 
 @SdkInternalApi
 public class DefaultDynamoDbTable<T> implements DynamoDbTable<T> {
@@ -126,50 +122,11 @@ public class DefaultDynamoDbTable<T> implements DynamoDbTable<T> {
 
     @Override
     public void createTable() {
-        Map<IndexType, List<IndexMetadata>> indexGroups = splitSecondaryIndicesToLocalAndGlobalOnes();
+        Map<IndexType, List<IndexMetadata>> indexGroups = splitSecondaryIndicesToLocalAndGlobalOnes(tableSchema);
         createTable(CreateTableEnhancedRequest.builder()
                                               .localSecondaryIndices(extractLocalSecondaryIndices(indexGroups))
                                               .globalSecondaryIndices(extractGlobalSecondaryIndices(indexGroups))
                                               .build());
-    }
-
-    private Map<IndexType, List<IndexMetadata>> splitSecondaryIndicesToLocalAndGlobalOnes() {
-        Collection<IndexMetadata> indices = tableSchema.tableMetadata().indices();
-        return indices.stream()
-                      .filter(index -> !TableMetadata.primaryIndexName().equals(index.name()))
-                      .collect(Collectors.groupingBy(metadata -> {
-                          String partitionKeyName = metadata.partitionKey().map(KeyAttributeMetadata::name).orElse(null);
-                          if (partitionKeyName == null) {
-                              return IndexType.LSI;
-                          }
-                          return IndexType.GSI;
-                      }));
-    }
-
-    private List<EnhancedLocalSecondaryIndex> extractLocalSecondaryIndices(Map<IndexType, List<IndexMetadata>> indicesGroups) {
-        return indicesGroups.getOrDefault(IndexType.LSI, emptyList()).stream()
-                            .map(this::mapIndexMetadataToEnhancedLocalSecondaryIndex)
-                            .collect(Collectors.toList());
-    }
-
-    private EnhancedLocalSecondaryIndex mapIndexMetadataToEnhancedLocalSecondaryIndex(IndexMetadata indexMetadata) {
-        return EnhancedLocalSecondaryIndex.builder()
-                                          .indexName(indexMetadata.name())
-                                          .projection(pb -> pb.projectionType(ProjectionType.ALL))
-                                          .build();
-    }
-
-    private List<EnhancedGlobalSecondaryIndex> extractGlobalSecondaryIndices(Map<IndexType, List<IndexMetadata>> indicesGroups) {
-        return indicesGroups.getOrDefault(IndexType.GSI, emptyList()).stream()
-                            .map(this::mapIndexMetadataToEnhancedGlobalSecondaryIndex)
-                            .collect(Collectors.toList());
-    }
-
-    private EnhancedGlobalSecondaryIndex mapIndexMetadataToEnhancedGlobalSecondaryIndex(IndexMetadata indexMetadata) {
-        return EnhancedGlobalSecondaryIndex.builder()
-                                           .indexName(indexMetadata.name())
-                                           .projection(pb -> pb.projectionType(ProjectionType.ALL))
-                                           .build();
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DynamoDbTableUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DynamoDbTableUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.client;
+
+import static java.util.Collections.emptyList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.IndexMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.KeyAttributeMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedLocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+
+@SdkInternalApi
+public final class DynamoDbTableUtils {
+
+    private DynamoDbTableUtils() {
+    }
+
+    public static Map<IndexType, List<IndexMetadata>> splitSecondaryIndicesToLocalAndGlobalOnes(TableSchema<?> tableSchema) {
+        Collection<IndexMetadata> indices = tableSchema.tableMetadata().indices();
+        return indices.stream()
+                      .filter(index -> !TableMetadata.primaryIndexName().equals(index.name()))
+                      .collect(Collectors.groupingBy(metadata -> {
+                          String partitionKeyName = metadata.partitionKey().map(KeyAttributeMetadata::name).orElse(null);
+                          if (partitionKeyName == null) {
+                              return IndexType.LSI;
+                          }
+                          return IndexType.GSI;
+                      }));
+    }
+
+    public static List<EnhancedLocalSecondaryIndex> extractLocalSecondaryIndices(Map<IndexType, List<IndexMetadata>> indicesGroups) {
+        return indicesGroups.getOrDefault(IndexType.LSI, emptyList()).stream()
+                            .map(DynamoDbTableUtils::mapIndexMetadataToEnhancedLocalSecondaryIndex)
+                            .collect(Collectors.toList());
+    }
+
+    public static EnhancedLocalSecondaryIndex mapIndexMetadataToEnhancedLocalSecondaryIndex(IndexMetadata indexMetadata) {
+        return EnhancedLocalSecondaryIndex.builder()
+                                          .indexName(indexMetadata.name())
+                                          .projection(pb -> pb.projectionType(ProjectionType.ALL))
+                                          .build();
+    }
+
+    public static List<EnhancedGlobalSecondaryIndex> extractGlobalSecondaryIndices(Map<IndexType, List<IndexMetadata>> indicesGroups) {
+        return indicesGroups.getOrDefault(IndexType.GSI, emptyList()).stream()
+                            .map(DynamoDbTableUtils::mapIndexMetadataToEnhancedGlobalSecondaryIndex)
+                            .collect(Collectors.toList());
+    }
+
+    public static EnhancedGlobalSecondaryIndex mapIndexMetadataToEnhancedGlobalSecondaryIndex(IndexMetadata indexMetadata) {
+        return EnhancedGlobalSecondaryIndex.builder()
+                                           .indexName(indexMetadata.name())
+                                           .projection(pb -> pb.projectionType(ProjectionType.ALL))
+                                           .build();
+    }
+
+}


### PR DESCRIPTION

## Motivation and Context
While migrating a project from the sync client to the async one I noticed failing tests in our project because of missing indices. We relied on createTable() to create the table in tests and after diving into it I saw that the secondary indices we have are not being created with the async variation. 

## Modifications
This adds the behaviour introduced in the sync DDB table to the async version as well. See commit ef2aa905c87 for original code

## Testing
Haven't added any new code and the existing code already has proper unit tests

## Screenshots (if appropriate)

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ x] Local run of `mvn install` succeeds
- [ x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed
- [ x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [ x] I confirm that this pull request can be released under the Apache 2 license
