### PR TITLE
Add retry conditions to the strategy if none is configured

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-8d6fb63.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-8d6fb63.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "This change adds the default retry conditions in the client builder if none are configured to behave similarly to retry policies that are configured behind the scenes without the users having to do that themselves. This will prevent customers using directly the retry strategies builders from `DefaultRetryStrategy` to end up with a no-op strategy."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -51,6 +51,7 @@ import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.internal.SdkInternalTestAdvancedClientOption;
+import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -64,6 +65,7 @@ import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.retries.internal.BaseRetryStrategy;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.AttributeMap.LazyValueSource;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -422,6 +424,20 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     private void configureRetryStrategy(SdkClientConfiguration.Builder config) {
         RetryStrategy strategy = config.option(SdkClientOption.RETRY_STRATEGY);
         if (strategy != null) {
+            // Fix the retry strategy if no retry predicates were configured. Users using
+            // DefaultRetryStrategy do not have any conditions configured as that package
+            // does not know anything about the SDK or AWS retry conditions. This mimics the
+            // retry policies behavior that are configured behind the scenes and avoids the
+            // risk of customers inadvertently using a no-op retry strategy.
+            if (strategy.maxAttempts() > 1
+                && (strategy instanceof BaseRetryStrategy)
+                && !((BaseRetryStrategy) strategy).hasRetryPredicates()
+            ) {
+                RetryStrategy.Builder<?, ?> builder = strategy.toBuilder();
+                SdkDefaultRetryStrategy.configureStrategy(builder);
+                AwsRetryStrategy.configureStrategy(builder);
+                config.option(SdkClientOption.RETRY_STRATEGY, builder.build());
+            }
             return;
         }
         config.lazyOption(SdkClientOption.RETRY_STRATEGY, this::resolveAwsRetryStrategy);

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -187,6 +187,15 @@ public abstract class BaseRetryStrategy implements RetryStrategy {
         return 0;
     }
 
+    /**
+     * Returns true if there are retry predicates configured for this retry strategy.
+     *
+     * @return true if there are retry predicates configured for this retry strategy.
+     */
+    public boolean hasRetryPredicates() {
+        return !retryPredicates.isEmpty();
+    }
+
     private DefaultRetryToken refreshToken(RefreshRetryTokenRequest request, AcquireResponse acquireResponse) {
         DefaultRetryToken token = asDefaultRetryToken(request.token());
         return token.toBuilder()

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -192,7 +192,7 @@ public abstract class BaseRetryStrategy implements RetryStrategy {
      *
      * @return true if there are retry predicates configured for this retry strategy.
      */
-    public boolean hasRetryPredicates() {
+    public final boolean hasRetryPredicates() {
         return !retryPredicates.isEmpty();
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetryStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetryStrategy.java
@@ -168,6 +168,22 @@ public final class SdkDefaultRetryStrategy {
         return builder;
     }
 
+    /**
+     * Configures a retry strategy using its builder to add SDK-generic retry exceptions.
+     *
+     * @param builder The builder to add the SDK-generic retry exceptions
+     * @return The given builder
+     */
+    public static RetryStrategy.Builder<?, ?> configureStrategy(RetryStrategy.Builder<?, ?> builder) {
+        builder.retryOnException(SdkDefaultRetryStrategy::retryOnRetryableException)
+               .retryOnException(SdkDefaultRetryStrategy::retryOnStatusCodes)
+               .retryOnException(SdkDefaultRetryStrategy::retryOnClockSkewException)
+               .retryOnException(SdkDefaultRetryStrategy::retryOnThrottlingCondition);
+        SdkDefaultRetrySetting.RETRYABLE_EXCEPTIONS.forEach(builder::retryOnExceptionOrCauseInstanceOf);
+        builder.treatAsThrottling(SdkDefaultRetryStrategy::treatAsThrottling);
+        return builder;
+    }
+
     private static boolean treatAsThrottling(Throwable t) {
         if (t instanceof SdkException) {
             return RetryUtils.isThrottlingException((SdkException) t);

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/RetryStrategyBackfillsEmptyRetryConditions.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/RetryStrategyBackfillsEmptyRetryConditions.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.protocoljsonrpc.model.AllTypesRequest;
 import software.amazon.awssdk.services.protocoljsonrpc.model.AllTypesResponse;
 import software.amazon.awssdk.services.protocoljsonrpc.model.ProtocolJsonRpcException;
 
-public class RetryStrategyBackfillsEmtpyRetryConditions {
+public class RetryStrategyBackfillsEmptyRetryConditions {
 
     private static final String PATH = "/";
     private static final String JSON_BODY = "{\"StringMember\":\"foo\"}";

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/RetryStrategyBackfillsEmtpyRetryConditions.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/RetryStrategyBackfillsEmtpyRetryConditions.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import java.net.URI;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.DefaultRetryStrategy;
+import software.amazon.awssdk.services.protocoljsonrpc.ProtocolJsonRpcClient;
+import software.amazon.awssdk.services.protocoljsonrpc.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocoljsonrpc.model.AllTypesResponse;
+import software.amazon.awssdk.services.protocoljsonrpc.model.ProtocolJsonRpcException;
+
+public class RetryStrategyBackfillsEmtpyRetryConditions {
+
+    private static final String PATH = "/";
+    private static final String JSON_BODY = "{\"StringMember\":\"foo\"}";
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(0);
+
+    private ProtocolJsonRpcClient client;
+
+    @Before
+    public void setupClient() {
+        client = ProtocolJsonRpcClient.builder()
+                                      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                                                       "skid")))
+                                      .region(Region.US_EAST_1)
+                                      .overrideConfiguration(o -> o.retryStrategy(DefaultRetryStrategy.standardStrategyBuilder().build()))
+                                      .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                      .build();
+    }
+
+    @Test
+    public void shouldRetryOn500() {
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at 500")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willSetStateTo("first attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(500)));
+
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at 500")
+                    .whenScenarioStateIs("first attempt")
+                    .willSetStateTo("second attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withBody(JSON_BODY)));
+
+        AllTypesResponse allTypesResponse = client.allTypes(AllTypesRequest.builder().build());
+        assertThat(allTypesResponse).isNotNull();
+    }
+
+    @Test
+    public void shouldRetryOnRetryableAwsErrorCode() {
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at PriorRequestNotComplete")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willSetStateTo("first attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(400)
+                                    .withHeader("x-amzn-ErrorType", "PriorRequestNotComplete")
+                                    .withBody("\"{\"__type\":\"PriorRequestNotComplete\",\"message\":\"Blah "
+                                              + "error\"}\"")));
+
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at PriorRequestNotComplete")
+                    .whenScenarioStateIs("first attempt")
+                    .willSetStateTo("second attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withBody(JSON_BODY)));
+
+        AllTypesResponse allTypesResponse = client.allTypes(AllTypesRequest.builder().build());
+        assertThat(allTypesResponse).isNotNull();
+    }
+
+    @Test
+    public void shouldRetryOnAwsThrottlingErrorCode() {
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at SlowDown")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willSetStateTo("first attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(400)
+                                    .withHeader("x-amzn-ErrorType", "SlowDown")
+                                    .withBody("\"{\"__type\":\"SlowDown\",\"message\":\"Blah "
+                                              + "error\"}\"")));
+
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at SlowDown")
+                    .whenScenarioStateIs("first attempt")
+                    .willSetStateTo("second attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withBody(JSON_BODY)));
+
+        AllTypesResponse allTypesResponse = client.allTypes(AllTypesRequest.builder().build());
+        assertThat(allTypesResponse).isNotNull();
+    }
+
+    @Test
+    public void retryStrategyNone_shouldNotRetry() {
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at 500")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willSetStateTo("first attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(500)));
+
+        stubFor(post(urlEqualTo(PATH))
+                    .inScenario("retry at 500")
+                    .whenScenarioStateIs("first attempt")
+                    .willSetStateTo("second attempt")
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withBody(JSON_BODY)));
+
+        ProtocolJsonRpcClient clientWithNoRetry =
+            ProtocolJsonRpcClient.builder()
+                                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                                                  "skid")))
+                                 .region(Region.US_EAST_1)
+                                 .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                 // When max attempts is 1 (i.e., just the first attempt is allowed but no retries),
+                                 // the back filling should not happen.
+                                 .overrideConfiguration(c -> c.retryStrategy(DefaultRetryStrategy.standardStrategyBuilder()
+                                                                                                 .maxAttempts(1)
+                                                                                                 .build()))
+                                 .build();
+
+        assertThatThrownBy(() -> clientWithNoRetry.allTypes(AllTypesRequest.builder().build())).isInstanceOf(ProtocolJsonRpcException.class);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This change adds the default retry conditions in the client builder if none are configured to behave similarly to retry policies that are configured behind the scenes without the users having to do that themselves. 

This will prevent customers using directly the retry strategies builders from `DefaultRetryStrategy` to end up with a no-op strategy.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
