### PR TITLE
Adding attempt count to error message

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-6db3e90.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-6db3e90.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Add retry attempt count to exception messages to improve debugging visibility."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ExceptionProperties.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ExceptionProperties.java
@@ -35,8 +35,7 @@ public class ExceptionProperties {
                 builderMethod(className, "statusCode", int.class),
                 builderMethod(className, "cause", Throwable.class),
                 builderMethod(className, "writableStackTrace", Boolean.class),
-                builderMethod(className, "numAttempts", Integer.class),
-                builderGetterMethodInterface("numAttempts", Integer.class));
+                builderMethod(className, "numAttempts", Integer.class));
 
     }
 
@@ -48,8 +47,7 @@ public class ExceptionProperties {
                 builderImplMethods(className, "statusCode", int.class),
                 builderImplMethods(className, "cause", Throwable.class),
                 builderImplMethods(className, "writableStackTrace", Boolean.class),
-                builderImplMethods(className, "numAttempts", Integer.class),
-                builderImplGetterMethods("numAttempts", Integer.class));
+                builderImplMethods(className, "numAttempts", Integer.class));
     }
 
     private static MethodSpec builderMethod(ClassName className, String name, Class clazz) {
@@ -58,14 +56,6 @@ public class ExceptionProperties {
                 .returns(className)
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addParameter(clazz, name)
-                .build();
-    }
-
-    private static MethodSpec builderGetterMethodInterface(String name, Class clazz) {
-        return MethodSpec.methodBuilder(name)
-                .addAnnotation(Override.class)
-                .returns(clazz)
-                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .build();
     }
 
@@ -78,14 +68,5 @@ public class ExceptionProperties {
                 .addStatement("this." + name + " = " + name)
                 .addStatement("return this")
                 .build();
-    }
-
-    private static MethodSpec builderImplGetterMethods(String name, Class clazz) {
-        return MethodSpec.methodBuilder(name)
-                         .addAnnotation(Override.class)
-                         .returns(clazz)
-                         .addModifiers(Modifier.PUBLIC)
-                         .addStatement("return " + name)
-                         .build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ExceptionProperties.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ExceptionProperties.java
@@ -34,7 +34,10 @@ public class ExceptionProperties {
                 builderMethod(className, "requestId", String.class),
                 builderMethod(className, "statusCode", int.class),
                 builderMethod(className, "cause", Throwable.class),
-                builderMethod(className, "writableStackTrace", Boolean.class));
+                builderMethod(className, "writableStackTrace", Boolean.class),
+                builderMethod(className, "numAttempts", Integer.class),
+                builderGetterMethodInterface("numAttempts", Integer.class));
+
     }
 
     public static List<MethodSpec> builderImplMethods(ClassName className) {
@@ -44,7 +47,9 @@ public class ExceptionProperties {
                 builderImplMethods(className, "requestId", String.class),
                 builderImplMethods(className, "statusCode", int.class),
                 builderImplMethods(className, "cause", Throwable.class),
-                builderImplMethods(className, "writableStackTrace", Boolean.class));
+                builderImplMethods(className, "writableStackTrace", Boolean.class),
+                builderImplMethods(className, "numAttempts", Integer.class),
+                builderImplGetterMethods("numAttempts", Integer.class));
     }
 
     private static MethodSpec builderMethod(ClassName className, String name, Class clazz) {
@@ -53,6 +58,14 @@ public class ExceptionProperties {
                 .returns(className)
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addParameter(clazz, name)
+                .build();
+    }
+
+    private static MethodSpec builderGetterMethodInterface(String name, Class clazz) {
+        return MethodSpec.methodBuilder(name)
+                .addAnnotation(Override.class)
+                .returns(clazz)
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .build();
     }
 
@@ -65,5 +78,14 @@ public class ExceptionProperties {
                 .addStatement("this." + name + " = " + name)
                 .addStatement("return this")
                 .build();
+    }
+
+    private static MethodSpec builderImplGetterMethods(String name, Class clazz) {
+        return MethodSpec.methodBuilder(name)
+                         .addAnnotation(Override.class)
+                         .returns(clazz)
+                         .addModifiers(Modifier.PUBLIC)
+                         .addStatement("return " + name)
+                         .build();
     }
 }

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/SourceException.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/SourceException.java.resource
@@ -23,6 +23,12 @@ public class SourceException extends SdkException {
 
         @Override
         SourceException build();
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
     }
 
     public static class BuilderImpl extends SdkException.BuilderImpl implements Builder {
@@ -47,6 +53,17 @@ public class SourceException extends SdkException {
         @Override
         public SourceException build() {
             return new SourceException(this);
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            super.numAttempts(numAttempts);
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return super.numAttempts();
         }
     }
 }

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/SourceException.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/SourceException.java.resource
@@ -26,9 +26,6 @@ public class SourceException extends SdkException {
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override
-        Integer numAttempts();
     }
 
     public static class BuilderImpl extends SdkException.BuilderImpl implements Builder {
@@ -59,11 +56,6 @@ public class SourceException extends SdkException {
         public Builder numAttempts(Integer numAttempts) {
             super.numAttempts(numAttempts);
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return super.numAttempts();
         }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
@@ -100,7 +100,7 @@ public class JsonProtocolTestsException extends AwsServiceException {
 
         @Override
         public Integer numAttempts() {
-            return this.numAttempts;
+            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
@@ -40,6 +40,12 @@ public class JsonProtocolTestsException extends AwsServiceException {
 
         @Override
         Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
     }
 
     protected static class BuilderImpl extends AwsServiceException.BuilderImpl implements Builder {
@@ -84,6 +90,17 @@ public class JsonProtocolTestsException extends AwsServiceException {
         public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public BuilderImpl numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return this.numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
@@ -43,9 +43,6 @@ public class JsonProtocolTestsException extends AwsServiceException {
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override
-        Integer numAttempts();
     }
 
     protected static class BuilderImpl extends AwsServiceException.BuilderImpl implements Builder {
@@ -96,11 +93,6 @@ public class JsonProtocolTestsException extends AwsServiceException {
         public BuilderImpl numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
@@ -70,6 +70,11 @@ public final class EmptyModeledException extends JsonProtocolTestsException impl
 
         @Override
         Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonProtocolTestsException.BuilderImpl implements Builder {
@@ -114,6 +119,17 @@ public final class EmptyModeledException extends JsonProtocolTestsException impl
         public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public BuilderImpl numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
@@ -73,8 +73,6 @@ public final class EmptyModeledException extends JsonProtocolTestsException impl
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonProtocolTestsException.BuilderImpl implements Builder {
@@ -125,11 +123,6 @@ public final class EmptyModeledException extends JsonProtocolTestsException impl
         public BuilderImpl numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinternalservererrorexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinternalservererrorexception.java
@@ -79,6 +79,12 @@ public final class JsonServiceInternalServerErrorException extends JsonException
 
         @Override
         Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonException.BuilderImpl implements Builder {
@@ -123,6 +129,17 @@ public final class JsonServiceInternalServerErrorException extends JsonException
         public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public BuilderImpl numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinternalservererrorexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinternalservererrorexception.java
@@ -82,9 +82,6 @@ public final class JsonServiceInternalServerErrorException extends JsonException
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override
-        Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonException.BuilderImpl implements Builder {
@@ -135,11 +132,6 @@ public final class JsonServiceInternalServerErrorException extends JsonException
         public BuilderImpl numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinvalidinputexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinvalidinputexception.java
@@ -73,6 +73,12 @@ public final class JsonServiceInvalidInputException extends JsonException implem
 
         @Override
         Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonException.BuilderImpl implements Builder {
@@ -117,6 +123,17 @@ public final class JsonServiceInvalidInputException extends JsonException implem
         public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public BuilderImpl numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinvalidinputexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinvalidinputexception.java
@@ -76,9 +76,6 @@ public final class JsonServiceInvalidInputException extends JsonException implem
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override
-        Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonException.BuilderImpl implements Builder {
@@ -129,11 +126,6 @@ public final class JsonServiceInvalidInputException extends JsonException implem
         public BuilderImpl numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonservicethrottlingexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonservicethrottlingexception.java
@@ -86,9 +86,6 @@ public final class JsonServiceThrottlingException extends JsonException implemen
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override
-        Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonException.BuilderImpl implements Builder {
@@ -139,11 +136,6 @@ public final class JsonServiceThrottlingException extends JsonException implemen
         public BuilderImpl numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonservicethrottlingexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonservicethrottlingexception.java
@@ -83,6 +83,12 @@ public final class JsonServiceThrottlingException extends JsonException implemen
 
         @Override
         Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
     }
 
     static final class BuilderImpl extends JsonException.BuilderImpl implements Builder {
@@ -127,6 +133,17 @@ public final class JsonServiceThrottlingException extends JsonException implemen
         public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public BuilderImpl numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -189,9 +189,6 @@ public class AwsServiceException extends SdkServiceException {
         Builder numAttempts(Integer numAttempts);
 
         @Override
-        Integer numAttempts();
-
-        @Override
         Builder cause(Throwable t);
 
         @Override
@@ -260,11 +257,6 @@ public class AwsServiceException extends SdkServiceException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -189,6 +189,9 @@ public class AwsServiceException extends SdkServiceException {
         Builder numAttempts(Integer numAttempts);
 
         @Override
+        Integer numAttempts();
+
+        @Override
         Builder cause(Throwable t);
 
         @Override
@@ -257,6 +260,11 @@ public class AwsServiceException extends SdkServiceException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -74,7 +74,7 @@ public class AwsServiceException extends SdkServiceException {
             joiner.add(serviceDiagnostics());
         }
 
-        if (numAttempts() != null && numAttempts() > 0) {
+        if (numAttempts() != null) {
             SdkDiagnostics diagnostics = SdkDiagnostics.builder().numAttempts(numAttempts()).build();
             joiner.add(diagnostics.toString());
         }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -74,7 +74,7 @@ public class AwsServiceException extends SdkServiceException {
             joiner.add(serviceDiagnostics());
         }
 
-        if (numAttempts() != null) {
+        if (numAttempts() != null && numAttempts() > 0) {
             SdkDiagnostics diagnostics = SdkDiagnostics.builder().numAttempts(numAttempts()).build();
             joiner.add(diagnostics.toString());
         }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -22,6 +22,7 @@ import java.util.StringJoiner;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.internal.AwsErrorCode;
 import software.amazon.awssdk.awscore.internal.AwsStatusCode;
+import software.amazon.awssdk.core.exception.SdkDiagnostics;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.retry.ClockSkew;
 import software.amazon.awssdk.http.SdkHttpResponse;
@@ -60,25 +61,36 @@ public class AwsServiceException extends SdkServiceException {
 
     @Override
     public String getMessage() {
-        if (awsErrorDetails != null) {
-            StringJoiner details = new StringJoiner(", ", "(", ")");
-            details.add("Service: " + awsErrorDetails().serviceName());
-            details.add("Status Code: " + statusCode());
-            details.add("Request ID: " + requestId());
-            if (extendedRequestId() != null) {
-                details.add("Extended Request ID: " + extendedRequestId());
-            }
-            String message = super.getMessage();
-            if (message == null) {
-                message = awsErrorDetails().errorMessage();
-            }
-            if (message == null) {
-                return details.toString();
-            }
-            return message + " " + details;
+        StringJoiner joiner = new StringJoiner(" ");
+        String primaryMessage = rawMessage();
+        if (primaryMessage == null && awsErrorDetails != null) {
+            primaryMessage = awsErrorDetails.errorMessage();
+        }
+        if (primaryMessage != null) {
+            joiner.add(primaryMessage);
         }
 
-        return super.getMessage();
+        if (awsErrorDetails != null) {
+            joiner.add(serviceDiagnostics());
+        }
+
+        if (numAttempts() != null) {
+            SdkDiagnostics diagnostics = SdkDiagnostics.builder().numAttempts(numAttempts()).build();
+            joiner.add(diagnostics.toString());
+        }
+
+        return joiner.toString();
+    }
+
+    private String serviceDiagnostics() {
+        StringJoiner details = new StringJoiner(", ", "(", ")");
+        details.add("Service: " + awsErrorDetails().serviceName());
+        details.add("Status Code: " + statusCode());
+        details.add("Request ID: " + requestId());
+        if (extendedRequestId() != null) {
+            details.add("Extended Request ID: " + extendedRequestId());
+        }
+        return details.toString();
     }
 
     @Override
@@ -116,9 +128,9 @@ public class AwsServiceException extends SdkServiceException {
     @Override
     public boolean isThrottlingException() {
         return super.isThrottlingException() ||
-                Optional.ofNullable(awsErrorDetails)
-                        .map(a -> AwsErrorCode.isThrottlingErrorCode(a.errorCode()))
-                        .orElse(false);
+               Optional.ofNullable(awsErrorDetails)
+                       .map(a -> AwsErrorCode.isThrottlingErrorCode(a.errorCode()))
+                       .orElse(false);
     }
 
     /**
@@ -172,6 +184,9 @@ public class AwsServiceException extends SdkServiceException {
 
         @Override
         Builder message(String message);
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
 
         @Override
         Builder cause(Throwable t);
@@ -235,6 +250,12 @@ public class AwsServiceException extends SdkServiceException {
         @Override
         public Builder message(String message) {
             this.message = message;
+            return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
             return this;
         }
 

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
@@ -88,7 +88,7 @@ public class AwsServiceExceptionTest {
 
     @ParameterizedTest
     @MethodSource("exceptionMessageTestCases")
-    void exceptionMessageTests(int numAttempts, String expectedMessage) {
+    void exceptionMessageTests(Integer numAttempts, String expectedMessage) {
         AwsServiceException e = AwsServiceException.builder()
                                                    .message("errorMessage")
                                                    .numAttempts(numAttempts)
@@ -114,7 +114,7 @@ public class AwsServiceExceptionTest {
                 3,
                 "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Attempt Count: 3)"),
             Arguments.of(
-                0,
+                null,
                 "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId)")
         );
     }

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
@@ -109,13 +109,13 @@ public class AwsServiceExceptionTest {
         return Stream.of(
             Arguments.of(
                 6,
-                "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Diagnostics: numAttempts = 6)"),
+                "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Attempt Count: 6)"),
             Arguments.of(
                 3,
-                "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Diagnostics: numAttempts = 3)"),
+                "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Attempt Count: 3)"),
             Arguments.of(
                 0,
-                "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Diagnostics: numAttempts = 0)")
+                "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId)")
         );
     }
 

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
@@ -114,6 +114,9 @@ public class AwsServiceExceptionTest {
                 3,
                 "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Attempt Count: 3)"),
             Arguments.of(
+                0,
+                "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId) (SDK Attempt Count: 0)"),
+            Arguments.of(
                 null,
                 "errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId)")
         );

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryFailedException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryFailedException.java
@@ -62,9 +62,6 @@ public class EndpointDiscoveryFailedException extends SdkClientException {
         Builder numAttempts(Integer numAttempts);
 
         @Override
-        Integer numAttempts();
-
-        @Override
         EndpointDiscoveryFailedException build();
     }
 
@@ -99,11 +96,6 @@ public class EndpointDiscoveryFailedException extends SdkClientException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryFailedException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryFailedException.java
@@ -59,6 +59,12 @@ public class EndpointDiscoveryFailedException extends SdkClientException {
         Builder writableStackTrace(Boolean writableStackTrace);
 
         @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
+
+        @Override
         EndpointDiscoveryFailedException build();
     }
 
@@ -87,6 +93,17 @@ public class EndpointDiscoveryFailedException extends SdkClientException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/AbortedException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/AbortedException.java
@@ -62,9 +62,6 @@ public final class AbortedException extends SdkClientException {
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override
-        Integer numAttempts();
     }
 
     protected static final class BuilderImpl extends SdkClientException.BuilderImpl implements Builder {
@@ -98,11 +95,6 @@ public final class AbortedException extends SdkClientException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/AbortedException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/AbortedException.java
@@ -59,6 +59,12 @@ public final class AbortedException extends SdkClientException {
 
         @Override
         AbortedException build();
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
     }
 
     protected static final class BuilderImpl extends SdkClientException.BuilderImpl implements Builder {
@@ -86,6 +92,17 @@ public final class AbortedException extends SdkClientException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallAttemptTimeoutException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallAttemptTimeoutException.java
@@ -65,9 +65,6 @@ public final class ApiCallAttemptTimeoutException extends SdkClientException {
         ApiCallAttemptTimeoutException.Builder numAttempts(Integer numAttempts);
 
         @Override
-        Integer numAttempts();
-
-        @Override
         ApiCallAttemptTimeoutException build();
     }
 
@@ -102,11 +99,6 @@ public final class ApiCallAttemptTimeoutException extends SdkClientException {
         public ApiCallAttemptTimeoutException.Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallAttemptTimeoutException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallAttemptTimeoutException.java
@@ -62,6 +62,12 @@ public final class ApiCallAttemptTimeoutException extends SdkClientException {
         Builder writableStackTrace(Boolean writableStackTrace);
 
         @Override
+        ApiCallAttemptTimeoutException.Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
+
+        @Override
         ApiCallAttemptTimeoutException build();
     }
 
@@ -90,6 +96,17 @@ public final class ApiCallAttemptTimeoutException extends SdkClientException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public ApiCallAttemptTimeoutException.Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallTimeoutException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallTimeoutException.java
@@ -62,6 +62,12 @@ public final class ApiCallTimeoutException extends SdkClientException {
         Builder writableStackTrace(Boolean writableStackTrace);
 
         @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
+
+        @Override
         ApiCallTimeoutException build();
     }
 
@@ -90,6 +96,17 @@ public final class ApiCallTimeoutException extends SdkClientException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallTimeoutException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallTimeoutException.java
@@ -65,9 +65,6 @@ public final class ApiCallTimeoutException extends SdkClientException {
         Builder numAttempts(Integer numAttempts);
 
         @Override
-        Integer numAttempts();
-
-        @Override
         ApiCallTimeoutException build();
     }
 
@@ -102,11 +99,6 @@ public final class ApiCallTimeoutException extends SdkClientException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/Crc32MismatchException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/Crc32MismatchException.java
@@ -62,6 +62,12 @@ public final class Crc32MismatchException extends SdkClientException {
         Builder writableStackTrace(Boolean writableStackTrace);
 
         @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
+
+        @Override
         Crc32MismatchException build();
     }
 
@@ -90,6 +96,17 @@ public final class Crc32MismatchException extends SdkClientException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/Crc32MismatchException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/Crc32MismatchException.java
@@ -65,9 +65,6 @@ public final class Crc32MismatchException extends SdkClientException {
         Builder numAttempts(Integer numAttempts);
 
         @Override
-        Integer numAttempts();
-
-        @Override
         Crc32MismatchException build();
     }
 
@@ -102,11 +99,6 @@ public final class Crc32MismatchException extends SdkClientException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
@@ -64,6 +64,12 @@ public final class NonRetryableException extends SdkClientException {
         Builder writableStackTrace(Boolean writableStackTrace);
 
         @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
+
+        @Override
         NonRetryableException build();
     }
 
@@ -102,6 +108,17 @@ public final class NonRetryableException extends SdkClientException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
@@ -67,9 +67,6 @@ public final class NonRetryableException extends SdkClientException {
         Builder numAttempts(Integer numAttempts);
 
         @Override
-        Integer numAttempts();
-
-        @Override
         NonRetryableException build();
     }
 
@@ -114,11 +111,6 @@ public final class NonRetryableException extends SdkClientException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
@@ -64,6 +64,12 @@ public final class RetryableException extends SdkClientException {
         Builder writableStackTrace(Boolean writableStackTrace);
 
         @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
+
+        @Override
         RetryableException build();
     }
 
@@ -92,6 +98,17 @@ public final class RetryableException extends SdkClientException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
@@ -67,9 +67,6 @@ public final class RetryableException extends SdkClientException {
         Builder numAttempts(Integer numAttempts);
 
         @Override
-        Integer numAttempts();
-
-        @Override
         RetryableException build();
     }
 
@@ -104,11 +101,6 @@ public final class RetryableException extends SdkClientException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
@@ -47,6 +47,16 @@ public class SdkClientException extends SdkException {
         return SdkClientException.builder().message(message).cause(cause).build();
     }
 
+    @Override
+    public String getMessage() {
+        String message = rawMessage();
+        if (numAttempts() != null) {
+            SdkDiagnostics sdkDiagnostics = SdkDiagnostics.builder().numAttempts(numAttempts()).build();
+            message = message + " " + sdkDiagnostics;
+        }
+        return message;
+    }
+
     /**
      * Create a {@link Builder} initialized with the properties of this {@code SdkClientException}.
      *

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
@@ -50,7 +50,7 @@ public class SdkClientException extends SdkException {
     @Override
     public String getMessage() {
         String message = rawMessage();
-        if (numAttempts() != null) {
+        if (numAttempts() != null && numAttempts() > 0) {
             SdkDiagnostics sdkDiagnostics = SdkDiagnostics.builder().numAttempts(numAttempts()).build();
             message = message + " " + sdkDiagnostics;
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
@@ -87,6 +87,12 @@ public class SdkClientException extends SdkException {
 
         @Override
         SdkClientException build();
+
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
     }
 
     protected static class BuilderImpl extends SdkException.BuilderImpl implements Builder {
@@ -114,6 +120,17 @@ public class SdkClientException extends SdkException {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
@@ -50,7 +50,7 @@ public class SdkClientException extends SdkException {
     @Override
     public String getMessage() {
         String message = rawMessage();
-        if (numAttempts() != null && numAttempts() > 0) {
+        if (numAttempts() != null) {
             SdkDiagnostics sdkDiagnostics = SdkDiagnostics.builder().numAttempts(numAttempts()).build();
             message = message + " " + sdkDiagnostics;
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
@@ -90,9 +90,6 @@ public class SdkClientException extends SdkException {
 
         @Override
         Builder numAttempts(Integer numAttempts);
-
-        @Override
-        Integer numAttempts();
     }
 
     protected static class BuilderImpl extends SdkException.BuilderImpl implements Builder {
@@ -126,11 +123,6 @@ public class SdkClientException extends SdkException {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.exception;
+
+import java.util.StringJoiner;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+@SdkProtectedApi
+public class SdkDiagnostics {
+    private final Integer numAttempts;
+
+    private SdkDiagnostics(Builder builder) {
+        this.numAttempts = builder.numAttempts();
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner details = new StringJoiner(", ", "(", ")");
+        details.add("SDK Diagnostics: numAttempts = " + numAttempts);
+        return details.toString();
+    }
+
+    public SdkDiagnostics.Builder toBuilder() {
+        return new SdkDiagnostics.BuilderImpl();
+    }
+
+    public interface Builder {
+        /**
+         * Sets the number of attempts.
+         *
+         * @param numAttempts The number of attempts
+         * @return Returns the builder for method chaining
+         */
+        Builder numAttempts(Integer numAttempts);
+
+        /**
+         * Builds the SdkDiagnostics instance.
+         *
+         * @return A new SdkDiagnostics instance
+         */
+        SdkDiagnostics build();
+
+        /**
+         * Gets the number of attempts.
+         *
+         * @return Returns the attempt count
+         */
+        Integer numAttempts();
+    }
+
+    private static class BuilderImpl implements Builder {
+        private Integer numAttempts;
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return this.numAttempts;
+        }
+
+        @Override
+        public SdkDiagnostics build() {
+            return new SdkDiagnostics(this);
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
@@ -35,8 +35,11 @@ public class SdkDiagnostics implements ToCopyableBuilder<SdkDiagnostics.Builder,
     @Override
     public String toString() {
         StringJoiner details = new StringJoiner(", ", "(", ")");
-        details.add("SDK Diagnostics: numAttempts = " + numAttempts);
-        return details.toString();
+        if (numAttempts != null && numAttempts > 0) {
+            details.add("SDK Attempt Count: " + numAttempts);
+            return details.toString();
+        }
+        return "";
     }
 
     public SdkDiagnostics.Builder toBuilder() {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
@@ -17,9 +17,11 @@ package software.amazon.awssdk.core.exception;
 
 import java.util.StringJoiner;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 @SdkProtectedApi
-public class SdkDiagnostics {
+public class SdkDiagnostics implements ToCopyableBuilder<SdkDiagnostics.Builder, SdkDiagnostics> {
     private final Integer numAttempts;
 
     private SdkDiagnostics(Builder builder) {
@@ -38,10 +40,10 @@ public class SdkDiagnostics {
     }
 
     public SdkDiagnostics.Builder toBuilder() {
-        return new SdkDiagnostics.BuilderImpl();
+        return new BuilderImpl().numAttempts(numAttempts);
     }
 
-    public interface Builder {
+    public interface Builder extends CopyableBuilder<Builder, SdkDiagnostics> {
         /**
          * Sets the number of attempts.
          *

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkDiagnostics.java
@@ -35,7 +35,7 @@ public class SdkDiagnostics implements ToCopyableBuilder<SdkDiagnostics.Builder,
     @Override
     public String toString() {
         StringJoiner details = new StringJoiner(", ", "(", ")");
-        if (numAttempts != null && numAttempts > 0) {
+        if (numAttempts != null) {
             details.add("SDK Attempt Count: " + numAttempts);
             return details.toString();
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -28,9 +28,31 @@ import software.amazon.awssdk.utils.builder.Buildable;
 public class SdkException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
+    private Integer attempts;
 
     protected SdkException(Builder builder) {
         super(messageFromBuilder(builder), builder.cause(), true, writableStackTraceFromBuilder(builder));
+        this.attempts = builder.numAttempts();
+    }
+
+    /**
+     * Returns the number of attempts made before this exception was thrown.
+     * This includes the initial attempt and any retries.
+     *
+     * @return The number of attempts made, or null if not set
+     */
+    public Integer numAttempts() {
+        return attempts;
+    }
+
+    /**
+     * Returns the raw message of this exception without any additional formatting.
+     * This is used internally to construct the complete exception message.
+     *
+     * @return The raw exception message
+     */
+    public String rawMessage() {
+        return super.getMessage();
     }
 
     /**
@@ -111,6 +133,19 @@ public class SdkException extends RuntimeException {
         String message();
 
         /**
+         *
+         * @param numAttempts The attempt count
+         * @return This method for object chaining
+         */
+        Builder numAttempts(Integer numAttempts);
+
+        /**
+         * The number of times a request was attempted before this exception was thrown
+         * @return the attempt count
+         */
+        Integer numAttempts();
+
+        /**
          * Specifies whether the stack trace in this exception can be written.
          *
          * @param writableStackTrace Whether the stack trace can be written.
@@ -136,6 +171,7 @@ public class SdkException extends RuntimeException {
 
         protected Throwable cause;
         protected String message;
+        protected Integer numAttempts;
         protected Boolean writableStackTrace;
 
         protected BuilderImpl() {
@@ -143,7 +179,8 @@ public class SdkException extends RuntimeException {
 
         protected BuilderImpl(SdkException ex) {
             this.cause = ex.getCause();
-            this.message = ex.getMessage();
+            this.message = ex.rawMessage();
+            this.numAttempts = ex.numAttempts();
         }
 
 
@@ -183,6 +220,25 @@ public class SdkException extends RuntimeException {
         @Override
         public String message() {
             return message;
+        }
+
+        public Integer getNumAttempts() {
+            return numAttempts;
+        }
+
+        public void setAttemptCount(Integer attemptCount) {
+            this.numAttempts = attemptCount;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            this.numAttempts = numAttempts;
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -174,7 +174,7 @@ public class SdkException extends RuntimeException {
     protected static class BuilderImpl implements Builder {
         protected Throwable cause;
         protected String message;
-        protected Integer numAttempts;
+        protected Integer numAttempts = 0;
         protected Boolean writableStackTrace;
 
         protected BuilderImpl() {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -174,7 +174,7 @@ public class SdkException extends RuntimeException {
     protected static class BuilderImpl implements Builder {
         protected Throwable cause;
         protected String message;
-        protected Integer numAttempts = 0;
+        protected Integer numAttempts;
         protected Boolean writableStackTrace;
 
         protected BuilderImpl() {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -145,7 +145,7 @@ public class SdkException extends RuntimeException {
          * The number of times a request was attempted before this exception was thrown
          * @return the attempt count
          */
-        Integer numAttempts();
+        default Integer numAttempts() { throw new UnsupportedOperationException(); }
 
         /**
          * Specifies whether the stack trace in this exception can be written.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -140,6 +140,7 @@ public class SdkException extends RuntimeException {
         default Builder numAttempts(Integer numAttempts) {
             throw new UnsupportedOperationException();
         }
+
         /**
          * The number of times a request was attempted before this exception was thrown
          * @return the attempt count

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -137,8 +137,9 @@ public class SdkException extends RuntimeException {
          * @param numAttempts The attempt count
          * @return This method for object chaining
          */
-        Builder numAttempts(Integer numAttempts);
-
+        default Builder numAttempts(Integer numAttempts) {
+            throw new UnsupportedOperationException();
+        }
         /**
          * The number of times a request was attempted before this exception was thrown
          * @return the attempt count
@@ -168,7 +169,6 @@ public class SdkException extends RuntimeException {
     }
 
     protected static class BuilderImpl implements Builder {
-
         protected Throwable cause;
         protected String message;
         protected Integer numAttempts;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -145,7 +145,9 @@ public class SdkException extends RuntimeException {
          * The number of times a request was attempted before this exception was thrown
          * @return the attempt count
          */
-        default Integer numAttempts() { throw new UnsupportedOperationException(); }
+        default Integer numAttempts() {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Specifies whether the stack trace in this exception can be written.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
@@ -141,9 +141,6 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         @Override
         Builder numAttempts(Integer numAttempts);
 
-        @Override
-        Integer numAttempts();
-
         /**
          * Specifies the requestId returned by the called service.
          *
@@ -235,11 +232,6 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         public Builder numAttempts(Integer numAttempts) {
             this.numAttempts = numAttempts;
             return this;
-        }
-
-        @Override
-        public Integer numAttempts() {
-            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
@@ -233,13 +233,13 @@ public class SdkServiceException extends SdkException implements SdkPojo {
 
         @Override
         public Builder numAttempts(Integer numAttempts) {
-            super.numAttempts(numAttempts);
+            this.numAttempts(numAttempts);
             return this;
         }
 
         @Override
         public Integer numAttempts() {
-            return super.numAttempts();
+            return this.numAttempts();
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
@@ -233,13 +233,13 @@ public class SdkServiceException extends SdkException implements SdkPojo {
 
         @Override
         public Builder numAttempts(Integer numAttempts) {
-            this.numAttempts(numAttempts);
+            this.numAttempts = numAttempts;
             return this;
         }
 
         @Override
         public Integer numAttempts() {
-            return this.numAttempts();
+            return numAttempts;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
@@ -138,6 +138,12 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         @Override
         Builder writableStackTrace(Boolean writableStackTrace);
 
+        @Override
+        Builder numAttempts(Integer numAttempts);
+
+        @Override
+        Integer numAttempts();
+
         /**
          * Specifies the requestId returned by the called service.
          *
@@ -223,6 +229,17 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         public Builder writableStackTrace(Boolean writableStackTrace) {
             this.writableStackTrace = writableStackTrace;
             return this;
+        }
+
+        @Override
+        public Builder numAttempts(Integer numAttempts) {
+            super.numAttempts(numAttempts);
+            return this;
+        }
+
+        @Override
+        public Integer numAttempts() {
+            return super.numAttempts();
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper.java
@@ -165,7 +165,11 @@ public final class RetryableStageHelper {
                                   .build();
             lastException.addSuppressed(pastException);
         }
-        return lastException;
+        SdkException newException = lastException.toBuilder().numAttempts(retriesAttemptedSoFar() + 1).build();
+        for (Throwable suppressed : lastException.getSuppressed()) {
+            newException.addSuppressed(suppressed);
+        }
+        return newException;
     }
 
     /**

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
@@ -122,7 +122,7 @@ public class AsyncClientHandlerExceptionTest {
     public void responseHandlerThrowsReportedThroughFuture() throws Exception {
         final SdkClientException e = SdkClientException.create("Could not handle response");
         when(responseHandler.handle(any(SdkHttpFullResponse.class), any(ExecutionAttributes.class))).thenThrow(e);
-        doVerify(() -> clientHandler.execute(executionParams), e);
+        doVerify(() -> clientHandler.execute(executionParams), thrown -> thrown.getCause() instanceof SdkClientException);
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
@@ -115,7 +115,7 @@ public class SyncClientHandlerTest {
 
     @Test
     public void failedExecutionCallsErrorResponseHandler() throws Exception {
-        SdkServiceException exception = (SdkServiceException) SdkServiceException.builder().message("Uh oh!").statusCode(500).numAttempts(1).build();
+        SdkServiceException exception = SdkServiceException.builder().message("Uh oh!").statusCode(500).numAttempts(1).build();
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("foo", Arrays.asList("bar"));

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
@@ -115,7 +115,7 @@ public class SyncClientHandlerTest {
 
     @Test
     public void failedExecutionCallsErrorResponseHandler() throws Exception {
-        SdkServiceException exception = SdkServiceException.builder().message("Uh oh!").statusCode(500).build();
+        SdkServiceException exception = (SdkServiceException) SdkServiceException.builder().message("Uh oh!").statusCode(500).numAttempts(1).build();
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("foo", Arrays.asList("bar"));

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
@@ -61,8 +61,8 @@ public class SdkExceptionMessageTest {
     }
 
     @Test
-    public void create_WithoutAttemptCount_UsesDefaultValue() {
+    public void create_WithoutAttemptCount_DefaultsToNull() {
         SdkException exception = SdkException.builder().message("message").cause(new RuntimeException()).build();
-        assertThat(exception.numAttempts()).isEqualTo(0);
+        assertThat(exception.numAttempts()).isEqualTo(null);
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
@@ -47,4 +47,22 @@ public class SdkExceptionMessageTest {
     public void noMessage_causeWithMessage_implies_messageFromCause() {
         assertThat(SdkException.builder().cause(new Exception("bar")).build().getMessage()).isEqualTo("bar");
     }
+
+    @Test
+    public void numAttempts_WithExplicitAttemptCount_ReturnsOneBased() {
+        assertThat(SdkException.builder().message("foo").numAttempts(2).build().numAttempts()).isEqualTo(2);
+    }
+
+    @Test
+    public void toBuilder_CopiesException_PreservesAttemptCount() {
+        SdkException original = SdkException.builder().numAttempts(2).build();
+        SdkException copy = original.toBuilder().build();
+        assertThat(copy.numAttempts()).isEqualTo(original.numAttempts());
+    }
+
+    @Test
+    public void create_WithoutAttemptCount_UsesDefaultValue() {
+        SdkException exception = SdkException.builder().message("message").cause(new RuntimeException()).numAttempts(6).build();
+        assertThat(exception.numAttempts()).isEqualTo(6);
+    }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
@@ -62,7 +62,7 @@ public class SdkExceptionMessageTest {
 
     @Test
     public void create_WithoutAttemptCount_UsesDefaultValue() {
-        SdkException exception = SdkException.builder().message("message").cause(new RuntimeException()).numAttempts(6).build();
-        assertThat(exception.numAttempts()).isEqualTo(6);
+        SdkException exception = SdkException.builder().message("message").cause(new RuntimeException()).build();
+        assertThat(exception.numAttempts()).isEqualTo(null);
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/exception/SdkExceptionMessageTest.java
@@ -63,6 +63,6 @@ public class SdkExceptionMessageTest {
     @Test
     public void create_WithoutAttemptCount_UsesDefaultValue() {
         SdkException exception = SdkException.builder().message("message").cause(new RuntimeException()).build();
-        assertThat(exception.numAttempts()).isEqualTo(null);
+        assertThat(exception.numAttempts()).isEqualTo(0);
     }
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumValidationTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/HttpChecksumValidationTest.java
@@ -238,7 +238,7 @@ public class HttpChecksumValidationTest {
             .isThrownBy(() -> client.getOperationWithChecksum(
                 r -> r.checksumMode(ChecksumMode.ENABLED),
                 ResponseTransformer.toBytes()))
-            .withMessage("Unable to unmarshall response (Data read has a different checksum than expected. Was i9aeUg==, "
+            .withMessageContaining("Unable to unmarshall response (Data read has a different checksum than expected. Was i9aeUg==, "
                          + "but expected i9aeUg=). Response Code: 200, Response Text: OK");
         assertThat(CaptureChecksumValidationInterceptor.checksumValidation).isEqualTo(ChecksumValidation.VALIDATED);
         assertThat(CaptureChecksumValidationInterceptor.expectedAlgorithm).isEqualTo(DefaultChecksumAlgorithm.CRC32);
@@ -369,7 +369,7 @@ public class HttpChecksumValidationTest {
                 r -> r.checksumMode(ChecksumMode.ENABLED),
                 AsyncResponseTransformer.toBytes()).join())
 
-            .withMessage("software.amazon.awssdk.core.exception.SdkClientException: Data read has a different checksum"
+            .withMessageContaining("software.amazon.awssdk.core.exception.SdkClientException: Data read has a different checksum"
                          + " than expected. Was i9aeUg==, but expected i9aeUg=");
         assertThat(CaptureChecksumValidationInterceptor.checksumValidation).isEqualTo(ChecksumValidation.VALIDATED);
         assertThat(CaptureChecksumValidationInterceptor.expectedAlgorithm).isEqualTo(DefaultChecksumAlgorithm.CRC32);

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ExceptionAttemptMessageBehaviorTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ExceptionAttemptMessageBehaviorTest.java
@@ -129,7 +129,7 @@ public abstract class ExceptionAttemptMessageBehaviorTest<ClientT, BuilderT exte
         AwsServiceException exception = assertThrows(AwsServiceException.class,
                                                      () -> callAllTypes(client));
 
-        assertThat(exception.getMessage()).contains("numAttempts = 2");
+        assertThat(exception.getMessage()).isEqualTo("Service returned HTTP status code 403 (Service: ProtocolRestJson, Status Code: 403, Request ID: null) (SDK Diagnostics: numAttempts = 2)");
         wireMock.verify(2, postRequestedFor(anyUrl()));
     }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ExceptionAttemptMessageBehaviorTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ExceptionAttemptMessageBehaviorTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import java.net.URI;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+
+/**
+ * A set of tests that verify the behavior of the SDK when attempts are added to the exception message.
+ */
+public abstract class ExceptionAttemptMessageBehaviorTest<ClientT, BuilderT extends AwsClientBuilder<BuilderT, ClientT>> {
+
+    protected WireMockServer wireMock = new WireMockServer(0);
+
+    protected abstract BuilderT newClientBuilder();
+
+    protected abstract AllTypesResponse callAllTypes(ClientT client);
+
+    private BuilderT clientBuilder() {
+        StaticCredentialsProvider credentialsProvider =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+        return newClientBuilder()
+            .credentialsProvider(credentialsProvider)
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create("http://localhost:" + wireMock.port()));
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        wireMock.start();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        wireMock.stop();
+    }
+
+    @Test
+    public void exceptionMessage_ioException_includesMultipleAttempts() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        ClientT client = clientBuilder()
+            .overrideConfiguration(o -> o.retryStrategy(
+                b -> b.retryOnException(AwsServiceException.class)))
+            .build();
+
+        SdkClientException exception = assertThrows(SdkClientException.class,
+                                                    () -> callAllTypes(client));
+
+        assertThat(exception.getMessage()).contains("numAttempts = 4");
+        wireMock.verify(4, postRequestedFor(anyUrl()));
+    }
+
+    @Test
+    public void exceptionMessage_whenNonRetryable_includesSingleAttempt() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(403)));
+
+        ClientT client = clientBuilder()
+            .overrideConfiguration(o -> o.retryStrategy(
+                b -> b.retryOnException(AwsServiceException.class)))
+            .build();
+
+        AwsServiceException exception = assertThrows(AwsServiceException.class,
+                                                     () -> callAllTypes(client));
+
+        assertThat(exception.getMessage()).contains("numAttempts = 1");
+        wireMock.verify(1, postRequestedFor(anyUrl()));
+    }
+
+    @Test
+    public void exceptionMessage_whenErrorTypeChanges_showsTotalAttempts() {
+        wireMock.stubFor(post(anyUrl())
+                             .inScenario("Mixed Errors")
+                             .whenScenarioStateIs(Scenario.STARTED)
+                             .willReturn(aResponse().withStatus(429))
+                             .willSetStateTo("Second Request"));
+
+        wireMock.stubFor(post(anyUrl())
+                             .inScenario("Mixed Errors")
+                             .whenScenarioStateIs("Second Request")
+                             .willReturn(aResponse().withStatus(403)));
+
+        ClientT client = clientBuilder()
+            .overrideConfiguration(o -> o.retryStrategy(
+                b -> b.retryOnException(AwsServiceException.class)))
+            .build();
+
+        AwsServiceException exception = assertThrows(AwsServiceException.class,
+                                                     () -> callAllTypes(client));
+
+        assertThat(exception.getMessage()).contains("numAttempts = 2");
+        wireMock.verify(2, postRequestedFor(anyUrl()));
+    }
+
+
+    static class RetryAttemptsMessageSyncTest extends ExceptionAttemptMessageBehaviorTest<ProtocolRestJsonClient, ProtocolRestJsonClientBuilder> {
+        @Override
+        protected ProtocolRestJsonClientBuilder newClientBuilder() {
+            return ProtocolRestJsonClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonClient client) {
+            AllTypesRequest.Builder requestBuilder = AllTypesRequest.builder();
+            return client.allTypes(requestBuilder.build());
+        }
+    }
+
+    static class RetryAttemptsMessageAsyncTest extends ExceptionAttemptMessageBehaviorTest<ProtocolRestJsonAsyncClient, ProtocolRestJsonAsyncClientBuilder> {
+
+        @Override
+        protected ProtocolRestJsonAsyncClientBuilder newClientBuilder() {
+            return ProtocolRestJsonAsyncClient.builder();
+        }
+
+        @Override
+        protected AllTypesResponse callAllTypes(ProtocolRestJsonAsyncClient client) {
+            try {
+                AllTypesRequest.Builder requestBuilder = AllTypesRequest.builder();
+                return client.allTypes(requestBuilder.build()).join();
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+                throw e;
+            }
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ExceptionAttemptMessageBehaviorTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/ExceptionAttemptMessageBehaviorTest.java
@@ -88,7 +88,7 @@ public abstract class ExceptionAttemptMessageBehaviorTest<ClientT, BuilderT exte
         SdkClientException exception = assertThrows(SdkClientException.class,
                                                     () -> callAllTypes(client));
 
-        assertThat(exception.getMessage()).contains("numAttempts = 4");
+        assertThat(exception.getMessage()).contains("SDK Attempt Count: 4");
         wireMock.verify(4, postRequestedFor(anyUrl()));
     }
 
@@ -104,7 +104,7 @@ public abstract class ExceptionAttemptMessageBehaviorTest<ClientT, BuilderT exte
         AwsServiceException exception = assertThrows(AwsServiceException.class,
                                                      () -> callAllTypes(client));
 
-        assertThat(exception.getMessage()).contains("numAttempts = 1");
+        assertThat(exception.getMessage()).contains("(SDK Attempt Count: 1)");
         wireMock.verify(1, postRequestedFor(anyUrl()));
     }
 
@@ -129,7 +129,7 @@ public abstract class ExceptionAttemptMessageBehaviorTest<ClientT, BuilderT exte
         AwsServiceException exception = assertThrows(AwsServiceException.class,
                                                      () -> callAllTypes(client));
 
-        assertThat(exception.getMessage()).isEqualTo("Service returned HTTP status code 403 (Service: ProtocolRestJson, Status Code: 403, Request ID: null) (SDK Diagnostics: numAttempts = 2)");
+        assertThat(exception.getMessage()).isEqualTo("Service returned HTTP status code 403 (Service: ProtocolRestJson, Status Code: 403, Request ID: null) (SDK Attempt Count: 2)");
         wireMock.verify(2, postRequestedFor(anyUrl()));
     }
 


### PR DESCRIPTION
## Motivation and Context
Improve debugging visibility by making attempt count immediately visible in exception messages. Currently, attempt information is only available through suppressed exceptions, requiring additional code to access. This change makes attempts visible directly in the exception message, matching behavior in other AWS SDKs.

## Modifications
- Added attempt count tracking and message formatting in `SdkException`
- Added SdkDiagnostics class to handle the formatting of the Diagnostics clause in error messages.
- Modified `AwsServiceException` to include attempts in AWS error details
- Modified `RetryableStageHelper` to track and propagate attempt counts during retries

## Testing
- Added new functional test `ExceptionAttemptMessageBehaviorTest` testing with different retry scenarios
- Modified existing tests in `AwsServiceExceptionTest` and `SdkExceptionSerializationTest` to verify attempt count behavior
- Added test cases in `SdkExceptionMessageTest` for new attempt count functionality

## Visualization of changes:

### Before change:
```java
// non-retryable scenario
try {
    // request to a non-existent bucket
    s3Client.listObjects(g -> g.bucket("some-non-existent-bucket"));
} catch (AwsServiceException e) {
    System.out.println(e);
}
// outputs:
// NoSuchBucketException: The specified bucket does not exist (Service: S3, Status Code: 404, Request ID: abc123, Extended Request ID: xyzdef123456)


// retryable scenario
try {
    // request that might cause a retryable error (e.g., throttling)
    dynamoDbClient.getItem(...);
} catch (AwsServiceException e) {
    System.out.println(e);
}
// outputs:
// ThrottlingException: Rate of requests exceeds the allowed throughput (Service: DynamoDB, Status Code: 429, Request ID: abc123, Extended Request ID: xyzdef123456)
// Note: attempts only visible through e.getSuppressed()
```
### After change:

```java
// non-retryable scenario
try {
    // request to a non-existent bucket
    s3Client.listObjects(g -> g.bucket("some-non-existent-bucket"));
} catch (AwsServiceException e) {
    System.out.println(e);
}
// outputs:
// NoSuchBucketException: The specified bucket does not exist (Service: S3, Status Code: 404, Request ID: abc123, Extended Request ID: xyzdef123456) (SDK Diagnostics: numAttempts = 1)


// retryable scenario
try {
    // request that might cause a retryable error (e.g., throttling)
    dynamoDbClient.getItem(...);
} catch (AwsServiceException e) {
    System.out.println(e);
}
// outputs:
// ThrottlingException: Rate of requests exceeds the allowed throughput (Service: DynamoDB, Status Code: 429, Request ID: abc123, Extended Request ID: xyzdef123456) (SDK Diagnostics: numAttempts = 4)
// Note: attempts now visible directly in the exception message
```

## Potential Impact:

Test or error handling code that relies on exact exception message matching might break as messages now include attempt count. We recommend using partial message matching for more resilient tests and error handling.

```java
// may break
assertEquals("Resource not found", e.getMessage());
if (e.getMessage().equals("Resource not found")) { ... }

// more resilient approach
assertTrue(e.getMessage().contains("Resource not found"));
```

```java
try {
    client.someOperation();
} catch (AwsServiceException e) {
	// may break
    if (e.getMessage().equals("Resource not found")) {
        handleNotFound();
    }
	// more resilient
    if (e.getMessage().contains("Resource not found")) {
        handleNotFound();
    }
}
```