### PR TITLE
Remove `useMultiAuth`  customization

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
@@ -80,7 +80,7 @@ final class AddMetadata {
                 .withSupportsH2(supportsH2(serviceMetadata))
                 .withJsonVersion(getJsonVersion(metadata, serviceMetadata))
                 .withAwsQueryCompatible(serviceMetadata.getAwsQueryCompatible())
-                .withAuth(getAuthFromServiceMetadata(serviceMetadata, customizationConfig.useMultiAuth()));
+                .withAuth(getAuthFromServiceMetadata(serviceMetadata));
 
         return metadata;
     }
@@ -136,18 +136,14 @@ final class AddMetadata {
     }
 
     /**
-     * Converts service metadata into a list of AuthTypes. If useMultiAuth is enabled, then
-     * {@code metadata.auth} will be used in the conversion if present. Otherwise, use
-     * {@code metadata.signatureVersion}.
+     * Converts a list of authentication type strings from the given {@link ServiceMetadata} into a list of
+     * {@link AuthType} objects.
      */
-    private static List<AuthType> getAuthFromServiceMetadata(ServiceMetadata serviceMetadata,
-                                                             boolean useMultiAuth) {
-        if (useMultiAuth) {
-            List<String> serviceAuth = serviceMetadata.getAuth();
-            if (serviceAuth != null) {
-                return serviceAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
-            }
+    private static List<AuthType> getAuthFromServiceMetadata(ServiceMetadata serviceMetadata) {
+        List<String> serviceAuth = serviceMetadata.getAuth();
+        if (serviceAuth != null) {
+            return serviceAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
         }
-        return Collections.singletonList(AuthType.fromValue(serviceMetadata.getSignatureVersion()));
+        return Collections.emptyList();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -47,14 +47,12 @@ final class AddOperations {
     private final NamingStrategy namingStrategy;
     private final Map<String, PaginatorDefinition> paginators;
     private final List<String> deprecatedShapes;
-    private final boolean useMultiAuth;
 
     AddOperations(IntermediateModelBuilder builder) {
         this.serviceModel = builder.getService();
         this.namingStrategy = builder.getNamingStrategy();
         this.paginators = builder.getPaginators().getPagination();
         this.deprecatedShapes = builder.getCustomConfig().getDeprecatedShapes();
-        this.useMultiAuth = builder.getCustomConfig().useMultiAuth();
     }
 
     private static boolean isAuthenticated(Operation op) {
@@ -238,16 +236,16 @@ final class AddOperations {
     }
 
     /**
-     * Returns the list of authTypes defined for an operation. If useMultiAuth is enabled, then
-     * {@code operation.auth} will be used in the conversion if present. Otherwise, use
-     * {@code operation.authtype} if present.
+     * Retrieves the list of {@link AuthType} for the given operation.
+     * <p>
+     * If {@link Operation#getAuth()}is available, it is converted to a list of {@link AuthType}.
+     * Otherwise, {@link Operation#getAuthtype()} is returned as a single-element list if present.
+     * If neither is available, an empty list is returned.
      */
     private List<AuthType> getAuthFromOperation(Operation op) {
-        if (useMultiAuth) {
-            List<String> opAuth = op.getAuth();
-            if (opAuth != null) {
-                return opAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
-            }
+        List<String> opAuth = op.getAuth();
+        if (opAuth != null) {
+            return opAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
         }
         AuthType legacyAuthType = op.getAuthtype();
         if (legacyAuthType != null) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -243,13 +243,15 @@ final class AddOperations {
      * If neither is available, an empty list is returned.
      */
     private List<AuthType> getAuthFromOperation(Operation op) {
-        List<String> opAuth = op.getAuth();
-        if (opAuth != null) {
-            return opAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
-        }
+
+        // First we check for legacy AuthType to support backward compatibility
         AuthType legacyAuthType = op.getAuthtype();
         if (legacyAuthType != null) {
             return Collections.singletonList(legacyAuthType);
+        }
+        List<String> opAuth = op.getAuth();
+        if (opAuth != null) {
+            return opAuth.stream().map(AuthType::fromValue).collect(Collectors.toList());
         }
         return Collections.emptyList();
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -320,13 +320,6 @@ public class CustomizationConfig {
     private String rootPackageName;
 
     /**
-     * Set to true to read from c2j multi-auth values. Currently defaults to false.
-     *
-     * TODO(multi-auth): full multi-auth support is not implemented
-     */
-    private boolean useMultiAuth;
-
-    /**
      * Special case for a service where model changes for endpoint params were not updated .
      * This should be removed once the service updates its models
      */
@@ -876,14 +869,6 @@ public class CustomizationConfig {
     public CustomizationConfig withRootPackageName(String packageName) {
         this.rootPackageName = packageName;
         return this;
-    }
-
-    public void setUseMultiAuth(boolean useMultiAuth) {
-        this.useMultiAuth = useMultiAuth;
-    }
-
-    public boolean useMultiAuth() {
-        return useMultiAuth;
     }
 
     public Map<String, ParameterModel> getEndpointParameters() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/ModelAuthSchemeKnowledgeIndex.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/ModelAuthSchemeKnowledgeIndex.java
@@ -165,6 +165,13 @@ public final class ModelAuthSchemeKnowledgeIndex {
      * Returns the list of modeled top-level auth-types.
      */
     private List<AuthType> serviceDefaultAuthTypes() {
+
+        // First, look at legacy signature versions.
+        if (intermediateModel.getMetadata().getAuthType() != null
+            && intermediateModel.getMetadata().getAuthType() != AuthType.V4) {
+            return Collections.singletonList(intermediateModel.getMetadata().getAuthType());
+        }
+
         List<AuthType> modeled = intermediateModel.getMetadata().getAuth();
         if (!modeled.isEmpty()) {
             return modeled;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-different-value/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-different-value/customization.config
@@ -1,3 +1,2 @@
 {
-    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-same-value/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/all-ops-with-auth-same-value/customization.config
@@ -1,3 +1,2 @@
 {
-    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/fine-grained-auth/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/fine-grained-auth/customization.config
@@ -1,3 +1,3 @@
 {
-    "useMultiAuth": true
 }
+

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-auth-sigv4a-value/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-auth-sigv4a-value/customization.config
@@ -1,3 +1,2 @@
 {
-    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-no-auth/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/ops-with-no-auth/customization.config
@@ -1,3 +1,2 @@
 {
-    "useMultiAuth": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/service-with-no-auth/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/service-with-no-auth/customization.config
@@ -1,3 +1,2 @@
 {
-    "useMultiAuth": true
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/multiauth/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/multiauth/customization.config
@@ -1,4 +1,4 @@
 {
-    "skipEndpointTestGeneration": true,
-     "useMultiAuth": true
+    "skipEndpointTestGeneration": true
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Remove `useMultiAuth`  customization
- The feature/master/multi-auth is for supporting multi-auth by default , no need of additional customization since this branch will support `MultiAuth` feature.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
- Removed customizaion for `useMultiAuth`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
- Already present , note that tests associated with `test/codegen-generated-classes-test/src/main/resources/codegen-resources/multiauth/`  are passing even after removal of this customization since by default Multi auth is supported.
<!--- see how your change affects other areas of the code, etc. -->



## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
