### PR TITLE
Add support for Multi Auth Sigv4a for Service metadata

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/AuthType.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/AuthType.java
@@ -24,7 +24,7 @@ public enum AuthType {
     CUSTOM("custom"),
     IAM("iam"),
     V4("v4"),
-    V4a("v4a"),
+    V4A("v4a"),
     V4_UNSIGNED_BODY("v4-unsigned-body"),
     S3("s3"),
     S3V4("s3v4"),
@@ -51,7 +51,7 @@ public enum AuthType {
             case "aws.auth#sigv4":
                 return V4;
             case "aws.auth#sigv4a":
-                return V4a;
+                return V4A;
             default:
                 String normalizedValue = StringUtils.lowerCase(value);
                 return Arrays.stream(values())

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/AuthType.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/AuthType.java
@@ -24,6 +24,7 @@ public enum AuthType {
     CUSTOM("custom"),
     IAM("iam"),
     V4("v4"),
+    V4a("v4a"),
     V4_UNSIGNED_BODY("v4-unsigned-body"),
     S3("s3"),
     S3V4("s3v4"),
@@ -49,6 +50,8 @@ public enum AuthType {
                 return NONE;
             case "aws.auth#sigv4":
                 return V4;
+            case "aws.auth#sigv4a":
+                return V4a;
             default:
                 String normalizedValue = StringUtils.lowerCase(value);
                 return Arrays.stream(values())

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadataExt.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadataExt.java
@@ -97,7 +97,7 @@ public final class AuthSchemeCodegenMetadataExt {
                 return BEARER;
             case NONE:
                 return NO_AUTH;
-            case V4a:
+            case V4A:
                 return SIGV4A;
             default:
                 String authTypeName = type.value();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadataExt.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeCodegenMetadataExt.java
@@ -25,7 +25,9 @@ import java.util.function.Supplier;
 import software.amazon.awssdk.codegen.model.service.AuthType;
 import software.amazon.awssdk.codegen.poet.auth.scheme.AuthSchemeCodegenMetadata.SignerPropertyValueProvider;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
 import software.amazon.awssdk.http.auth.scheme.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
@@ -59,6 +61,24 @@ public final class AuthSchemeCodegenMetadataExt {
         .authSchemeClass(BearerAuthScheme.class)
         .build();
 
+    static final AuthSchemeCodegenMetadata SIGV4A =
+        builder()
+            .schemeId(AwsV4aAuthScheme.SCHEME_ID)
+            .authSchemeClass(AwsV4aAuthScheme.class)
+            .addProperty(SignerPropertyValueProvider.builder()
+                                                    .containingClass(AwsV4aHttpSigner.class)
+                                                    .fieldName(
+                                                        "SERVICE_SIGNING_NAME")
+                                                    .valueEmitter((spec, utils) -> spec.add("$S", utils.signingName()))
+                                                    .build())
+            .addProperty(SignerPropertyValueProvider.builder()
+                                                    .containingClass(AwsV4aHttpSigner.class)
+                                                    .fieldName(
+                                                        "REGION_SET")
+                                                    .valueEmitter((spec, utils) -> spec.add("$L", "params.regionSet()"))
+                                                    .build())
+            .build();
+
     static final AuthSchemeCodegenMetadata NO_AUTH = builder()
         .schemeId(NoAuthAuthScheme.SCHEME_ID)
         .authSchemeClass(NoAuthAuthScheme.class)
@@ -77,6 +97,8 @@ public final class AuthSchemeCodegenMetadataExt {
                 return BEARER;
             case NONE:
                 return NO_AUTH;
+            case V4a:
+                return SIGV4A;
             default:
                 String authTypeName = type.value();
                 SigV4SignerDefaults defaults = AuthTypeToSigV4Default.authTypeToDefaults().get(authTypeName);

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -335,6 +335,21 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel opsWithSigv4a() {
+        File serviceModel =
+            new File(ClientTestModels.class.getResource("client/c2j/ops-with-auth-sigv4a-value/service-2.json").getFile());
+        File customizationModel =
+            new File(ClientTestModels.class.getResource("client/c2j/ops-with-auth-sigv4a-value/customization.config")
+                                           .getFile());
+        C2jModels models = C2jModels
+            .builder()
+            .serviceModel(getServiceModel(serviceModel))
+            .customizationConfig(getCustomizationConfig(customizationModel))
+            .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     public static IntermediateModel xmlServiceModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/xml/service-2.json").getFile());
         File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/xml/customization.config").getFile());

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecTest.java
@@ -189,6 +189,13 @@ public class AuthSchemeSpecTest {
                     .classSpecProvider(AuthSchemeInterceptorSpec::new)
                     .caseName("query-endpoint-auth-params-without-allowlist")
                     .outputFileSuffix("interceptor")
+                    .build(),
+            // Service with auth trait with Sigv4a
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::opsWithSigv4a)
+                    .classSpecProvider(ModelBasedAuthSchemeProviderSpec::new)
+                    .caseName("ops-auth-sigv4a-value")
+                    .outputFileSuffix("default-provider")
                     .build()
         );
     }
@@ -198,6 +205,14 @@ public class AuthSchemeSpecTest {
         private final Function<IntermediateModel, ClassSpec> classSpecProvider;
         private final String outputFileSuffix;
         private final String caseName;
+
+
+        @Override
+        public String toString() {
+            return "TestCase{" +
+                   "caseName='" + caseName + '\'' +
+                   '}';
+        }
 
         TestCase(Builder builder) {
             this.modelProvider = builder.modelProvider;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/ops-auth-sigv4a-value-auth-scheme-default-provider.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/ops-auth-sigv4a-value-auth-scheme-default-provider.java
@@ -1,0 +1,47 @@
+package software.amazon.awssdk.services.database.auth.scheme.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeParams;
+import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+public final class DefaultDatabaseAuthSchemeProvider implements DatabaseAuthSchemeProvider {
+    private static final DefaultDatabaseAuthSchemeProvider DEFAULT = new DefaultDatabaseAuthSchemeProvider();
+
+    private DefaultDatabaseAuthSchemeProvider() {
+    }
+
+    public static DefaultDatabaseAuthSchemeProvider create() {
+        return DEFAULT;
+    }
+
+    @Override
+    public List<AuthSchemeOption> resolveAuthScheme(DatabaseAuthSchemeParams params) {
+        List<AuthSchemeOption> options = new ArrayList<>();
+        switch (params.operation()) {
+            case "DeleteRow":
+            case "PutRow":
+                options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4")
+                                            .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "database-service")
+                                            .putSignerProperty(AwsV4HttpSigner.REGION_NAME, params.region().id()).build());
+                break;
+            default:
+                options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4a")
+                                            .putSignerProperty(AwsV4aHttpSigner.SERVICE_SIGNING_NAME, "database-service")
+                                            .putSignerProperty(AwsV4aHttpSigner.REGION_SET, params.regionSet()).build());
+                options.add(AuthSchemeOption.builder().schemeId("aws.auth#sigv4")
+                                            .putSignerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "database-service")
+                                            .putSignerProperty(AwsV4HttpSigner.REGION_NAME, params.region().id()).build());
+                break;
+        }
+        return Collections.unmodifiableList(options);
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-auth-sigv4a-value/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-auth-sigv4a-value/customization.config
@@ -1,0 +1,3 @@
+{
+    "useMultiAuth": true
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-auth-sigv4a-value/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-auth-sigv4a-value/service-2.json
@@ -1,0 +1,152 @@
+{
+    "version": "2.0",
+    "metadata": {
+        "apiVersion": "2023-06-08",
+        "endpointPrefix": "database-service-endpoint",
+        "globalEndpoint": "database-service.amazonaws.com",
+        "protocol": "rest-json",
+        "serviceAbbreviation": "Database Service",
+        "serviceFullName": "Some Service That Uses AWS Database Protocol",
+        "serviceId": "Database Service",
+        "signingName": "database-service",
+        "signatureVersion": "v4",
+        "auth": ["aws.auth#sigv4a", "aws.auth#sigv4"],
+        "uid": "database-service-2023-06-08",
+        "xmlNamespace": "https://database-service.amazonaws.com/doc/2023-06-08/"
+    },
+    "operations": {
+        "GetRow": {
+            "name": "GetRow",
+            "http": {
+                "method": "GET",
+                "requestUri": "/get-row/"
+            },
+            "input": {
+                "shape": "GetRowRequest"
+            },
+            "output": {
+                "shape": "GetRowResponse"
+            },
+            "errors": [
+                {
+                    "shape": "InvalidInputException"
+                }
+            ],
+            "documentation": "<p>Performs a get row operation no output</p>"
+        },
+        "PutRow": {
+            "name": "PutRow",
+            "auth": ["v4"],
+            "http": {
+                "method": "PUT",
+                "requestUri": "/put-row/"
+            },
+            "input": {
+                "shape": "PutRowRequest"
+            },
+            "output": {
+                "shape": "PutRowResponse"
+            },
+            "errors": [
+                {
+                    "shape": "InvalidInputException"
+                }
+            ],
+            "documentation": "<p>Performs a get row operation no output</p>"
+        },
+        "DeleteRow": {
+            "name": "DeleteRow",
+            "auth": [ "v4"],
+            "http": {
+                "method": "DELETE",
+                "requestUri": "/delete-row/"
+            },
+            "input": {
+                "shape": "DeleteRowRequest"
+            },
+            "output": {
+                "shape": "DeleteRowResponse"
+            },
+            "errors": [
+                {
+                    "shape": "InvalidInputException"
+                }
+            ],
+            "documentation": "<p>Performs a get row operation no output</p>"
+        }
+    },
+    "shapes": {
+        "GetRowRequest": {
+            "type": "structure",
+            "members": {
+                "StringMember": {
+                    "shape": "String",
+                    "documentation": "<p>A string Memer</p>"
+                }
+            }
+        },
+        "GetRowResponse": {
+            "type": "structure",
+            "members": {
+                "StringMember": {
+                    "shape": "String",
+                    "documentation": "<p>A string Memer</p>"
+                }
+            }
+        },
+        "PutRowRequest": {
+            "type": "structure",
+            "members": {
+                "StringMember": {
+                    "shape": "String",
+                    "documentation": "<p>A string Memer</p>"
+                }
+            }
+        },
+        "PutRowResponse": {
+            "type": "structure",
+            "members": {
+                "StringMember": {
+                    "shape": "String",
+                    "documentation": "<p>A string Memer</p>"
+                }
+            }
+        },
+        "DeleteRowRequest": {
+            "type": "structure",
+            "members": {
+                "StringMember": {
+                    "shape": "String",
+                    "documentation": "<p>A string Memer</p>"
+                }
+            }
+        },
+        "DeleteRowResponse": {
+            "type": "structure",
+            "members": {
+                "StringMember": {
+                    "shape": "String",
+                    "documentation": "<p>A string Memer</p>"
+                }
+            }
+        },
+        "InvalidInputException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "shape": "invalidInputMessage"
+                }
+            },
+            "documentation": "<p>The request was rejected because an invalid or out-of-range value was supplied for an input parameter.</p>",
+            "error": {
+                "code": "InvalidInput",
+                "httpStatusCode": 400,
+                "senderFault": true
+            },
+            "exception": true
+        },
+        "String":{"type":"string"},
+        "invalidInputMessage":{"type":"string"}
+    },
+    "documentation": "A Database Service with Fine granularity authorization schemes"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
 Support `sigv4a` auth

```json
"metadata": {
    "apiVersion": "2015-07-09",
    "endpointPrefix": "foo",
    "protocol": "rest-json",
    "serviceFullName": "Amazon Foo Service",
    "serviceId": "Foo",
    "signatureVersion": "v4",
    "auth": ["aws.auth#sigv4a" ,"aws.auth#sigv4"],
    "uid": "foo-2015-07-09"
}
```
## Modifications
<!--- Describe your changes in detail -->
- Added new AuthType 
- Added Default Authscheme creation for sigv4a in codegen

Note : Separate PR will be created for operation with Sigv4a trait and unsignedPayload. This PR is sepcific just to service metadata

## Testing
- Added Junits in codegen
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
