### PR TITLE
Fixing nullability issue of message and adding test coverage

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-4234091.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-4234091.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Fixing getMessage behavior of AwsServiceException to be nullable"
+    "description": "Fixed an issue in AwsServiceException#getMessage() where it returned an empty string instead of null when the message is null."
 }

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-4234091.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-4234091.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixing getMessage behavior of AwsServiceException to be nullable"
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -79,7 +79,8 @@ public class AwsServiceException extends SdkServiceException {
             joiner.add(diagnostics.toString());
         }
 
-        return joiner.toString();
+        String result = joiner.toString();
+        return result.isEmpty() ? super.getMessage() : result;
     }
 
     private String serviceDiagnostics() {

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
@@ -122,6 +122,32 @@ public class AwsServiceExceptionTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("messageNullabilityTestCases")
+    void getMessage_respectsNullBehavior(String testDescription,
+                                         AwsServiceException.Builder builder,
+                                         String expectedMessage) {
+        AwsServiceException e = builder.build();
+        assertThat(e.getMessage())
+            .as(testDescription)
+            .isEqualTo(expectedMessage);
+    }
+
+    private static Stream<Arguments> messageNullabilityTestCases() {
+        return Stream.of(
+            Arguments.of(
+                "No message or details set",
+                AwsServiceException.builder(),
+                null
+            ),
+            Arguments.of(
+                "Explicitly null message without details",
+                AwsServiceException.builder().message(null),
+                null
+            )
+        );
+    }
+
     @Test
     public void exceptionMessage_withoutErrorMessage() {
         AwsServiceException e = AwsServiceException.builder()


### PR DESCRIPTION
## Motivation and Context
#5834 refactors `AwsServiceException` to add the SDK diagnostics conditionally and refactors the `getMessage` impl to use String joiner. This change makes AwsServiceException's getMessage to always be not null which can break customers who are relying on nullability. 

This change preserves the behavior pre #5834. 

Added test coverage.