### PR TITLE
bugfix: Fixed memory leak issue in SqsBatchManager for RequestBatchManager sendRequest Calls in SqsBatchManager

### DIFF
--- a/.changes/next-release/bugfix-AmazonSimpleQueueService-fd99b27.json
+++ b/.changes/next-release/bugfix-AmazonSimpleQueueService-fd99b27.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon Simple Queue Service",
+    "contributor": "",
+    "description": "Fixed memory leak in SqsBatch Manager: Resolved an issue where pendingResponses and pendingBatchResponses collections in RequestBatchManager retained references to completed futures, causing memory accumulation over time."
+}

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,8 +57,8 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
         this.maxBatchItems = batchConfiguration.maxBatchItems();
         this.sendRequestFrequency = batchConfiguration.sendRequestFrequency();
         this.scheduledExecutor = Validate.notNull(scheduledExecutor, "Null scheduledExecutor");
-        pendingBatchResponses = Collections.newSetFromMap(new ConcurrentHashMap<>());
-        pendingResponses = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        pendingBatchResponses = ConcurrentHashMap.newKeySet();
+        pendingResponses = ConcurrentHashMap.newKeySet();
         this.requestsAndResponsesMaps = new BatchingMap<>(overrideConfiguration);
 
     }

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
@@ -132,7 +132,6 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
 
     private void handleAndCompleteResponses(BatchResponseT batchResult, Throwable exception,
                                             Map<String, BatchingExecutionContext<RequestT, ResponseT>> requests) {
-        requests.forEach((contextId, batchExecutionContext) ->  pendingResponses.add(batchExecutionContext.response()));
         if (exception != null) {
             requests.forEach((contextId, batchExecutionContext) -> batchExecutionContext.response()
                                                                                         .completeExceptionally(exception));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Sqs Batch Manager user reported Memory leak while using Batch Send Messages

## Modifications
<!--- Describe your changes in detail -->
- Cleared  the  entries  in the Collections used in RequestBatchManager after Completable futures are completdd

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Functionalty not impacted so existing test cases cover this.
- Locally ran profiler without fix and observed there was a memory leak in some time , then used the fix and ran again and made sure there is no leak due to Sqs Batch Manager.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
