### PR TITLE
Changed order of method calls in ProfileCredentialsProvider resolveCredentials method

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
@@ -122,8 +122,8 @@ public final class ProfileCredentialsProvider
         if (shouldUpdateCredentialsProvider(cachedOrRefreshedProfileFile)) {
             synchronized (credentialsProviderLock) {
                 if (shouldUpdateCredentialsProvider(cachedOrRefreshedProfileFile)) {
-                    currentProfileFile = cachedOrRefreshedProfileFile;
                     handleProfileFileReload(cachedOrRefreshedProfileFile);
+                    currentProfileFile = cachedOrRefreshedProfileFile;
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Problem - incorrect order of method calls 

The `handleProfileFileReload(cachedOrRefreshedProfileFile)` method should be called before updating the `currentProfileFile` to ensure that the credentials provider is updated with the new profile file before it is set as the current profile file.  

## Motivation and Context
#5001 
This change ensures that any subsequent calls to `resolveCredentials` method will use updated credentials provider.

## Modifications
Moved the `handleProfileFileReload(cachedOrRefreshedProfileFile)` call before the `currentProfileFile = cachedOrRefreshedProfileFile` assignment.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
