### PR TITLE
Providing an idle publisher to resolve race condition

### DIFF
--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -186,11 +186,6 @@ class FileAsyncResponseTransformerTest {
         assertThat(testPath).hasContent(existingString + content);
     }
 
-    @RepeatedTest(10000)
-    void foo() throws Exception {
-        exceptionOccurred_deleteFileBehavior(FileTransformerConfiguration.defaultCreateNew());
-    }
-
     @ParameterizedTest
     @MethodSource("configurations")
     void exceptionOccurred_deleteFileBehavior(FileTransformerConfiguration configuration) throws Exception {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,6 +54,7 @@ import software.amazon.awssdk.core.FileTransformerConfiguration;
 import software.amazon.awssdk.core.FileTransformerConfiguration.FileWriteOption;
 import software.amazon.awssdk.core.FileTransformerConfiguration.FailureBehavior;
 import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
 
 /**
  * Tests for {@link FileAsyncResponseTransformer}.
@@ -184,6 +186,11 @@ class FileAsyncResponseTransformerTest {
         assertThat(testPath).hasContent(existingString + content);
     }
 
+    @RepeatedTest(10000)
+    void foo() throws Exception {
+        exceptionOccurred_deleteFileBehavior(FileTransformerConfiguration.defaultCreateNew());
+    }
+
     @ParameterizedTest
     @MethodSource("configurations")
     void exceptionOccurred_deleteFileBehavior(FileTransformerConfiguration configuration) throws Exception {
@@ -193,7 +200,7 @@ class FileAsyncResponseTransformerTest {
             Files.write(testPath, "foobar".getBytes(StandardCharsets.UTF_8));
         }
         FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath, configuration);
-        stubException(RandomStringUtils.random(200), transformer);
+        stubException(transformer);
         if (configuration.failureBehavior() == LEAVE) {
             assertThat(testPath).exists();
         } else {
@@ -326,31 +333,17 @@ class FileAsyncResponseTransformerTest {
         assertThat(future.isCompletedExceptionally()).isFalse();
     }
 
-    private static void stubException(String newContent, FileAsyncResponseTransformer<String> transformer) throws Exception {
+    private static void stubException(FileAsyncResponseTransformer<String> transformer) throws Exception {
         CompletableFuture<String> future = transformer.prepare();
         transformer.onResponse("foobar");
 
         RuntimeException runtimeException = new RuntimeException("oops");
-        ByteBuffer content = ByteBuffer.wrap(newContent.getBytes(StandardCharsets.UTF_8));
-        SdkPublisher<ByteBuffer> idlePublisher = new SdkPublisher<ByteBuffer>() {
-            @Override
-            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
-                subscriber.onSubscribe(new Subscription() {
-                    @Override
-                    public void request(long l) {
-                        subscriber.onNext(content);
-                    }
-
-                    @Override
-                    public void cancel() {
-                    }
-                });
-            }
-        };
-        transformer.onStream(idlePublisher);
+        transformer.onStream(s -> s.onSubscribe(new NoopSubscription(s)));
         transformer.exceptionOccurred(runtimeException);
 
-        assertThatThrownBy(future::join).isInstanceOf(Exception.class);
+        assertThat(future).failsWithin(1, TimeUnit.SECONDS)
+                          .withThrowableOfType(ExecutionException.class)
+                          .withCause(runtimeException);
     }
 
     private static SdkPublisher<ByteBuffer> testPublisher(String content) {


### PR DESCRIPTION
## Motivation and Context
This test had two separate race conditions: 

1. the Transformer's `exceptionOccurred` function and the Subscriber's `failed()` method both race to complete the completeablefuture exceptionally resulting in:

```
java.lang.AssertionError: 
Expecting a cause with type:
  "java.lang.RuntimeException"
and message:
  "oops"
but type was:
  "java.nio.channels.ClosedChannelException"
and message was:
  null.
```

This can be solved by making the assertion more relaxed. This test is meant to test the delete file behavior, and not the exception handling. I believe this exception assertion that was added in the `stubException` helper function was to enforce the contract (an exception is propagated when the file transformer is terminated). This race condition caused that the specific exception could not be guaranteed. 

2. The FileSubscriber's `preformWrite` finished writing before the Transformer's `exceptionOccurred` handler was able to complete the future exceptionally:

```
java.lang.AssertionError: 
Expecting
  <CompletableFuture[Completed: "foobar"]>
to have failed within 1L SECONDS.
Be aware that the state of the future in this message might not reflect the one at the time when the assertion was performed as it is evaluated later on
```

The fix replaces the original `SdkPublisher` that emits data with `Flowable.just(content, content)` with an idle publisher that emits data but never completes. 
The original publisher would emit and immediately complete, creating a race between normal completion and exception handling. The idle publisher keeps the stream open, while the exception handling path has time to execute before completion.

## Testing
1. Created a `@RepeatedTest` wrapper with a 1000 executions to check for failure rates. The test was failing 0.4-1.2% of tests. After the fix I see a 0% failure rate. 

2. Added logging to each handler of the FileSubscriber and the Transformer to observe the race conditions. For example:

```
transformer calling onSubscribe
Transformer's exceptionOccurred start block
Transformer's exceptionOccurred: closing the channel
Transformer's exceptionOccurred: cleanup
transformer completed method is called
File Subscriber failed, future.completeExceptionally(exc) is called: java.nio.channels.ClosedChannelException
Transofmer exceptionOccured completes the future exceptionally

java.lang.AssertionError: 
Expecting a cause with type:
  "java.lang.RuntimeException"
and message:
  "oops"
but type was:
  "java.nio.channels.ClosedChannelException"
and message was:
  null.
```