### PR TITLE
Buffer if custom content provider stream

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-ee5927f.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-ee5927f.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Buffer input data from ContentStreamProvider in cases where content length is known."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProvider.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProvider.java
@@ -34,19 +34,21 @@ import software.amazon.awssdk.utils.IoUtils;
 @NotThreadSafe
 public final class BufferingContentStreamProvider implements ContentStreamProvider {
     private final ContentStreamProvider delegate;
-    private InputStream bufferedStream;
+    private final Long expectedLength;
+    private BufferStream bufferedStream;
 
     private byte[] bufferedStreamData;
     private int count;
 
-    public BufferingContentStreamProvider(ContentStreamProvider delegate) {
+    public BufferingContentStreamProvider(ContentStreamProvider delegate, Long expectedLength) {
         this.delegate = delegate;
+        this.expectedLength = expectedLength;
     }
 
     @Override
     public InputStream newStream() {
         if (bufferedStreamData != null) {
-            return new ByteArrayInputStream(bufferedStreamData, 0, this.count);
+            return new ByteArrayStream(bufferedStreamData, 0, this.count);
         }
 
         if (bufferedStream == null) {
@@ -59,36 +61,54 @@ public final class BufferingContentStreamProvider implements ContentStreamProvid
         return bufferedStream;
     }
 
-    private class BufferStream extends BufferedInputStream {
+    class ByteArrayStream extends ByteArrayInputStream {
+
+        ByteArrayStream(byte[] buf, int offset, int length) {
+            super(buf, offset, length);
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            bufferedStream.close();
+        }
+    }
+
+    class BufferStream extends BufferedInputStream {
         BufferStream(InputStream in) {
             super(in);
         }
 
-        @Override
-        public synchronized int read() throws IOException {
-            int read = super.read();
-            if (read < 0) {
-                saveBuffer();
-            }
-            return read;
+        public byte[] getBuf() {
+            return this.buf;
+        }
+
+        public int getCount() {
+            return this.count;
         }
 
         @Override
-        public synchronized int read(byte[] b, int off, int len) throws IOException {
-            int read = super.read(b, off, len);
-            if (read < 0) {
+        public void close() throws IOException {
+            if (!hasExpectedLength() || expectedLengthReached()) {
                 saveBuffer();
+                super.close();
             }
-            return read;
         }
+    }
 
-        private void saveBuffer() {
-            if (bufferedStreamData == null) {
-                IoUtils.closeQuietlyV2(in, null);
-                BufferingContentStreamProvider.this.bufferedStreamData = this.buf;
-                BufferingContentStreamProvider.this.count = this.count;
-            }
+    private void saveBuffer() {
+        if (bufferedStreamData == null) {
+            this.bufferedStreamData = bufferedStream.getBuf();
+            this.count = bufferedStream.getCount();
         }
+    }
+
+    private boolean expectedLengthReached() {
+        return bufferedStream.getCount() >= expectedLength;
+    }
+
+    private boolean hasExpectedLength() {
+        return this.expectedLength != null;
     }
 
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProvider.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/sync/BufferingContentStreamProvider.java
@@ -89,6 +89,9 @@ public final class BufferingContentStreamProvider implements ContentStreamProvid
 
         @Override
         public void close() throws IOException {
+            // We only want to close the underlying stream if we're confident all its data is buffered. In some cases, the
+            // stream might be closed before we read everything, and we want to avoid closing in these cases if the request
+            // body is being reused.
             if (!hasExpectedLength() || expectedLengthReached()) {
                 saveBuffer();
                 super.close();

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
@@ -209,6 +209,14 @@ public final class RequestBody {
 
     /**
      * Creates a {@link RequestBody} from the given {@link ContentStreamProvider}.
+     * <p>
+     * Important: Be aware that is implementation requires buffering the contents for {@code ContentStreamProvider}, which can
+     * cause increased memory usage.
+     * <p>
+     * If you are using this in conjunction with S3 and want to upload a stream with an unknown content length, you can refer
+     * S3's documentation for
+     * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/s3_example_s3_Scenario_UploadStream_section.html">alternative
+     * methods</a>.
      *
      * @param provider The content provider.
      * @param contentLength The content length.
@@ -217,17 +225,14 @@ public final class RequestBody {
      * @return The created {@code RequestBody}.
      */
     public static RequestBody fromContentProvider(ContentStreamProvider provider, long contentLength, String mimeType) {
-        return new RequestBody(provider, contentLength, mimeType);
+        return new RequestBody(new BufferingContentStreamProvider(provider, contentLength), contentLength, mimeType);
     }
 
     /**
-     * Creates a {@link RequestBody} from the given {@link ContentStreamProvider} when the content length is unknown. If you
-     * are able to provide the content length at creation time, consider using {@link #fromInputStream(InputStream, long)} or
-     * {@link #fromContentProvider(ContentStreamProvider, long, String)} to negate the need to read through the stream to find
-     * the content length.
+     * Creates a {@link RequestBody} from the given {@link ContentStreamProvider} when the content length is unknown.
      * <p>
-     * Important: Be aware that this override requires the SDK to buffer the entirety of your content stream to compute the
-     * content length. This will cause increased memory usage.
+     * Important: Be aware that is implementation requires buffering the contents for {@code ContentStreamProvider}, which can
+     * cause increased memory usage.
      * <p>
      * If you are using this in conjunction with S3 and want to upload a stream with an unknown content length, you can refer
      * S3's documentation for
@@ -240,7 +245,7 @@ public final class RequestBody {
      * @return The created {@code RequestBody}.
      */
     public static RequestBody fromContentProvider(ContentStreamProvider provider, String mimeType) {
-        return new RequestBody(new BufferingContentStreamProvider(provider), null, mimeType);
+        return new RequestBody(new BufferingContentStreamProvider(provider, null), null, mimeType);
     }
 
     /**


### PR DESCRIPTION
This updates the
`RequestBody.fromContentProvider(ContentStreamProvider,long,String)` override such that the underlying implementation will buffer the contents of the stream in memory during the first pass through the stream.

This is a followup to #5837.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
