### PR TITLE
Fixed DynamoDbEnhancedClient DefaultDynamoDbAsyncTable::createTable()…

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-bd68809.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-bd68809.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Fixed DynamoDbEnhancedClient DefaultDynamoDbAsyncTable::createTable() to create secondary indices that are defined on annotations of the POJO class, similar to DefaultDynamoDbTable::createTable()."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/TableIndices.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/TableIndices.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.IndexMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedLocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+
+@SdkInternalApi
+public class TableIndices {
+    private final List<IndexMetadata> indices;
+
+    public TableIndices(List<IndexMetadata> indices) {
+        this.indices = indices;
+    }
+
+    public List<EnhancedLocalSecondaryIndex> localSecondaryIndices() {
+        return Collections.unmodifiableList(indices.stream()
+                                                   .filter(index -> !TableMetadata.primaryIndexName().equals(index.name()))
+                                                   .filter(index -> !index.partitionKey().isPresent())
+                                                   .map(TableIndices::mapIndexMetadataToEnhancedLocalSecondaryIndex)
+                                                   .collect(Collectors.toList()));
+    }
+
+    public List<EnhancedGlobalSecondaryIndex> globalSecondaryIndices() {
+        return Collections.unmodifiableList(indices.stream()
+                                                   .filter(index -> !TableMetadata.primaryIndexName().equals(index.name()))
+                                                   .filter(index -> index.partitionKey().isPresent())
+                                                   .map(TableIndices::mapIndexMetadataToEnhancedGlobalSecondaryIndex)
+                                                   .collect(Collectors.toList()));
+    }
+
+    private static EnhancedLocalSecondaryIndex mapIndexMetadataToEnhancedLocalSecondaryIndex(IndexMetadata indexMetadata) {
+        return EnhancedLocalSecondaryIndex.builder()
+                                          .indexName(indexMetadata.name())
+                                          .projection(pb -> pb.projectionType(ProjectionType.ALL))
+                                          .build();
+    }
+
+    private static EnhancedGlobalSecondaryIndex mapIndexMetadataToEnhancedGlobalSecondaryIndex(IndexMetadata indexMetadata) {
+        return EnhancedGlobalSecondaryIndex.builder()
+                                           .indexName(indexMetadata.name())
+                                           .projection(pb -> pb.projectionType(ProjectionType.ALL))
+                                           .build();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.createKeyFromItem;
 
+import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -25,6 +26,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.internal.TableIndices;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.CreateTableOperation;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.DeleteItemOperation;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.DeleteTableOperation;
@@ -114,7 +116,12 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
 
     @Override
     public CompletableFuture<Void> createTable() {
-        return createTable(CreateTableEnhancedRequest.builder().build());
+        TableIndices indices = new TableIndices(new ArrayList<>(tableSchema.tableMetadata().indices()));
+
+        return createTable(CreateTableEnhancedRequest.builder()
+                                                     .localSecondaryIndices(indices.localSecondaryIndices())
+                                                     .globalSecondaryIndices(indices.globalSecondaryIndices())
+                                                     .build());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/TableIndicesTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/TableIndicesTest.java
@@ -1,0 +1,105 @@
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.internal.TableIndices;
+import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.StaticIndexMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.StaticKeyAttributeMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedLocalSecondaryIndex;
+
+public class TableIndicesTest {
+
+    @Test
+    public void testLocalSecondaryIndices_onlyIncludesLSIs() {
+        List<IndexMetadata> indices = Arrays.asList(StaticIndexMetadata.builder()
+                                                                       .name("lsi-1")
+                                                                       .build(),
+                                                    StaticIndexMetadata.builder()
+                                                                       .name("lsi-2")
+                                                                       .build(),
+                                                    StaticIndexMetadata.builder()
+                                                                       .name("gsi-1")
+                                                                       .partitionKey(StaticKeyAttributeMetadata.create(
+                                                                           "GlobalIndexPartitionKey",
+                                                                           AttributeValueType.N))
+                                                                       .build());
+
+        TableIndices tableIndices = new TableIndices(indices);
+
+        List<EnhancedLocalSecondaryIndex> lsiList = tableIndices.localSecondaryIndices();
+
+        assertEquals(2, lsiList.size());
+        assertTrue(lsiList.stream().anyMatch(i -> "lsi-1".equals(i.indexName())));
+        assertTrue(lsiList.stream().anyMatch(i -> "lsi-2".equals(i.indexName())));
+    }
+
+    @Test
+    public void testGlobalSecondaryIndices_onlyIncludesGSIs() {
+        List<IndexMetadata> indices = Arrays.asList(StaticIndexMetadata.builder()
+                                                                       .name("lsi-1")
+                                                                       .build(),
+                                                    StaticIndexMetadata.builder()
+                                                                       .name("gsi-1")
+                                                                       .partitionKey(StaticKeyAttributeMetadata.create(
+                                                                           "GlobalIndexPartitionKey1",
+                                                                           AttributeValueType.N))
+                                                                       .build(),
+                                                    StaticIndexMetadata.builder()
+                                                                       .name("gsi-2")
+                                                                       .partitionKey(StaticKeyAttributeMetadata.create(
+                                                                           "GlobalIndexPartitionKey2",
+                                                                           AttributeValueType.N))
+                                                                       .build());
+
+        TableIndices tableIndices = new TableIndices(indices);
+
+        List<EnhancedGlobalSecondaryIndex> gsiList = tableIndices.globalSecondaryIndices();
+
+        assertEquals(2, gsiList.size());
+        assertTrue(gsiList.stream().anyMatch(i -> "gsi-1".equals(i.indexName())));
+        assertTrue(gsiList.stream().anyMatch(i -> "gsi-2".equals(i.indexName())));
+    }
+
+    @Test
+    public void testPrimaryIndexIsExcluded() {
+        List<IndexMetadata> indices = Arrays.asList(StaticIndexMetadata.builder()
+                                                                       .name(TableMetadata.primaryIndexName())
+                                                                       .partitionKey(StaticKeyAttributeMetadata.create("pk",
+                                                                                                                       AttributeValueType.S))
+                                                                       .build(),
+                                                    StaticIndexMetadata.builder()
+                                                                       .name("lsi-1")
+                                                                       .build(),
+                                                    StaticIndexMetadata.builder()
+                                                                       .name("gsi-1")
+                                                                       .partitionKey(StaticKeyAttributeMetadata.create(
+                                                                           "GlobalIndexPartitionKey",
+                                                                           AttributeValueType.N))
+                                                                       .build());
+
+        TableIndices tableIndices = new TableIndices(indices);
+
+        List<EnhancedGlobalSecondaryIndex> gsiList = tableIndices.globalSecondaryIndices();
+        List<EnhancedLocalSecondaryIndex> lsiList = tableIndices.localSecondaryIndices();
+
+        assertEquals(1, gsiList.size());
+        assertEquals("gsi-1", gsiList.get(0).indexName());
+
+        assertEquals(1, lsiList.size());
+        assertEquals("lsi-1", lsiList.get(0).indexName());
+    }
+
+    @Test
+    public void testEmptyIndexList() {
+        TableIndices tableIndices = new TableIndices(Collections.emptyList());
+
+        assertTrue(tableIndices.globalSecondaryIndices().isEmpty());
+        assertTrue(tableIndices.localSecondaryIndices().isEmpty());
+    }
+}


### PR DESCRIPTION
Fixed DynamoDbEnhancedClient DefaultDynamoDbAsyncTable::createTable() to create secondary indices that are defined on annotations of the POJO class, similar to DefaultDynamoDbTable::createTable().

<!--- Provide a general summary of your changes in the Title above -->
## Description
Current behavior: DynamoDbEnhancedAsyncClient#createTable() fails to generate secondary indexes that are defined on annotations of the POJO class.

Expected behavior:  DynamoDbEnhancedAsyncClient#createTable() should generate secondary indexes that are defined on annotations of the POJO class, similar to DefaultDynamoDbTable::createTable().

## Motivation and Context
https://github.com/aws/aws-sdk-java-v2/issues/5400

## Modifications
Followed the same approach as the synchronous flow in DefaultDynamoDbTable::createTable(). Refactored existing code to enable reuse across both classes.

## Testing
The changes have already been tested in the synchronous flow, and additional unit tests have been added for the newly created utility class.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
