### PR TITLE
Migration tool skip transforming non-SDK libraries

### DIFF
--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtils.java
@@ -136,8 +136,16 @@ public final class SdkTypeUtils {
                       "com.amazonaws.services.s3.model.PresignedUrlDownloadConfig",
                       "com.amazonaws.services.s3.model.PresignedUrlUploadRequest",
                       "com.amazonaws.services.s3.model.PresignedUrlUploadResult",
-                      // non-SDK library, aws-lambda-java-core
-                      "com.amazonaws.services.lambda.runtime"
+                      // non-SDK libraries
+                      // Lambda Runtime : aws-lambda-java-core
+                      "com.amazonaws.services.lambda.runtime",
+                      // Kinesis Client Library (KCL) : amazon-kinesis-client
+                      "com.amazonaws.services.kinesis.clientlibrary",
+                      "com.amazonaws.services.kinesis.leases",
+                      "com.amazonaws.services.kinesis.metrics",
+                      "com.amazonaws.services.kinesis.multilang",
+                      // Kinesis Producer Library (KCL) : amazon-kinesis-producer
+                      "com.amazonaws.services.kinesis.producer"
         ));
 
     static {

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtils.java
@@ -135,7 +135,9 @@ public final class SdkTypeUtils {
                       "com.amazonaws.services.s3.model.PresignedUrlDownloadResult",
                       "com.amazonaws.services.s3.model.PresignedUrlDownloadConfig",
                       "com.amazonaws.services.s3.model.PresignedUrlUploadRequest",
-                      "com.amazonaws.services.s3.model.PresignedUrlUploadResult"
+                      "com.amazonaws.services.s3.model.PresignedUrlUploadResult",
+                      // non-SDK library, aws-lambda-java-core
+                      "com.amazonaws.services.lambda.runtime"
         ));
 
     static {

--- a/v2-migration/src/test/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtilsTest.java
+++ b/v2-migration/src/test/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtilsTest.java
@@ -137,7 +137,8 @@ public class SdkTypeUtilsTest {
                          Arguments.of("s3PresignedUrlDownloadResult_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlDownloadResult", false),
                          Arguments.of("s3PresignedUrlDownloadConfig_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlDownloadConfig", false),
                          Arguments.of("s3PresignedUrlUploadRequest_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlUploadRequest", false),
-                         Arguments.of("s3PresignedUrlUploadResult_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlUploadResult", false)
+                         Arguments.of("s3PresignedUrlUploadResult_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlUploadResult", false),
+                         Arguments.of("lambdaRuntimeNonJavaSDK_shouldReturnFalse", "com.amazonaws.services.lambda.runtime.Context", false)
                          );
     }
 

--- a/v2-migration/src/test/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtilsTest.java
+++ b/v2-migration/src/test/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtilsTest.java
@@ -138,7 +138,9 @@ public class SdkTypeUtilsTest {
                          Arguments.of("s3PresignedUrlDownloadConfig_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlDownloadConfig", false),
                          Arguments.of("s3PresignedUrlUploadRequest_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlUploadRequest", false),
                          Arguments.of("s3PresignedUrlUploadResult_shouldReturnFalse", "com.amazonaws.services.s3.model.PresignedUrlUploadResult", false),
-                         Arguments.of("lambdaRuntimeNonJavaSDK_shouldReturnFalse", "com.amazonaws.services.lambda.runtime.Context", false)
+                         Arguments.of("lambdaRuntimeNonJavaSDK_shouldReturnFalse", "com.amazonaws.services.lambda.runtime.Context", false),
+                         Arguments.of("kinesisClientNonJavaSDK_shouldReturnFalse", "com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker", false),
+                         Arguments.of("kinesisProducerNonJavaSDK_shouldReturnFalse", "com.amazonaws.services.kinesis.producer.UserRecordResult", false)
                          );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Skip transforming non-SDK libraries:

- Lambda runtime :https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
- Kinesis Client Library (KCL) : https://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-implementation-app-java.html
- Kinesis Producer Library (KPL) : https://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-kpl.html
