### PR TITLE
Add support for ML-KEM in Post-Quantum TLS Config

### DIFF
--- a/.changes/next-release/feature-AWSCRTHTTPClient-7ff47eb.json
+++ b/.changes/next-release/feature-AWSCRTHTTPClient-7ff47eb.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS CRT HTTP Client",
+    "contributor": "alexw91",
+    "description": "Add support for ML-KEM in Post-Quantum TLS Config"
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
@@ -58,7 +58,6 @@ public final class AwsCrtConfigurationUtils {
             return defaultTls;
         }
 
-        // TODO: change this to the new PQ TLS Policy that stays up to date when it's ready
         TlsCipherPreference pqTls = TlsCipherPreference.TLS_CIPHER_PQ_DEFAULT;
         if (!pqTls.isSupported()) {
             log.warn(() -> "Hybrid post-quantum cipher suites are not supported on this platform. The SDK will use the system "

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
@@ -59,7 +59,7 @@ public final class AwsCrtConfigurationUtils {
         }
 
         // TODO: change this to the new PQ TLS Policy that stays up to date when it's ready
-        TlsCipherPreference pqTls = TlsCipherPreference.TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05;
+        TlsCipherPreference pqTls = TlsCipherPreference.TLS_CIPHER_PQ_DEFAULT;
         if (!pqTls.isSupported()) {
             log.warn(() -> "Hybrid post-quantum cipher suites are not supported on this platform. The SDK will use the system "
                            + "default cipher suites instead");

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtilsTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtilsTest.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.http.crt.internal;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static software.amazon.awssdk.crt.io.TlsCipherPreference.TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05;
+import static software.amazon.awssdk.crt.io.TlsCipherPreference.TLS_CIPHER_PQ_DEFAULT;
 import static software.amazon.awssdk.crt.io.TlsCipherPreference.TLS_CIPHER_SYSTEM_DEFAULT;
 
 import java.time.Duration;
@@ -43,14 +43,14 @@ class AwsCrtConfigurationUtilsTest {
     @MethodSource("cipherPreferences")
     void resolveCipherPreference_pqNotSupported_shouldFallbackToSystemDefault(Boolean preferPqTls,
                                                                               TlsCipherPreference tlsCipherPreference) {
-        Assumptions.assumeFalse(TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05.isSupported());
+        Assumptions.assumeFalse(TLS_CIPHER_PQ_DEFAULT.isSupported());
         assertThat(AwsCrtConfigurationUtils.resolveCipherPreference(preferPqTls)).isEqualTo(tlsCipherPreference);
     }
 
     @Test
     void resolveCipherPreference_pqSupported_shouldHonor() {
-        Assumptions.assumeTrue(TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05.isSupported());
-        assertThat(AwsCrtConfigurationUtils.resolveCipherPreference(true)).isEqualTo(TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05);
+        Assumptions.assumeTrue(TLS_CIPHER_PQ_DEFAULT.isSupported());
+        assertThat(AwsCrtConfigurationUtils.resolveCipherPreference(true)).isEqualTo(TLS_CIPHER_PQ_DEFAULT);
     }
 
     private static Stream<Arguments> cipherPreferences() {

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.17.1</commons-codec.verion>
         <jmh.version>1.37</jmh.version>
-        <awscrt.version>0.33.9</awscrt.version>
+        <awscrt.version>0.34.1</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.10.0</junit5.version>


### PR DESCRIPTION
## Motivation and Context
This change updates the default Post Quantum TLS policy in the AWS Common Runtime HTTP SDK Client. This new TLS policy adds support for `X25519MLKEM768` Hybrid Post-Quantum TLS key exchange algorithm. Support for older draft hybrid algorithms that use Kyber are still kept, but at lower priority. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
Updates the default Post Quantum TLS policy in the AWS Common Runtime HTTP SDK Client to the new policy added in https://github.com/awslabs/aws-crt-java/pull/865. The effect of this update is to add X25519MLKEM768 to the top of the TLS SupportedGroups preference list. All other TLS SupportedGroups are kept. Older draft PQ algorithms will be removed in a later PR.

## Testing
Unit tests, CI tests, manual s2n-tls PQ tests against AWS TLS endpoints. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
