### PR TITLE
Filter out retry events for progress bar assertion on intg tests

### DIFF
--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/progress/LoggingTransferListenerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/progress/LoggingTransferListenerTest.java
@@ -62,6 +62,7 @@ class LoggingTransferListenerTest {
             String loggerName = LoggingTransferListener.class.getName();
             List<LogEvent> filteredEvents = events.stream()
                                                   .filter(e -> e.getLoggerName().equals(loggerName))
+                                                  .filter(e -> !e.getMessage().getFormattedMessage().contains("Retrying Request"))
                                                   .collect(Collectors.toList());
             assertLogged(filteredEvents, Level.INFO, "Transfer initiated...");
             assertLogged(filteredEvents, Level.INFO, "|                    | 0.0%");
@@ -99,6 +100,7 @@ class LoggingTransferListenerTest {
             String loggerName = LoggingTransferListener.class.getName();
             List<LogEvent> filteredEvents = events.stream()
                                                   .filter(e -> e.getLoggerName().equals(loggerName))
+                                                  .filter(e -> !e.getMessage().getFormattedMessage().contains("Retrying Request"))
                                                   .collect(Collectors.toList());
 
             assertLogged(filteredEvents, Level.INFO, "Transfer initiated...");


### PR DESCRIPTION
Our S3 transfer manager integ test has a progress bar assertion that is intermittently failing due to an unaccounted retry message.

```
[ERROR] software.amazon.awssdk.transfer.s3.progress.LoggingTransferListenerTest.test_customTicksListener_successfulTransfer -- Time elapsed: 0.027 s <<< FAILURE!
org.opentest4j.AssertionFailedError:

expected: "|==== | 80.0%"
but was: "Retrying Request: DefaultSdkHttpFullRequest(httpMethod=PUT, protocol=http, host=localhost, port=42741, encodedPath=/bucket/key, headers=[amz-sdk-invocation-id, Content-encoding, Content-Length, Content-Type, Expect, User-Agent, x-amz-content-sha256, x-amz-decoded-content-length, x-amz-sdk-checksum-algorithm, x-amz-trailer], queryParameters=[partNumber, uploadId])"
```

We can filter out this "Retrying Request" log from the stream so that only the progression bar logs appear.