### PR TITLE
Add backoff with jitter to Kinesis stabiltiy test

### DIFF
--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/kinesis/KinesisStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/kinesis/KinesisStabilityTest.java
@@ -187,6 +187,9 @@ public class KinesisStabilityTest extends AwsTestBase {
                                                        .startingPosition(s -> s.type(ShardIteratorType.TRIM_HORIZON)),
                                                  responseHandler)
                                .thenAccept(b -> {
+                                   // Only verify data if all events have been received and the received data is not empty.
+                                   // It is possible the received data is empty because there is no record at the position
+                                   // event with TRIM_HORIZON.
                                    if (responseHandler.allEventsReceived && !responseHandler.receivedData.isEmpty()) {
                                        assertThat(producedData).as(responseHandler.id + " has not received all events"
                                                                    + ".").containsSequence(responseHandler.receivedData);

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/kinesis/KinesisStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/kinesis/KinesisStabilityTest.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
@@ -116,7 +115,6 @@ public class KinesisStabilityTest extends AwsTestBase {
         asyncClient.close();
     }
 
-    @RepeatedTest(30)
     @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)
     public void putRecords_subscribeToShard() throws InterruptedException {
         putRecords();


### PR DESCRIPTION
### Context
The Kinesis Stability test was previously failing due to an eventual consistency - was fixed in https://github.com/aws/aws-sdk-java-v2/pull/6006. 

After the fix, the test was still failing because the subscribeToShard() call is hitting server side rate limit, and because of a [customization that prevents retries](https://github.com/aws/aws-sdk-java-v2/blob/master/services/kinesis/src/main/java/software/amazon/awssdk/services/kinesis/KinesisRetryPolicy.java#L71) on this operation, the test cannot take advantage of the retry policy of using exponential backoff with jitter.

In this test, I added manual backoff with jitter to space out the requests and avoid rate limiting. 

### Testing
Testing with a @RepeatedTest() suites running 8 times in a row. 

**Before the change**
1 failed 1 passed 6 ignored (meaning they failed, retried up to 3 times and eventually succeeded)
duration: 5min and 22-31 seconds

**After the change**
8 passed.
duration: 5min and 26-34 seconds