### PR TITLE
Add recipes for S3 non-streaming methods

### DIFF
--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/Application.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/Application.java
@@ -16,8 +16,6 @@
 package foo.bar;
 
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
-import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -108,15 +106,5 @@ public class Application {
             .build(), RequestBody.fromString(content));
 
         return result;
-    }
-
-    private static void createBucket(S3Client s3, String bucket) {
-        s3.createBucket(CreateBucketRequest.builder().bucket(bucket)
-            .build());
-    }
-
-    private static void deleteBucket(S3Client s3, String bucket) {
-        s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket)
-            .build());
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package foo.bar;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CORSConfiguration;
+import software.amazon.awssdk.services.s3.model.CORSRule;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketAnalyticsConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketCorsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketEncryptionRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketIntelligentTieringConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketInventoryConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketMetricsConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketPolicyRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketReplicationRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketTaggingRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketAclRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketAnalyticsConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketCorsRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketEncryptionRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketIntelligentTieringConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketInventoryConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketLifecycleConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketLoggingRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketMetricsConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketReplicationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketTaggingRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketWebsiteRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectAclRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutBucketCorsRequest;
+
+public class S3 {
+
+    private S3() {
+
+    }
+
+    private void headBucket(S3Client s3, String bucket) {
+        HeadBucketRequest headBucketRequest = HeadBucketRequest.builder().bucket(bucket)
+            .build();
+        HeadBucketResponse headBucketResult = s3.headBucket(headBucketRequest);
+        System.out.println(headBucketResult);
+    }
+
+    private void createBucket(S3Client s3, String bucket) {
+        CreateBucketRequest createBucketRequest = CreateBucketRequest.builder().bucket(bucket)
+            .build();
+        s3.createBucket(createBucketRequest);
+    }
+
+    private void deleteBucket(S3Client s3, String bucket) {
+        DeleteBucketRequest deleteBucketRequest = DeleteBucketRequest.builder().bucket(bucket)
+            .build();
+        s3.deleteBucket(deleteBucketRequest);
+    }
+
+    private void getObjectMetaData_to_headObject(S3Client s3, String bucket, String key) {
+        HeadObjectRequest getObjectMetadataRequest = HeadObjectRequest.builder().bucket("bucket").key("key")
+            .build();
+        HeadObjectResponse objectMetadata = s3.headObject(getObjectMetadataRequest);
+        System.out.println(objectMetadata);
+    }
+
+    private void initiateMpu_to_createMpu(S3Client s3, String bucket, String key) {
+        CreateMultipartUploadRequest initiateMultipartUploadRequest = CreateMultipartUploadRequest.builder().bucket(bucket).key(key)
+            .build();
+        CreateMultipartUploadResponse initiateMultipartUploadResult = s3.createMultipartUpload(initiateMultipartUploadRequest);
+        System.out.println(initiateMultipartUploadResult);
+    }
+
+    private void listObjects(S3Client s3, String bucket) {
+        ListObjectsRequest listObjectsRequest = ListObjectsRequest.builder().bucket(bucket)
+            .build();
+        ListObjectsResponse objectListing = s3.listObjects(listObjectsRequest);
+        System.out.println(objectListing);
+    }
+
+    private void listObjectsV2(S3Client s3, String bucket) {
+        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder().bucket(bucket)
+            .build();
+        ListObjectsV2Response listObjectsV2Result = s3.listObjectsV2(listObjectsV2Request);
+        System.out.println(listObjectsV2Result);
+    }
+
+    private void cors(S3Client s3, String bucket) {
+        CORSRule corsRule = CORSRule.builder().id("id").maxAgeSeconds(99)
+            .build();
+        CORSConfiguration cors = CORSConfiguration.builder().corsRules(corsRule)
+            .build();
+        PutBucketCorsRequest setBucketCrossOriginConfigurationRequest =
+            PutBucketCorsRequest.builder().bucket(bucket).corsConfiguration(cors)
+                .build();
+        s3.putBucketCors(setBucketCrossOriginConfigurationRequest);
+
+        GetBucketCorsRequest getBucketCrossOriginConfigurationRequest =
+            GetBucketCorsRequest.builder().bucket(bucket)
+                .build();
+        s3.getBucketCors(getBucketCrossOriginConfigurationRequest);
+
+        DeleteBucketCorsRequest deleteBucketCrossOriginConfigurationRequest =
+            DeleteBucketCorsRequest.builder().bucket(bucket)
+                .build();
+        s3.deleteBucketCors(deleteBucketCrossOriginConfigurationRequest);
+    }
+
+    private void singleBucketArgMethods(S3Client s3, String bucket) {
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket)
+            .build());
+        s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket)
+            .build());
+        s3.listObjects(ListObjectsRequest.builder().bucket(bucket)
+            .build());
+        s3.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket)
+            .build());
+        s3.getBucketCors(GetBucketCorsRequest.builder().bucket(bucket)
+            .build());
+        s3.deleteBucketCors(DeleteBucketCorsRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketVersioning(GetBucketVersioningRequest.builder()
+            .build());
+        s3.deleteBucketEncryption(DeleteBucketEncryptionRequest.builder().bucket(bucket)
+            .build());
+        s3.deleteBucketPolicy(DeleteBucketPolicyRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketAcl(GetBucketAclRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketEncryption(GetBucketEncryptionRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketLifecycleConfiguration(GetBucketLifecycleConfigurationRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketNotificationConfiguration(GetBucketNotificationConfigurationRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketPolicy(GetBucketPolicyRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketLocation(GetBucketLocationRequest.builder().bucket(bucket)
+            .build());
+        s3.deleteBucketLifecycle(DeleteBucketLifecycleRequest.builder().bucket(bucket)
+            .build());
+        s3.deleteBucketReplication(DeleteBucketReplicationRequest.builder().bucket(bucket)
+            .build());
+        s3.deleteBucketTagging(DeleteBucketTaggingRequest.builder().bucket(bucket)
+            .build());
+        s3.deleteBucketWebsite(DeleteBucketWebsiteRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketLogging(GetBucketLoggingRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketReplication(GetBucketReplicationRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketTagging(GetBucketTaggingRequest.builder().bucket(bucket)
+            .build());
+        s3.getBucketWebsite(GetBucketWebsiteRequest.builder().bucket(bucket)
+            .build());
+    }
+
+    private void bucketKeyArgsMethods(S3Client s3, String bucket, String key) {
+        s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key)
+            .build());
+        s3.getObject(GetObjectRequest.builder().bucket(bucket).key(key)
+            .build());
+        s3.getObjectAcl(GetObjectAclRequest.builder().bucket(bucket).key(key)
+            .build());
+        s3.headObject(HeadObjectRequest.builder().bucket(bucket).key(key)
+            .build());
+    }
+
+    private void bucketIdArgsMethods(S3Client s3, String bucket, String id) {
+        s3.deleteBucketAnalyticsConfiguration(DeleteBucketAnalyticsConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+        s3.deleteBucketIntelligentTieringConfiguration(DeleteBucketIntelligentTieringConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+        s3.deleteBucketInventoryConfiguration(DeleteBucketInventoryConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+        s3.deleteBucketMetricsConfiguration(DeleteBucketMetricsConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+        s3.getBucketAnalyticsConfiguration(GetBucketAnalyticsConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+        s3.getBucketIntelligentTieringConfiguration(GetBucketIntelligentTieringConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+        s3.getBucketInventoryConfiguration(GetBucketInventoryConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+        s3.getBucketMetricsConfiguration(GetBucketMetricsConfigurationRequest.builder().bucket(bucket).id(id)
+            .build());
+    }
+
+    private void bucketPrefixArgsMethods(S3Client s3, String bucket, String prefix) {
+        s3.listObjects(ListObjectsRequest.builder().bucket(bucket).prefix(prefix)
+            .build());
+        s3.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).prefix(prefix)
+            .build());
+        s3.listObjectVersions(ListObjectVersionsRequest.builder().bucket(bucket).prefix(prefix)
+            .build());
+    }
+}

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/Application.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/Application.java
@@ -100,12 +100,4 @@ public class Application {
 
         return result;
     }
-
-    private static void createBucket(AmazonS3 s3, String bucket) {
-        s3.createBucket(bucket);
-    }
-
-    private static void deleteBucket(AmazonS3 s3, String bucket) {
-        s3.deleteBucket(bucket);
-    }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package foo.bar;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.BucketCrossOriginConfiguration;
+import com.amazonaws.services.s3.model.CORSRule;
+import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.DeleteBucketCrossOriginConfigurationRequest;
+import com.amazonaws.services.s3.model.DeleteBucketRequest;
+import com.amazonaws.services.s3.model.GetBucketCrossOriginConfigurationRequest;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.HeadBucketRequest;
+import com.amazonaws.services.s3.model.HeadBucketResult;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.SetBucketCrossOriginConfigurationRequest;
+
+public class S3 {
+
+    private S3() {
+
+    }
+
+    private void headBucket(AmazonS3 s3, String bucket) {
+        HeadBucketRequest headBucketRequest = new HeadBucketRequest(bucket);
+        HeadBucketResult headBucketResult = s3.headBucket(headBucketRequest);
+        System.out.println(headBucketResult);
+    }
+
+    private void createBucket(AmazonS3 s3, String bucket) {
+        CreateBucketRequest createBucketRequest = new CreateBucketRequest(bucket);
+        s3.createBucket(createBucketRequest);
+    }
+
+    private void deleteBucket(AmazonS3 s3, String bucket) {
+        DeleteBucketRequest deleteBucketRequest = new DeleteBucketRequest(bucket);
+        s3.deleteBucket(deleteBucketRequest);
+    }
+
+    private void getObjectMetaData_to_headObject(AmazonS3 s3, String bucket, String key) {
+        GetObjectMetadataRequest getObjectMetadataRequest = new GetObjectMetadataRequest("bucket", "key");
+        ObjectMetadata objectMetadata = s3.getObjectMetadata(getObjectMetadataRequest);
+        System.out.println(objectMetadata);
+    }
+
+    private void initiateMpu_to_createMpu(AmazonS3 s3, String bucket, String key) {
+        InitiateMultipartUploadRequest initiateMultipartUploadRequest = new InitiateMultipartUploadRequest(bucket, key);
+        InitiateMultipartUploadResult initiateMultipartUploadResult = s3.initiateMultipartUpload(initiateMultipartUploadRequest);
+        System.out.println(initiateMultipartUploadResult);
+    }
+
+    private void listObjects(AmazonS3 s3, String bucket) {
+        ListObjectsRequest listObjectsRequest = new ListObjectsRequest().withBucketName(bucket);
+        ObjectListing objectListing = s3.listObjects(listObjectsRequest);
+        System.out.println(objectListing);
+    }
+
+    private void listObjectsV2(AmazonS3 s3, String bucket) {
+        ListObjectsV2Request listObjectsV2Request = new ListObjectsV2Request().withBucketName(bucket);
+        ListObjectsV2Result listObjectsV2Result = s3.listObjectsV2(listObjectsV2Request);
+        System.out.println(listObjectsV2Result);
+    }
+
+    private void cors(AmazonS3 s3, String bucket) {
+        CORSRule corsRule = new CORSRule().withId("id").withMaxAgeSeconds(99);
+        BucketCrossOriginConfiguration cors = new BucketCrossOriginConfiguration().withRules(corsRule);
+        SetBucketCrossOriginConfigurationRequest setBucketCrossOriginConfigurationRequest =
+            new SetBucketCrossOriginConfigurationRequest(bucket, cors);
+        s3.setBucketCrossOriginConfiguration(setBucketCrossOriginConfigurationRequest);
+
+        GetBucketCrossOriginConfigurationRequest getBucketCrossOriginConfigurationRequest =
+            new GetBucketCrossOriginConfigurationRequest(bucket);
+        s3.getBucketCrossOriginConfiguration(getBucketCrossOriginConfigurationRequest);
+
+        DeleteBucketCrossOriginConfigurationRequest deleteBucketCrossOriginConfigurationRequest =
+            new DeleteBucketCrossOriginConfigurationRequest(bucket);
+        s3.deleteBucketCrossOriginConfiguration(deleteBucketCrossOriginConfigurationRequest);
+    }
+
+    private void singleBucketArgMethods(AmazonS3 s3, String bucket) {
+        s3.createBucket(bucket);
+        s3.deleteBucket(bucket);
+        s3.listObjects(bucket);
+        s3.listObjectsV2(bucket);
+        s3.getBucketCrossOriginConfiguration(bucket);
+        s3.deleteBucketCrossOriginConfiguration(bucket);
+        s3.getBucketVersioningConfiguration(bucket);
+        s3.deleteBucketEncryption(bucket);
+        s3.deleteBucketPolicy(bucket);
+        s3.getBucketAccelerateConfiguration(bucket);
+        s3.getBucketAcl(bucket);
+        s3.getBucketEncryption(bucket);
+        s3.getBucketLifecycleConfiguration(bucket);
+        s3.getBucketNotificationConfiguration(bucket);
+        s3.getBucketPolicy(bucket);
+        s3.getBucketLocation(bucket);
+        s3.deleteBucketLifecycleConfiguration(bucket);
+        s3.deleteBucketReplicationConfiguration(bucket);
+        s3.deleteBucketTaggingConfiguration(bucket);
+        s3.deleteBucketWebsiteConfiguration(bucket);
+        s3.getBucketLoggingConfiguration(bucket);
+        s3.getBucketReplicationConfiguration(bucket);
+        s3.getBucketTaggingConfiguration(bucket);
+        s3.getBucketWebsiteConfiguration(bucket);
+    }
+
+    private void bucketKeyArgsMethods(AmazonS3 s3, String bucket, String key) {
+        s3.deleteObject(bucket, key);
+        s3.getObject(bucket, key);
+        s3.getObjectAcl(bucket, key);
+        s3.getObjectMetadata(bucket, key);
+    }
+
+    private void bucketIdArgsMethods(AmazonS3 s3, String bucket, String id) {
+        s3.deleteBucketAnalyticsConfiguration(bucket, id);
+        s3.deleteBucketIntelligentTieringConfiguration(bucket, id);
+        s3.deleteBucketInventoryConfiguration(bucket, id);
+        s3.deleteBucketMetricsConfiguration(bucket, id);
+        s3.getBucketAnalyticsConfiguration(bucket, id);
+        s3.getBucketIntelligentTieringConfiguration(bucket, id);
+        s3.getBucketInventoryConfiguration(bucket, id);
+        s3.getBucketMetricsConfiguration(bucket, id);
+    }
+
+    private void bucketPrefixArgsMethods(AmazonS3 s3, String bucket, String prefix) {
+        s3.listObjects(bucket, prefix);
+        s3.listObjectsV2(bucket, prefix);
+        s3.listVersions(bucket, prefix);
+    }
+}

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/NamingConversionUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/NamingConversionUtils.java
@@ -28,6 +28,7 @@ public final class NamingConversionUtils {
     private static final String V2_PACKAGE_PREFIX = "software.amazon.awssdk.services";
     private static final Map<String, String> PACKAGE_MAPPING = new HashMap<>();
     private static final Map<String, String> CLIENT_MAPPING = new HashMap<>();
+    private static final Map<String, String> S3_POJO_MAPPING = new HashMap<>();
 
     static {
         PACKAGE_MAPPING.put("appregistry", "servicecatalogappregistry");
@@ -132,12 +133,36 @@ public final class NamingConversionUtils {
         CLIENT_MAPPING.put("Workspaces", "WorkSpaces");
     }
 
+    static {
+        S3_POJO_MAPPING.put("GetBucketCrossOriginConfigurationRequest", "GetBucketCorsRequest");
+        S3_POJO_MAPPING.put("DeleteBucketCrossOriginConfigurationRequest", "DeleteBucketCorsRequest");
+        S3_POJO_MAPPING.put("SetBucketCrossOriginConfigurationRequest", "PutBucketCorsRequest");
+        S3_POJO_MAPPING.put("GetBucketVersioningConfigurationRequest", "GetBucketVersioningRequest");
+        S3_POJO_MAPPING.put("DeleteBucketLifecycleConfigurationRequest", "DeleteBucketLifecycleRequest");
+        S3_POJO_MAPPING.put("DeleteBucketReplicationConfigurationRequest", "DeleteBucketReplicationRequest");
+        S3_POJO_MAPPING.put("DeleteBucketTaggingConfigurationRequest", "DeleteBucketTaggingRequest");
+        S3_POJO_MAPPING.put("DeleteBucketWebsiteConfigurationRequest", "DeleteBucketWebsiteRequest");
+        S3_POJO_MAPPING.put("GetBucketLoggingConfigurationRequest", "GetBucketLoggingRequest");
+        S3_POJO_MAPPING.put("GetBucketReplicationConfigurationRequest", "GetBucketReplicationRequest");
+        S3_POJO_MAPPING.put("GetBucketTaggingConfigurationRequest", "GetBucketTaggingRequest");
+        S3_POJO_MAPPING.put("GetBucketWebsiteConfigurationRequest", "GetBucketWebsiteRequest");
+
+        S3_POJO_MAPPING.put("GetObjectMetadataRequest", "HeadObjectRequest");
+        S3_POJO_MAPPING.put("InitiateMultipartUploadRequest", "CreateMultipartUploadRequest");
+        S3_POJO_MAPPING.put("InitiateMultipartUploadResponse", "CreateMultipartUploadResponse");
+        S3_POJO_MAPPING.put("ListVersionsRequest", "ListObjectVersionsRequest");
+        S3_POJO_MAPPING.put("ObjectMetadata", "HeadObjectResponse");
+        S3_POJO_MAPPING.put("ObjectListing", "ListObjectsResponse");
+        S3_POJO_MAPPING.put("CorsRule", "CORSRule");
+        S3_POJO_MAPPING.put("BucketCrossOriginConfiguration", "CORSConfiguration");
+    }
+
     private NamingConversionUtils() {
     }
 
     public static String getV2Equivalent(String currentFqcn) {
-        int lastIndexOfDot = currentFqcn.lastIndexOf(".");
-        String v1ClassName = currentFqcn.substring(lastIndexOfDot + 1, currentFqcn.length());
+        int lastIndexOfDot = currentFqcn.lastIndexOf('.');
+        String v1ClassName = currentFqcn.substring(lastIndexOfDot + 1);
         String packagePrefix = currentFqcn.substring(0, lastIndexOfDot);
 
         String v2ClassName = CodegenNamingUtils.pascalCase(v1ClassName);
@@ -151,7 +176,15 @@ public final class NamingConversionUtils {
             v2ClassName = v1ClassName.substring(0, lastIndex) + "Response";
         }
 
+        if (isS3Package(v2PackagePrefix) && S3_POJO_MAPPING.containsKey(v2ClassName)) {
+            v2ClassName = S3_POJO_MAPPING.get(v2ClassName);
+        }
+
         return v2PackagePrefix + "." + v2ClassName;
+    }
+
+    private static boolean isS3Package(String packagePrefix) {
+        return packagePrefix.contains("services.s3");
     }
 
     /**
@@ -169,7 +202,7 @@ public final class NamingConversionUtils {
     }
 
     public static String getV2ModelPackageWildCardEquivalent(String currentFqcn) {
-        int lastIndexOfDot = currentFqcn.lastIndexOf(".");
+        int lastIndexOfDot = currentFqcn.lastIndexOf('.');
         String packagePrefix = currentFqcn.substring(0, lastIndexOfDot);
         String v2PackagePrefix = packagePrefix.replace(V1_PACKAGE_PREFIX, V2_PACKAGE_PREFIX);
         v2PackagePrefix = checkPackageServiceNameForV2Suffix(v2PackagePrefix);
@@ -203,7 +236,7 @@ public final class NamingConversionUtils {
         }
 
         if (!className.endsWith("Client") && !className.endsWith("Builder")) {
-            v2Style = v2Style + "Client";
+            v2Style += "Client";
         }
 
         return v2Style;

--- a/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
@@ -25,6 +25,7 @@ recipeList:
   - software.amazon.awssdk.v2migration.S3StreamingResponseToV2
   - software.amazon.awssdk.v2migration.S3StreamingRequestToV2
   - software.amazon.awssdk.v2migration.S3NonStreamingRequestToV2
+  - software.amazon.awssdk.v2migration.S3MethodsToV2
   - software.amazon.awssdk.v2migration.S3MethodsConstructorToFluent
   - software.amazon.awssdk.v2migration.EnumGettersToV2
   - software.amazon.awssdk.v2migration.ChangeSdkType

--- a/v2-migration/src/main/resources/META-INF/rewrite/change-s3-methods.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/change-s3-methods.yml
@@ -1,0 +1,120 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: software.amazon.awssdk.v2migration.S3MethodsToV2
+displayName: Change S3 methods to v2.
+description: Change S3 methods to v2.
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 getObjectMetadata(com.amazonaws.services.s3.model.GetObjectMetadataRequest)
+      newMethodName: headObject
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 initiateMultipartUpload(com.amazonaws.services.s3.model.InitiateMultipartUploadRequest)
+      newMethodName: createMultipartUpload
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 listVersions(com.amazonaws.services.s3.model.ListVersionsRequest)
+      newMethodName: listObjectVersions
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 setBucketCrossOriginConfiguration(com.amazonaws.services.s3.model.SetBucketCrossOriginConfigurationRequest)
+      newMethodName: putBucketCors
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 deleteBucketCrossOriginConfiguration(com.amazonaws.services.s3.model.DeleteBucketCrossOriginConfigurationRequest)
+      newMethodName: deleteBucketCors
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 getBucketCrossOriginConfiguration(com.amazonaws.services.s3.model.GetBucketCrossOriginConfigurationRequest)
+      newMethodName: getBucketCors
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 getBucketVersioningConfiguration(com.amazonaws.services.s3.model.GetBucketVersioningConfigurationRequest)
+      newMethodName: getBucketVersioning
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 deleteBucketLifecycleConfiguration(com.amazonaws.services.s3.model.DeleteBucketLifecycleConfigurationRequest)
+      newMethodName: deleteBucketLifecycle
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 deleteBucketReplicationConfiguration(com.amazonaws.services.s3.model.DeleteBucketReplicationConfigurationRequest)
+      newMethodName: deleteBucketReplication
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 deleteBucketTaggingConfiguration(com.amazonaws.services.s3.model.DeleteBucketTaggingConfigurationRequest)
+      newMethodName: deleteBucketTagging
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 deleteBucketWebsiteConfiguration(com.amazonaws.services.s3.model.DeleteBucketWebsiteConfigurationRequest)
+      newMethodName: deleteBucketWebsite
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 getBucketLoggingConfiguration(com.amazonaws.services.s3.model.GetBucketLoggingConfigurationRequest)
+      newMethodName: getBucketLogging
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 getBucketReplicationConfiguration(com.amazonaws.services.s3.model.GetBucketReplicationConfigurationRequest)
+      newMethodName: getBucketReplication
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 getBucketTaggingConfiguration(com.amazonaws.services.s3.model.GetBucketTaggingConfigurationRequest)
+      newMethodName: getBucketTagging
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3 getBucketWebsiteConfiguration(com.amazonaws.services.s3.model.GetBucketWebsiteConfigurationRequest)
+      newMethodName: getBucketWebsite
+
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client getObjectMetadata(com.amazonaws.services.s3.model.GetObjectMetadataRequest)
+      newMethodName: headObject
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client initiateMultipartUpload(com.amazonaws.services.s3.model.InitiateMultipartUploadRequest)
+      newMethodName: createMultipartUpload
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client listVersions(com.amazonaws.services.s3.model.ListVersionsRequest)
+      newMethodName: listObjectVersions
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client setBucketCrossOriginConfiguration(com.amazonaws.services.s3.model.SetBucketCrossOriginConfigurationRequest)
+      newMethodName: putBucketCors
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client deleteBucketCrossOriginConfiguration(com.amazonaws.services.s3.model.DeleteBucketCrossOriginConfigurationRequest)
+      newMethodName: deleteBucketCors
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client getBucketCrossOriginConfiguration(com.amazonaws.services.s3.model.GetBucketCrossOriginConfigurationRequest)
+      newMethodName: getBucketCors
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client getBucketVersioningConfiguration(com.amazonaws.services.s3.model.GetBucketVersioningConfigurationRequest)
+      newMethodName: getBucketVersioning
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client deleteBucketLifecycleConfiguration(com.amazonaws.services.s3.model.DeleteBucketLifecycleConfigurationRequest)
+      newMethodName: deleteBucketLifecycle
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client deleteBucketReplicationConfiguration(com.amazonaws.services.s3.model.DeleteBucketReplicationConfigurationRequest)
+      newMethodName: deleteBucketReplication
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client deleteBucketTaggingConfiguration(com.amazonaws.services.s3.model.DeleteBucketTaggingConfigurationRequest)
+      newMethodName: deleteBucketTagging
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client deleteBucketWebsiteConfiguration(com.amazonaws.services.s3.model.DeleteBucketWebsiteConfigurationRequest)
+      newMethodName: deleteBucketWebsite
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client getBucketLoggingConfiguration(com.amazonaws.services.s3.model.GetBucketLoggingConfigurationRequest)
+      newMethodName: getBucketLogging
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client getBucketReplicationConfiguration(com.amazonaws.services.s3.model.GetBucketReplicationConfigurationRequest)
+      newMethodName: getBucketReplication
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client getBucketTaggingConfiguration(com.amazonaws.services.s3.model.GetBucketTaggingConfigurationRequest)
+      newMethodName: getBucketTagging
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.AmazonS3Client getBucketWebsiteConfiguration(com.amazonaws.services.s3.model.GetBucketWebsiteConfigurationRequest)
+      newMethodName: getBucketWebsite
+
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.model.BucketCrossOriginConfiguration withRules(com.amazonaws.services.s3.model.CORSRule...)
+      newMethodName: withCorsRules
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.model.ListObjectsRequest withBucketName(String)
+      newMethodName: withBucket
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.model.ListObjectsV2Request withBucketName(String)
+      newMethodName: withBucket

--- a/v2-migration/src/main/resources/META-INF/rewrite/s3-methods-constructor-to-fluent.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/s3-methods-constructor-to-fluent.yml
@@ -46,3 +46,277 @@ recipeList:
         - java.lang.String
       fluentNames:
         - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.HeadBucketRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.InitiateMultipartUploadRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withKey
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.ListObjectsRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.ListObjectsV2Request
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketCrossOriginConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketCrossOriginConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketVersioningConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketEncryptionRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketPolicyRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketAccelerateConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketAclRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketEncryptionRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketLifecycleConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketNotificationConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketPolicyRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketLocationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketLifecycleConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketReplicationConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketTaggingConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketWebsiteConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketLoggingConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketReplicationConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketTaggingConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketWebsiteConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+      fluentNames:
+        - withBucket
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.SetBucketCrossOriginConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - com.amazonaws.services.s3.model.BucketCrossOriginConfiguration
+      fluentNames:
+        - withBucket
+        - withCorsConfiguration
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteObjectRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withKey
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetObjectRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withKey
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetObjectAclRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withKey
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetObjectMetadataRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withKey
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketAnalyticsConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketIntelligentTieringConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketInventoryConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.DeleteBucketMetricsConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketAnalyticsConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketIntelligentTieringConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketInventoryConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.GetBucketMetricsConfigurationRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withId
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.ListObjectsRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withPrefix
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.ListObjectsV2Request
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withPrefix
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.ListVersionsRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+      fluentNames:
+        - withBucket
+        - withPrefix

--- a/v2-migration/src/test/java/software/amazon/awssdk/v2migration/internal/utils/NamingConversionUtilsTest.java
+++ b/v2-migration/src/test/java/software/amazon/awssdk/v2migration/internal/utils/NamingConversionUtilsTest.java
@@ -114,4 +114,67 @@ public class NamingConversionUtilsTest {
         assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.dynamodbv2.AmazonDynamoDB"))
             .isEqualTo("software.amazon.awssdk.services.dynamodb.DynamoDbClient");
     }
+
+    @Test
+    void v1S3PojoSpecialCase_shouldConvertToV2() {
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.GetObjectMetadataRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.HeadObjectRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.InitiateMultipartUploadRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.InitiateMultipartUploadResponse"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.ListVersionsRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.ObjectMetadata"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.HeadObjectResponse");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.ObjectListing"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.ListObjectsResponse");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.CorsRule"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.CORSRule");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.BucketCrossOriginConfiguration"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.CORSConfiguration");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.GetBucketCrossOriginConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.GetBucketCorsRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.DeleteBucketCrossOriginConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.DeleteBucketCorsRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.SetBucketCrossOriginConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.PutBucketCorsRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.GetBucketVersioningConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.DeleteBucketLifecycleConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.DeleteBucketLifecycleRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.DeleteBucketReplicationConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.DeleteBucketReplicationRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.DeleteBucketTaggingConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.DeleteBucketTaggingRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.DeleteBucketWebsiteConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.DeleteBucketWebsiteRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.GetBucketLoggingConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.GetBucketLoggingRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.GetBucketReplicationConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.GetBucketReplicationRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.GetBucketTaggingConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.GetBucketTaggingRequest");
+
+        assertThat(NamingConversionUtils.getV2Equivalent("com.amazonaws.services.s3.model.GetBucketWebsiteConfigurationRequest"))
+            .isEqualTo("software.amazon.awssdk.services.s3.model.GetBucketWebsiteRequest");
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Adding support for additional S3 non-streaming methods

## Modifications
<!--- Describe your changes in detail -->
- Support for all single String (bucket) and two-String args methods
- Transform S3 API / POJO name mismatches, e.g. GetObjectMetadata -> HeadObject, InitiateMpu -> CreateMpu

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit and end-to-end tests
