### PR TITLE
Save previous version and use in migration tool

### DIFF
--- a/buildspecs/update-master-from-release.yml
+++ b/buildspecs/update-master-from-release.yml
@@ -20,6 +20,7 @@ phases:
     - echo 'For debugging, running version command without -q'
     - mvn -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec
     - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
+    - PREVIOUS_VERSION=$(mvn help:evaluate -Dexpression=awsjavasdk.previous.version -q -DforceStdout)
     - echo "Release version - $RELEASE_VERSION"
     -
     - MAJOR=$(echo $RELEASE_VERSION | cut -d'.' -f1)
@@ -39,6 +40,7 @@ phases:
 
         mvn versions:set -DnewVersion=$NEW_VERSION_SNAPSHOT -DgenerateBackupPoms=false -DprocessAllModules=true || { echo "Failed to update POMs to next snapshot version"; exit 1; }
         sed -i -E "s/(<version>).+(<\/version>)/\1$RELEASE_VERSION\2/" README.md
+        sed -i -E "s/(<awsjavasdk.previous-previous.version>).+(<\/awsjavasdk.previous-previous.version>)/\1$PREVIOUS_VERSION\2/" pom.xml
         sed -i -E "s/(<awsjavasdk.previous.version>).+(<\/awsjavasdk.previous.version>)/\1$RELEASE_VERSION\2/" pom.xml
       
         git commit -am "Update to next snapshot version: $NEW_VERSION_SNAPSHOT"

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
     <properties>
         <awsjavasdk.version>${project.version}</awsjavasdk.version>
         <awsjavasdk.previous.version>2.31.29</awsjavasdk.previous.version>
+        <awsjavasdk.previous-previous.version>2.31.28</awsjavasdk.previous-previous.version>
         <jackson.version>2.15.2</jackson.version>
         <jackson.databind.version>2.15.2</jackson.databind.version>
         <jacksonjr.version>2.17.3</jacksonjr.version>

--- a/test/test-utils/src/main/java/software/amazon/awssdk/testutils/SdkVersionUtils.java
+++ b/test/test-utils/src/main/java/software/amazon/awssdk/testutils/SdkVersionUtils.java
@@ -33,14 +33,14 @@ public final class SdkVersionUtils {
     public static String getSdkPreviousReleaseVersion(Path pomFile) throws IOException {
         Optional<String> versionString =
             Files.readAllLines(pomFile)
-                 .stream().filter(l -> l.contains("<awsjavasdk.previous.version>")).findFirst();
+                 .stream().filter(l -> l.contains("<awsjavasdk.previous-previous.version>")).findFirst();
 
         if (!versionString.isPresent()) {
             throw new AssertionError("No version is found");
         }
 
         String string = versionString.get().trim();
-        String substring = string.substring(29, string.indexOf('/') - 1);
+        String substring = string.substring(38, string.indexOf('/') - 1);
         return substring;
     }
 

--- a/v2-migration/pom.xml
+++ b/v2-migration/pom.xml
@@ -312,7 +312,7 @@
                     <velocitySources>src/main/resources/recipe-vm-templates</velocitySources>
                     <resourcesOutputDirectory>${project.build.directory}/classes/META-INF/rewrite</resourcesOutputDirectory>
                     <properties>
-                        <sdkVersion>${awsjavasdk.previous.version}</sdkVersion>
+                        <sdkVersion>${awsjavasdk.previous-previous.version}</sdkVersion>
                     </properties>
                 </configuration>
             </plugin>

--- a/v2-migration/src/main/resources/scripts/utils.py
+++ b/v2-migration/src/main/resources/scripts/utils.py
@@ -23,10 +23,10 @@ RECIPE_ROOT_DIR = os.path.join(RESOURCES_ROOT_DIR, 'META-INF/rewrite')
 
 def find_sdk_version():
     pom = open(os.path.join(PROJECT_DIR, "pom.xml"), 'r')
-    reg = re.compile("<awsjavasdk.previous.version>.+")
+    reg = re.compile("<awsjavasdk.previous-previous.version>.+")
     version = re.search(reg, pom.read())
     versionStr = version.group(0)
-    return versionStr[29:-30]
+    return versionStr[38:-39]
 
 
 def load_module_mappings(filename):

--- a/v2-migration/src/test/java/software/amazon/awssdk/v2migration/UpgradeSdkDependenciesTest.java
+++ b/v2-migration/src/test/java/software/amazon/awssdk/v2migration/UpgradeSdkDependenciesTest.java
@@ -79,14 +79,14 @@ public class UpgradeSdkDependenciesTest implements RewriteTest {
         Path pomFile = root.resolve("pom.xml");
         Optional<String> versionString =
             Files.readAllLines(pomFile)
-                 .stream().filter(l -> l.contains("<awsjavasdk.previous.version>")).findFirst();
+                 .stream().filter(l -> l.contains("<awsjavasdk.previous-previous.version>")).findFirst();
 
         if (!versionString.isPresent()) {
             throw new AssertionError("No version is found");
         }
 
         String string = versionString.get().trim();
-        String substring = string.substring(29, string.indexOf('/') - 1);
+        String substring = string.substring(38, string.indexOf('/') - 1);
         return substring;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently, migration tool uses the current SDK version. However, the artifacts aren't published to Maven until a few hours after the release, so the transformed code will not work during this period. Because of this, the migration tool tests are skipped during this period.

## Modifications
<!--- Describe your changes in detail -->
Save the previous SDK version and use it in the migration tool. Transformed dependencies will use the previous SDK version, instead of the current newly released.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran migration tool integ tests locally