### PR TITLE
Update AuthScemeParams with RegionSet for Sigv4a auth Scheme

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeParamsSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeParamsSpec.java
@@ -31,6 +31,8 @@ import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -117,7 +119,16 @@ public final class AuthSchemeParamsSpec implements ClassSpec {
                                   .addJavadoc("Returns the region. The region parameter may be used with the $S auth scheme.",
                                               AwsV4AuthScheme.SCHEME_ID)
                                   .build());
+        }
 
+        if (authSchemeSpecUtils.usesSigV4a()) {
+            b.addMethod(MethodSpec.methodBuilder("regionSet")
+                                  .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                                  .returns(RegionSet.class)
+                                  .addJavadoc("Returns the RegionSet. The regionSet parameter may be used with the $S auth "
+                                              + "scheme.",
+                                              AwsV4aAuthScheme.SCHEME_ID)
+                                  .build());
         }
 
         if (authSchemeSpecUtils.generateEndpointBasedParams()) {
@@ -158,6 +169,17 @@ public final class AuthSchemeParamsSpec implements ClassSpec {
                                   .returns(authSchemeSpecUtils.parametersInterfaceBuilderInterfaceName())
                                   .addJavadoc("Set the region. The region parameter may be used with the $S auth scheme.",
                                               AwsV4AuthScheme.SCHEME_ID)
+                                  .build());
+
+        }
+
+        if (authSchemeSpecUtils.usesSigV4a()) {
+            b.addMethod(MethodSpec.methodBuilder("regionSet")
+                                  .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                                  .addParameter(ParameterSpec.builder(RegionSet.class, "regionSet").build())
+                                  .returns(authSchemeSpecUtils.parametersInterfaceBuilderInterfaceName())
+                                  .addJavadoc("Set the RegionSet. The regionSet parameter may be used with the $S auth scheme.",
+                                              AwsV4aAuthScheme.SCHEME_ID)
                                   .build());
 
         }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
@@ -109,6 +109,10 @@ public final class AuthSchemeSpecUtils {
         return AuthUtils.usesAwsAuth(intermediateModel);
     }
 
+    public boolean usesSigV4a() {
+        return AuthUtils.usesSigv4aAuth(intermediateModel);
+    }
+
     public boolean useEndpointBasedAuthProvider() {
         // Endpoint based auth provider is gated using the same setting that enables the use of auth scheme params. One does
         // not make sense without the other so there's no much point on creating another setting if both have to be at the same

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/DefaultAuthSchemeParamsSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/DefaultAuthSchemeParamsSpec.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.Validate;
 
@@ -77,6 +78,10 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
 
         if (authSchemeSpecUtils.usesSigV4()) {
             b.addStatement("this.region = builder.region");
+        }
+
+        if (authSchemeSpecUtils.usesSigV4a()) {
+            b.addStatement("this.regionSet = builder.regionSet");
         }
 
         if (authSchemeSpecUtils.generateEndpointBasedParams()) {
@@ -145,6 +150,9 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
         if (authSchemeSpecUtils.usesSigV4()) {
             builderFromInstance.addStatement("this.region = params.region");
         }
+        if (authSchemeSpecUtils.usesSigV4a()) {
+            builderFromInstance.addStatement("this.regionSet = params.regionSet");
+        }
         if (authSchemeSpecUtils.generateEndpointBasedParams()) {
             parameters().forEach((name, model) -> {
                 if (authSchemeSpecUtils.includeParam(name)) {
@@ -178,6 +186,19 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
                                   .addAnnotation(Override.class)
                                   .returns(Region.class)
                                   .addStatement("return region")
+                                  .build());
+        }
+
+        if (authSchemeSpecUtils.usesSigV4a()) {
+            b.addField(FieldSpec.builder(RegionSet.class, "regionSet")
+                                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                                .build());
+
+            b.addMethod(MethodSpec.methodBuilder("regionSet")
+                                  .addModifiers(Modifier.PUBLIC)
+                                  .addAnnotation(Override.class)
+                                  .returns(RegionSet.class)
+                                  .addStatement("return regionSet")
                                   .build());
         }
 
@@ -225,6 +246,13 @@ public class DefaultAuthSchemeParamsSpec implements ClassSpec {
                                 .addModifiers(Modifier.PRIVATE)
                                 .build());
             b.addMethod(builderSetterMethod("region", TypeName.get(Region.class)));
+        }
+
+        if (authSchemeSpecUtils.usesSigV4a()) {
+            b.addField(FieldSpec.builder(RegionSet.class, "regionSet")
+                                .addModifiers(Modifier.PRIVATE)
+                                .build());
+            b.addMethod(builderSetterMethod("regionSet", TypeName.get(RegionSet.class)));
         }
 
         if (authSchemeSpecUtils.generateEndpointBasedParams()) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/utils/AuthUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/utils/AuthUtils.java
@@ -36,6 +36,16 @@ public final class AuthUtils {
                     .anyMatch(authType -> authType == AuthType.BEARER);
     }
 
+    public static boolean usesSigv4aAuth(IntermediateModel model) {
+        if (isServiceSigv4a(model)) {
+            return true;
+        }
+        return model.getOperations()
+                    .values()
+                    .stream()
+                    .anyMatch(operationModel -> operationModel.getAuth().stream().anyMatch(authType -> authType == AuthType.V4A));
+    }
+
     public static boolean usesAwsAuth(IntermediateModel model) {
         if (isServiceAwsAuthType(model)) {
             return true;
@@ -58,6 +68,10 @@ public final class AuthUtils {
 
     private static boolean isServiceBearerAuth(IntermediateModel model) {
         return model.getMetadata().getAuthType() == AuthType.BEARER;
+    }
+
+    private static boolean isServiceSigv4a(IntermediateModel model) {
+        return model.getMetadata().getAuth().stream().anyMatch(authType -> authType == AuthType.V4A);
     }
 
     private static boolean isServiceAwsAuthType(IntermediateModel model) {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecTest.java
@@ -196,6 +196,18 @@ public class AuthSchemeSpecTest {
                     .classSpecProvider(ModelBasedAuthSchemeProviderSpec::new)
                     .caseName("ops-auth-sigv4a-value")
                     .outputFileSuffix("default-provider")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::opsWithSigv4a)
+                    .classSpecProvider(AuthSchemeParamsSpec::new)
+                    .caseName("ops-auth-sigv4a-value")
+                    .outputFileSuffix("params")
+                    .build(),
+            TestCase.builder()
+                    .modelProvider(ClientTestModels::opsWithSigv4a)
+                    .classSpecProvider(DefaultAuthSchemeParamsSpec::new)
+                    .caseName("ops-auth-sigv4a-value")
+                    .outputFileSuffix("default-params")
                     .build()
         );
     }
@@ -210,7 +222,7 @@ public class AuthSchemeSpecTest {
         @Override
         public String toString() {
             return "TestCase{" +
-                   "caseName='" + caseName + '\'' +
+                   "caseName='" + caseName + "-" + outputFileSuffix + '\'' +
                    '}';
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/ops-auth-sigv4a-value-auth-scheme-default-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/ops-auth-sigv4a-value-auth-scheme-default-params.java
@@ -1,0 +1,88 @@
+package software.amazon.awssdk.services.database.auth.scheme.internal;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeParams;
+import software.amazon.awssdk.utils.Validate;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+public final class DefaultDatabaseAuthSchemeParams implements DatabaseAuthSchemeParams {
+    private final String operation;
+
+    private final Region region;
+
+    private final RegionSet regionSet;
+
+    private DefaultDatabaseAuthSchemeParams(Builder builder) {
+        this.operation = Validate.paramNotNull(builder.operation, "operation");
+        this.region = builder.region;
+        this.regionSet = builder.regionSet;
+    }
+
+    public static DatabaseAuthSchemeParams.Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String operation() {
+        return operation;
+    }
+
+    @Override
+    public Region region() {
+        return region;
+    }
+
+    @Override
+    public RegionSet regionSet() {
+        return regionSet;
+    }
+
+    @Override
+    public DatabaseAuthSchemeParams.Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    private static final class Builder implements DatabaseAuthSchemeParams.Builder {
+        private String operation;
+
+        private Region region;
+
+        private RegionSet regionSet;
+
+        Builder() {
+        }
+
+        Builder(DefaultDatabaseAuthSchemeParams params) {
+            this.operation = params.operation;
+            this.region = params.region;
+            this.regionSet = params.regionSet;
+        }
+
+        @Override
+        public Builder operation(String operation) {
+            this.operation = operation;
+            return this;
+        }
+
+        @Override
+        public Builder region(Region region) {
+            this.region = region;
+            return this;
+        }
+
+        @Override
+        public Builder regionSet(RegionSet regionSet) {
+            this.regionSet = regionSet;
+            return this;
+        }
+
+        @Override
+        public DatabaseAuthSchemeParams build() {
+            return new DefaultDatabaseAuthSchemeParams(this);
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/ops-auth-sigv4a-value-auth-scheme-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/auth/scheme/ops-auth-sigv4a-value-auth-scheme-params.java
@@ -1,0 +1,69 @@
+package software.amazon.awssdk.services.database.auth.scheme;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.database.auth.scheme.internal.DefaultDatabaseAuthSchemeParams;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * The parameters object used to resolve the auth schemes for the Database service.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface DatabaseAuthSchemeParams extends ToCopyableBuilder<DatabaseAuthSchemeParams.Builder, DatabaseAuthSchemeParams> {
+    /**
+     * Get a new builder for creating a {@link DatabaseAuthSchemeParams}.
+     */
+    static Builder builder() {
+        return DefaultDatabaseAuthSchemeParams.builder();
+    }
+
+    /**
+     * Returns the operation for which to resolve the auth scheme.
+     */
+    String operation();
+
+    /**
+     * Returns the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
+     */
+    Region region();
+
+    /**
+     * Returns the RegionSet. The regionSet parameter may be used with the "aws.auth#sigv4a" auth scheme.
+     */
+    RegionSet regionSet();
+
+    /**
+     * Returns a {@link Builder} to customize the parameters.
+     */
+    Builder toBuilder();
+
+    /**
+     * A builder for a {@link DatabaseAuthSchemeParams}.
+     */
+    interface Builder extends CopyableBuilder<Builder, DatabaseAuthSchemeParams> {
+        /**
+         * Set the operation for which to resolve the auth scheme.
+         */
+        Builder operation(String operation);
+
+        /**
+         * Set the region. The region parameter may be used with the "aws.auth#sigv4" auth scheme.
+         */
+        Builder region(Region region);
+
+        /**
+         * Set the RegionSet. The regionSet parameter may be used with the "aws.auth#sigv4a" auth scheme.
+         */
+        Builder regionSet(RegionSet regionSet);
+
+        /**
+         * Returns a {@link DatabaseAuthSchemeParams} object that is created from the properties that have been set on
+         * the builder.
+         */
+        DatabaseAuthSchemeParams build();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Update AuthScemeParams with RegionSet for Sigv4a auth Scheme
- These regionSet parameter will be updated from ExecutionAttributes in the AuthScemeInterceptor (later PR)

## Modifications
<!--- Describe your changes in detail -->
- Updated `AuthSchemeParamsSpec` and `DefaultAuthSchemeParamsSpec` to generate code only if Sigv4a Auth is defined.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Junits

## Screenshots (if appropriate)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
