### PR TITLE
Rewrite the javadocs to align the wording

### DIFF
--- a/core/retries/src/main/java/software/amazon/awssdk/retries/AdaptiveRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/AdaptiveRetryStrategy.java
@@ -41,8 +41,8 @@ import software.amazon.awssdk.retries.internal.ratelimiter.RateLimiterTokenBucke
  *     <li>Retries on the conditions configured in the {@link Builder}.
  *     <li>Retries 2 times (3 total attempts). Adjust with {@link Builder#maxAttempts}
  *     <li>Uses a dynamic backoff delay based on load currently perceived against the downstream resource
- *     <li>Circuit breaking (disabling retries) in the event of high downstream failures within an individual scope.
- *     Circuit breaking may prevent a first attempt in outage scenarios to protect the downstream service.
+ *     <li>Circuit breaking (disabling retries) in the event of high downstream failures within an individual scope. The
+ *     circuit breaking will never prevent the first attempt
  * </ol>
  *
  * @see StandardRetryStrategy

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/LegacyRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/LegacyRetryStrategy.java
@@ -35,8 +35,8 @@ import software.amazon.awssdk.retries.internal.circuitbreaker.TokenBucketStore;
  *     <li>For throttling exceptions uses the {@link BackoffStrategy#exponentialDelayHalfJitter} backoff strategy, with a base
  *     delay of 500 milliseconds  and max delay of 20 seconds. Adjust with
  *     {@link LegacyRetryStrategy.Builder#throttlingBackoffStrategy}
- *     <li>Circuit breaking (disabling retries) in the event of high downstream failures across the scope of
- *     the strategy. The circuit breaking will never prevent a successful first attempt. Adjust with
+ *     <li>Circuit breaking (disabling retries) in the event of high downstream failures within an individual scope. The
+ *     circuit breaking will never prevent the first attempt. Adjust with
  *     {@link Builder#circuitBreakerEnabled}
  *     <li>The state of the circuit breaker is not affected by throttling exceptions
  * </ol>

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/StandardRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/StandardRetryStrategy.java
@@ -33,8 +33,8 @@ import software.amazon.awssdk.retries.internal.circuitbreaker.TokenBucketStore;
  *     <li>Retries 2 times (3 total attempts). Adjust with {@link Builder#maxAttempts(int)}
  *     <li>Uses the {@link BackoffStrategy#exponentialDelay} backoff strategy, with a base delay of
  *     1 second and max delay of 20 seconds. Adjust with {@link Builder#backoffStrategy}
- *     <li>Circuit breaking (disabling retries) in the event of high downstream failures across the scope of
- *     the strategy. The circuit breaking will never prevent a successful first attempt. Adjust with
+ *     <li>Circuit breaking (disabling retries) in the event of high downstream failures within an individual scope. The
+ *     circuit breaking will never prevent the first attempt. Adjust with
  *     {@link Builder#circuitBreakerEnabled}.
  * </ol>
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Removed an incorrect wording in the Java docs in the `AdaptiveRetryStrategy` as per offline report. The phrase removed was:

> Circuit breaking may prevent a first attempt in outage scenarios to protect the downstream service.

Circuit breaking won't prevent the first attempt ever.

While there, I also aligned the docs to use the same wording on this regard.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
