### PR TITLE
Decouple policy logic from resource url for getSignedUrlWithCustomPolicy

### DIFF
--- a/.changes/next-release/bugfix-AmazonCloudfront-1fa6f75.json
+++ b/.changes/next-release/bugfix-AmazonCloudfront-1fa6f75.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon Cloudfront",
+    "contributor": "",
+    "description": "Decouple policy logic from resource url for getSignedUrlWithCustomPolicy"
+}

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -253,9 +253,9 @@ public final class CloudFrontUtilities {
     public SignedUrl getSignedUrlWithCustomPolicy(CustomSignerRequest request) {
         String resourceUrl = request.resourceUrl();
         try {
-            String resourceUrlPattern = request.resourceUrlPattern() != null && !StringUtils.isEmpty(request.resourceUrlPattern())
-                                    ? request.resourceUrlPattern()
-                                    : request.resourceUrl();
+            String resourceUrlPattern = StringUtils.isEmpty(request.resourceUrlPattern())
+                                        ? request.resourceUrl()
+                                        : request.resourceUrlPattern();
 
             String policy = SigningUtils.buildCustomPolicyForSignedUrl(resourceUrlPattern,
                                                                        request.activeDate(),

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -217,8 +217,13 @@ public final class CloudFrontUtilities {
      *
      * @param request
      *            A {@link CustomSignerRequest} configured with the following values:
-     *            resourceUrl, privateKey, keyPairId, expirationDate, activeDate (optional), ipRange (optional), resourceUrlPattern
-     *            (optional)
+     *            resourceUrl,
+     *            privateKey,
+     *            keyPairId,
+     *            expirationDate,
+     *            activeDate (optional),
+     *            ipRange (optional),
+     *            resourceUrlPattern (optional)
      * @return A signed URL that will permit access to distribution and S3
      *         objects as specified in the policy document.
      *

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -254,12 +254,6 @@ public final class CloudFrontUtilities {
      */
     public SignedUrl getSignedUrlWithCustomPolicy(CustomSignerRequest request) {
         String resourceUrl = request.resourceUrl();
-
-        if (resourceUrl == null) {
-            throw SdkClientException.create("resourceUrl must not be null. "
-                                            + "To provide a custom policy resource please use the policyResource parameter");
-        }
-
         try {
             String policyResource = request.policyResource() != null
                                     ? request.policyResource()

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -249,8 +249,12 @@ public final class CloudFrontUtilities {
     public SignedUrl getSignedUrlWithCustomPolicy(CustomSignerRequest request) {
         try {
             String resourceUrl = request.resourceUrl();
-            String policy = SigningUtils.buildCustomPolicyForSignedUrl(request.resourceUrl(), request.activeDate(),
-                                                                       request.expirationDate(), request.ipRange());
+            String policy = SigningUtils.buildCustomPolicyForSignedUrl(request.resourceUrl(),
+                                                                       request.activeDate(),
+                                                                       request.expirationDate(),
+                                                                       request.ipRange(),
+                                                                       request.policyResourceUrl());
+
             byte[] signatureBytes = SigningUtils.signWithSha1Rsa(policy.getBytes(UTF_8), request.privateKey());
             String urlSafePolicy = SigningUtils.makeStringUrlSafe(policy);
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.cloudfront.internal.auth.Pem;
 import software.amazon.awssdk.services.cloudfront.internal.auth.Rsa;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public final class SigningUtils {
@@ -175,9 +176,9 @@ public final class SigningUtils {
                                                        Instant activeDate,
                                                        Instant expirationDate,
                                                        String limitToIpAddressCidr) {
-        if (expirationDate == null) {
-            throw SdkClientException.create("Expiration date must be provided to sign CloudFront URLs");
-        }
+
+        Validate.notNull(expirationDate, "Expiration date must be provided to sign CloudFront URLs");
+
         if (resourceUrl == null) {
             resourceUrl = "*";
         }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -179,7 +179,7 @@ public final class SigningUtils {
         if (expirationDate == null) {
             throw SdkClientException.create("Expiration date must be provided to sign CloudFront URLs");
         }
-        if (resourceUrl == null){
+        if (resourceUrl == null) {
             throw SdkClientException.create("Resource URL must be provided to sign CloudFront URLs");
         }
         String policyResource = policyResourceUrl != null ? policyResourceUrl : resourceUrl;

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -174,16 +174,15 @@ public final class SigningUtils {
     public static String buildCustomPolicyForSignedUrl(String resourceUrl,
                                                        Instant activeDate,
                                                        Instant expirationDate,
-                                                       String limitToIpAddressCidr,
-                                                       String policyResourceUrl) {
+                                                       String limitToIpAddressCidr) {
         if (expirationDate == null) {
             throw SdkClientException.create("Expiration date must be provided to sign CloudFront URLs");
         }
         if (resourceUrl == null) {
-            throw SdkClientException.create("Resource URL must be provided to sign CloudFront URLs");
+            resourceUrl = "*";
         }
-        String policyResource = policyResourceUrl != null ? policyResourceUrl : resourceUrl;
-        return buildCustomPolicy(policyResource, activeDate, expirationDate, limitToIpAddressCidr);
+
+        return buildCustomPolicy(resourceUrl, activeDate, expirationDate, limitToIpAddressCidr);
     }
 
     /**

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -179,6 +179,9 @@ public final class SigningUtils {
         if (expirationDate == null) {
             throw SdkClientException.create("Expiration date must be provided to sign CloudFront URLs");
         }
+        if (resourceUrl == null){
+            throw SdkClientException.create("Resource URL must be provided to sign CloudFront URLs");
+        }
         String policyResource = policyResourceUrl != null ? policyResourceUrl : resourceUrl;
         return buildCustomPolicy(policyResource, activeDate, expirationDate, limitToIpAddressCidr);
     }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -174,14 +174,13 @@ public final class SigningUtils {
     public static String buildCustomPolicyForSignedUrl(String resourceUrl,
                                                        Instant activeDate,
                                                        Instant expirationDate,
-                                                       String limitToIpAddressCidr) {
+                                                       String limitToIpAddressCidr,
+                                                       String policyResourceUrl) {
         if (expirationDate == null) {
             throw SdkClientException.create("Expiration date must be provided to sign CloudFront URLs");
         }
-        if (resourceUrl == null) {
-            resourceUrl = "*";
-        }
-        return buildCustomPolicy(resourceUrl, activeDate, expirationDate, limitToIpAddressCidr);
+        String policyResource = policyResourceUrl != null ? policyResourceUrl : resourceUrl;
+        return buildCustomPolicy(policyResource, activeDate, expirationDate, limitToIpAddressCidr);
     }
 
     /**

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -100,7 +100,9 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         return ipRange;
     }
 
-    public String policyResourceUrl() { return policyResourceUrl; }
+    public String policyResourceUrl() {
+        return policyResourceUrl;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -35,13 +35,13 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 @SdkPublicApi
 public final class CustomSignerRequest implements CloudFrontSignerRequest,
                                                   ToCopyableBuilder<CustomSignerRequest.Builder, CustomSignerRequest> {
-
     private final String resourceUrl;
     private final PrivateKey privateKey;
     private final String keyPairId;
     private final Instant expirationDate;
     private final Instant activeDate;
     private final String ipRange;
+    private final String policyResourceUrl;
 
     private CustomSignerRequest(DefaultBuilder builder) {
         this.resourceUrl = builder.resourceUrl;
@@ -50,6 +50,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         this.expirationDate = builder.expirationDate;
         this.activeDate = builder.activeDate;
         this.ipRange = builder.ipRange;
+        this.policyResourceUrl = builder.policyResourceUrl;
     }
 
     /**
@@ -99,6 +100,8 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         return ipRange;
     }
 
+    public String policyResourceUrl() { return policyResourceUrl; }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -114,7 +117,8 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
                && Objects.equals(keyPairId, cookie.keyPairId)
                && Objects.equals(expirationDate, cookie.expirationDate)
                && Objects.equals(activeDate, cookie.activeDate)
-               && Objects.equals(ipRange, cookie.ipRange);
+               && Objects.equals(ipRange, cookie.ipRange)
+               && Objects.equals(policyResourceUrl, cookie.policyResourceUrl);
     }
 
     @Override
@@ -125,6 +129,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         result = 31 * result + (expirationDate != null ? expirationDate.hashCode() : 0);
         result = 31 * result + (activeDate != null ? activeDate.hashCode() : 0);
         result = 31 * result + (ipRange != null ? ipRange.hashCode() : 0);
+        result = 31 * result + (policyResourceUrl != null ? policyResourceUrl.hashCode() : 0);
         return result;
     }
 
@@ -179,6 +184,16 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
          * IPv6 format is not supported.
          */
         Builder ipRange(String ipRange);
+
+        /**
+         * Configure the resource URL pattern to be used in the policy
+         * <p>
+         * For custom policies, this specifies the URL pattern that determines which files
+         * can be accessed with this signed URL. This can include wildcard characters (*) to
+         * grant access to multiple files or paths. If not specified, the resourceUrl value
+         * will be used in the policy.
+         */
+        Builder policyResourceUrl(String policyResourceUrl);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -188,6 +203,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         private Instant expirationDate;
         private Instant activeDate;
         private String ipRange;
+        private String policyResourceUrl;
 
         private DefaultBuilder() {
         }
@@ -199,6 +215,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
             this.expirationDate = request.expirationDate;
             this.activeDate = request.activeDate;
             this.ipRange = request.ipRange;
+            this.policyResourceUrl = request.policyResourceUrl;
         }
 
         @Override
@@ -240,6 +257,12 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         @Override
         public Builder ipRange(String ipRange) {
             this.ipRange = ipRange;
+            return this;
+        }
+
+        @Override
+        public Builder policyResourceUrl(String policyResourceUrl) {
+            this.policyResourceUrl = policyResourceUrl;
             return this;
         }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
+import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -44,7 +45,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
     private final String policyResource;
 
     private CustomSignerRequest(DefaultBuilder builder) {
-        this.resourceUrl = builder.resourceUrl;
+        this.resourceUrl = Validate.notNull(builder.resourceUrl, "resourceUrl must not be null");
         this.privateKey = builder.privateKey;
         this.keyPairId = builder.keyPairId;
         this.expirationDate = builder.expirationDate;

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -42,7 +42,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
     private final Instant expirationDate;
     private final Instant activeDate;
     private final String ipRange;
-    private final String policyResource;
+    private final String resourceUrlPattern;
 
     private CustomSignerRequest(DefaultBuilder builder) {
         this.resourceUrl = Validate.notNull(builder.resourceUrl, "resourceUrl must not be null");
@@ -51,7 +51,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         this.expirationDate = builder.expirationDate;
         this.activeDate = builder.activeDate;
         this.ipRange = builder.ipRange;
-        this.policyResource = builder.policyResource;
+        this.resourceUrlPattern = builder.resourceUrlPattern;
     }
 
     /**
@@ -101,8 +101,8 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         return ipRange;
     }
 
-    public String policyResource() {
-        return policyResource;
+    public String resourceUrlPattern() {
+        return resourceUrlPattern;
     }
 
     @Override
@@ -121,7 +121,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
                && Objects.equals(expirationDate, cookie.expirationDate)
                && Objects.equals(activeDate, cookie.activeDate)
                && Objects.equals(ipRange, cookie.ipRange)
-               && Objects.equals(policyResource, cookie.policyResource);
+               && Objects.equals(resourceUrlPattern, cookie.resourceUrlPattern);
     }
 
     @Override
@@ -132,7 +132,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         result = 31 * result + (expirationDate != null ? expirationDate.hashCode() : 0);
         result = 31 * result + (activeDate != null ? activeDate.hashCode() : 0);
         result = 31 * result + (ipRange != null ? ipRange.hashCode() : 0);
-        result = 31 * result + (policyResource != null ? policyResource.hashCode() : 0);
+        result = 31 * result + (resourceUrlPattern != null ? resourceUrlPattern.hashCode() : 0);
         return result;
     }
 
@@ -196,7 +196,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
          * grant access to multiple files or paths. If not specified, the resourceUrl value
          * will be used in the policy.
          */
-        Builder policyResource(String policyResource);
+        Builder resourceUrlPattern(String resourceUrlPattern);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -206,7 +206,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         private Instant expirationDate;
         private Instant activeDate;
         private String ipRange;
-        private String policyResource;
+        private String resourceUrlPattern;
 
         private DefaultBuilder() {
         }
@@ -218,7 +218,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
             this.expirationDate = request.expirationDate;
             this.activeDate = request.activeDate;
             this.ipRange = request.ipRange;
-            this.policyResource = request.policyResource;
+            this.resourceUrlPattern = request.resourceUrlPattern;
         }
 
         @Override
@@ -264,8 +264,8 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         }
 
         @Override
-        public Builder policyResource(String policyResource) {
-            this.policyResource = policyResource;
+        public Builder resourceUrlPattern(String resourceUrlPattern) {
+            this.resourceUrlPattern = resourceUrlPattern;
             return this;
         }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -41,7 +41,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
     private final Instant expirationDate;
     private final Instant activeDate;
     private final String ipRange;
-    private final String policyResourceUrl;
+    private final String policyResource;
 
     private CustomSignerRequest(DefaultBuilder builder) {
         this.resourceUrl = builder.resourceUrl;
@@ -50,7 +50,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         this.expirationDate = builder.expirationDate;
         this.activeDate = builder.activeDate;
         this.ipRange = builder.ipRange;
-        this.policyResourceUrl = builder.policyResourceUrl;
+        this.policyResource = builder.policyResource;
     }
 
     /**
@@ -100,8 +100,8 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         return ipRange;
     }
 
-    public String policyResourceUrl() {
-        return policyResourceUrl;
+    public String policyResource() {
+        return policyResource;
     }
 
     @Override
@@ -120,7 +120,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
                && Objects.equals(expirationDate, cookie.expirationDate)
                && Objects.equals(activeDate, cookie.activeDate)
                && Objects.equals(ipRange, cookie.ipRange)
-               && Objects.equals(policyResourceUrl, cookie.policyResourceUrl);
+               && Objects.equals(policyResource, cookie.policyResource);
     }
 
     @Override
@@ -131,7 +131,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         result = 31 * result + (expirationDate != null ? expirationDate.hashCode() : 0);
         result = 31 * result + (activeDate != null ? activeDate.hashCode() : 0);
         result = 31 * result + (ipRange != null ? ipRange.hashCode() : 0);
-        result = 31 * result + (policyResourceUrl != null ? policyResourceUrl.hashCode() : 0);
+        result = 31 * result + (policyResource != null ? policyResource.hashCode() : 0);
         return result;
     }
 
@@ -195,7 +195,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
          * grant access to multiple files or paths. If not specified, the resourceUrl value
          * will be used in the policy.
          */
-        Builder policyResourceUrl(String policyResourceUrl);
+        Builder policyResource(String policyResource);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -205,7 +205,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         private Instant expirationDate;
         private Instant activeDate;
         private String ipRange;
-        private String policyResourceUrl;
+        private String policyResource;
 
         private DefaultBuilder() {
         }
@@ -217,7 +217,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
             this.expirationDate = request.expirationDate;
             this.activeDate = request.activeDate;
             this.ipRange = request.ipRange;
-            this.policyResourceUrl = request.policyResourceUrl;
+            this.policyResource = request.policyResource;
         }
 
         @Override
@@ -263,8 +263,8 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         }
 
         @Override
-        public Builder policyResourceUrl(String policyResourceUrl) {
-            this.policyResourceUrl = policyResourceUrl;
+        public Builder policyResource(String policyResource) {
+            this.policyResource = policyResource;
             return this;
         }
 

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -75,7 +75,7 @@ import software.amazon.awssdk.testutils.Waiter;
 
 public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     private static final Base64.Encoder ENCODER = Base64.getEncoder();
-    private static final String RESOURCE_PREFIX = "do-not-delete-cf-test-";
+    private static final String RESOURCE_PREFIX = "do-not-delete-cf-test-v2";
     private static final String CALLER_REFERENCE = UUID.randomUUID().toString();
     private static final String S3_OBJECT_KEY = "s3ObjectKey";
     private static final String S3_OBJECT_KEY_ON_SUB_PATH = "foo/specific-file";

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -285,7 +285,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                          .resourceUrl(resourceUrl)
                                                          .privateKey(keyFilePath)
                                                          .keyPairId(keyPairId)
-                                                         .policyResourceUrl(resourceUrl + "*")
+                                                         .policyResource(resourceUrl + "*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
                                                          .build();
@@ -323,7 +323,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                          .resourceUrl(resourceUri + "/foo/specific-file")
                                                          .privateKey(keyFilePath)
                                                          .keyPairId(keyPairId)
-                                                         .policyResourceUrl(resourceUri + "/foo/*")
+                                                         .policyResource(resourceUri + "/foo/*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
                                                          .build();
@@ -345,7 +345,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    void getSignedUrlWithCustomPolicy_wildCardPolicyResourceUrl_allowsAnyPath() throws Exception {
+    void getSignedUrlWithCustomPolicy_wildCardPolicyResource_allowsAnyPath() throws Exception {
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
                                           .toInstant(ZoneOffset.of("Z"));
@@ -358,7 +358,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                          .resourceUrl(resourceUrl)
                                                          .privateKey(keyFilePath)
                                                          .keyPairId(keyPairId)
-                                                         .policyResourceUrl("*")
+                                                         .policyResource("*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
                                                          .build();

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -285,7 +285,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                          .resourceUrl(resourceUrl)
                                                          .privateKey(keyFilePath)
                                                          .keyPairId(keyPairId)
-                                                         .policyResource(resourceUrl + "*")
+                                                         .resourceUrlPattern(resourceUrl + "*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
                                                          .build();
@@ -323,7 +323,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                          .resourceUrl(resourceUri + "/foo/specific-file")
                                                          .privateKey(keyFilePath)
                                                          .keyPairId(keyPairId)
-                                                         .policyResource(resourceUri + "/foo/*")
+                                                         .resourceUrlPattern(resourceUri + "/foo/*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
                                                          .build();
@@ -358,7 +358,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                          .resourceUrl(resourceUrl)
                                                          .privateKey(keyFilePath)
                                                          .keyPairId(keyPairId)
-                                                         .policyResource("*")
+                                                         .resourceUrlPattern("*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
                                                          .build();

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -77,6 +78,9 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     private static final String RESOURCE_PREFIX = "do-not-delete-cf-test-";
     private static final String CALLER_REFERENCE = UUID.randomUUID().toString();
     private static final String S3_OBJECT_KEY = "s3ObjectKey";
+    private static final String S3_OBJECT_KEY_ON_SUB_PATH = "foo/specific-file";
+    private static final String S3_OBJECT_KEY_ON_SUB_PATH_OTHER = "foo/other-file";
+
 
     private static String bucket;
     private static String domainName;
@@ -267,6 +271,114 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
     }
 
+    @Test
+    void getSignedUrlWithCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard() throws Exception {
+        Instant expirationDate = LocalDate.of(2050, 1, 1)
+                                          .atStartOfDay()
+                                          .toInstant(ZoneOffset.of("Z"));
+
+        Instant activeDate = LocalDate.of(2022, 1, 1)
+                                      .atStartOfDay()
+                                      .toInstant(ZoneOffset.of("Z"));
+
+        CustomSignerRequest request = CustomSignerRequest.builder()
+                                                         .resourceUrl(resourceUrl)
+                                                         .privateKey(keyFilePath)
+                                                         .keyPairId(keyPairId)
+                                                         .policyResourceUrl(resourceUrl + "*")
+                                                         .activeDate(activeDate)
+                                                         .expirationDate(expirationDate)
+                                                         .build();
+
+        SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
+
+        String urlWithDynamicParam = signedUrl.url() + "&foo=bar";
+        URI modifiedUri = URI.create(urlWithDynamicParam);
+
+
+        SdkHttpClient client = ApacheHttpClient.create();
+        HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                               .request(SdkHttpRequest.builder()
+                                                                                                      .encodedPath(modifiedUri.getRawPath() + "?" + modifiedUri.getRawQuery())
+                                                                                                      .host(modifiedUri.getHost())
+                                                                                                      .method(SdkHttpMethod.GET)
+                                                                                                      .protocol("https")
+                                                                                                      .build())
+                                                                               .build()).call();
+        assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void getSignedUrlWithCustomPolicy_wildCardPath() throws Exception {
+        String resourceUri = "https://" + domainName;
+        Instant expirationDate = LocalDate.of(2050, 1, 1)
+                                          .atStartOfDay()
+                                          .toInstant(ZoneOffset.of("Z"));
+
+        Instant activeDate = LocalDate.of(2022, 1, 1)
+                                      .atStartOfDay()
+                                      .toInstant(ZoneOffset.of("Z"));
+
+        CustomSignerRequest request = CustomSignerRequest.builder()
+                                                         .resourceUrl(resourceUri + "/foo/specific-file")
+                                                         .privateKey(keyFilePath)
+                                                         .keyPairId(keyPairId)
+                                                         .policyResourceUrl(resourceUri + "/foo/*")
+                                                         .activeDate(activeDate)
+                                                         .expirationDate(expirationDate)
+                                                         .build();
+
+        SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
+
+
+        URI modifiedUri = URI.create(signedUrl.url().replace("/specific-file","/other-file"));
+        SdkHttpClient client = ApacheHttpClient.create();
+        HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                               .request(SdkHttpRequest.builder()
+                                                                                                      .encodedPath(modifiedUri.getRawPath() + "?" + modifiedUri.getRawQuery())
+                                                                                                      .host(modifiedUri.getHost())
+                                                                                                      .method(SdkHttpMethod.GET)
+                                                                                                      .protocol("https")
+                                                                                                      .build())
+                                                                               .build()).call();
+        assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void getSignedUrlWithCustomPolicy_wildCardPolicyResourceUrl_allowsAnyPath() throws Exception {
+        Instant expirationDate = LocalDate.of(2050, 1, 1)
+                                          .atStartOfDay()
+                                          .toInstant(ZoneOffset.of("Z"));
+
+        Instant activeDate = LocalDate.of(2022, 1, 1)
+                                      .atStartOfDay()
+                                      .toInstant(ZoneOffset.of("Z"));
+
+        CustomSignerRequest request = CustomSignerRequest.builder()
+                                                         .resourceUrl(resourceUrl)
+                                                         .privateKey(keyFilePath)
+                                                         .keyPairId(keyPairId)
+                                                         .policyResourceUrl("*")
+                                                         .activeDate(activeDate)
+                                                         .expirationDate(expirationDate)
+                                                         .build();
+
+        SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
+
+
+        URI modifiedUri = URI.create(signedUrl.url().replace("/s3ObjectKey","/foo/other-file"));
+        SdkHttpClient client = ApacheHttpClient.create();
+        HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                               .request(SdkHttpRequest.builder()
+                                                                                                      .encodedPath(modifiedUri.getRawPath() + "?" + modifiedUri.getRawQuery())
+                                                                                                      .host(modifiedUri.getHost())
+                                                                                                      .method(SdkHttpMethod.GET)
+                                                                                                      .protocol("https")
+                                                                                                      .build())
+                                                                               .build()).call();
+        assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+    }
+
     private static void initStaticFields() throws Exception {
         initializeKeyFileAndPair();
         originAccessId = getOrCreateOriginAccessIdentity();
@@ -409,7 +521,11 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         s3Client.waiter().waitUntilBucketExists(r -> r.bucket(newBucketName));
 
         File content = new RandomTempFile("testFile", 1000L);
+        File content2 = new RandomTempFile("testFile2", 500L);
         s3Client.putObject(PutObjectRequest.builder().bucket(newBucketName).key(S3_OBJECT_KEY).build(), RequestBody.fromFile(content));
+        s3Client.putObject(PutObjectRequest.builder().bucket(newBucketName).key(S3_OBJECT_KEY_ON_SUB_PATH).build(), RequestBody.fromFile(content2));
+        s3Client.putObject(PutObjectRequest.builder().bucket(newBucketName).key(S3_OBJECT_KEY_ON_SUB_PATH_OTHER).build(), RequestBody.fromFile(content2));
+
 
         String bucketPolicy = "{\n"
                               + "\"Version\":\"2012-10-17\",\n"

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -341,7 +341,7 @@ class CloudFrontUtilitiesTest {
                                                          .resourceUrl(baseUrl)
                                                          .privateKey(keyPair.getPrivate())
                                                          .keyPairId("keyPairId")
-                                                         .policyResourceUrl("*")
+                                                         .policyResource("*")
                                                          .expirationDate(expiration)
                                                          .build();
 

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.cloudfront;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -341,7 +342,7 @@ class CloudFrontUtilitiesTest {
                                                          .resourceUrl(baseUrl)
                                                          .privateKey(keyPair.getPrivate())
                                                          .keyPairId("keyPairId")
-                                                         .policyResource("*")
+                                                         .resourceUrlPattern("*")
                                                          .expirationDate(expiration)
                                                          .build();
 
@@ -366,5 +367,11 @@ class CloudFrontUtilitiesTest {
               .append("}]}");
 
         assertThat(decodedPolicy.trim()).isEqualTo(expectedPolicy.toString().trim());
+    }
+
+    @Test
+    void customSignerRequest_nullResourceUrlShouldThrow(){
+        assertThatNullPointerException().isThrownBy(() -> CustomSignerRequest.builder().build())
+                                        .withMessageContaining("resourceUrl must not be null");
     }
 }

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -208,7 +208,7 @@ class CloudFrontUtilitiesTest {
 
     @Test
     void getSignedURLWithCustomPolicy_withMissingExpirationDate_shouldThrowException() {
-        SdkClientException exception = assertThrows(SdkClientException.class, () ->
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
             cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r
                 .resourceUrl(RESOURCE_URL)
                 .privateKey(keyPair.getPrivate())

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -30,9 +30,13 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.StringJoiner;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCannedPolicy;
 import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCustomPolicy;
@@ -334,39 +338,56 @@ class CloudFrontUtilitiesTest {
         assertThat(cookiesForCustomPolicy.keyPairIdHeaderValue()).isEqualTo("CloudFront-Key-Pair-Id=keyPairId");
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_policyResourceUrlShouldOverwriteResourceUrl() {
+    @ParameterizedTest
+    @MethodSource("provideUrlPatternsAndExpectedResources")
+    void getSignedURLWithCustomPolicy_policyResourceUrlShouldHandleVariousPatterns(
+        String resourceUrlPattern, String expectedResource) {
         String baseUrl = "https://d1234.cloudfront.net/images/photo.jpg";
         Instant expiration = Instant.now().plusSeconds(3600);
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(baseUrl)
                                                          .privateKey(keyPair.getPrivate())
                                                          .keyPairId("keyPairId")
-                                                         .resourceUrlPattern("*")
+                                                         .resourceUrlPattern(resourceUrlPattern)
                                                          .expirationDate(expiration)
                                                          .build();
 
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
 
+        // Extract and decode the policy
         String encodedPolicy = signedUrl.url().split("Policy=")[1].split("&")[0];
-        // Replace URL-safe characters back to standard Base64
         String standardBase64 = encodedPolicy
             .replace('-', '+')
             .replace('_', '=')
             .replace('~', '/');
         String decodedPolicy = new String(Base64.getDecoder().decode(standardBase64), UTF_8);
+
+        // Build expected policy
         StringBuilder expectedPolicy = new StringBuilder();
         StringJoiner conditions = new StringJoiner(",", "{", "}");
-
         conditions.add("\"DateLessThan\":{\"AWS:EpochTime\":" + expiration.getEpochSecond() + "}");
 
-
         expectedPolicy.append("{\"Statement\": [{")
-              .append("\"Resource\":\"").append("*").append("\",")
-              .append("\"Condition\":").append(conditions)
-              .append("}]}");
+                      .append("\"Resource\":\"").append(expectedResource).append("\",")
+                      .append("\"Condition\":").append(conditions)
+                      .append("}]}");
 
         assertThat(decodedPolicy.trim()).isEqualTo(expectedPolicy.toString().trim());
+    }
+
+
+    private static Stream<Arguments> provideUrlPatternsAndExpectedResources() {
+        return Stream.of(
+            Arguments.of("*", "*"),
+            Arguments.of("https://d1234.cloudfront.net/*", "https://d1234.cloudfront.net/*"),
+            Arguments.of("https://d1234.cloudfront.net/images/*", "https://d1234.cloudfront.net/images/*"),
+            Arguments.of("https://d1234.cloudfront.net/*/photo.jpg", "https://d1234.cloudfront.net/*/photo.jpg"),
+            Arguments.of("https://d1234.cloudfront.net/images/photo+with-plus.jpg",
+                         "https://d1234.cloudfront.net/images/photo+with-plus.jpg"),
+            Arguments.of("https://d1234.cloudfront.net/images/photo?param=value",
+                         "https://d1234.cloudfront.net/images/photo?param=value"),
+            Arguments.of("https://d1234.cloudfront.net/images/photo-ümlaut.jpg",
+                         "https://d1234.cloudfront.net/images/photo-ümlaut.jpg"));
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixes #5577 where users cannot specify a wildcard (*) resource URL policy separate from the actual URL to be signed
Current implementation couples the resource URL for both signing and policy specification
This change allows for more flexible URL signing scenarios.

## Modifications
Added new `resourceUrlPattern` field to `CustomSignerRequest`
Updated `CloudFrontUtilities.getSignedUrlWithCustomPolicy` to use resourceUrlPattern when specified


## Testing
Added a unit test to verify `resourceUrlPattern` applies the correct logic to the policy.
Added integration tests to verify real-world scenarios: (Passing on intg test acct ✅ )
- Testing with query parameters
- Testing with wildcard paths
- Testing with full wildcard policy
