### PR TITLE
Migration tool CompleteMpuRequest transform

### DIFF
--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
@@ -15,6 +15,7 @@
 
 package foo.bar;
 
+import java.util.ArrayList;
 import java.util.List;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
@@ -25,6 +26,8 @@ import software.amazon.awssdk.services.s3.model.BucketAccelerateStatus;
 import software.amazon.awssdk.services.s3.model.BucketLifecycleConfiguration;
 import software.amazon.awssdk.services.s3.model.CORSConfiguration;
 import software.amazon.awssdk.services.s3.model.CORSRule;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
@@ -141,6 +144,21 @@ public class S3 {
             .build();
         CreateMultipartUploadResponse initiateMultipartUploadResult = s3.createMultipartUpload(initiateMultipartUploadRequest);
         System.out.println(initiateMultipartUploadResult);
+    }
+
+    private void completeMpu(S3Client s3, String bucket, String key) {
+        CompletedPart partETag = CompletedPart.builder().partNumber(7).eTag("etag")
+            .build();
+        List<CompletedPart> partETags = new ArrayList<>();
+        partETags.add(partETag);
+
+        CompleteMultipartUploadRequest completeMpuRequest1 =
+            CompleteMultipartUploadRequest.builder().bucket(bucket).key(key).multipartUpload(CompletedMultipartUpload.builder().parts(partETags).build())
+            .build();
+
+        CompleteMultipartUploadRequest completeMpuRequest2 =
+            CompleteMultipartUploadRequest.builder().bucket(bucket).key(key).uploadId("uploadId").multipartUpload(CompletedMultipartUpload.builder().parts(partETags).build())
+                .build();
     }
 
     private void listObjects(S3Client s3, String bucket) {
@@ -322,8 +340,6 @@ public class S3 {
             .build();
         PutBucketWebsiteRequest websiteRequest = PutBucketWebsiteRequest.builder().bucket(bucket).websiteConfiguration(WebsiteConfiguration.builder()
             .build())
-            .build();
-        CompletedPart partETag = CompletedPart.builder().partNumber(7).eTag("etag")
             .build();
     }
 

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3.java
@@ -27,6 +27,7 @@ import com.amazonaws.services.s3.model.BucketReplicationConfiguration;
 import com.amazonaws.services.s3.model.BucketTaggingConfiguration;
 import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
 import com.amazonaws.services.s3.model.CORSRule;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CopyPartRequest;
 import com.amazonaws.services.s3.model.CopyPartResult;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
@@ -55,6 +56,7 @@ import com.amazonaws.services.s3.model.intelligenttiering.IntelligentTieringConf
 import com.amazonaws.services.s3.model.inventory.InventoryConfiguration;
 import com.amazonaws.services.s3.model.metrics.MetricsConfiguration;
 import com.amazonaws.services.s3.model.ownership.OwnershipControls;
+import java.util.ArrayList;
 import java.util.List;
 
 public class S3 {
@@ -89,6 +91,18 @@ public class S3 {
         InitiateMultipartUploadRequest initiateMultipartUploadRequest = new InitiateMultipartUploadRequest(bucket, key);
         InitiateMultipartUploadResult initiateMultipartUploadResult = s3.initiateMultipartUpload(initiateMultipartUploadRequest);
         System.out.println(initiateMultipartUploadResult);
+    }
+
+    private void completeMpu(AmazonS3 s3, String bucket, String key) {
+        PartETag partETag = new PartETag(7, "etag");
+        List<PartETag> partETags = new ArrayList<>();
+        partETags.add(partETag);
+
+        CompleteMultipartUploadRequest completeMpuRequest1 =
+            new CompleteMultipartUploadRequest().withBucketName(bucket).withKey(key).withPartETags(partETags);
+
+        CompleteMultipartUploadRequest completeMpuRequest2 =
+            new CompleteMultipartUploadRequest(bucket, key, "uploadId", partETags);
     }
 
     private void listObjects(AmazonS3 s3, String bucket) {
@@ -207,7 +221,6 @@ public class S3 {
         SetBucketNotificationConfigurationRequest notificationRequest = new SetBucketNotificationConfigurationRequest(bucket, new BucketNotificationConfiguration());
         SetBucketTaggingConfigurationRequest tagRequest = new SetBucketTaggingConfigurationRequest(bucket, new BucketTaggingConfiguration());
         SetBucketWebsiteConfigurationRequest websiteRequest = new SetBucketWebsiteConfigurationRequest(bucket, new BucketWebsiteConfiguration());
-        PartETag partETag = new PartETag(7, "etag");
     }
 
     private void setBucketConfigs(AmazonS3 s3, String bucket) {

--- a/v2-migration/src/main/resources/META-INF/rewrite/change-s3-methods.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/change-s3-methods.yml
@@ -214,3 +214,6 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.amazonaws.services.s3.model.CompleteMultipartUploadRequest withBucketName(String)
       newMethodName: withBucket
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.amazonaws.services.s3.model.CompleteMultipartUploadRequest withPartETags(java.util.List)
+      newMethodName: withMultipartUpload

--- a/v2-migration/src/main/resources/META-INF/rewrite/s3-methods-constructor-to-fluent.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/s3-methods-constructor-to-fluent.yml
@@ -516,3 +516,15 @@ recipeList:
       fluentNames:
         - withPartNumber
         - withETag
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.CompleteMultipartUploadRequest
+      parameterTypes:
+        - java.lang.String
+        - java.lang.String
+        - java.lang.String
+        - java.util.List<com.amazonaws.services.s3.model.PartETag>
+      fluentNames:
+        - withBucket
+        - withKey
+        - withUploadId
+        - withMultipartUpload


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Add transform for `CompleteMultipartUploadRequest` POJO

We cannot transform `.withPartETags()` setter that takes `UploadPartResult` because v1 has handwritten logic to add the part number to `UploadPartResult`, the part number is not returned by the server.
- `withPartETags(Collection<UploadPartResult> uploadPartResultsCollection)`
- `withPartETags(UploadPartResult... uploadPartResults)`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added end-to-end tests
