### PR TITLE
Avoid calling ContentStreamProvider#newStream when content length is …

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-535d16a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-535d16a.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Remove unnecessary invocation of `ContentStreamProvider#newStream` when content-length is known for requests that use AWS chunked encoding."
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/AwsChunkedV4aPayloadSigner.java
@@ -108,7 +108,7 @@ public final class AwsChunkedV4aPayloadSigner implements V4aPayloadSigner {
     @Override
     public void beforeSigning(SdkHttpRequest.Builder request, ContentStreamProvider payload, String checksum) {
         long encodedContentLength = 0;
-        long contentLength = moveContentLength(request, payload != null ? payload.newStream() : new StringInputStream(""));
+        long contentLength = moveContentLength(request, payload);
         setupPreExistingTrailers(request);
 
         // pre-existing trailers

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
@@ -47,7 +47,6 @@ import software.amazon.awssdk.http.auth.aws.internal.signer.io.ChecksumInputStre
 import software.amazon.awssdk.http.auth.aws.internal.signer.io.ResettableContentStreamProvider;
 import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.Pair;
-import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -124,7 +123,7 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
     @Override
     public void beforeSigning(SdkHttpRequest.Builder request, ContentStreamProvider payload) {
         long encodedContentLength = 0;
-        long contentLength = moveContentLength(request, payload != null ? payload.newStream() : new StringInputStream(""));
+        long contentLength = moveContentLength(request, payload);
         setupPreExistingTrailers(request);
 
         // pre-existing trailers

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtilsTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.signer.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_DECODED_CONTENT_LENGTH;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+public class SignerUtilsTest {
+
+    @Test
+    void moveContentLength_decodedContentLengthPresent_shouldNotInvokeNewStream() {
+        SdkHttpRequest.Builder request = SdkHttpRequest.builder()
+            .appendHeader(X_AMZ_DECODED_CONTENT_LENGTH, "10")
+            .appendHeader(CONTENT_LENGTH, "10");
+
+        ContentStreamProvider streamProvider = Mockito.mock(ContentStreamProvider.class);
+        long contentLength = SignerUtils.moveContentLength(request, streamProvider);
+        Mockito.verify(streamProvider, Mockito.never()).newStream();
+        assertThat(contentLength).isEqualTo(10L);
+        assertThat(request.firstMatchingHeader(CONTENT_LENGTH)).isEmpty();
+        assertThat(request.firstMatchingHeader(X_AMZ_DECODED_CONTENT_LENGTH)).contains("10");
+    }
+
+    @Test
+    void moveContentLength_contentLengthPresent_shouldNotInvokeNewStream() {
+        SdkHttpRequest.Builder request = SdkHttpRequest.builder()
+                                                       .appendHeader(CONTENT_LENGTH, "10");
+
+        ContentStreamProvider streamProvider = Mockito.mock(ContentStreamProvider.class);
+        long contentLength = SignerUtils.moveContentLength(request, streamProvider);
+        Mockito.verify(streamProvider, Mockito.never()).newStream();
+        assertThat(contentLength).isEqualTo(10L);
+        assertThat(request.firstMatchingHeader(CONTENT_LENGTH)).isEmpty();
+        assertThat(request.firstMatchingHeader(X_AMZ_DECODED_CONTENT_LENGTH)).contains("10");
+    }
+
+    public static Stream<Arguments> streams() {
+        return Stream.of(Arguments.of(new ByteArrayInputStream("hello".getBytes()), 5),
+                         Arguments.of(null, 0));
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("streams")
+    void moveContentLength_contentLengthNotPresent_shouldInvokeNewStream(InputStream inputStream, long expectedLength) {
+        SdkHttpRequest.Builder request = SdkHttpRequest.builder();
+
+        ContentStreamProvider streamProvider = Mockito.mock(ContentStreamProvider.class);
+        Mockito.when(streamProvider.newStream()).thenReturn(inputStream);
+
+        long contentLength = SignerUtils.moveContentLength(request, streamProvider);
+        Mockito.verify(streamProvider, Mockito.times(1)).newStream();
+        assertThat(contentLength).isEqualTo(expectedLength);
+        assertThat(request.firstMatchingHeader(CONTENT_LENGTH)).isEmpty();
+        assertThat(request.firstMatchingHeader(X_AMZ_DECODED_CONTENT_LENGTH)).contains(String.valueOf(expectedLength));
+    }
+}


### PR DESCRIPTION
…known

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
For requests that use AWS chunked encoding such as S3 putObject requests, currently we always invoke `ContentStreamProvider#newStream` in `moveContentLength` method where we'd buffer the content if content-length is not provided. `newStream` may be expensive in some implementations, and we don't really need to call `newStream()` if content-length is known.

#5859 

## Modifications
 
Remove `ContentStreamProvider#newStream` method call if content-length is known

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
