### PR TITLE
Fix typos - Singer -> Signer

### DIFF
--- a/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerTest.java
+++ b/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerTest.java
@@ -90,7 +90,7 @@ class DefaultPollyPresignerTest {
     }
 
     @Test
-    void presign_requestLevelSingerAndCredentials_honored() {
+    void presign_requestLevelSignerAndCredentials_honored() {
         IdentityProvider<AwsCredentialsIdentity> requestCedentialsProvider = StaticCredentialsProvider.create(
             AwsBasicCredentials.create("akid2", "skid2")
         );

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/plugins/S3OverrideAuthSchemePropertiesPlugin.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/plugins/S3OverrideAuthSchemePropertiesPlugin.java
@@ -99,7 +99,7 @@ public final class S3OverrideAuthSchemePropertiesPlugin implements SdkPlugin {
                 if (addConfiguredProperties(option, params)) {
                     AuthSchemeOption.Builder builder = option.toBuilder();
                     identityProperties.forEach((k, v) -> putIdentityProperty(builder, k, v));
-                    signerProperties.forEach((k, v) -> putSingerProperty(builder, k, v));
+                    signerProperties.forEach((k, v) -> putSignerProperty(builder, k, v));
                     result.add(builder.build());
                 } else {
                     result.add(option);
@@ -116,7 +116,7 @@ public final class S3OverrideAuthSchemePropertiesPlugin implements SdkPlugin {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> void putSingerProperty(AuthSchemeOption.Builder builder, SignerProperty<?> key, Object value) {
+    private <T> void putSignerProperty(AuthSchemeOption.Builder builder, SignerProperty<?> key, Object value) {
         // Safe because of Builder#putSignerProperty
         builder.putSignerProperty((SignerProperty<T>) key, (T) value);
     }


### PR DESCRIPTION
## Motivation and Context
I spotted a couple of typos in method names which aren't part of the public API.

## Modifications
Correct `Singer` to `Signer`.

## Testing
`git grep Singer` returns 0 results

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
