### PR TITLE
Do not sign Transfer-Encoding Header  if present on the request

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-ed80b40.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-ed80b40.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Transfer-Encoding headers will no longer be signed during SigV4 authentication"
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
@@ -68,7 +68,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
     private static final FifoCache<SignerKey> SIGNER_CACHE =
         new FifoCache<>(SIGNER_CACHE_MAX_SIZE);
     private static final List<String> LIST_OF_HEADERS_TO_IGNORE_IN_LOWER_CASE =
-        Arrays.asList("connection", "x-amzn-trace-id", "user-agent", "expect");
+        Arrays.asList("connection", "x-amzn-trace-id", "user-agent", "expect", "transfer-encoding");
 
     protected SdkHttpFullRequest.Builder doSign(SdkHttpFullRequest request,
                                                 Aws4SignerRequestParams requestParams,

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/util/HeaderTransformsHelper.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/util/HeaderTransformsHelper.java
@@ -32,7 +32,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 public final class HeaderTransformsHelper {
 
     private static final List<String> LIST_OF_HEADERS_TO_IGNORE_IN_LOWER_CASE =
-            Arrays.asList("connection", "x-amzn-trace-id", "user-agent", "expect");
+        Arrays.asList("connection", "x-amzn-trace-id", "user-agent", "expect", "transfer-encoding");
 
     private HeaderTransformsHelper() {
     }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/Aws4SignerTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/Aws4SignerTest.java
@@ -398,4 +398,19 @@ public class Aws4SignerTest {
         assertThat(signed.firstMatchingHeader(SignerConstant.X_AMZ_CONTENT_SHA256)).isNotPresent();
         assertThat(signed.firstMatchingHeader("Authorization")).hasValue(expectedAuthorization);
     }
+
+
+    @Test
+    public void TransferEncodingIsNotSigned_NotSigned() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create("akid", "skid");
+        SdkHttpFullRequest.Builder request = generateBasicRequest();
+        request.putHeader("Transfer-Encoding", "chunked");
+
+        SdkHttpFullRequest actual = SignerTestUtils.signRequest(signer, request.build(), credentials, "demo", signingOverrideClock, "us-east-1");
+
+        assertThat(actual.firstMatchingHeader("Authorization"))
+            .hasValue("AWS4-HMAC-SHA256 Credential=akid/19810216/us-east-1/demo/aws4_request, " +
+                      "SignedHeaders=host;x-amz-archive-description;x-amz-date, " +
+                      "Signature=581d0042389009a28d461124138f1fe8eeb8daed87611d2a2b47fd3d68d81d73");
+    }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/Aws4SignerTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/Aws4SignerTest.java
@@ -399,7 +399,6 @@ public class Aws4SignerTest {
         assertThat(signed.firstMatchingHeader("Authorization")).hasValue(expectedAuthorization);
     }
 
-
     @Test
     public void TransferEncodingIsNotSigned_NotSigned() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create("akid", "skid");

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/util/HeaderTransformsHelperTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/util/HeaderTransformsHelperTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+package software.amazon.awssdk.auth.signer.internal.util;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeaderTransformsHelperTest {
+
+    @Test
+    void shouldExcludeIgnoredHeadersWhenCanonicalizing() {
+        Map<String, List<String>> headers = new HashMap<>();
+
+        // Ignored headers that should be excluded from signing
+        headers.put("connection", Collections.singletonList("keep-alive"));
+        headers.put("x-amzn-trace-id", Collections.singletonList("Root=1-234567890"));
+        headers.put("user-agent", Collections.singletonList("md/user"));
+        headers.put("expect", Collections.singletonList("100-continue"));
+        headers.put("transfer-encoding", Collections.singletonList("chunked"));
+
+        // Headers that should be included in signing
+        headers.put("Content-Type", Collections.singletonList("application/json"));
+        headers.put("Host", Collections.singletonList("example.com"));
+
+        Map<String, List<String>> canonicalizedHeaders = HeaderTransformsHelper.canonicalizeSigningHeaders(headers);
+
+        assertEquals(2, canonicalizedHeaders.size(), "Should only contain non-ignored headers");
+
+        // Verify included headers
+        assertTrue(canonicalizedHeaders.containsKey("content-type"), "Should contain content-type header");
+        assertTrue(canonicalizedHeaders.containsKey("host"), "Should contain host header");
+
+        // Verify excluded headers
+        assertFalse(canonicalizedHeaders.containsKey("connection"), "Should not contain connection header");
+        assertFalse(canonicalizedHeaders.containsKey("x-amzn-trace-id"), "Should not contain x-amzn-trace-id header");
+        assertFalse(canonicalizedHeaders.containsKey("user-agent"), "Should not contain user-agent header");
+        assertFalse(canonicalizedHeaders.containsKey("expect"), "Should not contain expect header");
+        assertFalse(canonicalizedHeaders.containsKey("transfer-encoding"), "Should not contain transfer-encoding header");
+    }
+
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4CanonicalRequest.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4CanonicalRequest.java
@@ -43,7 +43,7 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @Immutable
 public final class V4CanonicalRequest {
     private static final List<String> HEADERS_TO_IGNORE_IN_LOWER_CASE =
-        Arrays.asList("connection", "x-amzn-trace-id", "user-agent", "expect");
+        Arrays.asList("connection", "x-amzn-trace-id", "user-agent", "expect", "transfer-encoding");
 
     private final SdkHttpRequest request;
     private final String contentHash;

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4CanonicalRequestTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/V4CanonicalRequestTest.java
@@ -84,6 +84,7 @@ public class V4CanonicalRequestTest {
                                                .method(SdkHttpMethod.PUT)
                                                .putHeader("foo", "bar")
                                                .putHeader("x-amzn-trace-id", "wontBePresent")
+                                               .putHeader("Transfer-Encoding", "wontBePresent")
                                                .build();
         V4CanonicalRequest cr = new V4CanonicalRequest(request, "sha-256",
                                                        new V4CanonicalRequest.Options(true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently, AWS SDKs sign the Transfer-Encoding chunked header during SigV4 authentication, causing signature validation failures in specific scenarios.

The issue occurs because Transfer-Encoding is a hop-by-hop header that intermediate proxies can modify. 

This change proposes to stop signing the Transfer-Encoding header in SigV4(a).

Note : for Sigv4a signers using CRT it is done in  crt side with https://github.com/awslabs/aws-c-auth/pull/261 

## Modifications
<!--- Describe your changes in detail -->
- Added Transfer-Encoding in list of `LIST_OF_HEADERS_TO_IGNORE_IN_LOWER_CASE` which already skips some of predefined headers

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits
- Added codegen-tst and checked Authorization doesnot have ` Transfer-Encoding`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
