### PR TITLE
Migration tool : Setters to toBuilder() setters

### DIFF
--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -64,9 +64,9 @@ public class S3Transforms {
         /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - ongoingRestore - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.ongoingRestore(false);
         /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - requesterCharged - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.requesterCharged(false);
 
-        /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - lastModified - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.lastModified(dateVal);
-        /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - expirationTime - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.expirationTime(dateVal);
-        /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - restoreExpirationTime - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.restoreExpirationTime(dateVal);
+        /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - lastModified - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.lastModified(dateVal.toInstant());
+        /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - expirationTime - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.expirationTime(dateVal.toInstant());
+        /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - restoreExpirationTime - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.restoreExpirationTime(dateVal.toInstant());
 
         /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - header - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.header("key", "val");
         /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - addUserMetadata - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.addUserMetadata("a", "b");

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/Application.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/Application.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.ListQueuesRequest;
 import software.amazon.awssdk.services.sqs.model.ListQueuesResponse;
 import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SqsException;
 
 public class Application {
@@ -113,5 +114,17 @@ public class Application {
             .startTime(start.toInstant())
             .endTime(end.toInstant())
             .build();
+
+        GetMetricStatisticsRequest getMetricStatisticsRequest2 = GetMetricStatisticsRequest.builder()
+            .build();
+        getMetricStatisticsRequest2 = getMetricStatisticsRequest2.toBuilder().startTime(start.toInstant()).build();
+        getMetricStatisticsRequest2 = getMetricStatisticsRequest2.toBuilder().endTime(end.toInstant()).build();
+    }
+
+    void pojoSettersAfterCreation() {
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+            .build();
+        sendMessageRequest = sendMessageRequest.toBuilder().messageGroupId("groupId").build();
+        sendMessageRequest = sendMessageRequest.toBuilder().queueUrl("queueUrl").build();
     }
 }

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/Application.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/Application.java
@@ -28,6 +28,7 @@ import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
 import com.amazonaws.services.sqs.model.AmazonSQSException;
 import com.amazonaws.services.sqs.model.ListQueuesRequest;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,5 +108,15 @@ public class Application {
         GetMetricStatisticsRequest getMetricStatisticsRequest = new GetMetricStatisticsRequest()
             .withStartTime(start)
             .withEndTime(end);
+
+        GetMetricStatisticsRequest getMetricStatisticsRequest2 = new GetMetricStatisticsRequest();
+        getMetricStatisticsRequest2.setStartTime(start);
+        getMetricStatisticsRequest2.setEndTime(end);
+    }
+
+    void pojoSettersAfterCreation() {
+        SendMessageRequest sendMessageRequest = new SendMessageRequest();
+        sendMessageRequest.setMessageGroupId("groupId");
+        sendMessageRequest.setQueueUrl("queueUrl");
     }
 }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/DateToInstant.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/DateToInstant.java
@@ -82,7 +82,8 @@ public class DateToInstant extends Recipe {
             }
 
             boolean isDateParam = javaType.isAssignableFrom(DATE_PATTERN);
-            return SdkTypeUtils.isV2ModelBuilder(declaringType) && isDateParam;
+            boolean isV2Model = SdkTypeUtils.isV2ModelBuilder(declaringType) || SdkTypeUtils.isV2ModelClass(declaringType);
+            return isDateParam && isV2Model;
         }
     }
 }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3NonStreamingRequestToV2Complex.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3NonStreamingRequestToV2Complex.java
@@ -57,7 +57,7 @@ public class S3NonStreamingRequestToV2Complex extends Recipe {
     private static final MethodMatcher LIST_BUCKETS = v2S3MethodMatcher("listBuckets()");
     private static final MethodMatcher RESTORE_OBJECT = v2S3MethodMatcher("restoreObject(String, String, int)");
     private static final MethodMatcher SET_OBJECT_REDIRECT_LOCATION =
-        v2S3MethodMatcher("objectRedirectLocation(String, String, String)");
+        v2S3MethodMatcher("setObjectRedirectLocation(String, String, String)");
     private static final MethodMatcher CHANGE_OBJECT_STORAGE_CLASS = v2S3MethodMatcher(
         String.format("changeObjectStorageClass(String, String, %sStorageClass)", V2_S3_MODEL_PKG));
     private static final MethodMatcher CREATE_BUCKET = v2S3MethodMatcher("createBucket(String, String)");

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SettersToBuilderV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/SettersToBuilderV2.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.v2migration;
+
+import static software.amazon.awssdk.v2migration.internal.utils.NamingUtils.isSetter;
+import static software.amazon.awssdk.v2migration.internal.utils.NamingUtils.removeSet;
+import static software.amazon.awssdk.v2migration.internal.utils.SdkTypeUtils.isV2ModelClass;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public class SettersToBuilderV2 extends Recipe {
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Convert V1 setters to V2 toBuilder setters";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Convert V1 setters to V2 toBuilder setters";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new Visitor();
+    }
+
+    private static final class Visitor extends JavaVisitor<ExecutionContext> {
+
+
+        @Override
+        public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+
+            if (isV2ModelClassSetter(method)) {
+                return convertSetterToBuilder(method);
+            }
+
+            return method;
+        }
+
+        private boolean isV2ModelClassSetter(J.MethodInvocation method) {
+            return isV2ModelClass(method.getType())
+                   && method.getArguments().size() == 1
+                   && isSetter(method.getSimpleName());
+        }
+
+        private J convertSetterToBuilder(J.MethodInvocation method) {
+            String v2Method = String.format("#{any()} = #{any()}.toBuilder().%s(#{any()}).build()",
+                                            removeSet(method.getSimpleName()));
+
+            return JavaTemplate.builder(v2Method).build()
+                               .apply(getCursor(), method.getCoordinates().replace(),
+                                      method.getSelect(), method.getSelect(), method.getArguments().get(0));
+        }
+    }
+}

--- a/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2-with-tm.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2-with-tm.yml
@@ -46,4 +46,5 @@ recipeList:
   - software.amazon.awssdk.v2migration.DateToInstant
   - software.amazon.awssdk.v2migration.S3NonStreamingRequestToV2Complex
   - software.amazon.awssdk.v2migration.S3PutObjectRequestToV2
+  - software.amazon.awssdk.v2migration.SettersToBuilderV2
   - software.amazon.awssdk.v2migration.TransferManagerMethodsToV2

--- a/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/aws-sdk-java-v1-to-v2.yml
@@ -44,3 +44,4 @@ recipeList:
   - software.amazon.awssdk.v2migration.DateToInstant
   - software.amazon.awssdk.v2migration.S3NonStreamingRequestToV2Complex
   - software.amazon.awssdk.v2migration.S3PutObjectRequestToV2
+  - software.amazon.awssdk.v2migration.SettersToBuilderV2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Transform v1 model POJO setters 

from:

`request.setXX(val);`

to: 

`request = request.toBuilder().XX(val).build();`

## Modifications
<!--- Describe your changes in detail -->
new recipe `SettersToBuilderV2`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added end to end tests