### PR TITLE
Fixed an issue that the SDK unnecessarily bufferred the entire conten…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-f6370d6.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-f6370d6.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue in the SDK where it unnecessarily buffers the entire content for streaming operations, causing OOM error. See [#5850](https://github.com/aws/aws-sdk-java-v2/issues/5850)."
+}

--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
@@ -392,6 +392,15 @@
             <property name="ignoreComments" value="true"/>
         </module>
 
+        <!-- Checks that we don't use RequestBody.fromContentProvider in the SDK core -->
+        <module name="Regexp">
+            <property name="format" value="RequestBody\.fromContentProvider"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="message" value="DO NOT use fromContentProvider for streaming operations because it will buffer the entire content.
+            Add suppression if it's for a non-streaming operation"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
         <!-- Checks that we don't use AttributeKey.newInstance directly -->
         <module name="Regexp">
             <property name="format" value="AttributeKey\.newInstance"/>

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -139,9 +139,9 @@ public abstract class BaseClientHandler {
                 streamProvider = () -> new SdkLengthAwareInputStream(toWrap.newStream(), contentLength);
             }
 
-            return RequestBody.fromContentProvider(streamProvider,
-                                                   contentLength,
-                                                   contentType);
+            return new SdkInternalOnlyRequestBody(streamProvider,
+                                                  contentLength,
+                                                  contentType);
         }
 
         return null;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/SdkInternalOnlyRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/SdkInternalOnlyRequestBody.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.handler;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.ContentStreamProvider;
+
+/**
+ * This class is needed as an alternative to {@link RequestBody#fromContentProvider(ContentStreamProvider, long, String)},
+ * which buffers the entire content.
+ *
+ * <p>
+ * THIS IS AN INTERNAL API. DO NOT USE IT OUTSIDE THE AWS SDK FOR JAVA V2.
+ */
+@SdkInternalApi
+class SdkInternalOnlyRequestBody extends RequestBody {
+
+    protected SdkInternalOnlyRequestBody(ContentStreamProvider contentStreamProvider, Long contentLength, String contentType) {
+        super(contentStreamProvider, contentLength, contentType);
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.internal.sync.BufferingContentStreamProvider;
 import software.amazon.awssdk.core.internal.sync.FileContentStreamProvider;
@@ -43,16 +44,20 @@ import software.amazon.awssdk.utils.IoUtils;
 /**
  * Represents the body of an HTTP request. Must be provided for operations that have a streaming input.
  * Offers various convenience factory methods from common sources of data (File, String, byte[], etc).
+ *
+ * <p>
+ * This class is NOT intended to be overridden.
  */
 @SdkPublicApi
-public final class RequestBody {
+public class RequestBody {
 
     // TODO Handle stream management (progress listener, orig input stream tracking, etc
     private final ContentStreamProvider contentStreamProvider;
     private final Long contentLength;
     private final String contentType;
 
-    private RequestBody(ContentStreamProvider contentStreamProvider, Long contentLength, String contentType) {
+    @SdkInternalApi
+    protected RequestBody(ContentStreamProvider contentStreamProvider, Long contentLength, String contentType) {
         this.contentStreamProvider = paramNotNull(contentStreamProvider, "contentStreamProvider");
         this.contentLength = contentLength != null ? isNotNegative(contentLength, "Content-length") : null;
         this.contentType = paramNotNull(contentType, "contentType");
@@ -61,7 +66,7 @@ public final class RequestBody {
     /**
      * @return RequestBody as an {@link InputStream}.
      */
-    public ContentStreamProvider contentStreamProvider() {
+    public final ContentStreamProvider contentStreamProvider() {
         return contentStreamProvider;
     }
 
@@ -70,7 +75,7 @@ public final class RequestBody {
      * @return Content length of {@link RequestBody}.
      */
     @Deprecated
-    public long contentLength() {
+    public final long contentLength() {
         validState(this.contentLength != null,
                    "Content length is invalid, please use optionalContentLength() for your case.");
         return contentLength;
@@ -79,14 +84,14 @@ public final class RequestBody {
     /**
      * @return Optional object of content length of {@link RequestBody}.
      */
-    public Optional<Long> optionalContentLength() {
+    public final Optional<Long> optionalContentLength() {
         return Optional.ofNullable(contentLength);
     }
 
     /**
      * @return Content type of {@link RequestBody}.
      */
-    public String contentType() {
+    public final String contentType() {
         return contentType;
     }
 

--- a/services/cloudsearchdomain/src/main/java/software/amazon/awssdk/services/cloudsearchdomain/internal/SwitchToPostInterceptor.java
+++ b/services/cloudsearchdomain/src/main/java/software/amazon/awssdk/services/cloudsearchdomain/internal/SwitchToPostInterceptor.java
@@ -54,10 +54,13 @@ public final class SwitchToPostInterceptor implements ExecutionInterceptor {
         if (context.request() instanceof SearchRequest) {
             byte[] params = context.httpRequest().encodedQueryParametersAsFormData().orElse("")
                                    .getBytes(StandardCharsets.UTF_8);
+            // CHECKSTYLE:OFF - Avoid flagging the use of fromContentProvider. This is fine here because it's non-streaming
+            // operation
             return Optional.of(RequestBody.fromContentProvider(() -> new ByteArrayInputStream(params),
                                                                params.length,
                                                                "application/x-www-form-urlencoded; charset=" +
                                                                lowerCase(StandardCharsets.UTF_8.toString())));
+            // CHECKSTYLE:ON
         }
         return context.requestBody();
     }


### PR DESCRIPTION
…t for streaming operations

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed an issue that the SDK unnecessarily buffered the entire content for streaming operations. See 
https://github.com/aws/aws-sdk-java-v2/issues/5850 

We changed `RequestBody#fromContenProvider` to buffer content in https://github.com/aws/aws-sdk-java-v2/commit/9523cf57f0de330eeed40d9523c3611351ec6e79#diff-1a88bd363dd55e33ebf3734f8a96c524d600b3f46745c82169482718d43c030a commit. It was released in 2.30.9.

The root cause is that we are calling `RequestBody#fromContenProvider` in [BaseClientHandler](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java#L142) within the SDK to wrap the inputstream with `SdkLengthAwareInputStream`, which means all streams with known content length will be buffered. 


## Modifications
Create an internal class to extend `RequestBody` that just uses the contentStreamProvider as-is (instead of buffering).

## Testing
Tested with customer's repro code and verified oom is no longer thrown

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
