### PR TITLE
Resolve credentials on retry for S3Express

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-auth-scheme-interceptor.java
@@ -113,10 +113,11 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
         authOption.forEachIdentityProperty(identityRequestBuilder::putProperty);
         CompletableFuture<? extends T> identity;
         SdkMetric<Duration> metric = getIdentityMetric(identityProvider);
+        ResolveIdentityRequest resolveIdentityRequest = identityRequestBuilder.build();
         if (metric == null) {
-            identity = identityProvider.resolveIdentity(identityRequestBuilder.build());
+            identity = identityProvider.resolveIdentity(resolveIdentityRequest);
         } else {
-            identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(identityRequestBuilder.build()),
+            identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(resolveIdentityRequest),
                                                   metricCollector, metric);
         }
         return new SelectedAuthScheme<>(identity, signer, authOption);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-with-allowlist-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-with-allowlist-auth-scheme-interceptor.java
@@ -130,10 +130,11 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
         authOption.forEachIdentityProperty(identityRequestBuilder::putProperty);
         CompletableFuture<? extends T> identity;
         SdkMetric<Duration> metric = getIdentityMetric(identityProvider);
+        ResolveIdentityRequest resolveIdentityRequest = identityRequestBuilder.build();
         if (metric == null) {
-            identity = identityProvider.resolveIdentity(identityRequestBuilder.build());
+            identity = identityProvider.resolveIdentity(resolveIdentityRequest);
         } else {
-            identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(identityRequestBuilder.build()),
+            identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(resolveIdentityRequest),
                                                   metricCollector, metric);
         }
         return new SelectedAuthScheme<>(identity, signer, authOption);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/query-endpoint-auth-params-without-allowlist-auth-scheme-interceptor.java
@@ -137,10 +137,11 @@ public final class QueryAuthSchemeInterceptor implements ExecutionInterceptor {
         authOption.forEachIdentityProperty(identityRequestBuilder::putProperty);
         CompletableFuture<? extends T> identity;
         SdkMetric<Duration> metric = getIdentityMetric(identityProvider);
+        ResolveIdentityRequest resolveIdentityRequest = identityRequestBuilder.build();
         if (metric == null) {
-            identity = identityProvider.resolveIdentity(identityRequestBuilder.build());
+            identity = identityProvider.resolveIdentity(resolveIdentityRequest);
         } else {
-            identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(identityRequestBuilder.build()),
+            identity = MetricUtils.reportDuration(() -> identityProvider.resolveIdentity(resolveIdentityRequest),
                                                   metricCollector, metric);
         }
         return new SelectedAuthScheme<>(identity, signer, authOption);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -31,7 +31,10 @@ import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeProvider;
+import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
 import software.amazon.awssdk.utils.AttributeMap;
 
 /**
@@ -152,6 +155,18 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<SelectedAuthScheme<?>> SELECTED_AUTH_SCHEME =
         new ExecutionAttribute<>("SelectedAuthScheme");
+
+    /**
+     * The selected identity provider for a request.
+     */
+    public static final ExecutionAttribute<IdentityProvider<? extends Identity>> SELECTED_IDENTITY_PROVIDER =
+        new ExecutionAttribute<>("SelectedIdentityProvider");
+
+    /**
+     * The resolve identity request used by the identity provider.
+     */
+    public static final ExecutionAttribute<ResolveIdentityRequest> RESOLVE_IDENTITY_REQUEST =
+        new ExecutionAttribute<>("ResolveIdentityRequest");
 
     /**
      * The supported compression algorithms for an operation, and whether the operation is streaming or not.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage2.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage2.java
@@ -95,6 +95,7 @@ public final class AsyncRetryableStage2<OutputT> implements RequestPipeline<SdkH
             try {
                 retryableStageHelper.startingAttempt();
                 retryableStageHelper.logSendingRequest();
+                retryableStageHelper.resolveCredentialsIfS3ExpressRetry(context);
                 responseFuture = requestPipeline.execute(retryableStageHelper.requestToSend(), context);
 
                 // If the result future fails, go ahead and fail the response future.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage2.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage2.java
@@ -53,6 +53,7 @@ public final class RetryableStage2<OutputT> implements RequestToResponsePipeline
         while (true) {
             try {
                 retryableStageHelper.startingAttempt();
+                retryableStageHelper.resolveCredentialsIfS3ExpressRetry(context);
                 Response<OutputT> response = executeRequest(retryableStageHelper, context);
                 retryableStageHelper.recordAttemptSucceeded();
                 return response;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper2.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper2.java
@@ -249,7 +249,7 @@ public final class RetryableStageHelper2 {
             return;
         }
 
-        IdentityProvider identityProvider =
+        IdentityProvider<?> identityProvider =
             requestExecutionContext.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_IDENTITY_PROVIDER);
 
         if (identityProvider == null || !isS3Express(identityProvider)) {
@@ -263,14 +263,14 @@ public final class RetryableStageHelper2 {
         SelectedAuthScheme<?> authScheme =
             requestExecutionContext.executionAttributes().getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
 
-        CompletableFuture newlyResolvedIdentity = identityProvider.resolveIdentity(resolveIdentityRequest);
+        CompletableFuture<?> newlyResolvedIdentity = identityProvider.resolveIdentity(resolveIdentityRequest);
         SelectedAuthScheme<?> updatedAuthScheme = new SelectedAuthScheme(newlyResolvedIdentity, authScheme.signer(),
                                                                          authScheme.authSchemeOption());
         requestExecutionContext.executionAttributes().putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
                                                                    updatedAuthScheme);
     }
 
-    private boolean isS3Express(IdentityProvider identityProvider) {
+    private boolean isS3Express(IdentityProvider<?> identityProvider) {
         String className = identityProvider.identityType().getSimpleName();
         return "S3ExpressSessionCredentials".equals(className);
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressRetryResolveCredentialsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressRetryResolveCredentialsTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.s3express;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
+
+@WireMockTest(httpsEnabled = true)
+public class S3ExpressRetryResolveCredentialsTest {
+
+    private static final Function<WireMockRuntimeInfo, URI> WM_HTTPS_ENDPOINT = wm -> URI.create(wm.getHttpsBaseUrl());
+    private static final PathStyleEnforcingInterceptor PATH_STYLE_INTERCEPTOR = new PathStyleEnforcingInterceptor();
+    private static final String S3EXPRESS_BUCKET = "s3express-cache-1--use1-az1--x-s3";
+    private static final String REGULAR_S3__BUCKET = "my-test-bucket";
+    private static final int RETRYABLE_ERROR_STATUS_CODE = 429;
+    private static final int NON_RETRYABLE_ERROR_STATUS_CODE = 400;
+
+    private S3Client s3;
+    private S3AsyncClient s3Async;
+    private TrackingCredentialsProvider trackingCredentialsProvider;
+
+    private static final String CREATE_SESSION_RESPONSE = String.format(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<ConnectResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n"
+        + "<Credentials>\n"
+        + "<SessionToken>%s</SessionToken>\n"
+        + "<SecretAccessKey>%s</SecretAccessKey>\n"
+        + "<AccessKeyId>%s</AccessKeyId>"
+        + "</Credentials>\n"
+        + "</ConnectResult>", "TheToken", "TheSecret", "TheAccessKey");
+
+    @BeforeEach
+    public void methodSetup(WireMockRuntimeInfo wm) {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create("akid_client", "skid_client");
+        AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(credentials);
+        trackingCredentialsProvider = new TrackingCredentialsProvider(credentialsProvider);
+        s3 = getS3ClientBuilder(wm).build();
+        s3Async = getS3AsyncClientBuilder(wm).build();
+
+        stubFor(get(urlMatching("/.*session")).atPriority(1).willReturn(aResponse()
+                                                                            .withStatus(200)
+                                                                            .withBody(CREATE_SESSION_RESPONSE)));
+    }
+
+    private static List<Arguments> testParams() {
+        return Arrays.asList(
+            Arguments.of(S3EXPRESS_BUCKET, RETRYABLE_ERROR_STATUS_CODE, 4), // + 3 retries
+            Arguments.of(S3EXPRESS_BUCKET, NON_RETRYABLE_ERROR_STATUS_CODE, 1),
+            Arguments.of(REGULAR_S3__BUCKET, RETRYABLE_ERROR_STATUS_CODE, 1),
+            Arguments.of(REGULAR_S3__BUCKET, NON_RETRYABLE_ERROR_STATUS_CODE, 1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testParams")
+    void syncClient_resolvesIdentityProperNumberOfTimes(String bucket, int statusCode, int resolveIdentityCount) {
+        stubFor(put(anyUrl()).willReturn(aResponse().withStatus(statusCode)));
+        try {
+            s3.putObject(r -> r.bucket(bucket).key("key"), RequestBody.fromString("tmp"));
+        } catch (Exception e) {
+            assertThat(trackingCredentialsProvider.resolveIdentityCount()).isEqualTo(resolveIdentityCount);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testParams")
+    void asyncClient_resolvesIdentityProperNumberOfTimes(String bucket, int statusCode, int resolveIdentityCount) {
+        stubFor(put(anyUrl()).willReturn(aResponse().withStatus(statusCode)));
+        try {
+            s3Async.putObject(r -> r.bucket(bucket).key("key"), AsyncRequestBody.fromString("tmp")).join();
+        } catch (Exception e) {
+            assertThat(trackingCredentialsProvider.resolveIdentityCount()).isEqualTo(resolveIdentityCount);
+        }
+    }
+
+    private S3ClientBuilder getS3ClientBuilder(WireMockRuntimeInfo wm) {
+        return S3Client.builder()
+                       .region(Region.US_EAST_1)
+                       .overrideConfiguration(c -> c.addExecutionInterceptor(PATH_STYLE_INTERCEPTOR))
+                       .credentialsProvider(trackingCredentialsProvider)
+                       .endpointOverride(WM_HTTPS_ENDPOINT.apply(wm))
+                       .httpClient(ApacheHttpClient.builder()
+                                                   .buildWithDefaults(AttributeMap.builder()
+                                                                                  .put(TRUST_ALL_CERTIFICATES, TRUE)
+                                                                                  .build()));
+    }
+
+    private S3AsyncClientBuilder getS3AsyncClientBuilder(WireMockRuntimeInfo wm) {
+        return S3AsyncClient.builder()
+                            .region(Region.US_EAST_1)
+                            .overrideConfiguration(c -> c.addExecutionInterceptor(PATH_STYLE_INTERCEPTOR))
+                            .credentialsProvider(trackingCredentialsProvider)
+                            .endpointOverride(WM_HTTPS_ENDPOINT.apply(wm))
+                            .httpClient(NettyNioAsyncHttpClient.builder()
+                                                               .buildWithDefaults(AttributeMap.builder()
+                                                                                              .put(TRUST_ALL_CERTIFICATES, TRUE)
+                                                                                              .build()));
+    }
+
+    private static final class PathStyleEnforcingInterceptor implements ExecutionInterceptor {
+
+        @Override
+        public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+            SdkHttpRequest sdkHttpRequest = context.httpRequest();
+            String host = sdkHttpRequest.host();
+            String bucket = host.substring(0, host.indexOf(".localhost"));
+
+            return sdkHttpRequest.toBuilder().host("localhost")
+                                 .encodedPath(SdkHttpUtils.appendUri(bucket, sdkHttpRequest.encodedPath()))
+                                 .build();
+        }
+    }
+
+    private static final class TrackingCredentialsProvider implements AwsCredentialsProvider {
+        private final AwsCredentialsProvider delegate;
+        private int resolveIdentityCount;
+
+        TrackingCredentialsProvider(AwsCredentialsProvider delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public AwsCredentials resolveCredentials() {
+            return delegate.resolveCredentials();
+        }
+
+        @Override
+        public CompletableFuture<AwsCredentialsIdentity> resolveIdentity(ResolveIdentityRequest resolveIdentityRequest) {
+            resolveIdentityCount++;
+            return delegate.resolveIdentity(resolveIdentityRequest);
+        }
+
+        public int resolveIdentityCount() {
+            return resolveIdentityCount;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Re-resolve credentials on retries for S3Express. Tokens have short lifespan (5 min) and can become stale while queued up. Currently, credentials are not re-resolved on retries

## Modifications
<!--- Describe your changes in detail -->
Save `IdentityProvider` and `ResolveIdentityRequest` in `S3AuthSchemeInterceptor` , retrieve and resolve identity for S3Express retries in retry stage

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added functional tests and updated codegenerated test classes

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
