### PR TITLE
Convert ByteBuffer to SdkBytes

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-21fc092.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-21fc092.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 Migration Tool",
+    "contributor": "",
+    "description": "Transform the setter methods on the service model classes that take SdkBytes to take ByteBuffer to be compatible with v1 style setters"
+}

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/SdkBytesGetterSetter.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/SdkBytesGetterSetter.java
@@ -16,13 +16,23 @@
 package foo.bar;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 
-public class SdkBytes {
+public class SdkBytesGetterSetter {
+
+    void byteBufferSetter() {
+        ByteBuffer buffer = ByteBuffer.wrap("helloworld".getBytes(StandardCharsets.UTF_8));
+        MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder()
+            .binaryValue(SdkBytes.fromByteBuffer(buffer))
+            .build();
+    }
 
     void sdkBytesGetters() {
         MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder()
             .build();
+
         ByteBuffer binaryValue = messageAttributeValue.binaryValue().asByteBuffer();
         String binaryString = new String(messageAttributeValue.binaryValue().asByteBuffer().array());
     }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/SdkBytesGetterSetter.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/SdkBytesGetterSetter.java
@@ -17,11 +17,19 @@ package foo.bar;
 
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
-public class SdkBytes {
+public class SdkBytesGetterSetter {
+
+    void byteBufferSetter() {
+        ByteBuffer buffer = ByteBuffer.wrap("helloworld".getBytes(StandardCharsets.UTF_8));
+        MessageAttributeValue messageAttributeValue = new MessageAttributeValue()
+            .withBinaryValue(buffer);
+    }
 
     void sdkBytesGetters() {
         MessageAttributeValue messageAttributeValue = new MessageAttributeValue();
+
         ByteBuffer binaryValue = messageAttributeValue.getBinaryValue();
         String binaryString = new String(messageAttributeValue.getBinaryValue().array());
     }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/ByteBufferToSdkBytes.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/ByteBufferToSdkBytes.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.v2migration;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.JavaType.FullyQualified;
+import org.openrewrite.java.tree.JavaType.Method;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.v2migration.internal.utils.SdkTypeUtils;
+
+@SdkInternalApi
+public class ByteBufferToSdkBytes extends Recipe {
+    private static final Pattern BYTE_BUFFER_PATTERN = Pattern.compile(ByteBuffer.class.getCanonicalName());
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Convert ByteBuffer to SdkBytes";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Convert ByteBuffer to SdkBytes by calling SdkBytes#fromByteBuffer";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new SdkBytesToBufferVisitor();
+    }
+
+    private static final class SdkBytesToBufferVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation originalMethod,
+                                                        ExecutionContext executionContext) {
+            J.MethodInvocation method =
+                super.visitMethodInvocation(originalMethod, executionContext);
+            if (!isV2ModelSetterWithByteBufferParam(method)) {
+                return method;
+            }
+
+            JavaTemplate template = JavaTemplate
+                .builder("SdkBytes.fromByteBuffer(#{any()})")
+                .contextSensitive()
+                .imports(SdkBytes.class.getCanonicalName())
+                .build();
+
+            method = template.apply(
+                updateCursor(method),
+                method.getCoordinates().replaceArguments(),
+                method.getArguments().toArray()
+            );
+
+            maybeAddImport(SdkBytes.class.getCanonicalName(), false);
+            return method;
+        }
+
+        private static boolean isV2ModelSetterWithByteBufferParam(J.MethodInvocation method) {
+            Method mt = method.getMethodType();
+
+            if (mt != null) {
+                FullyQualified declaringType = mt.getDeclaringType();
+                List<JavaType> parameterTypes = mt.getParameterTypes();
+                if (parameterTypes.size() != 1) {
+                    return false;
+                }
+
+                JavaType javaType = parameterTypes.get(0);
+                if (javaType == null) {
+                    return false;
+                }
+
+                boolean isByteBufferParam = javaType.isAssignableFrom(BYTE_BUFFER_PATTERN);
+                if (SdkTypeUtils.isV2ModelBuilder(declaringType) && isByteBufferParam) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
@@ -39,4 +39,5 @@ recipeList:
   - software.amazon.awssdk.v2migration.WrapSdkClientBuilderRegionStr
   - software.amazon.awssdk.v2migration.EnumCasingToV2
   - software.amazon.awssdk.v2migration.SdkBytesToByteBuffer
+  - software.amazon.awssdk.v2migration.ByteBufferToSdkBytes
   - software.amazon.awssdk.v2migration.S3NonStreamingRequestToV2Complex


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Similar to #5791 Java SDK v1 uses ByteBuffer to represent binary data while Java SDK v2 uses SdkBytes, so changing the method name is not sufficient for ByteBuffer setters and users will get compilation error.

v1 
```
        MessageAttributeValue messageAttributeValue = new MessageAttributeValue()
            .withBinaryValue(buffer);
```
to 
v2
```
        MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder()
            .binaryValue(SdkBytes.fromByteBuffer(buffer))
            .build();

```

## Modifications
Convert ByteBuffer to SdkBytes for POJO setters


## Testing
Added end to end tests
Unit tests are not possible for JavaTemplate since it can't recognize the types.
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
