### PR TITLE
Deprecate internal checksum APIs

### DIFF
--- a/.changes/next-release/deprecation-AWSSDKforJavav2-f4ed7f8.json
+++ b/.changes/next-release/deprecation-AWSSDKforJavav2-f4ed7f8.json
@@ -1,0 +1,6 @@
+{
+    "type": "deprecation",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Deprecate internal checksum classes."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Algorithm.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Algorithm.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.checksums;
 
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.internal.EnumUtils;
@@ -23,7 +24,7 @@ import software.amazon.awssdk.utils.internal.EnumUtils;
 /**
  * Enum that indicates all the checksums supported by Flexible checksums in a Service Request/Response Header.
  */
-@SdkPublicApi
+@SdkProtectedApi
 public enum Algorithm {
 
     CRC32C("crc32c", 8),

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/ChecksumSpecs.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/ChecksumSpecs.java
@@ -19,12 +19,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
  * Defines all the Specifications that are required while adding HttpChecksum to a request and validating HttpChecksum of a
  * response.
  */
-@SdkInternalApi
+@SdkProtectedApi
 public class ChecksumSpecs {
 
     private final Algorithm algorithm;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/ChecksumValidation.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/ChecksumValidation.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.checksums;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -33,7 +34,7 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
  * {@link #CHECKSUM_RESPONSE_NOT_FOUND}
  *
  */
-@SdkPublicApi
+@SdkProtectedApi
 public enum ChecksumValidation {
     /**
      * Checksum validation was performed on the response.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Crc32CChecksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Crc32CChecksum.java
@@ -26,7 +26,9 @@ import software.amazon.awssdk.core.internal.checksums.factory.SdkCrc32C;
 
 /**
  * Implementation of {@link SdkChecksum} to calculate an CRC32C checksum.
+ * @deprecated this is an internal class and is subject to removal.
  */
+@Deprecated
 @SdkInternalApi
 public class Crc32CChecksum implements SdkChecksum {
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Crc32Checksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Crc32Checksum.java
@@ -26,7 +26,9 @@ import software.amazon.awssdk.core.internal.checksums.factory.SdkCrc32;
 
 /**
  * Implementation of {@link SdkChecksum} to calculate an CRC32 checksum.
+ * @deprecated this is an internal class and is subject to removal.
  */
+@Deprecated
 @SdkInternalApi
 public class Crc32Checksum implements SdkChecksum {
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Md5Checksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Md5Checksum.java
@@ -20,7 +20,10 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Implementation of {@link SdkChecksum} to calculate an MD5 checksum.
+ *
+ * @deprecated this is an internal class and is subject to removal.
  */
+@Deprecated
 @SdkInternalApi
 public class Md5Checksum implements SdkChecksum {
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/SdkChecksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/SdkChecksum.java
@@ -17,13 +17,13 @@ package software.amazon.awssdk.core.checksums;
 
 import java.nio.ByteBuffer;
 import java.util.zip.Checksum;
-import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
  * Extension of {@link Checksum} to support checksums and checksum validations used by the SDK that
  * are not provided by the JDK.
  */
-@SdkPublicApi
+@SdkProtectedApi
 public interface SdkChecksum extends Checksum {
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Sha1Checksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Sha1Checksum.java
@@ -20,7 +20,9 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Implementation of {@link SdkChecksum} to calculate an Sha-1 checksum.
+ * @deprecated this is an internal class and is subject to removal.
  */
+@Deprecated
 @SdkInternalApi
 public class Sha1Checksum implements SdkChecksum {
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Sha256Checksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Sha256Checksum.java
@@ -20,7 +20,9 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Implementation of {@link SdkChecksum} to calculate an Sha-256 Checksum.
+ * @deprecated this is an internal class and is subject to removal.
  */
+@Deprecated
 @SdkInternalApi
 public class Sha256Checksum implements SdkChecksum {
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ChecksumCalculatingAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ChecksumCalculatingAsyncRequestBody.java
@@ -41,6 +41,10 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
 /**
  * Wrapper class to wrap an AsyncRequestBody.
  * This will read the data in chunk format and append Checksum as trailer at the end.
+ *
+ * <p>
+ * Checksum validation logic is now in "http-auth-aws". DO NOT make changes
+ * TODO(post-sra-identity-auth): remove this
  */
 @SdkInternalApi
 public class ChecksumCalculatingAsyncRequestBody implements AsyncRequestBody {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ChecksumValidatingPublisher.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ChecksumValidatingPublisher.java
@@ -28,6 +28,9 @@ import software.amazon.awssdk.utils.BinaryUtils;
 /**
  * Publisher to update the checksum as it reads the data and
  * finally compares the computed checksum with expected Checksum.
+ *
+ * Checksum validation logic is now in "http-auth-aws". DO NOT make changes
+ * TODO(post-sra-identity-auth): remove this
  */
 @SdkInternalApi
 public final class ChecksumValidatingPublisher implements SdkPublisher<ByteBuffer> {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/io/ChecksumValidatingInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/io/ChecksumValidatingInputStream.java
@@ -27,6 +27,9 @@ import software.amazon.awssdk.utils.Validate;
 /**
  * Stream that will update the Checksum as the data is read.
  * When end of the stream is reached the computed Checksum is validated with Expected checksum.
+ * <p>
+ * Checksum validation logic is now in "http-auth-aws". DO NOT make changes
+ * TODO(post-sra-identity-auth): remove this
  */
 @SdkInternalApi
 public class ChecksumValidatingInputStream extends InputStream implements Abortable {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/ChecksumUtils.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/ChecksumUtils.java
@@ -78,13 +78,6 @@ public final class ChecksumUtils {
         }
     }
 
-    public static String calculatedChecksum(String contentString, Algorithm algorithm) {
-        SdkChecksum sdkChecksum = SdkChecksum.forAlgorithm(algorithm);
-        for (byte character : contentString.getBytes(StandardCharsets.UTF_8)) {
-            sdkChecksum.update(character);
-        }
-        return BinaryUtils.toBase64(sdkChecksum.getChecksumBytes());
-    }
 
     public static String calculatedChecksum(Path path, Algorithm algorithm) {
         SdkChecksum sdkChecksum = SdkChecksum.forAlgorithm(algorithm);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
We have duplicate checksum classes, which is really confusing when we add new checksum algorithms.. Example: old [Md5Checksum](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Md5Checksum.java), new [Md5Checksum](https://github.com/aws/aws-sdk-java-v2/blob/master/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/checksums/Md5Checksum.java), same for other checksum algorithms.

## Modifications
- Deprecated internal checksum APIs. Since they are not in internal sub packages unfortunately, removing them could break users who didn't notice `SdkInternalApi` annotations, even though we don't maintain backwards compatibility guarantees for internal APIs.
- Changed annotation fo checksum classes that are used in generated sdk clients from `SdkPublicApi` to `SdkProtectedApi`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
