### PR TITLE
Fixed an issue where an error was not surfaced if request failed half…

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTbasedS3client-906e1ea.json
+++ b/.changes/next-release/bugfix-AWSCRTbasedS3client-906e1ea.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT-based S3 client",
+    "contributor": "",
+    "description": "Fixed an issue where an error was not surfaced if request failed halfway for a GetObject operation. See [#5631](https://github.com/aws/aws-sdk-java-v2/issues/5631)"
+}


### PR DESCRIPTION
…way for a GetObject operation.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed an issue where an error was not surfaced if request failed halfway for a GetObject operation. See #5631

### Root Cause
We have separate response handlers for successful response and error response and the SDK will initiate `successResponseHandler` if the initial response is 200 and otherwise initiate `errorResponseHandler`.

The root cause is that when the initial request succeeds, `successResponseHandler` has been initiated and there was no way to notify the SDK that subsequent request fails, so no error was surfaced.

## Modifications
Updated CRT-based S3 client to handle the case by checking if the response handler is already initiated by the point the error is thrown and failing the request accordingly.



## Testing
Added new unit tests and funitional tests. Also did local integ tests by deleting the S3 object after download was initialized and verifying that the request failed.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
