### PR TITLE
Fix NPE thrown from signer when a header value is null

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4CanonicalRequest.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4CanonicalRequest.java
@@ -249,10 +249,10 @@ public final class V4CanonicalRequest {
      * Matcher object as well.
      */
     private static void addAndTrim(StringBuilder result, String value) {
-        int valueLength = value.length();
-        if (valueLength == 0) {
+        if (StringUtils.isEmpty(value)) {
             return;
         }
+        int valueLength = value.length();
 
         int start = 0;
         // Find first non-whitespace


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix NPE thrown from signer when a header value is null by adding null check for the value.

