### PR TITLE
Fix intermittent ConcurrentModificationException thrown from codegen 

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/CodeGenerator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/CodeGenerator.java
@@ -26,9 +26,10 @@ import software.amazon.awssdk.codegen.emitters.tasks.AwsGeneratorTasks;
 import software.amazon.awssdk.codegen.internal.Jackson;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.utils.Logger;
 
 public class CodeGenerator {
-
+    private static final Logger log = Logger.loggerFor(CodeGenerator.class);
     private static final String MODEL_DIR_NAME = "models";
 
     private final C2jModels models;
@@ -85,6 +86,7 @@ public class CodeGenerator {
             emitCode(intermediateModel);
 
         } catch (Exception e) {
+            log.error(() -> "Failed to generate code. ", e);
             throw new RuntimeException(
                     "Failed to generate code. Exception message : " + e.getMessage(), e);
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/HttpChecksumTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/HttpChecksumTrait.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
@@ -141,11 +142,12 @@ public class HttpChecksumTrait {
      * with the fastest-to-calculate algorithms first.
      */
     private static void addResponseAlgorithmsCodeBlock(List<String> responseAlgorithms, CodeBlock.Builder codeBuilder) {
-        responseAlgorithms.sort(Comparator.comparingInt(o -> CHECKSUM_ALGORITHM_PRIORITY.getOrDefault(
-            o.toUpperCase(Locale.US), Integer.MAX_VALUE)));
+        List<String> sortedResponseAlgorithms =
+            responseAlgorithms.stream().sorted(Comparator.comparingInt(o -> CHECKSUM_ALGORITHM_PRIORITY.getOrDefault(
+            o.toUpperCase(Locale.US), Integer.MAX_VALUE))).collect(Collectors.toList());
 
         codeBuilder.add(CodeBlock.of(".responseAlgorithmsV2("));
-        List<CodeBlock> responseAlgorithmsCodeBlocks = responseAlgorithmsCodeBlocks(responseAlgorithms);
+        List<CodeBlock> responseAlgorithmsCodeBlocks = responseAlgorithmsCodeBlocks(sortedResponseAlgorithms);
         for (int i = 0; i < responseAlgorithmsCodeBlocks.size(); i++) {
             CodeBlock code = responseAlgorithmsCodeBlocks.get(i);
             codeBuilder.add(code);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix intermittent `ConcurrentModificationException` thrown from codegen

```
Failed to execute goal software.amazon.awssdk:codegen-maven-plugin:2.30.3-SNAPSHOT:generate (default) on project codegen-generated-classes-test: Execution default of goal software.amazon.awssdk:codegen-maven-plugin:2.30.3-SNAPSHOT:generate failed: Failed to generate code. Exception message : java.lang.RuntimeException: java.util.ConcurrentModificationException -> [Help 1]
```

The root cause is that we are sorting an ArrayList while iterating.

## Modifications
Updated the code to not sort the list while iterating

