### PR TITLE
Fix ApacheHttpClient's handling of request bodies on DELETE, GET, HEAD & OPTIONS requests

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-c212259.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-c212259.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "Xtansia",
+    "description": "Fix ApacheHttpClient's handling of request bodies on DELETE, GET, HEAD & OPTIONS requests"
+}

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientDefaultWireMockTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientDefaultWireMockTest.java
@@ -15,11 +15,16 @@
 
 package software.amazon.awssdk.http.urlconnection;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.ProtocolException;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpClientDefaultTestSuite;
+import software.amazon.awssdk.http.SdkHttpMethod;
 
 public class UrlConnectionHttpClientDefaultWireMockTest extends SdkHttpClientDefaultTestSuite {
 
@@ -31,5 +36,21 @@ public class UrlConnectionHttpClientDefaultWireMockTest extends SdkHttpClientDef
     @AfterEach
     public void reset() {
         HttpsURLConnection.setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+    }
+
+    @Test
+    @Override
+    public void supportsRequestBodyOnGetRequest() throws Exception {
+        // HttpURLConnection is hard-coded to switch GET requests with a body to POST requests, in #getOutputStream0.
+        testForResponseCode(200, SdkHttpMethod.GET, SdkHttpMethod.POST, true);
+    }
+
+    @Test
+    @Override
+    public void supportsRequestBodyOnPatchRequest() {
+        // HttpURLConnection does not support PATCH requests.
+        assertThatThrownBy(super::supportsRequestBodyOnPatchRequest)
+            .hasRootCauseInstanceOf(ProtocolException.class)
+            .hasRootCauseMessage("Invalid HTTP method: PATCH");
     }
 }

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
@@ -143,7 +143,14 @@ public abstract class SdkHttpClientDefaultTestSuite {
         testForResponseCode(returnCode, SdkHttpMethod.POST, true);
     }
 
-    private void testForResponseCode(int returnCode, SdkHttpMethod method, boolean includeBody) throws Exception {
+    protected void testForResponseCode(int returnCode, SdkHttpMethod method, boolean includeBody) throws Exception {
+        testForResponseCode(returnCode, method, method, includeBody);
+    }
+
+    protected void testForResponseCode(int returnCode,
+                                       SdkHttpMethod method,
+                                       SdkHttpMethod expectedMethod,
+                                       boolean includeBody) throws Exception {
         SdkHttpClient client = createSdkHttpClient();
 
         stubForMockRequest(returnCode);
@@ -156,7 +163,7 @@ public abstract class SdkHttpClientDefaultTestSuite {
                                                                           .build())
                                         .call();
 
-        validateResponse(rsp, returnCode, method, includeBody);
+        validateResponse(rsp, returnCode, expectedMethod, includeBody);
     }
 
     protected void testForResponseCodeUsingHttps(SdkHttpClient client, int returnCode) throws Exception {

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
@@ -61,7 +61,7 @@ public abstract class SdkHttpClientDefaultTestSuite {
     @Test
     public void supportsResponseCode200Head() throws Exception {
         // HEAD is special due to closing of the connection immediately and streams are null
-        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN, SdkHttpMethod.HEAD);
+        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN, SdkHttpMethod.HEAD, false);
     }
 
     @Test
@@ -76,7 +76,7 @@ public abstract class SdkHttpClientDefaultTestSuite {
 
     @Test
     public void supportsResponseCode403Head() throws Exception {
-        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN, SdkHttpMethod.HEAD);
+        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN, SdkHttpMethod.HEAD, false);
     }
 
     @Test
@@ -98,22 +98,57 @@ public abstract class SdkHttpClientDefaultTestSuite {
     public void validatesHttpsCertificateIssuer() {
         SdkHttpClient client = createSdkHttpClient();
 
-        SdkHttpFullRequest request = mockSdkRequest("https://localhost:" + mockServer.httpsPort(), SdkHttpMethod.POST);
+        SdkHttpFullRequest request = mockSdkRequest("https://localhost:" + mockServer.httpsPort(), SdkHttpMethod.POST, true);
 
         assertThatThrownBy(client.prepareRequest(HttpExecuteRequest.builder().request(request).build())::call)
             .isInstanceOf(SSLHandshakeException.class);
     }
 
-    private void testForResponseCode(int returnCode) throws Exception {
-        testForResponseCode(returnCode, SdkHttpMethod.POST);
+    @Test
+    public void supportsRequestBodyOnGetRequest() throws Exception {
+        testForResponseCode(200, SdkHttpMethod.GET, true);
     }
 
-    private void testForResponseCode(int returnCode, SdkHttpMethod method) throws Exception {
+    @Test
+    public void supportsRequestBodyOnPostRequest() throws Exception {
+        testForResponseCode(200, SdkHttpMethod.POST, true);
+    }
+
+    @Test
+    public void supportsRequestBodyOnPutRequest() throws Exception {
+        testForResponseCode(200, SdkHttpMethod.PUT, true);
+    }
+
+    @Test
+    public void supportsRequestBodyOnDeleteRequest() throws Exception {
+        testForResponseCode(200, SdkHttpMethod.DELETE, true);
+    }
+
+    @Test
+    public void supportsRequestBodyOnHeadRequest() throws Exception {
+        testForResponseCode(200, SdkHttpMethod.HEAD, true);
+    }
+
+    @Test
+    public void supportsRequestBodyOnPatchRequest() throws Exception {
+        testForResponseCode(200, SdkHttpMethod.PATCH, true);
+    }
+
+    @Test
+    public void supportsRequestBodyOnOptionsRequest() throws Exception {
+        testForResponseCode(200, SdkHttpMethod.OPTIONS, true);
+    }
+
+    private void testForResponseCode(int returnCode) throws Exception {
+        testForResponseCode(returnCode, SdkHttpMethod.POST, true);
+    }
+
+    private void testForResponseCode(int returnCode, SdkHttpMethod method, boolean includeBody) throws Exception {
         SdkHttpClient client = createSdkHttpClient();
 
         stubForMockRequest(returnCode);
 
-        SdkHttpFullRequest req = mockSdkRequest("http://localhost:" + mockServer.port(), method);
+        SdkHttpFullRequest req = mockSdkRequest("http://localhost:" + mockServer.port(), method, includeBody);
         HttpExecuteResponse rsp = client.prepareRequest(HttpExecuteRequest.builder()
                                                                           .request(req)
                                                                           .contentStreamProvider(req.contentStreamProvider()
@@ -121,14 +156,14 @@ public abstract class SdkHttpClientDefaultTestSuite {
                                                                           .build())
                                         .call();
 
-        validateResponse(rsp, returnCode, method);
+        validateResponse(rsp, returnCode, method, includeBody);
     }
 
     protected void testForResponseCodeUsingHttps(SdkHttpClient client, int returnCode) throws Exception {
         SdkHttpMethod sdkHttpMethod = SdkHttpMethod.POST;
         stubForMockRequest(returnCode);
 
-        SdkHttpFullRequest req = mockSdkRequest("https://localhost:" + mockServer.httpsPort(), sdkHttpMethod);
+        SdkHttpFullRequest req = mockSdkRequest("https://localhost:" + mockServer.httpsPort(), sdkHttpMethod, true);
         HttpExecuteResponse rsp = client.prepareRequest(HttpExecuteRequest.builder()
                                                                           .request(req)
                                                                           .contentStreamProvider(req.contentStreamProvider()
@@ -136,7 +171,7 @@ public abstract class SdkHttpClientDefaultTestSuite {
                                                                           .build())
                                         .call();
 
-        validateResponse(rsp, returnCode, sdkHttpMethod);
+        validateResponse(rsp, returnCode, sdkHttpMethod, true);
     }
 
     private void stubForMockRequest(int returnCode) {
@@ -151,17 +186,17 @@ public abstract class SdkHttpClientDefaultTestSuite {
         mockServer.stubFor(any(urlPathEqualTo("/")).willReturn(responseBuilder));
     }
 
-    private void validateResponse(HttpExecuteResponse response, int returnCode, SdkHttpMethod method) throws IOException {
+    private void validateResponse(HttpExecuteResponse response, int returnCode, SdkHttpMethod method, boolean expectBody) throws IOException {
         RequestMethod requestMethod = RequestMethod.fromString(method.name());
 
         RequestPatternBuilder patternBuilder = RequestPatternBuilder.newRequestPattern(requestMethod, urlMatching("/"))
                                                                     .withHeader("Host", containing("localhost"))
                                                                     .withHeader("User-Agent", equalTo("hello-world!"));
 
-        if (method == SdkHttpMethod.HEAD) {
-            patternBuilder.withRequestBody(absent());
-        } else {
+        if (expectBody) {
             patternBuilder.withRequestBody(equalTo("Body"));
+        } else {
+            patternBuilder.withRequestBody(absent());
         }
 
         mockServer.verify(1, patternBuilder);
@@ -177,14 +212,14 @@ public abstract class SdkHttpClientDefaultTestSuite {
         mockServer.resetMappings();
     }
 
-    private SdkHttpFullRequest mockSdkRequest(String uriString, SdkHttpMethod method) {
+    private SdkHttpFullRequest mockSdkRequest(String uriString, SdkHttpMethod method, boolean includeBody) {
         URI uri = URI.create(uriString);
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder()
                                                                       .uri(uri)
                                                                       .method(method)
                                                                       .putHeader("Host", uri.getHost())
                                                                       .putHeader("User-Agent", "hello-world!");
-        if (method != SdkHttpMethod.HEAD) {
+        if (includeBody) {
             byte[] content = "Body".getBytes(StandardCharsets.UTF_8);
             requestBuilder.putHeader("Content-Length", Integer.toString(content.length));
             requestBuilder.contentStreamProvider(() -> new ByteArrayInputStream(content));

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
@@ -186,7 +186,10 @@ public abstract class SdkHttpClientDefaultTestSuite {
         mockServer.stubFor(any(urlPathEqualTo("/")).willReturn(responseBuilder));
     }
 
-    private void validateResponse(HttpExecuteResponse response, int returnCode, SdkHttpMethod method, boolean expectBody) throws IOException {
+    private void validateResponse(HttpExecuteResponse response,
+                                  int returnCode,
+                                  SdkHttpMethod method,
+                                  boolean expectBody) throws IOException {
         RequestMethod requestMethod = RequestMethod.fromString(method.name());
 
         RequestPatternBuilder patternBuilder = RequestPatternBuilder.newRequestPattern(requestMethod, urlMatching("/"))

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
@@ -230,9 +230,11 @@
       "uri": "/no-payload",
       "method": "GET",
       "headers": {
+        "contains": {
+          "Content-Length": "0"
+        },
         "doesNotContain": [
-          "Content-Type",
-          "Content-Length"
+          "Content-Type"
         ]
       },
       "body": {
@@ -258,11 +260,11 @@
       "method": "GET",
       "headers": {
         "contains": {
+          "Content-Length": "0",
           "x-amz-test-id": "t-12345"
         },
         "doesNotContain": [
-          "Content-Type",
-          "Content-Length"
+          "Content-Type"
         ]
       },
       "body": {


### PR DESCRIPTION
## Motivation and Context
Though providing request bodies on these HTTP methods is uncommon, it is [not disallowed by the spec](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.1-6), and is used in certain Elasticsearch/OpenSearch APIs. Authenticating with Amazon OpenSearch Service can be done via SigV4 and we re-use the SDK's signing logic to provide that in https://github.com/opensearch-project/opensearch-java.
We've received multiple bug reports of users having trouble making certain requests using the `ApacheHttpClient` (https://github.com/opensearch-project/opensearch-java/issues/712, https://github.com/opensearch-project/opensearch-java/issues/521), where the client itself doesn't complain or error but silently drops the request body resulting in a mismatched signature on the server.
The Netty & CRT `Sdk(Async)HttpClient` implementations correctly send the request body for all methods, URL Connection does as well with the exception of `GET` which is hardcoded to swap to `POST` (and doesn't support `PATCH` at all).
As such I think it is not harmful to bring the Apache implementation in line with the other client implementations.

## Modifications
Generalize the Apache HTTP request factory implementation to attach the request body entity on all HTTP methods.
This matches the original implementations of the separate method classes:
- https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/methods/HttpDelete.java
- https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/methods/HttpGet.java
- https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/methods/HttpHead.java
- https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/methods/HttpOptions.java
- https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/methods/HttpPatch.java
- https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/methods/HttpPost.java
- https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/methods/HttpPut.java

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
