### PR TITLE
Fixed an issue in AWS CRT-based S3 client where checksums are not cal…

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTbasedS3Client-5465b9d.json
+++ b/.changes/next-release/bugfix-AWSCRTbasedS3Client-5465b9d.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT-based S3 Client",
+    "contributor": "",
+    "description": "Fixed an issue in AWS CRT-based S3 client where checksums are not calculated for operations that require checksums when RequestChecksumCalculation.WHEN_REQUIRED is configured, resulting error."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtils.java
@@ -78,7 +78,8 @@ public final class CrtChecksumUtils {
                                                           RequestChecksumCalculation requestChecksumCalculation) {
 
         if (httpChecksum.requestAlgorithm() == null) {
-            if (requestChecksumCalculation == RequestChecksumCalculation.WHEN_REQUIRED) {
+            if (!httpChecksum.isRequestChecksumRequired() &&
+                requestChecksumCalculation == RequestChecksumCalculation.WHEN_REQUIRED) {
                 return ChecksumAlgorithm.NONE;
             }
             return DEFAULT_CHECKSUM_ALGO;

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/crt/S3CrtChecksumTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/crt/S3CrtChecksumTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.crt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.AnythingPattern;
+import java.io.IOException;
+import java.net.URI;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.HttpChecksumConstant;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.DefaultRetention;
+import software.amazon.awssdk.services.s3.model.ObjectLockConfiguration;
+import software.amazon.awssdk.services.s3.model.ObjectLockEnabled;
+import software.amazon.awssdk.services.s3.model.ObjectLockRetentionMode;
+import software.amazon.awssdk.services.s3.model.ObjectLockRule;
+import software.amazon.awssdk.services.s3.model.PutObjectLockConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@WireMockTest
+@Timeout(10)
+public class S3CrtChecksumTest {
+
+    private S3CrtAsyncClientBuilder initializeAsync(WireMockRuntimeInfo wiremock,
+                                                    RequestChecksumCalculation calculation) {
+        return S3AsyncClient.crtBuilder()
+                            .credentialsProvider(AnonymousCredentialsProvider.create())
+                            .requestChecksumCalculation(calculation)
+                            .endpointOverride(URI.create("http://localhost:" + wiremock.getHttpPort()))
+                            .forcePathStyle(true)
+                            .region(Region.US_WEST_2);
+    }
+
+    private S3CrtAsyncClientBuilder initializeAsync(WireMockRuntimeInfo wiremock,
+                                                    ResponseChecksumValidation responseChecksumValidation) {
+        return S3AsyncClient.crtBuilder()
+                            .credentialsProvider(AnonymousCredentialsProvider.create())
+                            .responseChecksumValidation(responseChecksumValidation)
+                            .endpointOverride(URI.create("http://localhost:" + wiremock.getHttpPort()))
+                            .forcePathStyle(true)
+                            .region(Region.US_WEST_2);
+    }
+
+    @BeforeEach
+    public void setup() throws IOException {
+        stubFor(put(anyUrl()).willReturn(WireMock.aResponse().withStatus(200)));
+
+    }
+
+    public static Stream<Arguments> streamingInputChecksumCalculationParams() {
+        return Stream.of(Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, null, "x-amz-checksum-crc32",
+                                      "requestChecksumWhenSupported_checksumAlgorithmNotProvided_shouldAddCrc32ChecksumTrailerByDefault"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, ChecksumAlgorithm.SHA1,
+                                      "x-amz-checksum-sha1",
+                                      "requestChecksumWhenSupported_checksumAlgorithmProvided_shouldHonor"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, null, null,
+                                      "requestChecksumWhenRequired_checksumAlgorithmNotProvided_shouldNotAddChecksum"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, ChecksumAlgorithm.CRC32_C,
+                                      "x-amz-checksum-crc32c",
+                                      "requestChecksumWhenRequired_checksumAlgorithmProvided_shouldAddChecksumTrailer"));
+    }
+
+    public static Stream<Arguments> checksumInHeaderRequiredParams() {
+        return Stream.of(Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, null, "x-amz-checksum-crc32", "Rs0ofQ==",
+                                      "requestChecksumWhenSupported_checksumAlgorithmNotProvided_shouldAddCrc32ChecksumTrailerByDefault"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, ChecksumAlgorithm.SHA1,
+                                      "x-amz-checksum-sha1", "4wnI4cDeFPttl6wSYksrgmk41qk=",
+                                      "requestChecksumWhenSupported_checksumAlgorithmProvided_shouldHonor"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, null, "x-amz-checksum-crc32", "Rs0ofQ==",
+                                      "requestChecksumWhenRequired_checksumAlgorithmNotProvided_shouldAddChecksum"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, ChecksumAlgorithm.CRC32_C,
+                                      "x-amz-checksum-crc32c", "Zx3Wjw==",
+                                      "requestChecksumWhenRequired_checksumAlgorithmProvided_shouldAddChecksum"));
+    }
+
+
+    @ParameterizedTest(name = "{index} {3}")
+    @MethodSource("streamingInputChecksumCalculationParams")
+    public void streamingInput_checksumCalculation(RequestChecksumCalculation requestChecksumCalculation,
+                                                   ChecksumAlgorithm checksumAlgorithm,
+                                                   String expectedTrailer,
+                                                   String description,
+                                                   WireMockRuntimeInfo wiremock) {
+
+        try (S3AsyncClient client = initializeAsync(wiremock, requestChecksumCalculation).build()) {
+            client.putObject(PutObjectRequest.builder()
+                                             .bucket("bucket").key("key")
+                                             .checksumAlgorithm(checksumAlgorithm)
+                                             .build(),
+                             AsyncRequestBody.fromString("Hello world")).join();
+
+            validateChecksumTrailerHeader(expectedTrailer, wiremock);
+        }
+    }
+
+    @ParameterizedTest(name = "{index} {4}")
+    @MethodSource("checksumInHeaderRequiredParams")
+    public void checksumInHeaderRequired_checksumCalculation(RequestChecksumCalculation requestChecksumCalculation,
+                                                             ChecksumAlgorithm checksumAlgorithm,
+                                                             String expectedChecksumHeader,
+                                                             String expectedChecksumValue,
+                                                             String description,
+                                                             WireMockRuntimeInfo wiremock) {
+
+        try (S3AsyncClient client = initializeAsync(wiremock, requestChecksumCalculation).build()) {
+            PutObjectLockConfigurationRequest request =
+                PutObjectLockConfigurationRequest.builder()
+                                                 .bucket("bucket")
+                                                 .checksumAlgorithm(checksumAlgorithm)
+                                                 .objectLockConfiguration(
+                                                     ObjectLockConfiguration.builder()
+                                                                            .objectLockEnabled(ObjectLockEnabled.ENABLED)
+                                                                            .rule(ObjectLockRule.builder()
+                                                                                                .defaultRetention(DefaultRetention.builder().mode(ObjectLockRetentionMode.COMPLIANCE).days(Integer.valueOf(1)).build())
+                                                                                                .build())
+                                                                            .build())
+                                                 .build();
+
+            client.putObjectLockConfiguration(request).join();
+            validateChecksumHeader(expectedChecksumHeader, expectedChecksumValue);
+        }
+    }
+
+    private static void validateChecksumHeader(String expectedChecksumHeader,
+                                               String expectedChecksumValue) {
+        verify(putRequestedFor(anyUrl()).withoutHeader(HttpChecksumConstant.X_AMZ_TRAILER));
+        if (expectedChecksumHeader != null) {
+            verify(putRequestedFor(anyUrl()).withHeader(expectedChecksumHeader, equalTo(expectedChecksumValue)));
+            verify(putRequestedFor(anyUrl()).withHeader("x-amz-sdk-checksum-algorithm", new AnythingPattern()));
+        } else {
+            verify(putRequestedFor(anyUrl()).withoutHeader("x-amz-sdk-checksum-algorithm"));
+        }
+    }
+
+    private static void validateChecksumTrailerHeader(String expectedTrailer,
+                                                      WireMockRuntimeInfo wiremock) {
+
+
+        if (expectedTrailer != null) {
+            verify(putRequestedFor(anyUrl()).withHeader(HttpChecksumConstant.X_AMZ_TRAILER, equalTo(expectedTrailer)));
+            verify(putRequestedFor(anyUrl()).withHeader("x-amz-content-sha256", equalTo("STREAMING-UNSIGNED-PAYLOAD-TRAILER")));
+            verify(putRequestedFor(anyUrl()).withHeader("x-amz-sdk-checksum-algorithm", new AnythingPattern()));
+        } else {
+            verify(putRequestedFor(anyUrl()).withoutHeader(HttpChecksumConstant.X_AMZ_TRAILER));
+            verify(putRequestedFor(anyUrl()).withoutHeader("x-amz-sdk-checksum-algorithm"));
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtilsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtilsTest.java
@@ -37,8 +37,30 @@ class CrtChecksumUtilsTest {
         checksumAlgorithms.add(ChecksumAlgorithm.SHA256);
         checksumAlgorithms.add(ChecksumAlgorithm.SHA1);
         return Stream.of(
-            // DEFAULT request, should set default algorithm CRC32 in header
+            // DEFAULT request, operation w/o checksum required, WHEN_SUPPORTED config, should set default algorithm CRC32 in
+            // header
             Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.DEFAULT,
+                         RequestChecksumCalculation.WHEN_SUPPORTED, ResponseChecksumValidation.WHEN_SUPPORTED,
+                         new ChecksumConfig().withChecksumAlgorithm(ChecksumAlgorithm.CRC32)
+                                             .withChecksumLocation(ChecksumConfig.ChecksumLocation.HEADER)),
+
+            // DEFAULT request, operation w/o checksum required, WHEN_REQUIRED config, should pass empty config
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.DEFAULT,
+                         RequestChecksumCalculation.WHEN_REQUIRED, ResponseChecksumValidation.WHEN_SUPPORTED,
+                         new ChecksumConfig()),
+
+            // DEFAULT request, operation w/ checksum required, WHEN_REQUIRED config, should set default algorithm CRC32 in
+            // header
+            Arguments.of(HttpChecksum.builder().requestChecksumRequired(true).build(),
+                         S3MetaRequestOptions.MetaRequestType.DEFAULT,
+                         RequestChecksumCalculation.WHEN_REQUIRED, ResponseChecksumValidation.WHEN_SUPPORTED,
+                         new ChecksumConfig().withChecksumAlgorithm(ChecksumAlgorithm.CRC32)
+                                             .withChecksumLocation(ChecksumConfig.ChecksumLocation.HEADER)),
+
+            // DEFAULT request, operation w/ checksum required, WHEN_SUPPORTED config, should set default algorithm CRC32 in
+            // header
+            Arguments.of(HttpChecksum.builder().requestChecksumRequired(true).build(),
+                         S3MetaRequestOptions.MetaRequestType.DEFAULT,
                          RequestChecksumCalculation.WHEN_SUPPORTED, ResponseChecksumValidation.WHEN_SUPPORTED,
                          new ChecksumConfig().withChecksumAlgorithm(ChecksumAlgorithm.CRC32)
                                              .withChecksumLocation(ChecksumConfig.ChecksumLocation.HEADER)),


### PR DESCRIPTION
…culated for operations that require checksums when RequestChecksumCalculation.WHEN_REQUIRED is configured, resulting error.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed an issue in AWS CRT-based S3 client where checksums are not calculated for operations that require checksums when `RequestChecksumCalculation.WHEN_REQUIRED` is configured, resulting server error.

## Modifications
The root cause is that we didn't set checksum algorithm for operations where checksums are required.

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
