### PR TITLE
Make MetaTableSchemaCache thread-safe

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/mapper/MetaTableSchemaCache.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/mapper/MetaTableSchemaCache.java
@@ -15,9 +15,9 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.internal.mapper;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
@@ -27,7 +27,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 @SuppressWarnings("unchecked")
 public class MetaTableSchemaCache {
-    private final Map<Class<?>, MetaTableSchema<?>> cacheMap = new HashMap<>();
+    private final Map<Class<?>, MetaTableSchema<?>> cacheMap = new ConcurrentHashMap<>();
 
     public <T> MetaTableSchema<T> getOrCreate(Class<T> mappedClass) {
         return (MetaTableSchema<T>) cacheMap().computeIfAbsent(


### PR DESCRIPTION
Make MetaTableSchemaCache thread-safe - fixes #5955.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
We are having many random failures caused by #5955 in our tests.

## Modifications
Switched to `ConcurrentHashMap` instead of `HashMap` in `MetaTableSchemaCache` class.

## Testing
The current test should be enough.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
