### PR TITLE
Bumping openrewrite to 3.6.1

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-272d5e4.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-272d5e4.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "greg-at-moderne",
+    "description": "Bumping OpenRewrite to 3.6.1 for v2 migration tooling"
+}

--- a/v2-migration/pom.xml
+++ b/v2-migration/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <awsjavasdk.version>${project.parent.version}</awsjavasdk.version>
-        <openrewrite.version>2.23.0</openrewrite.version>
+        <openrewrite.version>3.6.1</openrewrite.version>
         <junit.version>5.10.3</junit.version>
         <awssdkjavav1.version>1.12.472</awssdkjavav1.version>
     </properties>


### PR DESCRIPTION
Bumping OpenRewrite to 3.6.1 of (rewrite-recipe-bom), which actually uses [OpenRewrite v8.50.2](https://github.com/openrewrite/rewrite/releases/tag/v8.50.2).

## Motivation and Context

To make sure AWS customers and OpenRewrite users can use the latest of OpenRewrite.

## Testing
- `mvn install` worked
- also I have executed:
```
mvn org.openrewrite.maven:rewrite-maven-plugin:dryRun \ 
  -Drewrite.recipeArtifactCoordinates=software.amazon.awssdk:v2-migration:2.31.23-SNAPSHOT-PREVIEW \
  -Drewrite.activeRecipes=software.amazon.awssdk.v2migration.AwsSdkJavaV1ToV2
```
against a third-party project using AWS SDK v1 and it worked. A reasonable patch was generated, no errors were observed.

## Screenshots (if appropriate)

<img width="825" alt="image" src="https://github.com/user-attachments/assets/14de52ce-057b-4c48-8aba-61b1b5f6fd7f" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Not sure what to select here.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
