### PR TITLE
Fix: Warn about SSL Certificate verification being disabled only when it's actually disabled

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -74,7 +74,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
                              .withCipherPreference(TlsCipherPreference.TLS_CIPHER_SYSTEM_DEFAULT);
 
         if (builder.httpConfiguration != null
-            && builder.httpConfiguration.trustAllCertificatesEnabled() != null) {
+            && Boolean.TRUE.equals(builder.httpConfiguration.trustAllCertificatesEnabled())) {
             log.warn(() -> "SSL Certificate verification is disabled. "
                            + "This is not a safe setting and should only be used for testing.");
             clientTlsContextOptions.withVerifyPeer(!builder.httpConfiguration.trustAllCertificatesEnabled());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Initializing a CRT-based `S3AsyncClient` with `.httpConfiguration(c -> c.trustAllCertificatesEnabled(ignoreCertificate))` (`ignoreCertificate` being a client-configured flag), works well for setting `ignoreCertificate = Boolean.TRUE` during tests. However, changing such flag to `Boolean.FALSE` didn't make the warning message go away, even though SSL Certificate was verified in this last case.

Basically, only `Boolean.TRUE` disables SSL Certificate Validation, so both `null` as well as `Boolean.FALSE` should skip the warning message.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since it's just a ternary `Boolean` check, I've just verified the state of `clientTlsContextOptions.verifyPeer` right after the `if` statement with a debugger.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
