### PR TITLE
Migration Tool : S3 generatePresignedUrl

### DIFF
--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -45,9 +45,9 @@ public class S3Transforms {
 
 
         HttpMethod httpMethod = HttpMethod.PUT;
-        URL urlWithHttpMethodVariable = /*AWS SDK for Java v2 migration: Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported. Update your code to pass in enum instead and run the migration tool again, or manually migrate your code - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
+        URL urlWithHttpMethodVariable = /*AWS SDK for Java v2 migration: Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported. Please manually migrate your code - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
 
         GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, key);
-        /*AWS SDK for Java v2 migration: Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code.- https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(request);
+        /*AWS SDK for Java v2 migration: Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(request);
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.Date;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GeneratePresignedUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
@@ -45,5 +46,8 @@ public class S3Transforms {
 
         HttpMethod httpMethod = HttpMethod.PUT;
         URL urlWithHttpMethodVariable = /*AWS SDK for Java v2 migration: Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported. Update your code to pass in HttpMethod literal enum, or manually migrate your code.*/s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
+
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, key);
+        /*AWS SDK for Java v2 migration: Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code.*/s3.generatePresignedUrl(request);
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -37,17 +37,17 @@ public class S3Transforms {
     }
 
     private void generatePresignedUrl(S3Client s3, String bucket, String key, Date expiration) {
-        URL urlHead = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with HEAD HTTP method is not supported in v2.*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.HEAD);
+        URL urlHead = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with HEAD HTTP method is not supported in v2. Only GET, PUT, and DELETE are supported - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.HEAD);
 
-        URL urlPatch = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with PATCH HTTP method is not supported in v2.*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.PATCH);
+        URL urlPatch = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with PATCH HTTP method is not supported in v2. Only GET, PUT, and DELETE are supported - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.PATCH);
 
-        URL urlPost = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with POST HTTP method is not supported in v2.*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.POST);
+        URL urlPost = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with POST HTTP method is not supported in v2. Only GET, PUT, and DELETE are supported - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.POST);
 
 
         HttpMethod httpMethod = HttpMethod.PUT;
-        URL urlWithHttpMethodVariable = /*AWS SDK for Java v2 migration: Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported. Update your code to pass in HttpMethod literal enum, or manually migrate your code.*/s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
+        URL urlWithHttpMethodVariable = /*AWS SDK for Java v2 migration: Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported. Update your code to pass in enum instead and run the migration tool again, or manually migrate your code - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
 
         GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, key);
-        /*AWS SDK for Java v2 migration: Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code.*/s3.generatePresignedUrl(request);
+        /*AWS SDK for Java v2 migration: Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code.- https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html*/s3.generatePresignedUrl(request);
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -15,13 +15,16 @@
 
 package foo.bar;
 
+import com.amazonaws.HttpMethod;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 
 public class S3Transforms {
 
@@ -30,5 +33,17 @@ public class S3Transforms {
         PutObjectRequest requestWithInputStream = PutObjectRequest.builder().bucket(bucket).key(key).websiteRedirectLocation("location")
                 .build();
         /*AWS SDK for Java v2 migration: When using InputStream to upload with TransferManager, you must specify Content-Length and ExecutorService.*/tm.upload(UploadRequest.builder().putObjectRequest(requestWithInputStream).requestBody(AsyncRequestBody.fromInputStream(inputStream, -1L, newExecutorServiceVariableToDefine)).build());
+    }
+
+    private void generatePresignedUrl(S3Client s3, String bucket, String key, Date expiration) {
+        URL urlHead = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with HEAD HTTP method is not supported in v2.*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.HEAD);
+
+        URL urlPatch = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with PATCH HTTP method is not supported in v2.*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.PATCH);
+
+        URL urlPost = /*AWS SDK for Java v2 migration: S3 generatePresignedUrl() with POST HTTP method is not supported in v2.*/s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.POST);
+
+
+        HttpMethod httpMethod = HttpMethod.PUT;
+        URL urlWithHttpMethodVariable = /*AWS SDK for Java v2 migration: Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported. Update your code to pass in HttpMethod literal enum, or manually migrate your code.*/s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/before/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/before/src/main/java/foo/bar/S3Transforms.java
@@ -17,6 +17,7 @@ package foo.bar;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import java.io.ByteArrayInputStream;
@@ -43,5 +44,8 @@ public class S3Transforms {
 
         HttpMethod httpMethod = HttpMethod.PUT;
         URL urlWithHttpMethodVariable = s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
+
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, key);
+        s3.generatePresignedUrl(request);
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/before/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/before/src/main/java/foo/bar/S3Transforms.java
@@ -15,10 +15,14 @@
 
 package foo.bar;
 
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
 
 public class S3Transforms {
 
@@ -27,5 +31,17 @@ public class S3Transforms {
         PutObjectRequest requestWithInputStream = new PutObjectRequest(bucket, key, "location");
         requestWithInputStream.setInputStream(inputStream);
         tm.upload(requestWithInputStream);
+    }
+
+    private void generatePresignedUrl(AmazonS3 s3, String bucket, String key, Date expiration) {
+        URL urlHead = s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.HEAD);
+
+        URL urlPatch = s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.PATCH);
+
+        URL urlPost = s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.POST);
+
+
+        HttpMethod httpMethod = HttpMethod.PUT;
+        URL urlWithHttpMethodVariable = s3.generatePresignedUrl(bucket, key, expiration, httpMethod);
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
@@ -409,12 +409,24 @@ public class S3 {
     }
 
     private void generatePresignedUrl(S3Client s3, String bucket, String key, Date expiration) {
-        URL urlGet1 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
+        URL urlGet1 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+                .presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key))
+                    .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
+                .url();
 
-        URL urlPut = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignPutObject(p -> p.putObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
+        URL urlPut = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+                .presignPutObject(p -> p.putObjectRequest(r -> r.bucket(bucket).key(key))
+                    .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
+                .url();
 
-        URL urlGet2 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
+        URL urlGet2 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+                .presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key))
+                    .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
+                .url();
 
-        URL urlDelete = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignDeleteObject(p -> p.deleteObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
+        URL urlDelete = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+                .presignDeleteObject(p -> p.deleteObjectRequest(r -> r.bucket(bucket).key(key))
+                    .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
+                .url();
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
@@ -16,7 +16,11 @@
 package foo.bar;
 
 import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -110,6 +114,7 @@ import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
 import software.amazon.awssdk.services.s3.model.WebsiteConfiguration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 public class S3 {
 
@@ -401,5 +406,15 @@ public class S3 {
         S3Uri s3UriFromString = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/S3Utilities.builder().build().parseUri(URI.create(uriAsString));
 
         S3Uri s3UriFromStringWithUrlEncodeFalse = S3Utilities.builder().build().parseUri(URI.create(uriAsString));
+    }
+
+    private void generatePresignedUrl(S3Client s3, String bucket, String key, Date expiration) {
+        URL urlGet1 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
+
+        URL urlPut = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignPutObject(p -> p.putObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
+
+        URL urlGet2 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
+
+        URL urlDelete = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build().presignDeleteObject(p -> p.deleteObjectRequest(r -> r.bucket(bucket).key(key)).signatureDuration(Duration.between(Instant.now(), expiration.toInstant()))).url();
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3.java
@@ -15,6 +15,7 @@
 
 package foo.bar;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
@@ -59,7 +60,9 @@ import com.amazonaws.services.s3.model.inventory.InventoryConfiguration;
 import com.amazonaws.services.s3.model.metrics.MetricsConfiguration;
 import com.amazonaws.services.s3.model.ownership.OwnershipControls;
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public class S3 {
@@ -258,5 +261,15 @@ public class S3 {
         AmazonS3URI s3UriFromString = new AmazonS3URI(uriAsString);
 
         AmazonS3URI s3UriFromStringWithUrlEncodeFalse = new AmazonS3URI(uriAsString, false);
+    }
+
+    private void generatePresignedUrl(AmazonS3 s3, String bucket, String key, Date expiration) {
+        URL urlGet1 = s3.generatePresignedUrl(bucket, key, expiration);
+
+        URL urlPut = s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.PUT);
+
+        URL urlGet2 = s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.GET);
+
+        URL urlDelete = s3.generatePresignedUrl(bucket, key, expiration, HttpMethod.DELETE);
     }
 }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3NonStreamingRequestToV2Complex.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3NonStreamingRequestToV2Complex.java
@@ -136,9 +136,9 @@ public class S3NonStreamingRequestToV2Complex extends Recipe {
                 return method.withComments(assignedVariableHttpMethodNotSupportedComment());
             }
 
-            String v2Method = String.format("S3Presigner.builder().s3Client(#{any()}).build()\n"
-                                            + ".presign%sObject(p -> p.%sObjectRequest(r -> r.bucket(#{any()}).key(#{any()}))\n"
-                                            + ".signatureDuration(Duration.between(Instant.now(), #{any()}.toInstant())))\n"
+            String v2Method = String.format("S3Presigner.builder().s3Client(#{any()}).build()%n"
+                                            + ".presign%sObject(p -> p.%sObjectRequest(r -> r.bucket(#{any()}).key(#{any()}))%n"
+                                            + ".signatureDuration(Duration.between(Instant.now(), #{any()}.toInstant())))%n"
                                             + ".url()",
                                             httpMethod, httpMethod.toLowerCase(Locale.ROOT));
 

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3NonStreamingRequestToV2Complex.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3NonStreamingRequestToV2Complex.java
@@ -86,7 +86,7 @@ public class S3NonStreamingRequestToV2Complex extends Recipe {
                 return transformCompleteMpuRequestCompletedPartsArg(method);
             }
             if (isGeneratePresignedUrl(method)) {
-                return transformGeneratePresignedUrl(method);
+                return maybeAutoFormat(method, transformGeneratePresignedUrl(method), executionContext);
             }
             if (DISABLE_REQUESTER_PAYS.matches(method, false)) {
                 return transformSetRequesterPays(method, false);
@@ -136,9 +136,10 @@ public class S3NonStreamingRequestToV2Complex extends Recipe {
                 return method.withComments(assignedVariableHttpMethodNotSupportedComment());
             }
 
-            String v2Method = String.format("S3Presigner.builder().s3Client(#{any()}).build().presign%sObject"
-                                            + "(p -> p.%sObjectRequest(r -> r.bucket(#{any()}).key(#{any()}))"
-                                            + ".signatureDuration(Duration.between(Instant.now(), #{any()}.toInstant()))).url()",
+            String v2Method = String.format("S3Presigner.builder().s3Client(#{any()}).build()\n"
+                                            + ".presign%sObject(p -> p.%sObjectRequest(r -> r.bucket(#{any()}).key(#{any()}))\n"
+                                            + ".signatureDuration(Duration.between(Instant.now(), #{any()}.toInstant())))\n"
+                                            + ".url()",
                                             httpMethod, httpMethod.toLowerCase(Locale.ROOT));
 
             removeV1HttpMethodImport();

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
@@ -79,17 +79,23 @@ public final class S3TransformUtils {
 
     public static List<Comment> assignedVariableHttpMethodNotSupportedComment() {
         String comment = "Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported."
-                         + " Update your code to pass in HttpMethod literal enum, or manually migrate your code.";
+                         + " Update your code to pass in enum instead and run the migration tool again, or manually migrate "
+                         + "your code - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner"
+                         + "/S3Presigner.html";
         return createComments(comment);
     }
 
     public static List<Comment> requestPojoTransformNotSupportedComment() {
-        String comment = "Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code.";
+        String comment = "Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code."
+                         + "- https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner"
+                         + "/S3Presigner.html";
         return createComments(comment);
     }
 
     public static List<Comment> httpMethodNotSupportedComment(String httpMethod) {
-        String comment = String.format("S3 generatePresignedUrl() with %s HTTP method is not supported in v2.",
+        String comment = String.format("S3 generatePresignedUrl() with %s HTTP method is not supported in v2. Only GET, PUT, "
+                                       + "and DELETE are supported - https://sdk.amazonaws"
+                                       + ".com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html",
                                        httpMethod.toUpperCase(Locale.ROOT));
         return createComments(comment);
     }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
@@ -79,14 +79,13 @@ public final class S3TransformUtils {
 
     public static List<Comment> assignedVariableHttpMethodNotSupportedComment() {
         String comment = "Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported."
-                         + " Update your code to pass in enum instead and run the migration tool again, or manually migrate "
-                         + "your code - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner"
-                         + "/S3Presigner.html";
+                         + " Please manually migrate your code - https://sdk.amazonaws"
+                         + ".com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html";
         return createComments(comment);
     }
 
     public static List<Comment> requestPojoTransformNotSupportedComment() {
-        String comment = "Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code."
+        String comment = "Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code "
                          + "- https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner"
                          + "/S3Presigner.html";
         return createComments(comment);

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
@@ -15,11 +15,15 @@
 
 package software.amazon.awssdk.v2migration.internal.utils;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markers;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
@@ -56,5 +60,44 @@ public final class S3TransformUtils {
     public static List<Comment> createComments(String comment) {
         return Collections.singletonList(
             new TextComment(true, "AWS SDK for Java v2 migration: " + comment, "", Markers.EMPTY));
+    }
+
+    public static boolean isCompleteMpuRequestMultipartUploadSetter(J.MethodInvocation method) {
+        return "multipartUpload".equals(method.getSimpleName())
+               && TypeUtils.isAssignableTo(V2_S3_MODEL_PKG + "CompleteMultipartUploadRequest.Builder",
+                                           method.getSelect().getType());
+    }
+
+    public static boolean isGeneratePresignedUrl(J.MethodInvocation method) {
+        return "generatePresignedUrl".equals(method.getSimpleName())
+               && TypeUtils.isAssignableTo(V2_S3_CLIENT, method.getSelect().getType());
+    }
+
+    public static boolean isUnsupportedHttpMethod(String httpMethod) {
+        return Arrays.asList("Head", "Post", "Patch").contains(httpMethod);
+    }
+
+    public static List<Comment> assignedVariableHttpMethodNotSupportedComment() {
+        String comment = "Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported."
+                         + " Update your code to pass in HttpMethod literal enum, or manually migrate your code.";
+        return createComments(comment);
+    }
+
+    public static List<Comment> requestPojoTransformNotSupportedComment() {
+        String comment = "Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code.";
+        return createComments(comment);
+    }
+
+    public static List<Comment> httpMethodNotSupportedComment(String httpMethod) {
+        String comment = String.format("S3 generatePresignedUrl() with %s HTTP method is not supported in v2.",
+                                       httpMethod.toUpperCase(Locale.ROOT));
+        return createComments(comment);
+    }
+
+    public static List<Comment> presignerSingleInstanceSuggestion() {
+        String comment = "If generating multiple pre-signed URLs, it is recommended to create a single instance of "
+                         + "S3Presigner, since creating a presigner can be expensive. If applicable, please manually "
+                         + "refactor the transformed code.";
+        return createComments(comment);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Transforms for S3 `generatePresignedUrl()`

Does not cover `GeneratePresignedUrlRequest` POJO

## Modifications
<!--- Describe your changes in detail -->
Added to `S3NonStreamingRequestToV2Complex` recipe

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
End to end tests