### PR TITLE
Skip ALPN if request is HTTP endpoint

### DIFF
--- a/.changes/next-release/feature-NettyNIOHTTPClient-8f8589d.json
+++ b/.changes/next-release/feature-NettyNIOHTTPClient-8f8589d.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Netty NIO HTTP Client",
+    "contributor": "",
+    "description": "Fallback to prior knowledge if default client setting is ALPN and request has HTTP endpoint"
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -136,10 +136,9 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
     }
 
     private void failIfAlpnUsedWithHttp(AsyncExecuteRequest request) {
-        if ("http".equals(request.request().protocol())) {
-            if (isAlpnUserConfigured) {
-                throw new UnsupportedOperationException("ALPN can only be used with HTTPS, not HTTP.");
-            }
+        if (isAlpnUserConfigured && "http".equals(request.request().protocol())) {
+            throw new UnsupportedOperationException("ALPN can only be used with HTTPS, not HTTP. "
+                                                    + "Use ProtocolNegotiation.ASSUME_PROTOCOL instead.");
         }
     }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -86,7 +86,7 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
     private final SdkChannelPoolMap<URI, ? extends SdkChannelPool> pools;
     private final NettyConfiguration configuration;
     private final ProtocolNegotiation protocolNegotiation;
-    private boolean userSetAlpn;
+    private boolean isAlpnUserConfigured;
 
     private NettyNioAsyncHttpClient(DefaultBuilder builder, AttributeMap serviceDefaultsMap) {
         this.configuration = new NettyConfiguration(serviceDefaultsMap);
@@ -137,7 +137,7 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
 
     private void failIfAlpnUsedWithHttp(AsyncExecuteRequest request) {
         if ("http".equals(request.request().protocol())) {
-            if (userSetAlpn) {
+            if (isAlpnUserConfigured) {
                 throw new UnsupportedOperationException("ALPN can only be used with HTTPS, not HTTP.");
             }
             if (protocolNegotiation == ProtocolNegotiation.ALPN) {
@@ -189,7 +189,7 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
     private ProtocolNegotiation resolveProtocolNegotiation(ProtocolNegotiation userSetValue, AttributeMap serviceDefaultsMap,
                                                            Protocol protocol, SslProvider sslProvider) {
         if (userSetValue == ProtocolNegotiation.ALPN) {
-            this.userSetAlpn = true;
+            this.isAlpnUserConfigured = true;
             // TODO - remove once we implement support for ALPN with HTTP1
             if (protocol == Protocol.HTTP1_1) {
                 throw new UnsupportedOperationException("ALPN with HTTP/1.1 is not yet supported, use prior knowledge instead "

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -140,10 +140,6 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
             if (isAlpnUserConfigured) {
                 throw new UnsupportedOperationException("ALPN can only be used with HTTPS, not HTTP.");
             }
-            if (protocolNegotiation == ProtocolNegotiation.ALPN) {
-                log.debug(null, () -> "Default client protocol negotiation is ALPN, but request endpoint is HTTP. Prior "
-                                      + "knowledge negotiation will be used instead");
-            }
         }
     }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
@@ -191,7 +191,7 @@ public final class ChannelPipelineInitializer extends AbstractChannelPoolHandler
     }
 
     private void configureAlpnH2(ChannelPipeline pipeline) {
-        pipeline.addLast(new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_2) {
+        pipeline.addLast(new ApplicationProtocolNegotiationHandler("") {
             @Override
             protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
                 if (protocol.equals(ApplicationProtocolNames.HTTP_2)) {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyClientAlpnTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyClientAlpnTest.java
@@ -96,7 +96,7 @@ public class NettyClientAlpnTest {
 
     @Test
     @EnabledIf("alpnSupported")
-    public void alpnClient_httpRequest_throwsException() throws Exception {
+    public void clientWithUserConfiguredAlpn_httpRequest_throwsException() throws Exception {
         initClient(ProtocolNegotiation.ALPN, SslProvider.JDK);
         initServer(true);
         UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, this::makeHttpRequest);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyClientAlpnTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyClientAlpnTest.java
@@ -100,7 +100,7 @@ public class NettyClientAlpnTest {
         initClient(ProtocolNegotiation.ALPN, SslProvider.JDK);
         initServer(true);
         UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, this::makeHttpRequest);
-        assertThat(e.getMessage()).isEqualTo("ALPN can only be used with HTTPS, not HTTP.");
+        assertThat(e.getMessage()).isEqualTo("ALPN can only be used with HTTPS, not HTTP. Use ProtocolNegotiation.ASSUME_PROTOCOL instead.");
     }
 
     private void makeHttpsRequest() throws Exception {

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/h2/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/h2/service-2.json
@@ -1,0 +1,37 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"h2-service",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "protocolSettings":{"h2":"eventstream"},
+    "serviceAbbreviation":"H2 Service",
+    "serviceFullName":"H2 Test Service",
+    "serviceId":"H2 Service",
+    "signatureVersion":"v4",
+    "targetPrefix":"ProtocolTestsService",
+    "uid":"restjson-2016-03-11"
+  },
+  "operations":{
+    "OneOperation":{
+      "name":"OneOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/oneoperation"
+      },
+      "input":{"shape":"OneShape"}
+    }
+  },
+  "shapes": {
+    "OneShape": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "String":{"type":"string"}
+  }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/h2/AlpnHttpTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/h2/AlpnHttpTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.h2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.ConnectException;
+import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.CompletionException;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.ProtocolNegotiation;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+
+public class AlpnHttpTest {
+
+    @Test
+    @EnabledIf("alpnSupported")
+    public void clientWithDefaultSettingAlpn_httpRequest_doesNotThrowUnsupportedOperationException() {
+        H2AsyncClient client = clientBuilderWithHttpEndpoint().build();
+
+        CompletionException e = assertThrows(CompletionException.class, () -> makeRequest(client));
+        assertThat(e).hasCauseInstanceOf(SdkClientException.class);
+        assertThat(e.getCause()).hasCauseInstanceOf(ConnectException.class);
+        assertThat(e.getMessage()).contains("Connection refused");
+        assertThat(e.getMessage()).doesNotContain("ALPN can only be used with HTTPS, not HTTP");
+    }
+
+    @Test
+    @EnabledIf("alpnSupported")
+    public void clientWithUserConfiguredAlpn_httpRequest_throwsUnsupportedOperationException() {
+        H2AsyncClient client = clientBuilderWithHttpEndpoint().httpClient(NettyNioAsyncHttpClient.builder()
+                                                                                                 .protocolNegotiation(ProtocolNegotiation.ALPN)
+                                                                                                 .protocol(Protocol.HTTP2)
+                                                                                                 .build())
+                                                              .build();
+
+        CompletionException e = assertThrows(CompletionException.class, () -> makeRequest(client));
+        assertThat(e).hasCauseInstanceOf(SdkClientException.class);
+        assertThat(e.getCause()).hasCauseInstanceOf(UnsupportedOperationException.class);
+        assertThat(e.getMessage()).contains("ALPN can only be used with HTTPS, not HTTP");
+    }
+
+    private H2AsyncClientBuilder clientBuilderWithHttpEndpoint() {
+        return H2AsyncClient.builder()
+                            .endpointOverride(URI.create("http://localhost:8080"));
+    }
+
+    private void makeRequest(H2AsyncClient client) {
+        client.oneOperation(c -> c.stringMember("payload")).join();
+    }
+
+    private static boolean alpnSupported() {
+        try {
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, null, null);
+            SSLEngine engine = context.createSSLEngine();
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+            MethodHandle getApplicationProtocol = AccessController.doPrivileged(
+                (PrivilegedExceptionAction<MethodHandle>) () ->
+                    lookup.findVirtual(SSLEngine.class, "getApplicationProtocol", MethodType.methodType(String.class)));
+
+            getApplicationProtocol.invoke(engine);
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/h2/AlpnHttpTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/h2/AlpnHttpTest.java
@@ -46,7 +46,7 @@ public class AlpnHttpTest {
         assertThat(e).hasCauseInstanceOf(SdkClientException.class);
         assertThat(e.getCause()).hasCauseInstanceOf(ConnectException.class);
         assertThat(e.getMessage()).contains("Connection refused");
-        assertThat(e.getMessage()).doesNotContain("ALPN can only be used with HTTPS, not HTTP");
+        assertThat(e.getMessage()).doesNotContain("ALPN can only be used with HTTPS, not HTTP. Use ProtocolNegotiation.ASSUME_PROTOCOL instead.");
     }
 
     @Test
@@ -61,7 +61,7 @@ public class AlpnHttpTest {
         CompletionException e = assertThrows(CompletionException.class, () -> makeRequest(client));
         assertThat(e).hasCauseInstanceOf(SdkClientException.class);
         assertThat(e.getCause()).hasCauseInstanceOf(UnsupportedOperationException.class);
-        assertThat(e.getMessage()).contains("ALPN can only be used with HTTPS, not HTTP");
+        assertThat(e.getMessage()).contains("ALPN can only be used with HTTPS, not HTTP. Use ProtocolNegotiation.ASSUME_PROTOCOL instead.");
     }
 
     private H2AsyncClientBuilder clientBuilderWithHttpEndpoint() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Mock tests with h2 clients making requests to HTTP endpoints fail with [recent ALPN addition](https://github.com/aws/aws-sdk-java-v2/pull/5794)

## Modifications
<!--- Describe your changes in detail -->
Skip adding ALPN handler if request endpoint is HTTP and the default client setting is ALPN. This maintains previous behavior of prior knowledge protocol negotiation, and avoids breaking changes for existing generated clients with h2 protocol setting

Continue to throw error if request endpoint is HTTP and user configures ALPN on client

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
