### PR TITLE
Remove outdated buffering note in RequestBody.fromInputStream

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
@@ -129,7 +129,6 @@ public class RequestBody {
      * 128 KiB. If you need more control, use {@link #fromContentProvider(ContentStreamProvider, long, String)} or
      * {@link #fromContentProvider(ContentStreamProvider, String)}.
      * <p>
-     * <b>Important:</b> If {@code inputStream} does not support mark and reset, the stream will be buffered.
      *
      * @param inputStream   Input stream to send to the service. The stream will not be closed by the SDK.
      * @param contentLength Content length of data in input stream.


### PR DESCRIPTION
Removes the documentation statement claiming that non-markable input streams 
are buffered in `RequestBody.fromInputStream`, as this behavior was removed in version 2.30.17 (PR #5841). 
This fixes the documentation to reflect the current behavior.

Fixes #6038
