### PR TITLE
Buffer if content provider provided w/o len

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-9db145b.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-9db145b.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Buffer input data from ContentStreamProvider to avoid the need to reread the stream after calculating its length."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProvider.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.sync;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * {@code ContentStreamProvider} implementation that buffers the data stream data to memory as it's read. Once the underlying
+ * stream is read fully, all subsequent calls to {@link #newStream()} will use the buffered data.
+ */
+@SdkInternalApi
+@NotThreadSafe
+public final class BufferingContentStreamProvider implements ContentStreamProvider {
+    private final ContentStreamProvider delegate;
+    private InputStream bufferedStream;
+
+    private byte[] bufferedStreamData;
+    private int count;
+
+    public BufferingContentStreamProvider(ContentStreamProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public InputStream newStream() {
+        if (bufferedStreamData != null) {
+            return new ByteArrayInputStream(bufferedStreamData, 0, this.count);
+        }
+
+        if (bufferedStream == null) {
+            InputStream delegateStream = delegate.newStream();
+            bufferedStream = new BufferStream(delegateStream);
+            IoUtils.markStreamWithMaxReadLimit(bufferedStream, Integer.MAX_VALUE);
+        }
+
+        invokeSafely(bufferedStream::reset);
+        return bufferedStream;
+    }
+
+    private class BufferStream extends BufferedInputStream {
+        BufferStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public synchronized int read() throws IOException {
+            int read = super.read();
+            if (read < 0) {
+                saveBuffer();
+            }
+            return read;
+        }
+
+        @Override
+        public synchronized int read(byte[] b, int off, int len) throws IOException {
+            int read = super.read(b, off, len);
+            if (read < 0) {
+                saveBuffer();
+            }
+            return read;
+        }
+
+        private void saveBuffer() {
+            if (bufferedStreamData == null) {
+                IoUtils.closeQuietlyV2(in, null);
+                BufferingContentStreamProvider.this.bufferedStreamData = this.buf;
+                BufferingContentStreamProvider.this.count = this.count;
+            }
+        }
+    }
+
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProviderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProviderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
+import software.amazon.awssdk.checksums.SdkChecksum;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.IoUtils;
+
+class BufferingContentStreamProviderTest {
+    private static final SdkChecksum CRC32 = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC32);
+    private static final byte[] TEST_DATA = "BufferingContentStreamProviderTest".getBytes(StandardCharsets.UTF_8);
+    private static final String TEST_DATA_CHECKSUM = "f9ed1825";
+
+    private RequestBody requestBody;
+
+    @BeforeEach
+    void setup() {
+        ByteArrayInputStream stream = new ByteArrayInputStream(TEST_DATA);
+        requestBody = RequestBody.fromContentProvider(() -> stream, "text/plain");
+    }
+
+    @Test
+    void newStream_alwaysStartsAtBeginning() {
+        String stream1Crc32 = getCrc32(requestBody.contentStreamProvider().newStream());
+        String stream2Crc32 = getCrc32(requestBody.contentStreamProvider().newStream());
+
+        assertThat(stream1Crc32).isEqualTo(TEST_DATA_CHECKSUM);
+        assertThat(stream2Crc32).isEqualTo(TEST_DATA_CHECKSUM);
+    }
+
+    @Test
+    void newStream_buffersSkippedBytes() throws IOException {
+        InputStream stream1 = requestBody.contentStreamProvider().newStream();
+
+        assertThat(stream1.skip(Long.MAX_VALUE)).isEqualTo(TEST_DATA.length);
+
+        String stream2Crc32 = getCrc32(requestBody.contentStreamProvider().newStream());
+
+        assertThat(stream2Crc32).isEqualTo(TEST_DATA_CHECKSUM);
+    }
+
+    @Test
+    void newStream_oneByteReads_dataBufferedCorrectly() throws IOException {
+        InputStream stream = requestBody.contentStreamProvider().newStream();
+        int read;
+        do {
+            read = stream.read();
+        } while (read != -1);
+
+        assertThat(getCrc32(requestBody.contentStreamProvider().newStream())).isEqualTo(TEST_DATA_CHECKSUM);
+    }
+
+    @Test
+    void newStream_wholeArrayReads_dataBufferedCorrectly() throws IOException {
+        InputStream stream = requestBody.contentStreamProvider().newStream();
+        int read;
+        byte[] buff = new byte[32];
+        do {
+            read = stream.read(buff);
+        } while (read != -1);
+
+        assertThat(getCrc32(requestBody.contentStreamProvider().newStream())).isEqualTo(TEST_DATA_CHECKSUM);
+    }
+
+    @Test
+    void newStream_offsetArrayReads_dataBufferedCorrectly() throws IOException {
+        InputStream stream = requestBody.contentStreamProvider().newStream();
+        int read;
+        byte[] buff = new byte[32];
+        do {
+            read = stream.read(buff, 0, 32);
+        } while (read != -1);
+
+        assertThat(getCrc32(requestBody.contentStreamProvider().newStream())).isEqualTo(TEST_DATA_CHECKSUM);
+    }
+
+    @Test
+    void newStream_closeClosesDelegateStream() throws IOException {
+        InputStream stream = Mockito.spy(new ByteArrayInputStream(TEST_DATA));
+        requestBody = RequestBody.fromContentProvider(() -> stream, "text/plain");
+        requestBody.contentStreamProvider().newStream().close();
+
+        Mockito.verify(stream).close();
+    }
+
+    @Test
+    void newStream_allDataBuffered_closesDelegateStream() throws IOException {
+        InputStream delegateStream = Mockito.spy(new ByteArrayInputStream(TEST_DATA));
+
+        requestBody = RequestBody.fromContentProvider(() -> delegateStream, "text/plain");
+
+        IoUtils.drainInputStream(requestBody.contentStreamProvider().newStream());
+        Mockito.verify(delegateStream, Mockito.atLeast(1)).read(any(), anyInt(), anyInt());
+        Mockito.verify(delegateStream).close();
+
+        IoUtils.drainInputStream(requestBody.contentStreamProvider().newStream());
+        Mockito.verifyNoMoreInteractions(delegateStream);
+    }
+
+    private static String getCrc32(InputStream inputStream) {
+        byte[] buff = new byte[1024];
+        int read;
+
+        CRC32.reset();
+        try {
+            while ((read = inputStream.read(buff)) != -1) {
+                CRC32.update(buff, 0, read);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return BinaryUtils.toHex(CRC32.getChecksumBytes());
+    }
+}


### PR DESCRIPTION
This updates the `RequestBody.fromContentProvider(ContentProvider, String)` method such that the underlying implementation will buffer the contents of the stream in memory during the first pass through the stream.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
