### PR TITLE
Flush writer after writing generated code

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/CodeWriter.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/CodeWriter.java
@@ -119,6 +119,7 @@ public class CodeWriter extends StringWriter {
             if (fileSize(outputFile) == 0) {
                 try (BufferedWriter writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8)) {
                     writer.write(formattedContents);
+                    writer.flush();
                 }
             } else {
                 validateFileContentMatches(outputFile, formattedContents);


### PR DESCRIPTION
## Motivation and Context
BufferedWriter is created in a try-with-resources, so it is always closed, but closing the writer does not actually flush the output stream; it just flushes the remaining data *buffered* in BufferedWriter to the stream:

https://github.com/openjdk/jdk/blob/3c72c04de7a43d265dae7160fe53baaaa8ae6f73/src/java.base/share/classes/java/io/BufferedWriter.java#L311-L322

We still need to call BufferedWriter#flush() explicitly so that the output stream is flushed:

https://github.com/openjdk/jdk/blob/3c72c04de7a43d265dae7160fe53baaaa8ae6f73/src/java.base/share/classes/java/io/BufferedWriter.java#L298-L308

This should hopefully fix issues where
CodeWriter#validateFileContentMatches fails when comparing contents because the file on disk is truncated.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
