### PR TITLE
remove japicmp exclusion for rds InvalidMaxAcuException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -678,10 +678,6 @@
                             <exclude>software.amazon.awssdk.regions.*</exclude>
                             <!-- TODO revert - Temporarily disable because system setting USER_REGION was removed -->
                             <exclude>software.amazon.awssdk.utils.JavaSystemSetting</exclude>
-
-                            <!-- TODO revert - temporarily disable to release InvalidMaxAcuException removal -->
-                            <exclude>software.amazon.awssdk.services.rds.model.InvalidMaxAcuException</exclude>
-                            <exclude>software.amazon.awssdk.services.rds.model.InvalidMaxAcuException$Builder</exclude>
                         </excludes>
 
                         <ignoreMissingOldVersion>true</ignoreMissingOldVersion>


### PR DESCRIPTION
remove japicmp exclusion which was added yesterday, that was required for rds feature release