### PR TITLE
Renamed API name `sigv4aRegionSet` to `sigv4aSigningRegionSet` to be conssistent with Environment variable and System Property name for this option

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeInterceptorSpec.java
@@ -159,7 +159,7 @@ public final class AuthSchemeInterceptorSpec implements ClassSpec {
                                      AwsExecutionAttribute.class);
                 builder.addStatement("builder.region(region)");
             }
-            generateSigv4aRegionSet(builder);
+            generateSigv4aSigningRegionSet(builder);
             builder.addStatement("return builder.build()");
             return builder.build();
         }
@@ -186,7 +186,7 @@ public final class AuthSchemeInterceptorSpec implements ClassSpec {
                                  AwsExecutionAttribute.class);
             builder.addStatement("builder.region(region)");
         }
-        generateSigv4aRegionSet(builder);
+        generateSigv4aSigningRegionSet(builder);
         ClassName paramsBuilderClass = authSchemeSpecUtils.parametersEndpointAwareDefaultImplName().nestedClass("Builder");
         builder.beginControlFlow("if (builder instanceof $T)",
                                  paramsBuilderClass);
@@ -450,7 +450,7 @@ public final class AuthSchemeInterceptorSpec implements ClassSpec {
         return result;
     }
 
-    private void generateSigv4aRegionSet(MethodSpec.Builder builder) {
+    private void generateSigv4aSigningRegionSet(MethodSpec.Builder builder) {
         if (authSchemeSpecUtils.hasSigV4aSupport()) {
             builder.addStatement(
                 "executionAttributes.getOptionalAttribute($T.AWS_SIGV4A_SIGNING_REGION_SET)\n" +

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/EndpointBasedAuthSchemeProviderSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/EndpointBasedAuthSchemeProviderSpec.java
@@ -224,8 +224,6 @@ public class EndpointBasedAuthSchemeProviderSpec implements ClassSpec {
                           ".filter(set -> !$3T.isNullOrEmpty(set)).map($1T::create).orElse(null))",
                           RegionSet.class, Optional.class, CollectionUtils.class);
 
-
-
         CodeBlock.Builder block = CodeBlock.builder();
         block.add("$1T.builder().schemeId($2T.SCHEME_ID)", AuthSchemeOption.class,
                   AwsV4aAuthScheme.class)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -821,8 +821,8 @@ public class BaseClientBuilderClass implements ClassSpec {
                          .addModifiers(Modifier.PUBLIC)
                          .returns(TypeVariableName.get("B"))
                          .addParameter(RegionSet.class, "sigv4aSigningRegionSet")
-                         .addStatement("clientConfiguration.option($T.AWS_SIGV4A_SIGNING_REGION_SET, sigv4aSigningRegionSet == null ? "
-                                       + "$T.emptySet() : sigv4aSigningRegionSet.asSet())",
+                         .addStatement("clientConfiguration.option($T.AWS_SIGV4A_SIGNING_REGION_SET, "
+                                       + "sigv4aSigningRegionSet == null ? $T.emptySet() : sigv4aSigningRegionSet.asSet())",
                                        AwsClientOption.class, Collections.class)
                          .addStatement("return thisBuilder()")
                          .build();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -216,7 +216,7 @@ public class BaseClientBuilderClass implements ClassSpec {
         builder.addMethod(validateClientOptionsMethod());
 
         if (authSchemeSpecUtils.hasSigV4aSupport()) {
-            builder.addMethod(sigv4aRegionSetMethod());
+            builder.addMethod(sigv4aSigningRegionSetMethod());
         }
 
         return builder.build();
@@ -816,13 +816,13 @@ public class BaseClientBuilderClass implements ClassSpec {
                          .build();
     }
 
-    private MethodSpec sigv4aRegionSetMethod() {
-        return MethodSpec.methodBuilder("sigv4aRegionSet")
+    private MethodSpec sigv4aSigningRegionSetMethod() {
+        return MethodSpec.methodBuilder("sigv4aSigningRegionSet")
                          .addModifiers(Modifier.PUBLIC)
                          .returns(TypeVariableName.get("B"))
-                         .addParameter(RegionSet.class, "sigv4aRegionSet")
-                         .addStatement("clientConfiguration.option($T.AWS_SIGV4A_SIGNING_REGION_SET, sigv4aRegionSet == null ? "
-                                       + "$T.emptySet() : sigv4aRegionSet.asSet())",
+                         .addParameter(RegionSet.class, "sigv4aSigningRegionSet")
+                         .addStatement("clientConfiguration.option($T.AWS_SIGV4A_SIGNING_REGION_SET, sigv4aSigningRegionSet == null ? "
+                                       + "$T.emptySet() : sigv4aSigningRegionSet.asSet())",
                                        AwsClientOption.class, Collections.class)
                          .addStatement("return thisBuilder()")
                          .build();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
@@ -119,7 +119,7 @@ public class BaseClientBuilderInterface implements ClassSpec {
         }
 
         if (authSchemeSpecUtils.hasSigV4aSupport()) {
-            builder.addMethod(sigv4aRegionSetMethod());
+            builder.addMethod(sigv4aSigningRegionSetMethod());
         }
 
         return builder.build();
@@ -292,10 +292,10 @@ public class BaseClientBuilderInterface implements ClassSpec {
                && !model.getCustomizationConfig().getCustomClientContextParams().isEmpty();
     }
 
-    private MethodSpec sigv4aRegionSetMethod() {
-        return MethodSpec.methodBuilder("sigv4aRegionSet")
+    private MethodSpec sigv4aSigningRegionSetMethod() {
+        return MethodSpec.methodBuilder("sigv4aSigningRegionSet")
                          .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
-                         .addParameter(RegionSet.class, "sigv4aRegionSet")
+                         .addParameter(RegionSet.class, "sigv4aSigningRegionSet")
                          .addJavadoc("Sets the {@link $T} to be used for operations using Sigv4a signing requests.\n" +
                                      "This is optional; if not provided, the following precedence is used:\n" +
                                      "<ol>\n" +

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-client-builder-endpoints-auth-params.java
@@ -278,9 +278,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                          "The 'tokenProvider' must be configured in the client builder.");
     }
 
-    public B sigv4aRegionSet(RegionSet sigv4aRegionSet) {
+    public B sigv4aSigningRegionSet(RegionSet sigv4aSigningRegionSet) {
         clientConfiguration.option(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET,
-                                   sigv4aRegionSet == null ? Collections.emptySet() : sigv4aRegionSet.asSet());
+                                   sigv4aSigningRegionSet == null ? Collections.emptySet() : sigv4aSigningRegionSet.asSet());
         return thisBuilder();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-multi-auth-sigv4a-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/sra/test-multi-auth-sigv4a-client-builder-class.java
@@ -189,9 +189,9 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
     protected static void validateClientOptions(SdkClientConfiguration c) {
     }
 
-    public B sigv4aRegionSet(RegionSet sigv4aRegionSet) {
+    public B sigv4aSigningRegionSet(RegionSet sigv4aSigningRegionSet) {
         clientConfiguration.option(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET,
-                                   sigv4aRegionSet == null ? Collections.emptySet() : sigv4aRegionSet.asSet());
+                                   sigv4aSigningRegionSet == null ? Collections.emptySet() : sigv4aSigningRegionSet.asSet());
         return thisBuilder();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -253,9 +253,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                          "The 'tokenProvider' must be configured in the client builder.");
     }
 
-    public B sigv4aRegionSet(RegionSet sigv4aRegionSet) {
+    public B sigv4aSigningRegionSet(RegionSet sigv4aSigningRegionSet) {
         clientConfiguration.option(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET,
-                                   sigv4aRegionSet == null ? Collections.emptySet() : sigv4aRegionSet.asSet());
+                                   sigv4aSigningRegionSet == null ? Collections.emptySet() : sigv4aSigningRegionSet.asSet());
         return thisBuilder();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-interface.java
@@ -39,7 +39,7 @@ public interface DatabaseBaseClientBuilder<B extends DatabaseBaseClientBuilder<B
      * <li>The region configured for the client.</li>
      * </ol>
      */
-    default B sigv4aRegionSet(RegionSet sigv4aRegionSet) {
+    default B sigv4aSigningRegionSet(RegionSet sigv4aSigningRegionSet) {
         throw new UnsupportedOperationException();
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -196,7 +196,7 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                             .applyMutation(this::configureRetryPolicy)
                             .applyMutation(this::configureRetryStrategy)
                             .lazyOptionIfAbsent(SdkClientOption.IDENTITY_PROVIDERS, this::resolveIdentityProviders)
-                            .lazyOptionIfAbsent(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET, this::resolveSigv4aRegionSet)
+                            .lazyOptionIfAbsent(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET, this::resolveSigv4aSigningRegionSet)
                             .build();
     }
 
@@ -387,7 +387,7 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                                        .orElse(null);
     }
 
-    private Set<String> resolveSigv4aRegionSet(LazyValueSource config) {
+    private Set<String> resolveSigv4aSigningRegionSet(LazyValueSource config) {
         Supplier<ProfileFile> profileFile = config.get(SdkClientOption.PROFILE_FILE_SUPPLIER);
         String profileName = config.get(SdkClientOption.PROFILE_NAME);
         return Sigv4aSigningRegionSetProvider.builder()

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -196,7 +196,8 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                             .applyMutation(this::configureRetryPolicy)
                             .applyMutation(this::configureRetryStrategy)
                             .lazyOptionIfAbsent(SdkClientOption.IDENTITY_PROVIDERS, this::resolveIdentityProviders)
-                            .lazyOptionIfAbsent(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET, this::resolveSigv4aSigningRegionSet)
+                            .lazyOptionIfAbsent(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET,
+                                                this::resolveSigv4aSigningRegionSet)
                             .build();
     }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/auth/Sigv4aSigningRegionSetTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/auth/Sigv4aSigningRegionSetTest.java
@@ -150,7 +150,7 @@ class Sigv4aSigningRegionSetTest {
                 "us-west-4",
                 "us-west-5",
                 setOf("*"),
-                "sigv4aRegionSet set to GLOBAL value, takes highest precedence")),
+                "sigv4aSigningRegionSet set to GLOBAL value, takes highest precedence")),
 
             Arguments.of(new SuccessCase(
                 RegionSet.create("us-west-3"),
@@ -158,7 +158,7 @@ class Sigv4aSigningRegionSetTest {
                 "us-west-4",
                 "us-west-5",
                 setOf("us-west-3"),
-                "sigv4aRegionSet set to different value, takes highest precedence"))
+                "sigv4aSigningRegionSet set to different value, takes highest precedence"))
         );
     }
 
@@ -182,7 +182,7 @@ class Sigv4aSigningRegionSetTest {
                                .region(Region.US_WEST_2)
                                .credentialsProvider(AnonymousCredentialsProvider.create());
             if (testCase.regionSet != null) {
-                builder.sigv4aRegionSet(testCase.regionSet);
+                builder.sigv4aSigningRegionSet(testCase.regionSet);
             }
             if (testCase.systemPropSetting != null) {
                 System.setProperty(SdkSystemSetting.AWS_SIGV4A_SIGNING_REGION_SET.property(), testCase.systemPropSetting);

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/multiauth/MultiAuthSigningPropertiesTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/multiauth/MultiAuthSigningPropertiesTest.java
@@ -133,7 +133,7 @@ class MultiAuthSigningPropertiesTest {
                                                     .httpClient(mockHttpClient)
                                                     .region(Region.US_WEST_2)
                                                     .putAuthScheme(authScheme("aws.auth#sigv4a", signer))
-                                                    .sigv4aRegionSet(RegionSet.create(new StringJoiner(",")
+                                                    .sigv4aSigningRegionSet(RegionSet.create(new StringJoiner(",")
                                                                                           .add(Region.US_WEST_2.id())
                                                                                           .add(Region.US_GOV_EAST_1.id())
                                                                                           .toString()))


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
After internal surface api review we decided to change `sigv4aRegionSet` to `sigv4aSigningRegionSet` to be consistent with environment variable  and configuration file property  as mentioned below in specs
```
This configuration must also be supported as an environment variable called AWS_SIGV4A_SIGNING_REGION_SET and as a configuration file property called sigv4a_signing_region_set
```

## Modifications
<!--- Describe your changes in detail -->
- renamed  sigv4aRegionSet to sigv4aSigningRegionSet

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
