### PR TITLE
Clarify readBufferSizeInBytes usage

### DIFF
--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -115,11 +115,15 @@ public final class AwsCrtAsyncHttpClient extends AwsCrtHttpClientBase implements
         AwsCrtAsyncHttpClient.Builder maxConcurrency(Integer maxConcurrency);
 
         /**
-         * Configures the number of unread bytes that can be buffered in the
-         * client before we stop reading from the underlying TCP socket and wait for the Subscriber
-         * to read more data.
+         * Configures the number of bytes that can be buffered in the client for sending and receiving data.
+         * <p>
+         * For requests, this is the number unsent bytes the client will buffer from the request content publisher until it has to
+         * wait for the socket to allow more data to be written to it.
+         * <p>
+         * When reading responses, this is the number of bytes the client will buffer before we stop reading from the
+         * underlying TCP socket and wait for the Subscriber to read more data.
          *
-         * @param readBufferSize The number of bytes that can be buffered.
+         * @param readBufferSize The number of bytes that can be buffered for sending and receiving.
          * @return The builder of the method chaining.
          */
         AwsCrtAsyncHttpClient.Builder readBufferSizeInBytes(Long readBufferSize);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This commit updates the
`AwsCrtAsyncHttpClient.Builder#readBufferSizeInBytes` javadoc to mention that this configuration also affects buffering of data from the request content publisher.

`CrtRequestBodyAdapter` configures the `ByteBufferStoringSubscriber` here using `readLimit`: 
https://github.com/aws/aws-sdk-java-v2/blob/cd0172d77c3cf9ffd7ee777887a6d186bea6bffa/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestBodyAdapter.java#L32

`readLimit` is taken from `readBufferSizeInBytes`: 
 - https://github.com/aws/aws-sdk-java-v2/blob/cd0172d77c3cf9ffd7ee777887a6d186bea6bffa/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapter.java#L57
 - https://github.com/aws/aws-sdk-java-v2/blob/cd0172d77c3cf9ffd7ee777887a6d186bea6bffa/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java#L87
 - https://github.com/aws/aws-sdk-java-v2/blob/cd0172d77c3cf9ffd7ee777887a6d186bea6bffa/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java#L81
 - https://github.com/aws/aws-sdk-java-v2/blob/65b048b7d50d6daa16a0a53f72d228586d99ba3f/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java#L94-L101


## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
