### PR TITLE
Compile v2 migration OpenRewrite recipes with `-parameters`

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-8ca55d3.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-8ca55d3.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "greg-at-moderne",
+    "description": "Compile v2 migration OpenRewrite recipes with `-parameters`"
+}

--- a/v2-migration/pom.xml
+++ b/v2-migration/pom.xml
@@ -288,6 +288,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.nativelibs4java</groupId>
                 <artifactId>maven-velocity-plugin</artifactId>
                 <version>${maven-velocity-plugin.version}</version>


### PR DESCRIPTION
Changing how the OpenRewrite recipes defined in `v2-migration/` are compiled. Adding `-parameters` option to Java compiler.

## Motivation and Context

Without it, OpenRewrite might fail with errors like:
```
[ERROR] Recipe validation error in AddCommentToMethod.methodPattern: is required
[ERROR] Recipe validation error in NumberToDuration.methodPattern: is required
```
or
```
java.lang.NullPointerException: Cannot invoke "String.length()" because "s" is null
    at org.antlr.v4.runtime.CharStreams.fromString (CharStreams.java:222)
    at org.antlr.v4.runtime.CharStreams.fromString (CharStreams.java:212)
    at org.openrewrite.java.MethodMatcher.<init> (MethodMatcher.java:112)
    at software.amazon.awssdk.v2migration.NumberToDuration$Visitor.<init> (NumberToDuration.java:76)
```

## Explanation

Without `-parameters`, the code defined in this repo (incl. classes like `NumberToDuration.java`) gets compiled in a way that does not keep the method argument names in byte code. Which in turn prevents the logic in OpenRewrite for matching YAML arguments to find the corresponding constructor names, i.e.:
- when a YAML recipe like [this one](https://github.com/aws/aws-sdk-java-v2/blob/877bff8001775faa85808037d6d26fac75ef75c9/v2-migration/src/main/resources/META-INF/rewrite/change-config-types.yml#L29) has `methodPattern: ...` as the argument
- the [OpenRewrite code for inspecting constructors in your recipes](https://github.com/openrewrite/rewrite/blob/d93a22128dc624f652d57d756528f6ad9383a1ea/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java#L117) sees `arg0` and `arg1` as the argument names
- as a consequence, there's no match between `methodPattern` and `arg1`, thus the recipe is called with null arguments
- which in turns results in it failing with an error

## Testing

I've executed:
```
mvn org.openrewrite.maven:rewrite-maven-plugin:dryRun \
  -Drewrite.recipeArtifactCoordinates=software.amazon.awssdk:v2-migration:$VERSION \
  -Drewrite.activeRecipes=software.amazon.awssdk.v2migration.AwsSdkJavaV1ToV2
```
against a 3rd-party project using AWS SDK v1 and Maven.

Without the change I saw errors like above.
With the change everything works and a patch is output by OpenRewrite.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
