### PR TITLE
Fixing race conditions in transferProgressListenerTest

### DIFF
--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3JavaMultipartTransferProgressListenerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3JavaMultipartTransferProgressListenerTest.java
@@ -217,6 +217,7 @@ public class S3JavaMultipartTransferProgressListenerTest {
         Mockito.verify(transferListenerMock, times(1)).transferInitiated(ArgumentMatchers.any());
         Mockito.verify(transferListenerMock, timeout(1000).times(1)).transferComplete(ArgumentMatchers.any());
 
+        // when false, the generic S3 TM will read 16KiB chunks, so OBJ_SIZE / 16KiB = 16MiB / 16KiB = 1024
         int numTimesBytesTransferred = multipartEnabled ? 2 : 1024;
         Mockito.verify(transferListenerMock, times(numTimesBytesTransferred)).bytesTransferred(ArgumentMatchers.any());
     }


### PR DESCRIPTION
## Motivation and Context
Tests in this class are intermittently failing due to a race condition. Expanding the verify clause with a `timeout` allows for padding and polling reducing the failure rate almost to 0%.

## Testing
Ran all of those test cases with a `@RepeatedTest(500)` wrapper and observed an error rate of 0.7%
After adding timeout I ran the wrapper multiple times and observed 0% failures (local environment testing only).