### PR TITLE
Add AwsJsonProtocol.SMITHY_RPC_V2_CBOR to properly handle it

### DIFF
--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -283,7 +283,7 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
                 if (protocol == AwsJsonProtocol.AWS_JSON) {
                     // For RPC formats, this content type will later be pushed down into the `initial-event` in the body
                     request.putHeader(CONTENT_TYPE, contentType);
-                } else if (protocol == AwsJsonProtocol.REST_JSON) {
+                } else if (protocol == AwsJsonProtocol.REST_JSON || protocol == AwsJsonProtocol.SMITHY_RPC_V2_CBOR) {
                     request.putHeader(CONTENT_TYPE, MIMETYPE_EVENT_STREAM);
                 } else {
                     throw new IllegalArgumentException("Unknown AwsJsonProtocol: " + protocol);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Smithy RPCv2 uses `application/vnd.amazon.eventstream` as its `Content-Type` for event streams. See [the requests section](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests) of the spec.

This bit was missed when the protocol was added, and was found during testing.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
