### PR TITLE
bugfix : Skip wrapEntity for HEAD GET DELETE OPTIONS if there is no contentStreamProvider

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-afc7760.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-afc7760.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Skip warpping entities for DELETE, GET, HEAD & OPTIONS requests if it didnot have cintentStreamProvider , since sending empting content length for these request was causing failures in some services."
+}

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-afc7760.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-afc7760.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Skip warpping entities for DELETE, GET, HEAD & OPTIONS requests if it didnot have cintentStreamProvider , since sending empting content length for these request was causing failures in some services."
+    "description": "Skip wrapping entities for DELETE, GET, HEAD & OPTIONS requests if they do not have ContentStreamProvider, since sending empty content length for these requests cause failures in some services."
 }

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
@@ -116,19 +116,19 @@ public class ApacheHttpRequestFactory {
 
         switch (method) {
             case HEAD:
-                return request.contentStreamProvider().isPresent()
+                return isRequestBodyPresent(request)
                        ? wrapEntity(request, new HttpRequestImpl(method, uri))
                        : new HttpHead(uri);
             case GET:
-                return request.contentStreamProvider().isPresent()
+                return isRequestBodyPresent(request)
                        ? wrapEntity(request, new HttpRequestImpl(method, uri))
                        : new HttpGet(uri);
             case DELETE:
-                return request.contentStreamProvider().isPresent()
+                return isRequestBodyPresent(request)
                        ? wrapEntity(request, new HttpRequestImpl(method, uri))
                        : new HttpDelete(uri);
             case OPTIONS:
-                return request.contentStreamProvider().isPresent()
+                return isRequestBodyPresent(request)
                        ? wrapEntity(request, new HttpRequestImpl(method, uri))
                        : new HttpOptions(uri);
             case PATCH:
@@ -136,10 +136,9 @@ public class ApacheHttpRequestFactory {
             case PUT:
                 return wrapEntity(request, new HttpRequestImpl(method, uri));
             default:
-                throw new IllegalArgumentException("Unknown or unsupported HTTP method: " + method);
+                throw new RuntimeException("Unknown HTTP method name: " + request.httpRequest().method());
         }
     }
-
 
     private HttpRequestBase wrapEntity(HttpExecuteRequest request,
                                        HttpEntityEnclosingRequestBase entityEnclosingRequest) {
@@ -211,4 +210,9 @@ public class ApacheHttpRequestFactory {
             return this.method.toString();
         }
     }
+
+    private static boolean isRequestBodyPresent(HttpExecuteRequest request) {
+        return request.contentStreamProvider().isPresent();
+    }
+
 }

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
@@ -230,11 +230,9 @@
       "uri": "/no-payload",
       "method": "GET",
       "headers": {
-        "contains": {
-          "Content-Length": "0"
-        },
         "doesNotContain": [
-          "Content-Type"
+          "Content-Type",
+          "Content-Length"
         ]
       },
       "body": {
@@ -260,11 +258,11 @@
       "method": "GET",
       "headers": {
         "contains": {
-          "Content-Length": "0",
           "x-amz-test-id": "t-12345"
         },
         "doesNotContain": [
-          "Content-Type"
+          "Content-Type",
+          "Content-Length"
         ]
       },
       "body": {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
After [PR#5704](https://github.com/aws/aws-sdk-java-v2/pull/5704) some service calls like supply chain api calls
```
supplyChainClient.getBillOfMaterialsImportJob(request)
```
started failing because of empty content length was getting added to thier requests

## Modifications
<!--- Describe your changes in detail -->

- Added contentStreamProvider check before warpping the entity for HEAD, GET, DELETE , OPTION requests

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Updated existing test cases

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
