### PR TITLE
Add support for etag validation in resumableFileDownload

### DIFF
--- a/.changes/next-release/feature-AmazonS3TransferManager-21d3a50.json
+++ b/.changes/next-release/feature-AmazonS3TransferManager-21d3a50.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon S3 Transfer Manager",
+    "contributor": "",
+    "description": "Add support for etag validation in resumableFileDownload"
+}

--- a/.changes/next-release/feature-AmazonS3TransferManager-21d3a50.json
+++ b/.changes/next-release/feature-AmazonS3TransferManager-21d3a50.json
@@ -2,5 +2,5 @@
     "type": "feature",
     "category": "Amazon S3 Transfer Manager",
     "contributor": "",
-    "description": "Add support for etag validation in resumableFileDownload"
+    "description": "Add support for etag validation in resumableFileDownload: restart paused downloads when etag does not match"
 }

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadPauseResumeIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadPauseResumeIntegrationTest.java
@@ -21,12 +21,16 @@ import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBu
 import static software.amazon.awssdk.transfer.s3.SizeConstant.MB;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,7 +42,10 @@ import software.amazon.awssdk.core.waiters.Waiter;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.testutils.LogCaptor;
 import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
 import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
@@ -68,6 +75,56 @@ public class S3TransferManagerDownloadPauseResumeIntegrationTest extends S3Integ
     public static void cleanup() {
         deleteBucketAndAllContents(BUCKET);
         sourceFile.delete();
+    }
+
+    @ParameterizedTest
+    @MethodSource("transferManagers")
+    void pauseAndResume_ObjectEtagChange_shouldRestartDownload(S3TransferManager tm) throws IOException {
+        Path path = RandomTempFile.randomUncreatedFile().toPath();
+
+        TestDownloadListener testDownloadListener = new TestDownloadListener();
+        DownloadFileRequest request = DownloadFileRequest.builder()
+                                                         .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
+                                                         .destination(path)
+                                                         .addTransferListener(testDownloadListener)
+                                                         .build();
+        FileDownload download = tm.downloadFile(request);
+        waitUntilFirstByteBufferDelivered(download);
+
+        ResumableFileDownload resumableFileDownload = download.pause();
+        log.debug(() -> "Paused: " + resumableFileDownload);
+
+        String originalEtag = testDownloadListener.getObjectResponse.eTag();
+
+        File newSourceFile = new RandomTempFile(OBJ_SIZE);
+        PutObjectResponse putResponse = s3.putObject(PutObjectRequest.builder()
+                                                                     .bucket(BUCKET)
+                                                                     .key(KEY)
+                                                                     .build(), newSourceFile.toPath());
+
+        String newEtag = putResponse.eTag();
+        assertThat(newEtag).isNotEqualTo(originalEtag);
+        try (LogCaptor logCaptor = LogCaptor.create(Level.DEBUG)) {
+
+            FileDownload resumedFileDownload = tm.resumeDownloadFile(resumableFileDownload);
+            CompletedFileDownload completedDownload = resumedFileDownload.completionFuture().join();
+
+            assertThat(completedDownload.response().eTag()).isEqualTo(newEtag);
+            assertThat(testDownloadListener.transferInitiatedCount == 2).isTrue();
+
+            List<LogEvent> logEvents = logCaptor.loggedEvents();
+            StringBuilder sb = new StringBuilder();
+            logEvents.forEach(logEvent -> {
+                sb.append(logEvent.getMessage().getFormattedMessage());
+            });
+
+            assertThat(sb)
+                .contains(String.format("The ETag of the requested object in bucket (%s) with key (%s) "
+                                        + "has changed since the last "
+                                        + "pause. The SDK will download the S3 object from "
+                                        + "the beginning",
+                                        BUCKET, KEY));
+        }
     }
 
     @ParameterizedTest
@@ -187,7 +244,13 @@ public class S3TransferManagerDownloadPauseResumeIntegrationTest extends S3Integ
     }
 
     private static final class TestDownloadListener implements TransferListener {
+        private int transferInitiatedCount = 0;
         private GetObjectResponse getObjectResponse;
+
+        @Override
+        public void transferInitiated(Context.TransferInitiated context) {
+            transferInitiatedCount++;
+        }
 
         @Override
         public void bytesTransferred(Context.BytesTransferred context) {

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -444,34 +444,6 @@ class GenericS3TransferManager implements S3TransferManager {
         CompletableFutureUtils.forwardExceptionTo(returnFuture, headFuture);
 
         headFuture.thenAccept(headObjectResponse -> {
-            resumableFileDownload.s3ObjectEtag().ifPresent(eTag -> {
-                if (!eTag.equals(headObjectResponse.eTag())) {
-                    throw SdkClientException.builder()
-                                            .message(String.format("ETag mismatch detected during resumed download. Object in "
-                                                                    + "bucket '%s' with key '%s' has been modified."
-                                                                    + " Expected ETag: %s, Found: %s",
-                                                                   getObjectRequest.bucket(),
-                                                                   getObjectRequest.key(),
-                                                                   eTag,
-                                                                   headObjectResponse.eTag())
-                                            ).build();
-                }
-            });
-
-            resumableFileDownload.s3ObjectLastModified().ifPresent(storedLastModified -> {
-                if (storedLastModified.isBefore(headObjectResponse.lastModified())) {
-                    throw SdkClientException.builder()
-                                            .message(String.format(
-                                                "The requested object in bucket '%s' with key '%s' is modified on Amazon S3 since the last pause. " +
-                                                "Last modified time recorded: %s, Current last modified time: %s",
-                                                getObjectRequest.bucket(),
-                                                getObjectRequest.key(),
-                                                storedLastModified,
-                                                headObjectResponse.lastModified())
-                                            ).build();
-                }
-            });
-
             Pair<DownloadFileRequest, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>>
                 requestPair = toDownloadFileRequestAndTransformer(resumableFileDownload, headObjectResponse,
                                                                   originalDownloadRequest);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -444,6 +444,34 @@ class GenericS3TransferManager implements S3TransferManager {
         CompletableFutureUtils.forwardExceptionTo(returnFuture, headFuture);
 
         headFuture.thenAccept(headObjectResponse -> {
+            resumableFileDownload.s3ObjectEtag().ifPresent(eTag -> {
+                if (!eTag.equals(headObjectResponse.eTag())) {
+                    throw SdkClientException.builder()
+                                            .message(String.format("ETag mismatch detected during resumed download. Object in "
+                                                                    + "bucket '%s' with key '%s' has been modified."
+                                                                    + " Expected ETag: %s, Found: %s",
+                                                                   getObjectRequest.bucket(),
+                                                                   getObjectRequest.key(),
+                                                                   eTag,
+                                                                   headObjectResponse.eTag())
+                                            ).build();
+                }
+            });
+
+            resumableFileDownload.s3ObjectLastModified().ifPresent(storedLastModified -> {
+                if (storedLastModified.isBefore(headObjectResponse.lastModified())) {
+                    throw SdkClientException.builder()
+                                            .message(String.format(
+                                                "The requested object in bucket '%s' with key '%s' is modified on Amazon S3 since the last pause. " +
+                                                "Last modified time recorded: %s, Current last modified time: %s",
+                                                getObjectRequest.bucket(),
+                                                getObjectRequest.key(),
+                                                storedLastModified,
+                                                headObjectResponse.lastModified())
+                                            ).build();
+                }
+            });
+
             Pair<DownloadFileRequest, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>>
                 requestPair = toDownloadFileRequestAndTransformer(resumableFileDownload, headObjectResponse,
                                                                   originalDownloadRequest);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/model/DefaultFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/model/DefaultFileDownload.java
@@ -66,15 +66,18 @@ public final class DefaultFileDownload implements FileDownload {
         completionFuture.cancel(true);
 
         Instant s3objectLastModified = null;
+        String s3objectEtag = null;
         Long totalSizeInBytes = null;
         TransferProgressSnapshot snapshot = progress.snapshot();
 
         if (snapshot.sdkResponse().isPresent() && snapshot.sdkResponse().get() instanceof GetObjectResponse) {
             GetObjectResponse getObjectResponse = (GetObjectResponse) snapshot.sdkResponse().get();
             s3objectLastModified = getObjectResponse.lastModified();
+            s3objectEtag = getObjectResponse.eTag();
             totalSizeInBytes = getObjectResponse.contentLength();
         } else if (resumedDownload != null) {
             s3objectLastModified = resumedDownload.s3ObjectLastModified().orElse(null);
+            s3objectEtag = resumedDownload.s3ObjectEtag().orElse(null);
             totalSizeInBytes = resumedDownload.totalSizeInBytes().isPresent() ? resumedDownload.totalSizeInBytes().getAsLong()
                                                                               : null;
         }
@@ -87,6 +90,7 @@ public final class DefaultFileDownload implements FileDownload {
         return ResumableFileDownload.builder()
                                     .downloadFileRequest(request)
                                     .s3ObjectLastModified(s3objectLastModified)
+                                    .s3ObjectEtag(s3objectEtag)
                                     .fileLastModified(fileLastModified)
                                     .bytesTransferred(length)
                                     .totalSizeInBytes(totalSizeInBytes)

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/ResumableFileDownloadSerializer.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/serialization/ResumableFileDownloadSerializer.java
@@ -62,6 +62,11 @@ public final class ResumableFileDownloadSerializer {
                                        jsonGenerator,
                                        "s3ObjectLastModified");
         }
+        if (download.s3ObjectEtag().isPresent()) {
+            TransferManagerJsonMarshaller.STRING.marshall(download.s3ObjectEtag().get(),
+                                                           jsonGenerator,
+                                                           "s3ObjectEtag");
+        }
         marshallDownloadFileRequest(download.downloadFileRequest(), jsonGenerator);
         TransferManagerJsonMarshaller.LIST.marshall(download.completedParts(), jsonGenerator, "completedParts");
         jsonGenerator.writeEndObject();
@@ -127,6 +132,8 @@ public final class ResumableFileDownloadSerializer {
             (TransferManagerJsonUnmarshaller<Long>) getUnmarshaller(MarshallingType.LONG);
         TransferManagerJsonUnmarshaller<Instant> instantUnmarshaller =
             (TransferManagerJsonUnmarshaller<Instant>) getUnmarshaller(MarshallingType.INSTANT);
+        TransferManagerJsonUnmarshaller<String> stringUnmarshaller =
+            (TransferManagerJsonUnmarshaller<String>) getUnmarshaller(MarshallingType.STRING);
 
         ResumableFileDownload.Builder builder = ResumableFileDownload.builder();
         builder.bytesTransferred(longUnmarshaller.unmarshall(downloadNodes.get("bytesTransferred")));
@@ -137,6 +144,10 @@ public final class ResumableFileDownloadSerializer {
 
         if (downloadNodes.get("s3ObjectLastModified") != null) {
             builder.s3ObjectLastModified(instantUnmarshaller.unmarshall(downloadNodes.get("s3ObjectLastModified")));
+        }
+
+        if (downloadNodes.get("s3ObjectEtag") != null) {
+            builder.s3ObjectEtag(stringUnmarshaller.unmarshall(downloadNodes.get("s3ObjectEtag")));
         }
         builder.downloadFileRequest(parseDownloadFileRequest(downloadNodes.get("downloadFileRequest")));
         if (downloadNodes.get("completedParts") != null) {

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/utils/ResumableRequestConverter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/utils/ResumableRequestConverter.java
@@ -60,15 +60,19 @@ public final class ResumableRequestConverter {
         GetObjectRequest getObjectRequest = originalDownloadRequest.getObjectRequest();
         DownloadFileRequest newDownloadFileRequest;
         Instant lastModified = resumableFileDownload.s3ObjectLastModified().orElse(null);
-        boolean s3ObjectModified = !headObjectResponse.lastModified().equals(lastModified);
+        String resumableFileDownloadEtag = resumableFileDownload.s3ObjectEtag().orElse(null);
 
+        String s3ObjectEtag = headObjectResponse.eTag();
+        boolean etagModified = resumableFileDownloadEtag != null && !s3ObjectEtag.equals(resumableFileDownloadEtag);
+
+        boolean s3ObjectModified = !headObjectResponse.lastModified().equals(lastModified);
         boolean fileModified = !fileNotModified(resumableFileDownload.bytesTransferred(),
                                                 resumableFileDownload.fileLastModified(),
                                                 resumableFileDownload.downloadFileRequest().destination());
 
-        if (fileModified || s3ObjectModified) {
+        if (fileModified || s3ObjectModified || etagModified) {
             // modification detected: new download request for the whole object from the beginning
-            logIfNeeded(originalDownloadRequest, getObjectRequest, fileModified, s3ObjectModified);
+            logIfNeeded(originalDownloadRequest, getObjectRequest, fileModified, s3ObjectModified, etagModified);
             newDownloadFileRequest = newDownloadFileRequest(originalDownloadRequest, getObjectRequest, headObjectResponse);
 
             AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> responseTransformer =
@@ -128,7 +132,8 @@ public final class ResumableRequestConverter {
     private static void logIfNeeded(DownloadFileRequest downloadRequest,
                                     GetObjectRequest getObjectRequest,
                                     boolean fileModified,
-                                    boolean s3ObjectModified) {
+                                    boolean s3ObjectModified,
+                                    boolean s3ObjectEtagModified) {
         if (log.logger().isDebugEnabled()) {
             if (s3ObjectModified) {
                 log.debug(() -> String.format("The requested object in bucket (%s) with key (%s) "
@@ -149,6 +154,14 @@ public final class ResumableRequestConverter {
                                               getObjectRequest.bucket(),
                                               getObjectRequest.key()));
             }
+            if (s3ObjectEtagModified) {
+                log.debug(() -> String.format("The ETag of the requested object in bucket (%s) with key (%s) "
+                                              + "has changed since the last "
+                                              + "pause. The SDK will download the S3 object from "
+                                              + "the beginning",
+                                              getObjectRequest.bucket(), getObjectRequest.key()));
+            }
+
         }
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/utils/ResumableRequestConverter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/utils/ResumableRequestConverter.java
@@ -63,7 +63,9 @@ public final class ResumableRequestConverter {
         String resumableFileDownloadEtag = resumableFileDownload.s3ObjectEtag().orElse(null);
 
         String s3ObjectEtag = headObjectResponse.eTag();
-        boolean etagModified = resumableFileDownloadEtag != null && !s3ObjectEtag.equals(resumableFileDownloadEtag);
+        boolean etagModified = resumableFileDownloadEtag != null &&
+                               !resumableFileDownloadEtag.equals(s3ObjectEtag);
+
 
         boolean s3ObjectModified = !headObjectResponse.lastModified().equals(lastModified);
         boolean fileModified = !fileNotModified(resumableFileDownload.bytesTransferred(),

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
@@ -47,6 +47,10 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 /**
  * An opaque token that holds the state and can be used to resume a paused download operation.
  * <p>
+ * This token stores metadata about the S3 object, including its last modified time and ETag,
+ * which are used to validate that the object has not changed between pause and resume operations.
+ * </p>
+ * <p>
  * <b>Serialization: </b>When serializing this token, the following structures will not be preserved/persisted:
  * <ul>
  *     <li>{@link TransferRequestOverrideConfiguration}</li>
@@ -62,6 +66,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
     private final DownloadFileRequest downloadFileRequest;
     private final long bytesTransferred;
     private final Instant s3ObjectLastModified;
+    private final String s3ObjectEtag;
     private final Long totalSizeInBytes;
     private final Instant fileLastModified;
     private final List<Integer> completedParts;
@@ -71,6 +76,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
         this.bytesTransferred = builder.bytesTransferred == null ? 0 : Validate.isNotNegative(builder.bytesTransferred,
                                                                                               "bytesTransferred");
         this.s3ObjectLastModified = builder.s3ObjectLastModified;
+        s3ObjectEtag = builder.s3ObjectEtag;
         this.totalSizeInBytes = Validate.isPositiveOrNull(builder.totalSizeInBytes, "totalSizeInBytes");
         this.fileLastModified = builder.fileLastModified;
         List<Integer> compledPartsList =  Validate.getOrDefault(builder.completedParts, Collections::emptyList);
@@ -97,6 +103,9 @@ public final class ResumableFileDownload implements ResumableTransfer,
         if (!Objects.equals(s3ObjectLastModified, that.s3ObjectLastModified)) {
             return false;
         }
+        if (!Objects.equals(s3ObjectEtag, that.s3ObjectEtag)) {
+            return false;
+        }
         if (!Objects.equals(fileLastModified, that.fileLastModified)) {
             return false;
         }
@@ -111,6 +120,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
         int result = downloadFileRequest.hashCode();
         result = 31 * result + (int) (bytesTransferred ^ (bytesTransferred >>> 32));
         result = 31 * result + (s3ObjectLastModified != null ? s3ObjectLastModified.hashCode() : 0);
+        result = 31 * result + (s3ObjectEtag != null ? s3ObjectEtag.hashCode() : 0);
         result = 31 * result + (fileLastModified != null ? fileLastModified.hashCode() : 0);
         result = 31 * result + (totalSizeInBytes != null ? totalSizeInBytes.hashCode() : 0);
         result = 31 * result + (completedParts != null ? completedParts.hashCode() : 0);
@@ -144,6 +154,13 @@ public final class ResumableFileDownload implements ResumableTransfer,
     }
 
     /**
+     * Etag of the S3 object since last pause, or {@link Optional#empty()} if unknown
+     */
+    public Optional<String> s3ObjectEtag() {
+        return Optional.ofNullable(s3ObjectEtag);
+    }
+
+    /**
      * Last modified time of the file since last pause
      */
     public Instant fileLastModified() {
@@ -174,6 +191,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
                        .add("bytesTransferred", bytesTransferred)
                        .add("fileLastModified", fileLastModified)
                        .add("s3ObjectLastModified", s3ObjectLastModified)
+                       .add("s3ObjectEtag", s3ObjectEtag)
                        .add("totalSizeInBytes", totalSizeInBytes)
                        .add("downloadFileRequest", downloadFileRequest)
                        .add("completedParts", completedParts)
@@ -332,6 +350,13 @@ public final class ResumableFileDownload implements ResumableTransfer,
         Builder s3ObjectLastModified(Instant s3ObjectLastModified);
 
         /**
+         * Sets the Etag of the object
+         *
+         * @param s3ObjectEtag the Etag of the object
+         * @return a reference to this object so that method calls can be chained together.
+         */
+        Builder s3ObjectEtag(String s3ObjectEtag);
+        /**
          * Sets the last modified time of the object
          *
          * @param lastModified the last modified time of the object
@@ -353,6 +378,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
         private DownloadFileRequest downloadFileRequest;
         private Long bytesTransferred;
         private Instant s3ObjectLastModified;
+        private String s3ObjectEtag;
         private Long totalSizeInBytes;
         private Instant fileLastModified;
         private List<Integer> completedParts;
@@ -366,6 +392,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
             this.totalSizeInBytes = persistableFileDownload.totalSizeInBytes;
             this.fileLastModified = persistableFileDownload.fileLastModified;
             this.s3ObjectLastModified = persistableFileDownload.s3ObjectLastModified;
+            this.s3ObjectEtag = persistableFileDownload.s3ObjectEtag;
             this.completedParts = persistableFileDownload.completedParts;
         }
 
@@ -390,6 +417,12 @@ public final class ResumableFileDownload implements ResumableTransfer,
         @Override
         public Builder s3ObjectLastModified(Instant s3ObjectLastModified) {
             this.s3ObjectLastModified = s3ObjectLastModified;
+            return this;
+        }
+
+        @Override
+        public Builder s3ObjectEtag(String s3ObjectEtag) {
+            this.s3ObjectEtag = s3ObjectEtag;
             return this;
         }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
@@ -352,6 +352,7 @@ public final class ResumableFileDownload implements ResumableTransfer,
          * @return a reference to this object so that method calls can be chained together.
          */
         Builder s3ObjectEtag(String s3ObjectEtag);
+
         /**
          * Sets the last modified time of the object
          *

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/ResumableFileDownload.java
@@ -47,10 +47,6 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 /**
  * An opaque token that holds the state and can be used to resume a paused download operation.
  * <p>
- * This token stores metadata about the S3 object, including its last modified time and ETag,
- * which are used to validate that the object has not changed between pause and resume operations.
- * </p>
- * <p>
  * <b>Serialization: </b>When serializing this token, the following structures will not be preserved/persisted:
  * <ul>
  *     <li>{@link TransferRequestOverrideConfiguration}</li>

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/util/ResumableRequestConverterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/util/ResumableRequestConverterTest.java
@@ -47,6 +47,9 @@ import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 import software.amazon.awssdk.utils.Pair;
 
 class ResumableRequestConverterTest {
+    private static final String ETAG_FOO = "acbd18db4cc2f85cedef654fccc4a4d8";
+    private static final String ETAG_BAR = "37b51d194a7513e45b56f6524f2d51f2";
+    private static final String ETAG_BAR_UPPERCASE = "ddc35f88fa71b6ef142ae61f35364653";
 
     private File file;
 
@@ -126,10 +129,10 @@ class ResumableRequestConverterTest {
 
     static Stream<Arguments> EtagTestCases() {
         return Stream.of(
-            Arguments.of("acbd18db4cc2f85cedef654fccc4a4d8", null), // etag of "foo"
-            Arguments.of("37b51d194a7513e45b56f6524f2d51f2", "bytes=1000-2000"), // etag of "bar"
+            Arguments.of(ETAG_FOO, null),
+            Arguments.of(ETAG_BAR, "bytes=1000-2000"),
             Arguments.of(null, "bytes=1000-2000"),
-            Arguments.of("ddc35f88fa71b6ef142ae61f35364653", null) // etag of "Bar"
+            Arguments.of(ETAG_BAR_UPPERCASE, null)
         );
     }
 
@@ -216,7 +219,7 @@ class ResumableRequestConverterTest {
             .builder()
             .contentLength(2000L)
             .lastModified(s3ObjectLastModified)
-            .eTag("37b51d194a7513e45b56f6524f2d51f2")
+            .eTag(ETAG_BAR)
             .build();
     }
 


### PR DESCRIPTION
## Motivation and Context
Added support for ETag validation in resumable file downloads. The Transfer Manager now validates both the `lastModified` timestamp and the ETag when resuming a download. This aims to make sure that if the object has changed on S3 (indicated by a different ETag), the download will restart from the beginning rather than attempting to resume, which could lead to corrupted files.

## Modifications

- Added `s3ObjectEtag` field to `ResumableFileDownload` to store the ETag 
- Updated the serialization/deserialization logic in `ResumableFileDownloadSerializer` to include the ETag values.
- Updated `ResumableRequestConverter` to compare the stored ETag with the current S3 object's ETag.
- Added logging when an ETag mismatch is detected

## Testing

- Tests for different ETag values causing downloads to restart
- Tests for matching ETag values allowing downloads to 
- Tests for null/missing ETag values
-  Tests for case sensitivity in ETag comparisons
- Test for logging the hint about download being restarted
