### PR TITLE
Create EC2MetadataClientException for IMDS 4XX errors (#5947)

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-8a464f3.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-8a464f3.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "EC2 Metadata Client",
+    "contributor": "",
+    "description": "Added new Ec2MetadataClientException extending SdkClientException for IMDS unsuccessful responses that captures HTTP status codes, headers, and raw response content for improved error handling. See [#5786](https://github.com/aws/aws-sdk-java-v2/issues/5786)"
+}

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/Ec2MetadataAsyncClient.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/Ec2MetadataAsyncClient.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.imds.internal.DefaultEc2MetadataAsyncClient;
@@ -68,6 +69,11 @@ public interface Ec2MetadataAsyncClient extends SdkAutoCloseable {
      *
      * @param path Input path
      * @return A CompletableFuture that completes when the MetadataResponse is made available.
+     * @throws Ec2MetadataClientException if the request returns a 4XX error response. The exception includes
+     *          the HTTP status code, headers, and error response body
+     * @throws RetryableException if the request returns a 5XX error response and should be retried
+     * @throws SdkClientException if the maximum number of retries is reached, if there's an IO error during
+     *          the request, or if the response is empty when success is expected
      */
     CompletableFuture<Ec2MetadataResponse> get(String path);
 

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/Ec2MetadataClient.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/Ec2MetadataClient.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.imds;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.imds.internal.DefaultEc2MetadataClient;
@@ -66,6 +67,11 @@ public interface Ec2MetadataClient extends SdkAutoCloseable {
      *
      * @param path  Input path
      * @return Instance metadata value as part of MetadataResponse Object
+     * @throws Ec2MetadataClientException if the request returns a 4XX error response. The exception includes
+     *         the HTTP status code, headers, and error response body
+     * @throws RetryableException if the request returns a 5XX error response and should be retried
+     * @throws SdkClientException if the maximum number of retries is reached, if there's an IO error during
+     *         the request, or if the response is empty when success is expected
      */
     Ec2MetadataResponse get(String path);
 

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/Ec2MetadataClientException.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/Ec2MetadataClientException.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.imds;
+
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+/**
+ * Extends {@link SdkClientException} for EC2 Instance Metadata Service (IMDS) non-successful
+ * responses (4XX codes). Provides detailed error information through:
+ * <p>
+ * - HTTP status code via {@link #statusCode()} for specific error handling
+ * - Raw response content via {@link #rawResponse()} containing the error response body
+ * - HTTP headers via {@link #sdkHttpResponse()} providing additional error context from the response
+ */
+
+@SdkPublicApi
+public final class Ec2MetadataClientException extends SdkClientException {
+
+    private final int statusCode;
+    private final SdkBytes rawResponse;
+    private final SdkHttpResponse sdkHttpResponse;
+
+    private Ec2MetadataClientException(BuilderImpl builder) {
+        super(builder);
+        this.statusCode = builder.statusCode;
+        this.rawResponse = builder.rawResponse;
+        this.sdkHttpResponse = builder.sdkHttpResponse;
+    }
+
+    /**
+     * @return The HTTP status code returned by the IMDS service.
+     */
+    public int statusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Returns the response payload as bytes.
+     */
+    public SdkBytes rawResponse() {
+        return rawResponse;
+    }
+
+    /**
+     * Returns a map of HTTP headers associated with the error response.
+     */
+    public SdkHttpResponse sdkHttpResponse() {
+        return sdkHttpResponse;
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder extends SdkClientException.Builder {
+        Builder statusCode(int statusCode);
+
+        Builder rawResponse(SdkBytes rawResponse);
+
+        Builder sdkHttpResponse(SdkHttpResponse sdkHttpResponse);
+
+        @Override
+        Ec2MetadataClientException build();
+    }
+
+    private static final class BuilderImpl extends SdkClientException.BuilderImpl implements Builder {
+        private int statusCode;
+        private SdkBytes rawResponse;
+        private SdkHttpResponse sdkHttpResponse;
+
+        @Override
+        public Builder statusCode(int statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        @Override
+        public Builder rawResponse(SdkBytes rawResponse) {
+            this.rawResponse = rawResponse;
+            return this;
+        }
+
+        @Override
+        public Builder sdkHttpResponse(SdkHttpResponse sdkHttpResponse) {
+            this.sdkHttpResponse = sdkHttpResponse;
+            return this;
+        }
+
+        @Override
+        public Ec2MetadataClientException build() {
+            return new Ec2MetadataClientException(this);
+        }
+    }
+}


### PR DESCRIPTION
* Creating EC2MetadataClientException for IMDS unsuccessful responses.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The IMDS client currently throws SdkClientException for all 4XX errors, contradicting AWS SDK guidelines which state that client exceptions should only be used when the client fails to make a service call. When IMDS returns a response (even 4XX), it means the call was successful but rejected by the service. This improper error classification prevents specific error handling. Users can't implement specific handling for such cases because the client discards the HTTP status code information, forcing all errors to be treated the same way.
Fixing https://github.com/aws/aws-sdk-java-v2/issues/5786

## Modifications
Created a new Ec2MetadataClientException extending SdkClientException that preserves HTTP status codes from IMDS responses.
The exception includes better error messaging including response content and provides access to status codes via the statusCode() method.
Modified error handling in both sync and async implementations to throw this new exception for 4XX responses instead of the SdkClientException.

## Testing
Added unit tests to verify the new Ec2MetadataClientException. Tests include mocked IMDS responses with different status codes (4XX), verifying status code preservation, error message formatting, and proper exception handling in both sync and async clients.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
