### PR TITLE
Convert SdkBytes to ByteBuffer for POJO getters

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-996edb5.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-996edb5.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 Migration Tool",
+    "contributor": "",
+    "description": "Transform the getter methods on the service model classes that return SdkBytes to return ByteBuffer to be compatible with v1 style getters"
+}

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/SdkBytes.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/SdkBytes.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package foo.bar;
+
+import java.nio.ByteBuffer;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+
+public class SdkBytes {
+
+    void sdkBytesGetters() {
+        MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder()
+            .build();
+        ByteBuffer binaryValue = messageAttributeValue.binaryValue().asByteBuffer();
+        String binaryString = new String(messageAttributeValue.binaryValue().asByteBuffer().array());
+    }
+}

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/SdkBytes.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/SdkBytes.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package foo.bar;
+
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import java.nio.ByteBuffer;
+
+public class SdkBytes {
+
+    void sdkBytesGetters() {
+        MessageAttributeValue messageAttributeValue = new MessageAttributeValue();
+        ByteBuffer binaryValue = messageAttributeValue.getBinaryValue();
+        String binaryString = new String(messageAttributeValue.getBinaryValue().array());
+    }
+}

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.v2migration;
+
+import java.nio.ByteBuffer;
+import java.util.regex.Pattern;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType.FullyQualified;
+import org.openrewrite.java.tree.JavaType.Method;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.v2migration.internal.utils.SdkTypeUtils;
+
+@SdkInternalApi
+public class SdkBytesToByteBuffer extends Recipe {
+    private static final Pattern BYTE_BUFFER_PATTERN = Pattern.compile(ByteBuffer.class.getCanonicalName());
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Convert SdkBytes to ByteBuffer";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Convert SdkBytes to ByteBuffer by calling SdkBytes#asByteBuffer()";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation originalMethod, ExecutionContext executionContext) {
+                J.MethodInvocation method = super.visitMethodInvocation(originalMethod, executionContext);
+                if (!isV2ModelGetterReturningByteBuffer(method)) {
+                    return method;
+                }
+
+                String methodName = method.getSimpleName();
+                JavaTemplate template = JavaTemplate
+                    .builder(method.getSelect() + "." + methodName + "()." + "asByteBuffer()")
+                    .contextSensitive()
+                    .build();
+
+                method = template.apply(
+                    updateCursor(method),
+                    method.getCoordinates().replace()
+                );
+
+                return method;
+            }
+        };
+    }
+
+    private static boolean isV2ModelGetterReturningByteBuffer(J.MethodInvocation method) {
+        Method mt = method.getMethodType();
+
+        if (mt != null) {
+            FullyQualified declaringType = mt.getDeclaringType();
+            boolean isByteBuffer = mt.getReturnType().isAssignableFrom(BYTE_BUFFER_PATTERN);
+            if (SdkTypeUtils.isV2ModelClass(declaringType) && isByteBuffer) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
@@ -48,7 +48,7 @@ public class SdkBytesToByteBuffer extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation originalMethod,
-            ExecutionContext executionContext) {
+                ExecutionContext executionContext) {
                 J.MethodInvocation method = super.visitMethodInvocation(originalMethod, executionContext);
                 if (!isV2ModelGetterReturningByteBuffer(method)) {
                     return method;

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
@@ -27,7 +27,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType.FullyQualified;
 import org.openrewrite.java.tree.JavaType.Method;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.v2migration.internal.utils.SdkTypeUtils;
 
 @SdkInternalApi

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SdkBytesToByteBuffer.java
@@ -47,7 +47,8 @@ public class SdkBytesToByteBuffer extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation originalMethod, ExecutionContext executionContext) {
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation originalMethod,
+            ExecutionContext executionContext) {
                 J.MethodInvocation method = super.visitMethodInvocation(originalMethod, executionContext);
                 if (!isV2ModelGetterReturningByteBuffer(method)) {
                     return method;

--- a/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
@@ -38,3 +38,4 @@ recipeList:
   - software.amazon.awssdk.v2migration.HttpSettingsToHttpClient
   - software.amazon.awssdk.v2migration.WrapSdkClientBuilderRegionStr
   - software.amazon.awssdk.v2migration.EnumCasingToV2
+  - software.amazon.awssdk.v2migration.SdkBytesToByteBuffer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Java SDK v1 uses `ByteBuffer` to represent binary data while Java SDK v2 uses `SdkBytes`, so changing the method name is not sufficient for ByteBuffer getters and users will get compilation error.

Setter will be in a separate PR.

Convert SdkBytes to ByteBuffer for POJO getters
## Modifications
v1
```
        ByteBuffer binaryValue = messageAttributeValue.getBinaryValue();
```
->
v2
```
        ByteBuffer binaryValue = messageAttributeValue.binaryValue().asByteBuffer();
```

## Testing
Added end to end tests.
Unit tests are not possible for `JavaTemplate` since it can't recognize the types.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
