### PR TITLE
Update InternalApiBoundaryTest to skip flagging the use of protected APIs that are in internal package

### DIFF
--- a/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/internal/NullJsonNode.java
+++ b/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/internal/NullJsonNode.java
@@ -17,14 +17,18 @@ package software.amazon.awssdk.protocols.jsoncore.internal;
 
 import java.util.List;
 import java.util.Map;
-import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.protocols.jsoncore.JsonNodeVisitor;
 
 /**
  * A null {@link JsonNode}.
+ *
+ * <p>
+ * Implementation notes: this class should've been outside internal package,
+ * but we can't fix it due to backwards compatibility reasons.
  */
-@SdkInternalApi
+@SdkProtectedApi
 public final class NullJsonNode implements JsonNode {
     private static final NullJsonNode INSTANCE = new NullJsonNode();
 

--- a/test/architecture-tests/archunit_store/c898eee1-aeb5-4355-bb3b-ea56bf58cacb
+++ b/test/architecture-tests/archunit_store/c898eee1-aeb5-4355-bb3b-ea56bf58cacb
@@ -14,6 +14,7 @@ Class <software.amazon.awssdk.core.internal.util.MetricUtils> does not reside ou
 Class <software.amazon.awssdk.core.internal.waiters.ResponseOrException> does not reside outside of package '..internal..' in (ResponseOrException.java:0)
 Class <software.amazon.awssdk.core.internal.waiters.WaiterAttribute> does not reside outside of package '..internal..' in (WaiterAttribute.java:0)
 Class <software.amazon.awssdk.http.nio.netty.internal.DnsResolverLoader> does not reside outside of package '..internal..' in (DnsResolverLoader.java:0)
+Class <software.amazon.awssdk.protocols.jsoncore.internal.NullJsonNode> does not reside outside of package '..internal..' in (NullJsonNode.java:0)
 Class <software.amazon.awssdk.retries.api.internal.backoff.ExponentialDelayWithHalfJitter> does not reside outside of package '..internal..' in (ExponentialDelayWithHalfJitter.java:0)
 Class <software.amazon.awssdk.retries.internal.DefaultAwareRetryStrategy> does not reside outside of package '..internal..' in (DefaultAwareRetryStrategy.java:0)
 Class <software.amazon.awssdk.retries.internal.RetryStrategyDefaults> does not reside outside of package '..internal..' in (RetryStrategyDefaults.java:0)

--- a/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/InternalApiBoundaryTest.java
+++ b/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/InternalApiBoundaryTest.java
@@ -31,6 +31,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.awscore.internal.AwsProtocolMetadata;
 import software.amazon.awssdk.awscore.internal.AwsServiceProtocol;
 import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
@@ -92,7 +94,9 @@ public class InternalApiBoundaryTest {
                 }
 
                 if (JavaClass.Predicates.resideInAPackage("software.amazon.awssdk..internal..").test(dependencyTargetClass)) {
-                    if (!ArchUtils.resideInSameRootPackage(packageName, dependencyPackageName)) {
+                    if (!ArchUtils.resideInSameRootPackage(packageName, dependencyPackageName) &&
+                        // Ignore if the dependency class is not annotated with SdkInternalApi since it's an exception case
+                        dependencyTargetClass.isAnnotatedWith(SdkInternalApi.class)) {
                         String errorMessage = String.format("%s depends on an internal API from a different module (%s)",
                                                             item.getDescription(),
                                                             dependencyTargetClass.getDescription());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Update `InternalApiBoundaryTest` to skip flagging the use of protected APIs that are in internal package because those APIs should already be flagged and given exceptions in `PackageContainmentTest`

- Mark NullJsonNode as protected API because it's already used in other modules.