### PR TITLE
Migration Tool - PutObjectRequest setters

### DIFF
--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -66,12 +66,12 @@ public class S3Transforms {
             .build();
 
         PutObjectRequest request = /*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter accessControlList is not supported, please manually migrate your code to use the v2 setters: acl, grantReadACP, grantWriteACP - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#acl(java.lang.String)*/
-            /*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter sseCustomerKey is not supported, please manually migrate your code to use the v2 setters: sseCustomerKey, sseCustomerKeyMD5 - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#sseCustomerKey(java.lang.String)*/
-                /*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter sseAwsKeyManagementParam is not supported, please manually migrate your code to use the v2 setters: ssekmsKeyId, serverSideEncryption, sseCustomerAlgorithm - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#ssekmsKeyId(java.lang.String)*/
-                    PutObjectRequest.builder().bucket("bucket").key("key").websiteRedirectLocation("location")
-                        .sseCustomerKey(sseCustomerKey)
-                    .sseAwsKeyManagementParams(sseParams)
-                .accessControlList(accessControlList)
+/*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter sseCustomerKey is not supported, please manually migrate your code to use the v2 setters: sseCustomerKey, sseCustomerKeyMD5 - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#sseCustomerKey(java.lang.String)*/
+/*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter sseAwsKeyManagementParam is not supported, please manually migrate your code to use the v2 setters: ssekmsKeyId, serverSideEncryption, sseCustomerAlgorithm - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#ssekmsKeyId(java.lang.String)*/
+PutObjectRequest.builder().bucket("bucket").key("key").websiteRedirectLocation("location")
+            .sseCustomerKey(sseCustomerKey)
+            .sseAwsKeyManagementParams(sseParams)
+            .accessControlList(accessControlList)
             .build();
     }
 

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -16,12 +16,15 @@
 package foo.bar;
 
 import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
+import com.amazonaws.services.s3.model.SSECustomerKey;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Date;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AccessControlPolicy;
 import software.amazon.awssdk.services.s3.model.GeneratePresignedUrlRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -32,33 +35,49 @@ public class S3Transforms {
 
     void upload_streamWithLiteralLength(S3TransferManager tm, String bucket, String key) {
         HeadObjectResponse metadata = HeadObjectResponse.builder()
-                .build();
+            .build();
         InputStream inputStream = new ByteArrayInputStream(("HelloWorld").getBytes());
         PutObjectRequest requestWithStreamAndLiteralLength = PutObjectRequest.builder().bucket(bucket).key(key).websiteRedirectLocation("location").contentLength(333L)
-                .build();
+            .build();
         /*AWS SDK for Java v2 migration: When using InputStream to upload with TransferManager, you must specify Content-Length and ExecutorService.*/tm.upload(UploadRequest.builder().putObjectRequest(requestWithStreamAndLiteralLength).requestBody(AsyncRequestBody.fromInputStream(inputStream, 333, newExecutorServiceVariableToDefine)).build());
     }
 
     void upload_streamWithAssignedLength(S3TransferManager tm, String bucket, String key) {
         HeadObjectResponse metadata = HeadObjectResponse.builder()
-                .build();
+            .build();
         long contentLen = 777;
         InputStream inputStream = new ByteArrayInputStream(("HelloWorld").getBytes());
         PutObjectRequest requestWithStreamAndAssignedLength = PutObjectRequest.builder().bucket(bucket).key(key).websiteRedirectLocation("location").contentLength(contentLen)
-                .build();
+            .build();
         /*AWS SDK for Java v2 migration: When using InputStream to upload with TransferManager, you must specify Content-Length and ExecutorService.*/tm.upload(UploadRequest.builder().putObjectRequest(requestWithStreamAndAssignedLength).requestBody(AsyncRequestBody.fromInputStream(inputStream, contentLen, newExecutorServiceVariableToDefine)).build());
     }
 
     void upload_streamWithoutLength(S3TransferManager tm, String bucket, String key) {
         InputStream inputStream = new ByteArrayInputStream(("HelloWorld").getBytes());
         PutObjectRequest requestWithStreamAndNoLength = PutObjectRequest.builder().bucket(bucket).key(key).websiteRedirectLocation("location")
-                .build();
+            .build();
         /*AWS SDK for Java v2 migration: When using InputStream to upload with TransferManager, you must specify Content-Length and ExecutorService.*/tm.upload(UploadRequest.builder().putObjectRequest(requestWithStreamAndNoLength).requestBody(AsyncRequestBody.fromInputStream(inputStream, -1L, newExecutorServiceVariableToDefine)).build());
+    }
+
+    void putObjectRequest_unsupportedSetters() {
+        SSECustomerKey sseCustomerKey = new SSECustomerKey("val");
+        SSEAwsKeyManagementParams sseParams = new SSEAwsKeyManagementParams();
+        AccessControlPolicy accessControlList = AccessControlPolicy.builder()
+            .build();
+
+        PutObjectRequest request = /*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter accessControlList is not supported, please manually migrate your code to use the v2 setters: acl, grantReadACP, grantWriteACP - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#acl(java.lang.String)*/
+            /*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter sseCustomerKey is not supported, please manually migrate your code to use the v2 setters: sseCustomerKey, sseCustomerKeyMD5 - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#sseCustomerKey(java.lang.String)*/
+                /*AWS SDK for Java v2 migration: Transform for PutObjectRequest setter sseAwsKeyManagementParam is not supported, please manually migrate your code to use the v2 setters: ssekmsKeyId, serverSideEncryption, sseCustomerAlgorithm - https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.Builder.html#ssekmsKeyId(java.lang.String)*/
+                    PutObjectRequest.builder().bucket("bucket").key("key").websiteRedirectLocation("location")
+                        .sseCustomerKey(sseCustomerKey)
+                    .sseAwsKeyManagementParams(sseParams)
+                .accessControlList(accessControlList)
+            .build();
     }
 
     void objectmetadata_unsupportedSetters(Date dateVal) {
         HeadObjectResponse metadata = HeadObjectResponse.builder()
-                .build();
+            .build();
 
         /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - expirationTimeRuleId - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.expirationTimeRuleId("expirationTimeRuleId");
         /*AWS SDK for Java v2 migration: Transform for ObjectMetadata setter - ongoingRestore - is not supported, please manually migrate the code by setting it on the v2 request/response object.*/metadata.ongoingRestore(false);

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/before/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/before/src/main/java/foo/bar/S3Transforms.java
@@ -17,9 +17,12 @@ package foo.bar;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
+import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -52,6 +55,17 @@ public class S3Transforms {
         PutObjectRequest requestWithStreamAndNoLength = new PutObjectRequest(bucket, key, "location");
         requestWithStreamAndNoLength.setInputStream(inputStream);
         tm.upload(requestWithStreamAndNoLength);
+    }
+
+    void putObjectRequest_unsupportedSetters() {
+        SSECustomerKey sseCustomerKey = new SSECustomerKey("val");
+        SSEAwsKeyManagementParams sseParams = new SSEAwsKeyManagementParams();
+        AccessControlList accessControlList = new AccessControlList();
+
+        PutObjectRequest request = new PutObjectRequest("bucket", "key", "location")
+            .withSSECustomerKey(sseCustomerKey)
+            .withSSEAwsKeyManagementParams(sseParams)
+            .withAccessControlList(accessControlList);
     }
 
     void objectmetadata_unsupportedSetters(Date dateVal) {

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3.java
@@ -409,22 +409,26 @@ public class S3 {
     }
 
     private void generatePresignedUrl(S3Client s3, String bucket, String key, Date expiration) {
-        URL urlGet1 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+        URL urlGet1 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/
+            S3Presigner.builder().s3Client(s3).build()
                 .presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key))
                     .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
                 .url();
 
-        URL urlPut = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+        URL urlPut = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/
+            S3Presigner.builder().s3Client(s3).build()
                 .presignPutObject(p -> p.putObjectRequest(r -> r.bucket(bucket).key(key))
                     .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
                 .url();
 
-        URL urlGet2 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+        URL urlGet2 = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/
+            S3Presigner.builder().s3Client(s3).build()
                 .presignGetObject(p -> p.getObjectRequest(r -> r.bucket(bucket).key(key))
                     .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
                 .url();
 
-        URL urlDelete = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/S3Presigner.builder().s3Client(s3).build()
+        URL urlDelete = /*AWS SDK for Java v2 migration: If generating multiple pre-signed URLs, it is recommended to create a single instance of S3Presigner, since creating a presigner can be expensive. If applicable, please manually refactor the transformed code.*/
+            S3Presigner.builder().s3Client(s3).build()
                 .presignDeleteObject(p -> p.deleteObjectRequest(r -> r.bucket(bucket).key(key))
                     .signatureDuration(Duration.between(Instant.now(), expiration.toInstant())))
                 .url();

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
@@ -65,6 +65,8 @@ public class S3Streaming {
         HeadObjectResponse metadataWithoutLength = HeadObjectResponse.builder()
             .build();
         /*AWS SDK for Java v2 migration: When using InputStream to upload with S3Client, Content-Length should be specified and used with RequestBody.fromInputStream(). Otherwise, the entire stream will be buffered in memory. If content length must be unknown, we recommend using the CRT-based S3 client - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html*/s3.putObject(PutObjectRequest.builder().bucket(bucket).key(key).build(), RequestBody.fromContentProvider(() -> stream, "application/octet-stream"));
+
+        /*AWS SDK for Java v2 migration: When using InputStream to upload with S3Client, Content-Length should be specified and used with RequestBody.fromInputStream(). Otherwise, the entire stream will be buffered in memory. If content length must be unknown, we recommend using the CRT-based S3 client - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html*/s3.putObject(PutObjectRequest.builder().bucket("bucket").key("key").build(), RequestBody.fromContentProvider(() -> stream, "application/octet-stream"));
     }
 
     /**

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
@@ -18,8 +18,10 @@ package foo.bar;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -30,6 +32,8 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.RequestPayer;
+import software.amazon.awssdk.services.s3.model.Tag;
+import software.amazon.awssdk.services.s3.model.Tagging;
 
 public class S3Streaming {
 
@@ -108,10 +112,16 @@ public class S3Streaming {
 
 
     void putObjectSetters() {
+        List<Tag> tags = new ArrayList<>();
+        Tagging objectTagging = Tagging.builder().tagSet(tags)
+            .build();
+
         PutObjectRequest putObjectRequest =
             PutObjectRequest.builder().bucket("bucket").key("key").websiteRedirectLocation("location")
                 .bucket("bucketName")
+                .websiteRedirectLocation("redirectLocation")
                 .acl(ObjectCannedACL.AWS_EXEC_READ)
+                .tagging(objectTagging)
             .build();
     }
 
@@ -160,7 +170,7 @@ public class S3Streaming {
             .build();
     }
 
-    void putObjectRequester_emptyMetadata() {
+    void putObjectRequest_emptyMetadata() {
         HeadObjectResponse emptyMetadata1 = HeadObjectResponse.builder()
             .build();
         PutObjectRequest request1 =PutObjectRequest.builder().bucket("bucket").key("key").websiteRedirectLocation("location")

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
@@ -19,13 +19,17 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.Tag;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class S3Streaming {
@@ -95,10 +99,15 @@ public class S3Streaming {
 
 
     void putObjectSetters() {
+        List<Tag> tags = new ArrayList<>();
+        ObjectTagging objectTagging = new ObjectTagging(tags);
+
         PutObjectRequest putObjectRequest =
             new PutObjectRequest("bucket", "key", "location")
-            .withBucketName("bucketName")
-                .withCannedAcl(CannedAccessControlList.AwsExecRead);
+                .withBucketName("bucketName")
+                .withRedirectLocation("redirectLocation")
+                .withCannedAcl(CannedAccessControlList.AwsExecRead)
+                .withTagging(objectTagging);
     }
 
     void putObjectRequesterPaysSetter() {
@@ -141,7 +150,7 @@ public class S3Streaming {
         PutObjectRequest request = new PutObjectRequest("bucket", "key", "location").withMetadata(metadata);
     }
 
-    void putObjectRequester_emptyMetadata() {
+    void putObjectRequest_emptyMetadata() {
         ObjectMetadata emptyMetadata1 = new ObjectMetadata();
         PutObjectRequest request1 = new PutObjectRequest("bucket", "key", "location").withMetadata(emptyMetadata1);
 

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
@@ -57,6 +57,8 @@ public class S3Streaming {
 
         ObjectMetadata metadataWithoutLength = new ObjectMetadata();
         s3.putObject(bucket, key, stream, metadataWithoutLength);
+
+        s3.putObject("bucket", "key", stream, new ObjectMetadata());
     }
 
     /**

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3PutObjectRequestToV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3PutObjectRequestToV2.java
@@ -108,7 +108,7 @@ public class S3PutObjectRequestToV2 extends Recipe {
                     return transformWithRequesterPays(method);
                 }
                 if (isUnsupportedPutObjectRequestSetter(method)) {
-                    method = maybeAutoFormat(method, addCommentForUnsupportedPutObjectRequestSetter(method), ctx);
+                    method = addCommentForUnsupportedPutObjectRequestSetter(method);
                     return super.visitMethodInvocation(method, ctx);
                 }
             }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3PutObjectRequestToV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3PutObjectRequestToV2.java
@@ -321,11 +321,18 @@ public class S3PutObjectRequestToV2 extends Recipe {
             addS3Import("PutObjectRequest");
 
             Expression metadata = method.getArguments().get(3);
-            String metadataName = ((J.Identifier) metadata).getSimpleName();
+            String metadataName = null;
+            if (metadata instanceof J.Identifier) {
+                metadataName = ((J.Identifier) metadata).getSimpleName();
+            }
 
             StringBuilder sb = new StringBuilder("PutObjectRequest.builder().bucket(#{any()}).key(#{any()})");
-            addMetadataFields(sb, metadataName, metadataMap);
-            Expression contentLen = retrieveContentLengthForMetadataIfSet(metadataName);
+
+            Expression contentLen = null;
+            if (metadataName != null) {
+                addMetadataFields(sb, metadataName, metadataMap);
+                contentLen = retrieveContentLengthForMetadataIfSet(metadataName);
+            }
 
             Expression[] params = {method.getArguments().get(0), method.getArguments().get(1),
                                    method.getArguments().get(2)};

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/NamingConversionUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/NamingConversionUtils.java
@@ -180,6 +180,8 @@ public final class NamingConversionUtils {
         S3_POJO_MAPPING.put("ReplicationFilter", "ReplicationRuleFilter");
         S3_POJO_MAPPING.put("ReplicationAndOperator", "ReplicationRuleAndOperator");
         S3_POJO_MAPPING.put("PartETag", "CompletedPart");
+        S3_POJO_MAPPING.put("ObjectTagging", "Tagging");
+        S3_POJO_MAPPING.put("AccessControlList", "AccessControlPolicy");
 
         //Special Enum mapping
         S3_POJO_MAPPING.put("S3Event", "Event");

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
@@ -61,6 +61,13 @@ public final class S3TransformUtils {
         "httpExpiresDate"
     )));
 
+    public static final Set<String> UNSUPPORTED_PUT_OBJ_REQUEST_TRANSFORMS = Collections.unmodifiableSet(new HashSet<>(
+        Arrays.asList(
+            "sseCustomerKey",
+            "sseAwsKeyManagementParams",
+            "accessControlList"
+        )));
+
 
     private S3TransformUtils() {
 
@@ -153,9 +160,29 @@ public final class S3TransformUtils {
         return ((J.Identifier) select).getSimpleName();
     }
 
+    private static Comment generateComment(String comment, boolean withNewLine) {
+        String suffix = withNewLine ? "\n" : "";
+        return new TextComment(true, "AWS SDK for Java v2 migration: " + comment, suffix, Markers.EMPTY);
+    }
+
+    public static Comment createComment(String comment) {
+        return generateComment(comment, false);
+    }
+
+    public static Comment createCommentWithNewline(String comment) {
+        return generateComment(comment, true);
+    }
+
     public static List<Comment> createComments(String comment) {
-        return Collections.singletonList(
-            new TextComment(true, "AWS SDK for Java v2 migration: " + comment, "", Markers.EMPTY));
+        return Arrays.asList(createComment(comment));
+    }
+
+    public static List<Comment> createCommentsWithNewline(String comment) {
+        return Arrays.asList(createCommentWithNewline(comment));
+    }
+
+    public static boolean isUnsupportedPutObjectRequestSetter(J.MethodInvocation method) {
+        return UNSUPPORTED_PUT_OBJ_REQUEST_TRANSFORMS.contains(method.getSimpleName());
     }
 
     public static boolean isObjectMetadataSetter(J.MethodInvocation method) {
@@ -221,24 +248,34 @@ public final class S3TransformUtils {
         return Arrays.asList("Head", "Post", "Patch").contains(httpMethod);
     }
 
+    public static List<Comment> inputStreamBufferingWarningComment() {
+        String warning = "When using InputStream to upload with S3Client, Content-Length should be specified and used "
+                         + "with RequestBody.fromInputStream(). Otherwise, the entire stream will be buffered in memory. If"
+                         + " content length must be unknown, we recommend using the CRT-based S3 client - "
+                         + "https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html";
+        return createComments(warning);
+    }
+
     public static List<Comment> assignedVariableHttpMethodNotSupportedComment() {
         String comment = "Transform for S3 generatePresignedUrl() with an assigned variable for HttpMethod is not supported."
-                         + " Please manually migrate your code - https://sdk.amazonaws"
-                         + ".com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html";
+                         + " Please manually migrate your code - "
+                         + "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner"
+                         + ".html";
         return createComments(comment);
     }
 
     public static List<Comment> requestPojoTransformNotSupportedComment() {
-        String comment = "Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code "
-                         + "- https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner"
-                         + "/S3Presigner.html";
+        String comment = "Transforms are not supported for GeneratePresignedUrlRequest, please manually migrate your code - "
+                         + "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner"
+                         + ".html";
         return createComments(comment);
     }
 
     public static List<Comment> httpMethodNotSupportedComment(String httpMethod) {
         String comment = String.format("S3 generatePresignedUrl() with %s HTTP method is not supported in v2. Only GET, PUT, "
-                                       + "and DELETE are supported - https://sdk.amazonaws"
-                                       + ".com/java/api/latest/software/amazon/awssdk/services/s3/presigner/S3Presigner.html",
+                                       + "and DELETE are supported - "
+                                       + "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3"
+                                       + "/presigner/S3Presigner.html",
                                        httpMethod.toUpperCase(Locale.ROOT));
         return createComments(comment);
     }
@@ -247,6 +284,54 @@ public final class S3TransformUtils {
         String comment = "If generating multiple pre-signed URLs, it is recommended to create a single instance of "
                          + "S3Presigner, since creating a presigner can be expensive. If applicable, please manually "
                          + "refactor the transformed code.";
-        return createComments(comment);
+        return createCommentsWithNewline(comment);
+    }
+
+    public static J.MethodInvocation sseAwsKeyManagementParamsNotSupportedComment(J.MethodInvocation method) {
+        String comment = "Transform for PutObjectRequest setter sseAwsKeyManagementParam is not supported, please manually "
+                         + "migrate your code to use the v2 setters: ssekmsKeyId, serverSideEncryption, sseCustomerAlgorithm - "
+                         + "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model"
+                         + "/PutObjectRequest.Builder.html#ssekmsKeyId(java.lang.String)";
+        return appendCommentToMethod(method, comment);
+    }
+
+    public static J.MethodInvocation sseCustomerKeyNotSupportedComment(J.MethodInvocation method) {
+        String comment = "Transform for PutObjectRequest setter sseCustomerKey is not supported, please manually "
+                         + "migrate your code to use the v2 setters: sseCustomerKey, sseCustomerKeyMD5 - "
+                         + "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model"
+                         + "/PutObjectRequest.Builder.html#sseCustomerKey(java.lang.String)";
+        return appendCommentToMethod(method, comment);
+    }
+
+    public static J.MethodInvocation accessControlListNotSupportedComment(J.MethodInvocation method) {
+        String comment = "Transform for PutObjectRequest setter accessControlList is not supported, please manually "
+                         + "migrate your code to use the v2 setters: acl, grantReadACP, grantWriteACP - "
+                         + "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model"
+                         + "/PutObjectRequest.Builder.html#acl(java.lang.String)";
+        return appendCommentToMethod(method, comment);
+    }
+
+    public static J.MethodInvocation addCommentForUnsupportedPutObjectRequestSetter(J.MethodInvocation method) {
+        String methodName = method.getSimpleName();
+        switch (methodName) {
+            case "sseCustomerKey":
+                return sseAwsKeyManagementParamsNotSupportedComment(method);
+            case "sseAwsKeyManagementParams":
+                return sseCustomerKeyNotSupportedComment(method);
+            case "accessControlList":
+                return accessControlListNotSupportedComment(method);
+            default:
+                return method;
+        }
+    }
+
+    public static J.MethodInvocation appendCommentToMethod(J.MethodInvocation method, String comment) {
+        if (method.getComments().isEmpty()) {
+            return method.withComments(createCommentsWithNewline(comment));
+        }
+
+        List<Comment> existingComments = method.getComments();
+        existingComments.add(createCommentWithNewline(comment));
+        return method.withComments(existingComments);
     }
 }

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/SdkTypeUtils.java
@@ -148,7 +148,10 @@ public final class SdkTypeUtils {
                       "com.amazonaws.services.kinesis.metrics",
                       "com.amazonaws.services.kinesis.multilang",
                       // Kinesis Producer Library (KCL) : amazon-kinesis-producer
-                      "com.amazonaws.services.kinesis.producer"
+                      "com.amazonaws.services.kinesis.producer",
+                      // S3 POJOs with no v2 equivalent
+                      "com.amazonaws.services.s3.model.SSEAwsKeyManagementParams",
+                      "com.amazonaws.services.s3.model.SSECustomerKey"
         ));
 
     static {

--- a/v2-migration/src/main/resources/META-INF/rewrite/change-s3-methods.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/change-s3-methods.yml
@@ -197,12 +197,6 @@ recipeList:
       methodPattern: com.amazonaws.services.s3.model.BucketCrossOriginConfiguration withRules(com.amazonaws.services.s3.model.CORSRule...)
       newMethodName: withCorsRules
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.services.s3.model.ListObjectsRequest withBucketName(String)
-      newMethodName: withBucket
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.services.s3.model.ListObjectsV2Request withBucketName(String)
-      newMethodName: withBucket
-  - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.amazonaws.services.s3.model.CopyPartRequest withSourceBucketName(String)
       newMethodName: withSourceBucket
   - org.openrewrite.java.ChangeMethodName:
@@ -212,16 +206,12 @@ recipeList:
       methodPattern: com.amazonaws.services.s3.model.analytics.AnalyticsS3BucketDestination withBucketArn(String)
       newMethodName: withBucket
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.services.s3.model.CompleteMultipartUploadRequest withBucketName(String)
-      newMethodName: withBucket
-  - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.amazonaws.services.s3.model.CompleteMultipartUploadRequest withPartETags(java.util.List)
       newMethodName: withMultipartUpload
 
-
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.amazonaws.services.s3.model.PutObjectRequest withBucketName(String)
-      newMethodName: withBucket
+      methodPattern: com.amazonaws.services.s3.model.PutObjectRequest withRedirectLocation(String)
+      newMethodName: withWebsiteRedirectLocation
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.amazonaws.services.s3.model.PutObjectRequest withCannedAcl(com.amazonaws.services.s3.model.CannedAccessControlList)
       newMethodName: withAcl

--- a/v2-migration/src/main/resources/META-INF/rewrite/s3-methods-constructor-to-fluent.yml
+++ b/v2-migration/src/main/resources/META-INF/rewrite/s3-methods-constructor-to-fluent.yml
@@ -622,3 +622,9 @@ recipeList:
         - withKey
         - withUploadId
         - withMultipartUpload
+  - software.amazon.awssdk.v2migration.ConstructorToFluent:
+      clzzFqcn: com.amazonaws.services.s3.model.ObjectTagging
+      parameterTypes:
+        - java.util.List<com.amazonaws.services.s3.model.Tag>
+      fluentNames:
+        - withTagSet


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Adds support for S3 POJO transforms:
`ObjectTagging, AccessControlList`

Adds support for `PutObjectRequest` setters:
`redirectLocation, tagging`

Adds comments for `PutObjectRequest` unsupported setters:
`sseCustomerKey, sseAwsKeyManagementParams, accessControlList`

Adds type check for `ObjectMetadata` arg in `putObject(bucket, key, InputStream, ObjectMetadata)` , as user could pass in a non variable, e.g. empty `new ObjectMetadata()` or mock value `any(ObjectMetadata.class)`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added end to end tests
