### PR TITLE
Make DefaultSdkAutoConstructList/Map Serializable.

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructList.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructList.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.util;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -30,7 +31,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * @param <T> The element type.
  */
 @SdkProtectedApi
-public final class DefaultSdkAutoConstructList<T> implements SdkAutoConstructList<T> {
+public final class DefaultSdkAutoConstructList<T> implements SdkAutoConstructList<T>, Serializable {
     private static final DefaultSdkAutoConstructList INSTANCE = new DefaultSdkAutoConstructList();
 
     private final List impl = Collections.emptyList();
@@ -171,6 +172,10 @@ public final class DefaultSdkAutoConstructList<T> implements SdkAutoConstructLis
     @Override
     public String toString() {
         return impl.toString();
+    }
+
+    private Object readResolve() {
+        return getInstance();
     }
 
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructMap.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructMap.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.util;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -30,7 +31,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * @param <V> The value type.
  */
 @SdkProtectedApi
-public final class DefaultSdkAutoConstructMap<K, V> implements SdkAutoConstructMap<K, V> {
+public final class DefaultSdkAutoConstructMap<K, V> implements SdkAutoConstructMap<K, V>, Serializable {
     private static final DefaultSdkAutoConstructMap INSTANCE = new DefaultSdkAutoConstructMap();
 
     private final Map<K, V> impl = Collections.emptyMap();
@@ -117,4 +118,9 @@ public final class DefaultSdkAutoConstructMap<K, V> implements SdkAutoConstructM
     public String toString() {
         return impl.toString();
     }
+
+    private Object readResolve() {
+        return getInstance();
+    }
+
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructListTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructListTest.java
@@ -17,7 +17,13 @@ package software.amazon.awssdk.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.LinkedList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class DefaultSdkAutoConstructListTest {
@@ -41,5 +47,33 @@ public class DefaultSdkAutoConstructListTest {
     @Test
     public void toString_emptyList() {
         assertThat(INSTANCE.toString()).isEqualTo("[]");
+    }
+
+    @Test
+    @DisplayName("DefaultSdkAutoConstruct is Serializable, and is same instance.")
+    public void serialization_sameSingletonInstance() throws Exception {
+        // Create instance of DefaultSdkAutoConstructList
+        List defaultSdkAutoConstructList = DefaultSdkAutoConstructList.getInstance();
+
+        // Serialize instance into byte array
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(baos);
+
+        objectOutputStream.writeObject(defaultSdkAutoConstructList);
+        objectOutputStream.flush();
+        objectOutputStream.close();
+
+        // Serialization result
+        byte[] bytes = baos.toByteArray();
+
+        // Deserialize bytes
+        ByteArrayInputStream fileInputStream = new ByteArrayInputStream(bytes);
+        ObjectInputStream objectInputStream = new ObjectInputStream(fileInputStream);
+        // Deserialized result
+        DefaultSdkAutoConstructList resultList = (DefaultSdkAutoConstructList) objectInputStream.readObject();
+        objectInputStream.close();
+
+        // Compare using "==", to make sure it is the same reference.
+        assertThat(resultList == defaultSdkAutoConstructList).isTrue();
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructMapTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/DefaultSdkAutoConstructMapTest.java
@@ -17,7 +17,14 @@ package software.amazon.awssdk.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class DefaultSdkAutoConstructMapTest {
@@ -40,5 +47,32 @@ public class DefaultSdkAutoConstructMapTest {
     @Test
     public void toString_emptyMap() {
         assertThat(AUTO_CONSTRUCT_MAP.toString()).isEqualTo("{}");
+    }
+    @Test
+    @DisplayName("DefaultSdkAutoConstructMap is Serializable, and is same instance.")
+    public void serialization_sameSingletonInstance() throws Exception {
+        // Create instance of DefaultSdkAutoConstructMap
+        Map defaultSdkAutoConstructMap = DefaultSdkAutoConstructMap.getInstance();
+
+        // Serialize instance into byte array
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(baos);
+
+        objectOutputStream.writeObject(defaultSdkAutoConstructMap);
+        objectOutputStream.flush();
+        objectOutputStream.close();
+
+        // Serialization result
+        byte[] bytes = baos.toByteArray();
+
+        // Deserialize bytes
+        ByteArrayInputStream fileInputStream = new ByteArrayInputStream(bytes);
+        ObjectInputStream objectInputStream = new ObjectInputStream(fileInputStream);
+        // Deserialized result
+        DefaultSdkAutoConstructMap resultMap = (DefaultSdkAutoConstructMap) objectInputStream.readObject();
+        objectInputStream.close();
+
+        // Compare using "==", to make sure it is the same reference.
+        assertThat(resultMap == defaultSdkAutoConstructMap).isTrue();
     }
 }


### PR DESCRIPTION

## Motivation and Context

See Issue #3143

Classes AttributeValue, S3Object, DynamoDb GetItemRequest implement the Serializable interface, but throws a NotSerializableException since v2. 

This is due to using DefaultSdkAutoConstructList/Map as member field. When a Map/List does not exist in the request, These DefaultSdkAutoConstruct represent the non-existence, in contrary to an existing but empty List/Map.

There is a 4 line fix, to make these 2 classes Serializable. The challenge here is that they are both singleton classes. Java provides a readResolve() interface to handle this case.

The official documentation is here:
https://docs.oracle.com/en/java/javase/17/docs/specs/serialization/input.html

Other 3rd party references:
https://www.baeldung.com/java-serialization-readobject-vs-readresolve
https://stackoverflow.com/questions/3930181/how-to-deal-with-singleton-along-with-serialization

This feature is available since java 8:
https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html

## Modifications

Make DefaultSdkAutoConstructList/Map Serializable.
- Add the Serializable to both classes
- Implement the readResolve() method, to return the singleton INSTANCE.
- Add unit test, testing serialization/deserialization is working, and the deserialized result is not a new instance.

## Testing
- New unit tests implemented

java version "1.8.0_441"
Java(TM) SE Runtime Environment (build 1.8.0_441-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.441-b07, mixed mode)
Darwin **** 23.4.0 Darwin Kernel Version 23.4.0: Fri Mar 15 00:19:22 PDT 2024; root:xnu-10063.101.17~1/RELEASE_ARM64_T8112 arm64

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
