### PR TITLE
Move default backoff strategies to the builders to match the docs

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-8c50ffa.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-8c50ffa.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Moves setting the default backoff strategies for all retry strategies to the builder as per the javadocs instead of only doing it in the `DefaultRetryStrategy` builder methods."
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/AdaptiveRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/AdaptiveRetryStrategy.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.retries.api.AcquireInitialTokenRequest;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.retries.internal.DefaultAdaptiveRetryStrategy;
 import software.amazon.awssdk.retries.internal.circuitbreaker.TokenBucketStore;
@@ -70,7 +71,12 @@ public interface AdaptiveRetryStrategy extends RetryStrategy {
                                               .tokenBucketMaxCapacity(DefaultRetryStrategy.Standard.TOKEN_BUCKET_SIZE)
                                               .build())
             .tokenBucketExceptionCost(DefaultRetryStrategy.Standard.DEFAULT_EXCEPTION_TOKEN_COST)
-            .rateLimiterTokenBucketStore(RateLimiterTokenBucketStore.builder().build());
+            .rateLimiterTokenBucketStore(RateLimiterTokenBucketStore.builder().build())
+            .backoffStrategy(BackoffStrategy.exponentialDelay(DefaultRetryStrategy.Standard.BASE_DELAY,
+                                                              DefaultRetryStrategy.Standard.MAX_BACKOFF))
+            .throttlingBackoffStrategy(BackoffStrategy.exponentialDelay(
+                DefaultRetryStrategy.Standard.THROTTLED_BASE_DELAY,
+                DefaultRetryStrategy.Standard.MAX_BACKOFF));
     }
 
     @Override

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/DefaultRetryStrategy.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.retries;
 
 import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 
 /**
@@ -51,12 +50,7 @@ public final class DefaultRetryStrategy {
      * }
      */
     public static StandardRetryStrategy.Builder standardStrategyBuilder() {
-        return StandardRetryStrategy.builder()
-                                    .maxAttempts(Standard.MAX_ATTEMPTS)
-                                    .backoffStrategy(BackoffStrategy.exponentialDelay(Standard.BASE_DELAY, Standard.MAX_BACKOFF))
-                                    .throttlingBackoffStrategy(BackoffStrategy.exponentialDelay(
-                                        Standard.THROTTLED_BASE_DELAY,
-                                        Standard.MAX_BACKOFF));
+        return StandardRetryStrategy.builder();
     }
 
     /**
@@ -72,12 +66,7 @@ public final class DefaultRetryStrategy {
      * }
      */
     public static LegacyRetryStrategy.Builder legacyStrategyBuilder() {
-        return LegacyRetryStrategy.builder()
-                                  .maxAttempts(Legacy.MAX_ATTEMPTS)
-                                  .backoffStrategy(BackoffStrategy.exponentialDelay(Legacy.BASE_DELAY, Legacy.MAX_BACKOFF))
-                                  .throttlingBackoffStrategy(BackoffStrategy.exponentialDelayHalfJitter(
-                                      Legacy.THROTTLED_BASE_DELAY,
-                                      Legacy.MAX_BACKOFF));
+        return LegacyRetryStrategy.builder();
     }
 
     /**
@@ -93,13 +82,7 @@ public final class DefaultRetryStrategy {
      * }
      */
     public static AdaptiveRetryStrategy.Builder adaptiveStrategyBuilder() {
-        return AdaptiveRetryStrategy.builder()
-                                    .maxAttempts(Adaptive.MAX_ATTEMPTS)
-                                    .backoffStrategy(BackoffStrategy.exponentialDelay(Standard.BASE_DELAY,
-                                                                                      Standard.MAX_BACKOFF))
-                                    .throttlingBackoffStrategy(BackoffStrategy.exponentialDelay(
-                                        Standard.THROTTLED_BASE_DELAY,
-                                        Standard.MAX_BACKOFF));
+        return AdaptiveRetryStrategy.builder();
     }
 
     static final class Standard {

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/LegacyRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/LegacyRetryStrategy.java
@@ -68,7 +68,12 @@ public interface LegacyRetryStrategy extends RetryStrategy {
                                   .tokenBucketMaxCapacity(DefaultRetryStrategy.Legacy.TOKEN_BUCKET_SIZE)
                                   .build())
             .tokenBucketExceptionCost(DefaultRetryStrategy.Legacy.DEFAULT_EXCEPTION_TOKEN_COST)
-            .tokenBucketThrottlingExceptionCost(DefaultRetryStrategy.Legacy.THROTTLE_EXCEPTION_TOKEN_COST);
+            .tokenBucketThrottlingExceptionCost(DefaultRetryStrategy.Legacy.THROTTLE_EXCEPTION_TOKEN_COST)
+            .backoffStrategy(BackoffStrategy.exponentialDelay(DefaultRetryStrategy.Legacy.BASE_DELAY,
+                                                              DefaultRetryStrategy.Legacy.MAX_BACKOFF))
+            .throttlingBackoffStrategy(BackoffStrategy.exponentialDelayHalfJitter(
+                DefaultRetryStrategy.Legacy.THROTTLED_BASE_DELAY,
+                DefaultRetryStrategy.Legacy.MAX_BACKOFF));
     }
 
     @Override

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/StandardRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/StandardRetryStrategy.java
@@ -63,7 +63,11 @@ public interface StandardRetryStrategy extends RetryStrategy {
                                   .builder()
                                   .tokenBucketMaxCapacity(DefaultRetryStrategy.Standard.TOKEN_BUCKET_SIZE)
                                   .build())
-            .tokenBucketExceptionCost(DefaultRetryStrategy.Standard.DEFAULT_EXCEPTION_TOKEN_COST);
+            .tokenBucketExceptionCost(DefaultRetryStrategy.Standard.DEFAULT_EXCEPTION_TOKEN_COST)
+            .backoffStrategy(BackoffStrategy.exponentialDelay(DefaultRetryStrategy.Standard.BASE_DELAY,
+                                                              DefaultRetryStrategy.Standard.MAX_BACKOFF))
+            .throttlingBackoffStrategy(BackoffStrategy.exponentialDelay(DefaultRetryStrategy.Standard.THROTTLED_BASE_DELAY,
+                                                                        DefaultRetryStrategy.Standard.MAX_BACKOFF));
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

As reported offline the javadocs of the retries strategies do not match the defaults, in particular regarding the backoff strategies, since those are only applied in the static builders in `DefaultRetryStrategy` class. This change moves setting the default backoff strategies out of `DefaultRetryStrategy` and into the builders themselves.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
