### PR TITLE
Stop populating SessionMode by default for the SDK-created S3 express sessions.

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-6b41d5e.json
+++ b/.changes/next-release/bugfix-AmazonS3-6b41d5e.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Stopped populating SessionMode by default for the SDK-created S3 express sessions. This value already matched the service-side default, and was already not sent by most SDK languages."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressIdentityCache.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressIdentityCache.java
@@ -29,7 +29,6 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateSessionRequest;
 import software.amazon.awssdk.services.s3.model.SessionCredentials;
-import software.amazon.awssdk.services.s3.model.SessionMode;
 import software.amazon.awssdk.services.s3.s3express.S3ExpressSessionCredentials;
 import software.amazon.awssdk.utils.cache.lru.LruCache;
 
@@ -103,7 +102,6 @@ public class S3ExpressIdentityCache {
         Duration requestApiCallTimeout = clientSetTimeoutIfExists(serviceClientConfiguration).orElse(DEFAULT_API_CALL_TIMEOUT);
 
         return CreateSessionRequest.builder().bucket(bucket)
-                     .sessionMode(SessionMode.READ_WRITE)
                      .overrideConfiguration(o -> o.credentialsProvider(provider)
                                                   .apiCallTimeout(requestApiCallTimeout)).build();
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/S3ExpressTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/S3ExpressTest.java
@@ -264,7 +264,7 @@ public class S3ExpressTest extends BaseRuleSetClientTest {
 
     private static void verifySessionHeaders() {
         verify(1, getRequestedFor(urlMatching("/.*session"))
-            .withHeader("x-amz-create-session-mode", equalTo("ReadWrite"))
+            .withoutHeader("x-amz-create-session-mode")
             .withHeader("x-amz-content-sha256", equalTo("UNSIGNED-PAYLOAD")));
     }
 


### PR DESCRIPTION
This value already matched the service-side default, and was already not sent by most SDK languages.