### PR TITLE
Updated the SDK to calculate checksums for checksum required operatio…

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-b718c3e.json
+++ b/.changes/next-release/bugfix-AmazonS3-b718c3e.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fixed an issue in the S3 client where it skipped checksum calculation for operations that use SigV4a signing and require checksums. See [#5878](https://github.com/aws/aws-sdk-java-v2/issues/5878)."
+}

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
@@ -60,7 +60,7 @@ public final class TestUtils {
                                                      .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
                                                      .build()
                                                      .copy(requestOverrides))
-                          .payload(() -> new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
+                          .payload(() -> new ByteArrayInputStream("Hello world".getBytes()))
                           .putProperty(REGION_SET, RegionSet.create("aws-global"))
                           .putProperty(SERVICE_SIGNING_NAME, "demo")
                           .putProperty(SIGNING_CLOCK, new TickingClock(Instant.ofEpochMilli(1596476903000L)))

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/MultiRegionAccessPointChecksumTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/MultiRegionAccessPointChecksumTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static software.amazon.awssdk.core.HttpChecksumConstant.HTTP_CHECKSUM_HEADER_PREFIX;
+
+import io.reactivex.Flowable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.HttpChecksumConstant;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+public class MultiRegionAccessPointChecksumTest {
+    private static final String MRAP_ARN = "arn:aws:s3::123456789012:accesspoint:test.mrap";
+
+    private SdkHttpClient httpClient;
+    private SdkAsyncHttpClient httpAsyncClient;
+
+    private S3ClientBuilder initializeSync(RequestChecksumCalculation requestChecksumCalculation) {
+        return S3Client.builder()
+                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                       .region(Region.AP_SOUTH_1)
+                       .requestChecksumCalculation(requestChecksumCalculation)
+                       .httpClient(httpClient)
+                       .serviceConfiguration(S3Configuration.builder()
+                                                            .useArnRegionEnabled(true)
+                                                            .build());
+    }
+
+    private S3AsyncClientBuilder initializeAsync(RequestChecksumCalculation requestChecksumCalculation) {
+        return S3AsyncClient.builder()
+                            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                            .region(Region.AP_SOUTH_1)
+                            .requestChecksumCalculation(requestChecksumCalculation)
+                            .httpClient(httpAsyncClient)
+                            .serviceConfiguration(S3Configuration.builder()
+                                                                 .useArnRegionEnabled(true)
+                                                                 .build());
+    }
+
+    @BeforeEach
+    public void setup() throws IOException {
+        httpClient = Mockito.mock(SdkHttpClient.class);
+        httpAsyncClient = Mockito.mock(SdkAsyncHttpClient.class);
+
+        SdkHttpFullResponse successfulHttpResponse = SdkHttpResponse.builder()
+                                                                    .statusCode(200)
+                                                                    .putHeader("Content-Length", "0")
+                                                                    .build();
+
+        ExecutableHttpRequest request = Mockito.mock(ExecutableHttpRequest.class);
+        Mockito.when(request.call()).thenReturn(HttpExecuteResponse.builder()
+                                                                   .response(successfulHttpResponse)
+                                                                   .build());
+        Mockito.when(httpClient.prepareRequest(any())).thenReturn(request);
+
+        Mockito.when(httpAsyncClient.execute(any())).thenAnswer(invocation -> {
+            AsyncExecuteRequest asyncExecuteRequest = invocation.getArgument(0, AsyncExecuteRequest.class);
+            asyncExecuteRequest.responseHandler().onHeaders(successfulHttpResponse);
+            asyncExecuteRequest.responseHandler().onStream(Flowable.empty());
+            return CompletableFuture.completedFuture(null);
+        });
+    }
+
+    public static Stream<Arguments> streamingInputChecksumCalculationParams() {
+        return Stream.of(Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, null, "x-amz-checksum-crc32",
+                                      "requestChecksumWhenSupported_checksumAlgorithmNotProvided_shouldAddCrc32ChecksumTrailerByDefault"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, ChecksumAlgorithm.SHA1,
+                                      "x-amz-checksum-sha1",
+                                      "requestChecksumWhenSupported_checksumAlgorithmProvided_shouldHonor"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, null, null,
+                                      "requestChecksumWhenRequired_checksumAlgorithmNotProvided_shouldNotAddChecksum"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, ChecksumAlgorithm.CRC32_C,
+                                      "x-amz-checksum-crc32c",
+                                      "requestChecksumWhenRequired_checksumAlgorithmProvided_shouldAddChecksumTrailer"));
+    }
+
+    public static Stream<Arguments> checksumInHeaderRequiredParams() {
+        return Stream.of(Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, null, "x-amz-checksum-crc32", "+I+deA==",
+                                      "requestChecksumWhenSupported_checksumAlgorithmNotProvided_shouldAddCrc32ChecksumTrailerByDefault"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_SUPPORTED, ChecksumAlgorithm.SHA1,
+                                      "x-amz-checksum-sha1", "w4KeXNteQEw9UKWqdUCzNDW+8Rc=",
+                                      "requestChecksumWhenSupported_checksumAlgorithmProvided_shouldHonor"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, null, "x-amz-checksum-crc32", "+I+deA==",
+                                      "requestChecksumWhenRequired_checksumAlgorithmNotProvided_shouldAddChecksum"),
+
+                         Arguments.of(RequestChecksumCalculation.WHEN_REQUIRED, ChecksumAlgorithm.CRC32_C,
+                                      "x-amz-checksum-crc32c", "5xfxpQ==",
+                                      "requestChecksumWhenRequired_checksumAlgorithmProvided_shouldAddChecksum"));
+    }
+
+    @ParameterizedTest(name = "{index} {4}")
+    @MethodSource("checksumInHeaderRequiredParams")
+    public void syncChecksumInHeaderRequired_checksumCalculation(RequestChecksumCalculation requestChecksumCalculation,
+                                                                 ChecksumAlgorithm checksumAlgorithm,
+                                                                 String expectedChecksumHeader,
+                                                                 String expectedChecksumValue,
+                                                                 String description) {
+
+        try (S3Client client = initializeSync(requestChecksumCalculation).build()) {
+            client.deleteObjects(getDeleteObjectsRequest(checksumAlgorithm));
+            SdkHttpRequest request = getSyncRequest();
+            validateChecksumHeader(expectedChecksumHeader, expectedChecksumValue, request);
+        }
+    }
+
+    @ParameterizedTest(name = "{index} {4}")
+    @MethodSource("checksumInHeaderRequiredParams")
+    public void asyncChecksumInHeaderRequired_checksumCalculation(RequestChecksumCalculation requestChecksumCalculation,
+                                                                  ChecksumAlgorithm checksumAlgorithm,
+                                                                  String expectedChecksumHeader,
+                                                                  String expectedChecksumValue,
+                                                                  String description) {
+
+        try (S3AsyncClient client = initializeAsync(requestChecksumCalculation).build()) {
+            client.deleteObjects(getDeleteObjectsRequest(checksumAlgorithm)).join();
+            SdkHttpRequest request = getAsyncRequest();
+            validateChecksumHeader(expectedChecksumHeader, expectedChecksumValue, request);
+        }
+    }
+
+    @ParameterizedTest(name = "{index} {3}")
+    @MethodSource("streamingInputChecksumCalculationParams")
+    public void syncStreamingInput_checksumCalculation(RequestChecksumCalculation requestChecksumCalculation,
+                                                       ChecksumAlgorithm checksumAlgorithm,
+                                                       String expectedTrailer,
+                                                       String description) {
+
+        try (S3Client client = initializeSync(requestChecksumCalculation).build()) {
+            client.putObject(PutObjectRequest.builder().bucket(MRAP_ARN).key("key")
+                                             .checksumAlgorithm(checksumAlgorithm)
+                                             .build(),
+                             RequestBody.fromString("Hello world"));
+
+            SdkHttpRequest request = getSyncRequest();
+            validateChecksumTrailerHeader(expectedTrailer, request);
+        }
+    }
+
+    private static DeleteObjectsRequest getDeleteObjectsRequest(ChecksumAlgorithm checksumAlgorithm) {
+        return DeleteObjectsRequest.builder()
+                                   .bucket(MRAP_ARN)
+                                   .delete(Delete.builder()
+                                                 .objects(ObjectIdentifier.builder()
+                                                                          .key("test")
+                                                                          .build()).build())
+                                   .checksumAlgorithm(checksumAlgorithm)
+                                   .build();
+    }
+
+    private SdkHttpRequest getSyncRequest() {
+        ArgumentCaptor<HttpExecuteRequest> captor = ArgumentCaptor.forClass(HttpExecuteRequest.class);
+        Mockito.verify(httpClient).prepareRequest(captor.capture());
+        return captor.getValue().httpRequest();
+    }
+
+    private SdkHttpRequest getAsyncRequest() {
+        ArgumentCaptor<AsyncExecuteRequest> captor = ArgumentCaptor.forClass(AsyncExecuteRequest.class);
+        Mockito.verify(httpAsyncClient).execute(captor.capture());
+        return captor.getValue().request();
+    }
+
+    private static void validateChecksumHeader(String expectedChecksumHeader,
+                                               String expectedChecksumValue,
+                                               SdkHttpRequest request) {
+        assertThat(request.firstMatchingHeader(HttpChecksumConstant.X_AMZ_TRAILER)).isEmpty();
+        List<String> checksumHeaders = request.headers()
+                                              .keySet()
+                                              .stream()
+                                              .filter(header -> header.contains(HTTP_CHECKSUM_HEADER_PREFIX) && !header.equals(
+                                                  "x-amz-checksum-algorithm"))
+                                              .collect(Collectors.toList());
+
+        if (expectedChecksumHeader != null) {
+            assertThat(checksumHeaders).containsExactly(expectedChecksumHeader);
+            assertThat(request.firstMatchingHeader(expectedChecksumHeader)).contains(expectedChecksumValue);
+            assertThat(request.firstMatchingHeader("x-amz-sdk-checksum-algorithm")).isNotEmpty();
+        } else {
+            assertThat(checksumHeaders).isEmpty();
+            assertThat(request.firstMatchingHeader("x-amz-sdk-checksum-algorithm")).isEmpty();
+        }
+    }
+
+    private static void validateChecksumTrailerHeader(String expectedTrailer, SdkHttpRequest request) {
+        if (expectedTrailer != null) {
+            assertThat(request.firstMatchingHeader(HttpChecksumConstant.X_AMZ_TRAILER)).contains(expectedTrailer);
+            assertThat(request.firstMatchingHeader("x-amz-sdk-checksum-algorithm")).isNotEmpty();
+            assertThat(request.firstMatchingHeader("x-amz-content-sha256")).contains("STREAMING-UNSIGNED-PAYLOAD-TRAILER");
+        } else {
+            assertThat(request.firstMatchingHeader(HttpChecksumConstant.X_AMZ_TRAILER)).isEmpty();
+            assertThat(request.firstMatchingHeader("x-amz-sdk-checksum-algorithm")).isEmpty();
+        }
+    }
+
+
+}


### PR DESCRIPTION
…ns that require sigV4a signer

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
#5878 
Fixed the issue where the SDK skipped checksum calculation for operations that require checksum and use SigV4a scheme

## Modifications

The root cause is that  [DefaultAwsCrtV4aHttpSigner](https://github.com/aws/aws-sdk-java-v2/blob/master/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java#L63) did not add checksum header, similar to what [AwsV4HttpSigner](https://github.com/aws/aws-sdk-java-v2/blob/master/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java#L61) does. It had been relying on the SDK core to calculate the legacy content-md5 checksum for those operations,  and as part of the checksums by default feature, we removed the legacy md5 calculation and thus no checksum was added. 

We may consider moving checksum header logic back to the core so that we decouple checksum from signing logic in the future

## Testing
Added tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
