### PR TITLE
Fix issue in generating event shapes shared between multiple eventstreams

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1924edd.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1924edd.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix issue in generating event shapes shared between multiple eventstreams."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/common/AbstractEnumClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/common/AbstractEnumClass.java
@@ -56,12 +56,14 @@ public abstract class AbstractEnumClass implements ClassSpec {
                 .addMethod(knownValuesSpec())
                 .addMethod(createConstructor());
 
+        addSuperInterface(enumBuilder);
         addDeprecated(enumBuilder);
         addJavadoc(enumBuilder);
         addEnumConstants(enumBuilder);
 
         enumBuilder.addEnumConstant(UNKNOWN_TO_SDK_VERSION, TypeSpec.anonymousClassBuilder("null").build());
 
+        addAdditionalMethods(enumBuilder);
         return enumBuilder.build();
     }
 
@@ -74,6 +76,14 @@ public abstract class AbstractEnumClass implements ClassSpec {
     protected abstract void addJavadoc(Builder enumBuilder);
 
     protected abstract void addEnumConstants(Builder enumBuilder);
+
+    protected void addSuperInterface(Builder enumBuilder) {
+        // no-op
+    }
+
+    protected void addAdditionalMethods(Builder enumBuilder) {
+        // no-op
+    }
     
     private FieldSpec valueMapField() {
         ParameterizedTypeName mapType = ParameterizedTypeName.get(ClassName.get(Map.class),

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
@@ -171,11 +171,11 @@ public class EventStreamUtils {
      * Returns true if the given event shape is a sub-member of any operation request.
      */
     public static boolean isRequestEvent(IntermediateModel model, ShapeModel eventShape) {
-        return getBaseEventStreamShape(model, eventShape)
-            .map(stream -> model.getOperations().values()
-                                .stream()
-                                .anyMatch(o -> doesShapeContainsEventStream(o.getInputShape(), stream)))
-            .orElse(false);
+        return getBaseEventStreamShapes(model, eventShape)
+            .stream()
+            .anyMatch(streamShape -> model.getOperations().values()
+                                          .stream()
+                                          .anyMatch(o -> doesShapeContainsEventStream(o.getInputShape(), streamShape)));
     }
 
     private static boolean operationContainsEventStream(OperationModel opModel, ShapeModel eventStreamShape) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventTypeEnumSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventTypeEnumSpec.java
@@ -16,13 +16,17 @@
 package software.amazon.awssdk.codegen.poet.eventstream;
 
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
+import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.naming.NamingStrategy;
 import software.amazon.awssdk.codegen.poet.common.AbstractEnumClass;
+import software.amazon.awssdk.core.SdkEventType;
 
 public class EventTypeEnumSpec extends AbstractEnumClass {
+    private static final Object VALUE = "value";
     private final String enumPackageName;
     private final IntermediateModel intermediateModel;
 
@@ -30,6 +34,11 @@ public class EventTypeEnumSpec extends AbstractEnumClass {
         super(eventStream);
         this.enumPackageName = enumPackageName;
         this.intermediateModel = intermediateModel;
+    }
+
+    @Override
+    protected void addSuperInterface(TypeSpec.Builder enumBuilder) {
+        enumBuilder.addSuperinterface(ClassName.get(SdkEventType.class));
     }
 
     @Override
@@ -52,6 +61,20 @@ public class EventTypeEnumSpec extends AbstractEnumClass {
                     String name = namingStrategy.getEnumValueName(value);
                     enumBuilder.addEnumConstant(name, TypeSpec.anonymousClassBuilder("$S", value).build());
                 });
+    }
+
+    @Override
+    protected void addAdditionalMethods(TypeSpec.Builder enumBuilder) {
+        enumBuilder.addMethod(idMethod());
+    }
+
+    private MethodSpec idMethod() {
+        return MethodSpec.methodBuilder("id")
+            .addAnnotation(Override.class)
+            .returns(String.class)
+            .addModifiers(Modifier.PUBLIC)
+                  .addStatement("return $T.valueOf($N)", String.class, VALUE)
+                  .build();
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventTypeEnumSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventTypeEnumSpec.java
@@ -65,16 +65,14 @@ public class EventTypeEnumSpec extends AbstractEnumClass {
 
     @Override
     protected void addAdditionalMethods(TypeSpec.Builder enumBuilder) {
-        enumBuilder.addMethod(idMethod());
-    }
-
-    private MethodSpec idMethod() {
-        return MethodSpec.methodBuilder("id")
-            .addAnnotation(Override.class)
-            .returns(String.class)
-            .addModifiers(Modifier.PUBLIC)
-                  .addStatement("return $T.valueOf($N)", String.class, VALUE)
-                  .build();
+        enumBuilder.addMethod(
+            MethodSpec.methodBuilder("id")
+                      .addAnnotation(Override.class)
+                      .returns(String.class)
+                      .addModifiers(Modifier.PUBLIC)
+                      .addStatement("return $T.valueOf($N)", String.class, VALUE)
+                      .build()
+        );
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
@@ -60,6 +60,7 @@ import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.codegen.poet.model.TypeProvider.TypeNameOptions;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.StringUtils;
@@ -169,12 +170,11 @@ public class AwsServiceModel implements ClassSpec {
                          .addType(helper.eventTypeEnumSpec());
 
 
-        ClassName eventTypeEnum = helper.eventTypeEnumClassName();
         builder.addMethod(MethodSpec.methodBuilder("sdkEventType")
                 .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
-                .returns(eventTypeEnum)
+                .returns(SdkEventType.class)
                 .addJavadoc("The type of this event. Corresponds to the {@code :event-type} header on the Message.")
-                .addStatement("return $T.UNKNOWN_TO_SDK_VERSION", eventTypeEnum)
+                .addStatement("throw new $T($S)", UnsupportedOperationException.class, "Unknown event type")
                 .build());
 
         if (!outputOperations.isEmpty()) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/service-2.json
@@ -171,5 +171,25 @@
        "type": "string"
     }
   },
-  "documentation": "A service that is implemented using the query protocol"
+  "StreamA": {
+    "type": "structure",
+    "members": {
+      "payloadA": "Payload"
+    },
+    "eventstream": true
+  },
+  "StreamB": {
+    "type": "structure",
+    "members": {
+      "payloadB": "Payload"
+    },
+    "eventstream": true
+  },
+  "Payload": {
+    "members": {
+      "data": "blob"
+    },
+    "event": true
+  },
+  "documentation": "A service with event stream operations that is implemented using the rest-json protocol"
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/service-2.json
@@ -171,25 +171,5 @@
        "type": "string"
     }
   },
-  "StreamA": {
-    "type": "structure",
-    "members": {
-      "payloadA": "Payload"
-    },
-    "eventstream": true
-  },
-  "StreamB": {
-    "type": "structure",
-    "members": {
-      "payloadB": "Payload"
-    },
-    "eventstream": true
-  },
-  "Payload": {
-    "members": {
-      "data": "blob"
-    },
-    "event": true
-  },
-  "documentation": "A service with event stream operations that is implemented using the rest-json protocol"
+  "documentation": "A service that is implemented using the query protocol"
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventone.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventone.java
@@ -12,6 +12,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -146,6 +147,11 @@ public class EventOne implements SdkPojo, Serializable, ToCopyableBuilder<EventO
     @Override
     public void accept(EventStreamOperationResponseHandler.Visitor visitor) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown Event");
     }
 
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, EventOne> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstream.java
@@ -33,6 +33,11 @@ public interface EventStream extends SdkPojo {
         }
 
         @Override
+        public SdkEventType sdkEventType() {
+            return EventType.UNKNOWN_TO_SDK_VERSION;
+        }
+
+        @Override
         public void accept(EventStreamOperationResponseHandler.Visitor visitor) {
             visitor.visitDefault(this);
         }
@@ -76,9 +81,7 @@ public interface EventStream extends SdkPojo {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default SdkEventType sdkEventType() {
-        throw new UnsupportedOperationException("Unknown event type");
-    }
+    SdkEventType sdkEventType();
 
     /**
      * Calls the appropriate visit method depending on the subtype of {@link EventStream}.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstream.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.services.jsonprotocoltests.model.eventstream.DefaultEventOne;
@@ -75,8 +76,8 @@ public interface EventStream extends SdkPojo {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default EventType sdkEventType() {
-        return EventType.UNKNOWN_TO_SDK_VERSION;
+    default SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown event type");
     }
 
     /**
@@ -91,7 +92,7 @@ public interface EventStream extends SdkPojo {
      * The known possible types of events for {@code EventStream}.
      */
     @Generated("software.amazon.awssdk:codegen")
-    enum EventType {
+    enum EventType implements SdkEventType {
         EVENT_ONE("EventOne"),
 
         SECOND_EVENT_ONE("SecondEventOne"),
@@ -141,6 +142,11 @@ public interface EventStream extends SdkPojo {
             Set<EventType> knownValues = EnumSet.allOf(EventType.class);
             knownValues.remove(UNKNOWN_TO_SDK_VERSION);
             return knownValues;
+        }
+
+        @Override
+        public String id() {
+            return String.valueOf(value);
         }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventtwo.java
@@ -12,6 +12,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -146,6 +147,11 @@ public class EventTwo implements SdkPojo, Serializable, ToCopyableBuilder<EventT
     @Override
     public void accept(EventStreamOperationResponseHandler.Visitor visitor) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown Event");
     }
 
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, EventTwo> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
@@ -14,6 +14,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -143,6 +144,11 @@ public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<Inpu
 
     private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
         return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    @Override
+    public SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown Event");
     }
 
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, InputEvent> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstream.java
@@ -25,9 +25,7 @@ public interface InputEventStream {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default SdkEventType sdkEventType() {
-        throw new UnsupportedOperationException("Unknown event type");
-    }
+    SdkEventType sdkEventType();
 
     /**
      * The known possible types of events for {@code InputEventStream}.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstream.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.services.jsonprotocoltests.model.inputeventstream.DefaultInputEvent;
 import software.amazon.awssdk.utils.internal.EnumUtils;
 
@@ -24,15 +25,15 @@ public interface InputEventStream {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default EventType sdkEventType() {
-        return EventType.UNKNOWN_TO_SDK_VERSION;
+    default SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown event type");
     }
 
     /**
      * The known possible types of events for {@code InputEventStream}.
      */
     @Generated("software.amazon.awssdk:codegen")
-    enum EventType {
+    enum EventType implements SdkEventType {
         INPUT_EVENT("InputEvent"),
 
         UNKNOWN_TO_SDK_VERSION(null);
@@ -74,6 +75,11 @@ public interface InputEventStream {
             Set<EventType> knownValues = EnumSet.allOf(EventType.class);
             knownValues.remove(UNKNOWN_TO_SDK_VERSION);
             return knownValues;
+        }
+
+        @Override
+        public String id() {
+            return String.valueOf(value);
         }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstreamtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstreamtwo.java
@@ -25,9 +25,7 @@ public interface InputEventStreamTwo {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default SdkEventType sdkEventType() {
-        throw new UnsupportedOperationException("Unknown event type");
-    }
+    SdkEventType sdkEventType();
 
     /**
      * The known possible types of events for {@code InputEventStreamTwo}.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstreamtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstreamtwo.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.services.jsonprotocoltests.model.inputeventstreamtwo.DefaultInputEventTwo;
 import software.amazon.awssdk.utils.internal.EnumUtils;
 
@@ -24,15 +25,15 @@ public interface InputEventStreamTwo {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default EventType sdkEventType() {
-        return EventType.UNKNOWN_TO_SDK_VERSION;
+    default SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown event type");
     }
 
     /**
      * The known possible types of events for {@code InputEventStreamTwo}.
      */
     @Generated("software.amazon.awssdk:codegen")
-    enum EventType {
+    enum EventType implements SdkEventType {
         INPUT_EVENT_TWO("InputEventTwo"),
 
         UNKNOWN_TO_SDK_VERSION(null);
@@ -74,6 +75,11 @@ public interface InputEventStreamTwo {
             Set<EventType> knownValues = EnumSet.allOf(EventType.class);
             knownValues.remove(UNKNOWN_TO_SDK_VERSION);
             return knownValues;
+        }
+
+        @Override
+        public String id() {
+            return String.valueOf(value);
         }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
@@ -14,6 +14,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -188,6 +189,11 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
 
     private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
         return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    @Override
+    public SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown Event");
     }
 
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, InputEventTwo> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/eventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/eventstream.java
@@ -29,6 +29,11 @@ public interface EventStream extends SdkPojo {
         }
 
         @Override
+        public SdkEventType sdkEventType() {
+            return EventType.UNKNOWN_TO_SDK_VERSION;
+        }
+
+        @Override
         public void accept(StreamBirthsResponseHandler.Visitor visitor) {
             visitor.visitDefault(this);
         }
@@ -49,9 +54,7 @@ public interface EventStream extends SdkPojo {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default SdkEventType sdkEventType() {
-        throw new UnsupportedOperationException("Unknown event type");
-    }
+    SdkEventType sdkEventType();
 
     /**
      * Calls the appropriate visit method depending on the subtype of {@link EventStream}.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/eventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/eventstream.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.services.sharedeventstream.model.eventstream.DefaultPerson;
@@ -48,8 +49,8 @@ public interface EventStream extends SdkPojo {
     /**
      * The type of this event. Corresponds to the {@code :event-type} header on the Message.
      */
-    default EventType sdkEventType() {
-        return EventType.UNKNOWN_TO_SDK_VERSION;
+    default SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown event type");
     }
 
     /**
@@ -72,7 +73,7 @@ public interface EventStream extends SdkPojo {
      * The known possible types of events for {@code EventStream}.
      */
     @Generated("software.amazon.awssdk:codegen")
-    enum EventType {
+    enum EventType implements SdkEventType {
         PERSON("Person"),
 
         UNKNOWN_TO_SDK_VERSION(null);
@@ -114,6 +115,11 @@ public interface EventStream extends SdkPojo {
             Set<EventType> knownValues = EnumSet.allOf(EventType.class);
             knownValues.remove(UNKNOWN_TO_SDK_VERSION);
             return knownValues;
+        }
+
+        @Override
+        public String id() {
+            return String.valueOf(value);
         }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
@@ -12,6 +12,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -156,6 +157,11 @@ public class GetRandomPersonResponse extends SharedEventStreamResponse implement
 
     private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
         return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    @Override
+    public SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown Event");
     }
 
     public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
@@ -13,6 +13,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkEventType;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -178,6 +179,11 @@ public class Person implements SdkPojo, Serializable, ToCopyableBuilder<Person.B
     @Override
     public void accept(StreamDeathsResponseHandler.Visitor visitor) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SdkEventType sdkEventType() {
+        throw new UnsupportedOperationException("Unknown Event");
     }
 
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, Person> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
@@ -26,7 +26,8 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 /**
  */
 @Generated("software.amazon.awssdk:codegen")
-public class Person implements SdkPojo, Serializable, ToCopyableBuilder<Person.Builder, Person>, EventStream {
+public class Person implements SdkPojo, Serializable, ToCopyableBuilder<Person.Builder, Person>, StreamBirthsInputEventStream,
+                               EventStream, StreamDeathsInputEventStream {
     private static final SdkField<String> NAME_FIELD = SdkField.<String> builder(MarshallingType.STRING).memberName("Name")
                                                                .getter(getter(Person::name)).setter(setter(Builder::name))
                                                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("Name").build()).build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/service-2.json
@@ -33,6 +33,26 @@
         "shape": "PeopleOutput"
       }
     },
+    "StreamBirthsInput" : {
+      "name": "StreamBirths",
+      "http": {
+        "method": "POST",
+        "requestUri": "/births"
+      },
+      "input": {
+        "shape": "StreamBirthsInputRequest"
+      }
+    },
+    "StreamDeathsInput" : {
+      "name": "StreamDeathsInput",
+      "http": {
+        "method": "POST",
+        "requestUri": "/deaths"
+      },
+      "input": {
+        "shape": "StreamDeathsInputRequest"
+      }
+    },
     "GetRandomPerson" : {
       "name" : "GetRandomPerson",
       "http": {
@@ -79,6 +99,40 @@
         }
       },
       "event": true
+    },
+    "StreamBirthsInputRequest": {
+      "type": "structure",
+      "members": {
+        "StreamBirthsInputEventStream": {
+          "shape": "StreamBirthsInputEventStream"
+        }
+      }
+    },
+    "StreamDeathsInputRequest": {
+      "type": "structure",
+      "members": {
+        "StreamDeathsInputEventStream": {
+          "shape": "StreamDeathsInputEventStream"
+        }
+      }
+    },
+    "StreamBirthsInputEventStream": {
+      "type": "structure",
+      "members": {
+        "Person": {
+          "shape": "Person"
+        }
+      },
+      "eventstream": true
+    },
+    "StreamDeathsInputEventStream": {
+      "type": "structure",
+      "members": {
+        "Person": {
+          "shape": "Person"
+        }
+      },
+      "eventstream": true
     }
   },
   "documentation": "A service that streams births and deaths"

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsinputeventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsinputeventstream.java
@@ -1,0 +1,83 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkEventType;
+import software.amazon.awssdk.services.sharedeventstream.model.streambirthsinputeventstream.DefaultPerson;
+import software.amazon.awssdk.utils.internal.EnumUtils;
+
+/**
+ * Base interface for all event types in StreamBirthsInputEventStream.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface StreamBirthsInputEventStream {
+    /**
+     * Create a builder for the {@code Person} event type for this stream.
+     */
+    static Person.Builder personBuilder() {
+        return DefaultPerson.builder();
+    }
+
+    /**
+     * The type of this event. Corresponds to the {@code :event-type} header on the Message.
+     */
+    SdkEventType sdkEventType();
+
+    /**
+     * The known possible types of events for {@code StreamBirthsInputEventStream}.
+     */
+    @Generated("software.amazon.awssdk:codegen")
+    enum EventType implements SdkEventType {
+        PERSON("Person"),
+
+        UNKNOWN_TO_SDK_VERSION(null);
+
+        private static final Map<String, EventType> VALUE_MAP = EnumUtils.uniqueIndex(EventType.class, EventType::toString);
+
+        private final String value;
+
+        private EventType(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        /**
+         * Use this in place of valueOf to convert the raw string returned by the service into the enum value.
+         *
+         * @param value
+         *        real value
+         * @return EventType corresponding to the value
+         */
+        public static EventType fromValue(String value) {
+            if (value == null) {
+                return null;
+            }
+            return VALUE_MAP.getOrDefault(value, UNKNOWN_TO_SDK_VERSION);
+        }
+
+        /**
+         * Use this in place of {@link #values()} to return a {@link Set} of all values known to the SDK. This will
+         * return all known enum values except {@link #UNKNOWN_TO_SDK_VERSION}.
+         *
+         * @return a {@link Set} of known {@link EventType}s
+         */
+        public static Set<EventType> knownValues() {
+            Set<EventType> knownValues = EnumSet.allOf(EventType.class);
+            knownValues.remove(UNKNOWN_TO_SDK_VERSION);
+            return knownValues;
+        }
+
+        @Override
+        public String id() {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsinputrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsinputrequest.java
@@ -1,0 +1,139 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamBirthsInputRequest extends SharedEventStreamRequest implements
+                                                                             ToCopyableBuilder<StreamBirthsInputRequest.Builder, StreamBirthsInputRequest> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.emptyList();
+
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+
+    private StreamBirthsInputRequest(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public final int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public final boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamBirthsInputRequest)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public final String toString() {
+        return ToString.builder("StreamBirthsInputRequest").build();
+    }
+
+    public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public final List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    @Override
+    public final Map<String, SdkField<?>> sdkFieldNameToField() {
+        return SDK_NAME_TO_FIELD;
+    }
+
+    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
+        return Collections.emptyMap();
+    }
+
+    public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, StreamBirthsInputRequest> {
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends SharedEventStreamRequest.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamBirthsInputRequest model) {
+            super(model);
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public StreamBirthsInputRequest build() {
+            return new StreamBirthsInputRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return SDK_NAME_TO_FIELD;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsinputresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsinputresponse.java
@@ -1,0 +1,118 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamBirthsInputResponse extends SharedEventStreamResponse implements
+                                                                               ToCopyableBuilder<StreamBirthsInputResponse.Builder, StreamBirthsInputResponse> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.emptyList();
+
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+
+    private StreamBirthsInputResponse(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public final int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public final boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamBirthsInputResponse)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public final String toString() {
+        return ToString.builder("StreamBirthsInputResponse").build();
+    }
+
+    public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public final List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    @Override
+    public final Map<String, SdkField<?>> sdkFieldNameToField() {
+        return SDK_NAME_TO_FIELD;
+    }
+
+    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
+        return Collections.emptyMap();
+    }
+
+    public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, StreamBirthsInputResponse> {
+    }
+
+    static final class BuilderImpl extends SharedEventStreamResponse.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamBirthsInputResponse model) {
+            super(model);
+        }
+
+        @Override
+        public StreamBirthsInputResponse build() {
+            return new StreamBirthsInputResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return SDK_NAME_TO_FIELD;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsinputeventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsinputeventstream.java
@@ -1,0 +1,83 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkEventType;
+import software.amazon.awssdk.services.sharedeventstream.model.streamdeathsinputeventstream.DefaultPerson;
+import software.amazon.awssdk.utils.internal.EnumUtils;
+
+/**
+ * Base interface for all event types in StreamDeathsInputEventStream.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface StreamDeathsInputEventStream {
+    /**
+     * Create a builder for the {@code Person} event type for this stream.
+     */
+    static Person.Builder personBuilder() {
+        return DefaultPerson.builder();
+    }
+
+    /**
+     * The type of this event. Corresponds to the {@code :event-type} header on the Message.
+     */
+    SdkEventType sdkEventType();
+
+    /**
+     * The known possible types of events for {@code StreamDeathsInputEventStream}.
+     */
+    @Generated("software.amazon.awssdk:codegen")
+    enum EventType implements SdkEventType {
+        PERSON("Person"),
+
+        UNKNOWN_TO_SDK_VERSION(null);
+
+        private static final Map<String, EventType> VALUE_MAP = EnumUtils.uniqueIndex(EventType.class, EventType::toString);
+
+        private final String value;
+
+        private EventType(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        /**
+         * Use this in place of valueOf to convert the raw string returned by the service into the enum value.
+         *
+         * @param value
+         *        real value
+         * @return EventType corresponding to the value
+         */
+        public static EventType fromValue(String value) {
+            if (value == null) {
+                return null;
+            }
+            return VALUE_MAP.getOrDefault(value, UNKNOWN_TO_SDK_VERSION);
+        }
+
+        /**
+         * Use this in place of {@link #values()} to return a {@link Set} of all values known to the SDK. This will
+         * return all known enum values except {@link #UNKNOWN_TO_SDK_VERSION}.
+         *
+         * @return a {@link Set} of known {@link EventType}s
+         */
+        public static Set<EventType> knownValues() {
+            Set<EventType> knownValues = EnumSet.allOf(EventType.class);
+            knownValues.remove(UNKNOWN_TO_SDK_VERSION);
+            return knownValues;
+        }
+
+        @Override
+        public String id() {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsinputrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsinputrequest.java
@@ -1,0 +1,139 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamDeathsInputRequest extends SharedEventStreamRequest implements
+                                                                             ToCopyableBuilder<StreamDeathsInputRequest.Builder, StreamDeathsInputRequest> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.emptyList();
+
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+
+    private StreamDeathsInputRequest(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public final int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public final boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamDeathsInputRequest)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public final String toString() {
+        return ToString.builder("StreamDeathsInputRequest").build();
+    }
+
+    public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public final List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    @Override
+    public final Map<String, SdkField<?>> sdkFieldNameToField() {
+        return SDK_NAME_TO_FIELD;
+    }
+
+    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
+        return Collections.emptyMap();
+    }
+
+    public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, StreamDeathsInputRequest> {
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends SharedEventStreamRequest.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamDeathsInputRequest model) {
+            super(model);
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public StreamDeathsInputRequest build() {
+            return new StreamDeathsInputRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return SDK_NAME_TO_FIELD;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsinputresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsinputresponse.java
@@ -1,0 +1,118 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamDeathsInputResponse extends SharedEventStreamResponse implements
+                                                                               ToCopyableBuilder<StreamDeathsInputResponse.Builder, StreamDeathsInputResponse> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.emptyList();
+
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+
+    private StreamDeathsInputResponse(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public final int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public final boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamDeathsInputResponse)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public final String toString() {
+        return ToString.builder("StreamDeathsInputResponse").build();
+    }
+
+    public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public final List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    @Override
+    public final Map<String, SdkField<?>> sdkFieldNameToField() {
+        return SDK_NAME_TO_FIELD;
+    }
+
+    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
+        return Collections.emptyMap();
+    }
+
+    public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, StreamDeathsInputResponse> {
+    }
+
+    static final class BuilderImpl extends SharedEventStreamResponse.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamDeathsInputResponse model) {
+            super(model);
+        }
+
+        @Override
+        public StreamDeathsInputResponse build() {
+            return new StreamDeathsInputResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return SDK_NAME_TO_FIELD;
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkEventType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkEventType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * TODO
+ */
+@SdkProtectedApi
+public interface SdkEventType {
+    /**
+     * TODO
+     *
+     * @return The id of the event type.
+     */
+     String id();
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkEventType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkEventType.java
@@ -18,14 +18,12 @@ package software.amazon.awssdk.core;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
- * TODO
+ * Interface for all generated EventStream EventType enums.
  */
 @SdkProtectedApi
 public interface SdkEventType {
     /**
-     * TODO
-     *
-     * @return The id of the event type.
+     * @return The id for the event type.
      */
-     String id();
+    String id();
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/EventTransformTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/EventTransformTest.java
@@ -35,6 +35,8 @@ import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
 import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.services.protocolrestjson.model.InputEvent;
+import software.amazon.awssdk.services.protocolrestjson.model.InputEventStream;
+import software.amazon.awssdk.services.protocolrestjson.model.InputEventStreamStringPayload;
 import software.amazon.awssdk.services.protocolrestjson.model.InputEventStringPayload;
 import software.amazon.awssdk.services.protocolrestjson.transform.InputEventMarshaller;
 import software.amazon.awssdk.services.protocolrestjson.transform.InputEventStringPayloadMarshaller;
@@ -98,10 +100,11 @@ public class EventTransformTest {
     public void testMarshalling_BlobPayload(String payload) {
         InputEventMarshaller marshaller = new InputEventMarshaller(protocolFactory);
 
-        InputEvent e = InputEvent.builder()
-                .headerMember(HEADER_MEMBER)
-                .explicitPayloadMember(SdkBytes.fromUtf8String(payload))
-                .build();
+        InputEvent e = InputEventStream
+            .inputEventBuilder()
+            .headerMember(HEADER_MEMBER)
+            .explicitPayloadMember(SdkBytes.fromUtf8String(payload))
+            .build();
 
         SdkHttpFullRequest marshalled = marshaller.marshall(e);
 
@@ -115,10 +118,10 @@ public class EventTransformTest {
     public void testMarshalling_StringPayload(String payload) {
         InputEventStringPayloadMarshaller marshaller = new InputEventStringPayloadMarshaller(protocolFactory);
 
-        InputEventStringPayload e = InputEventStringPayload.builder()
-                                                           .headerMember(HEADER_MEMBER)
-                                                           .explicitPayloadStringMember(payload)
-                                                           .build();
+        InputEventStringPayload e = InputEventStreamStringPayload
+            .inputEventBuilder()
+            .headerMember(HEADER_MEMBER)
+            .explicitPayloadStringMember(payload).build();
 
         SdkHttpFullRequest marshalled = marshaller.marshall(e);
 


### PR DESCRIPTION
Fix issue in generating event shapes shared between multiple eventstreams by introducing new `SdkEventType` interface.

## Motivation and Context
Currently in Java 2.x, we generate an interface for each eventstream shape. The interface contains an `EventType` enum and an `sdkEventType` method. Values in `EventType` map to the event members in the eventstream, and classes that implement the interface return the appropriate value from `sdkEventType` to signify which event they are. When an event shape is shared between multiple eventstreams it will implement the interface for each eventstream, which leads to incompatible type signatures on the `sdkEventType` method.

## Modifications
1. Introduces a new `SdkEventType` interface that all `EventType` enums implement.
2. The base event POJO defines `sdkEventType` method that returns the new `SdkEventType`. Specific implementations of the event are unchanged and still return the Evenstream specific `EventType`.

## Testing
* Existing eventstream codegen test cases (require minor updates, see updated test code)
* New codegen shared evenstream tests (see model updates in /sharedstream/service-2.json)
* Manually run codgeneration for internal test case model that motivated change.

## Screenshots (if appropriate)
NA.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
