### PR TITLE
Fix javadocs to clarify interrrupted status

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/io/SdkFilterInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/io/SdkFilterInputStream.java
@@ -35,7 +35,7 @@ public class SdkFilterInputStream extends FilterInputStream implements Releasabl
 
     /**
      * Aborts with subclass specific abortion logic executed if needed.
-     * Note the interrupted status of the thread is cleared by this method.
+     * Note the interrupted status of the thread will not be cleared by this method.
      *
      * @throws AbortedException if found necessary.
      */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix javadocs for `SdkFilterInputStream.abortIfNeeded()`

https://github.com/aws/aws-sdk-java-v2/issues/5979