### PR TITLE
Fix timestamp unmarshalling off-by-one errors

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-2256787.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-2256787.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "brandondahler",
+    "description": "Fix timestamp unmarshalling off-by-one errors"
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallingParser.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallingParser.java
@@ -383,17 +383,14 @@ final class JsonUnmarshallingParser {
         JsonToken lookAhead
     ) throws IOException {
         TimestampFormatTrait.Format format = resolveTimestampFormat(field);
-        switch (format) {
-            case UNIX_TIMESTAMP:
-                return Instant.ofEpochMilli(Math.round(parser.getDoubleValue() * 1_000d));
-            case UNIX_TIMESTAMP_MILLIS:
-                return Instant.ofEpochMilli(parser.getLongValue());
-            default:
-                JsonUnmarshaller<Object> unmarshaller = unmarshallerRegistry.getUnmarshaller(MarshallLocation.PAYLOAD,
-                                                                                             field.marshallingType());
-                return (Instant) unmarshaller.unmarshall(context, jsonValueNodeFactory.node(parser, lookAhead),
-                                                         (SdkField<Object>) field);
+        if (format == TimestampFormatTrait.Format.UNIX_TIMESTAMP_MILLIS) {
+            return Instant.ofEpochMilli(parser.getLongValue());
         }
+
+        JsonUnmarshaller<Object> unmarshaller = unmarshallerRegistry.getUnmarshaller(MarshallLocation.PAYLOAD,
+                                                                                     field.marshallingType());
+        return (Instant) unmarshaller.unmarshall(context, jsonValueNodeFactory.node(parser, lookAhead),
+                                                 (SdkField<Object>) field);
     }
 
     /**

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallingParser.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallingParser.java
@@ -385,7 +385,7 @@ final class JsonUnmarshallingParser {
         TimestampFormatTrait.Format format = resolveTimestampFormat(field);
         switch (format) {
             case UNIX_TIMESTAMP:
-                return Instant.ofEpochMilli((long) (parser.getDoubleValue() * 1_000d));
+                return Instant.ofEpochMilli(Math.round(parser.getDoubleValue() * 1_000d));
             case UNIX_TIMESTAMP_MILLIS:
                 return Instant.ofEpochMilli(parser.getLongValue());
             default:

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallingParser.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallingParser.java
@@ -159,7 +159,7 @@ final class JsonUnmarshallingParser {
         if (isScalarType(marshallingType)) {
             MarshallingKnownType marshallingKnownType = marshallingType.getKnownType();
             while (currentToken != JsonToken.END_ARRAY) {
-                result.add(simpleValueFor(field, marshallingKnownType, c, parser, currentToken));
+                result.add(simpleValueFor(memberInfo, marshallingKnownType, c, parser, currentToken));
                 currentToken = parser.nextToken();
             }
             return result;
@@ -190,7 +190,7 @@ final class JsonUnmarshallingParser {
             while (currentToken != JsonToken.END_OBJECT) {
                 String fieldName = parser.getText();
                 currentToken = parser.nextToken();
-                Object valueFor = simpleValueFor(field, valueMarshallingKnownType, c, parser, currentToken);
+                Object valueFor = simpleValueFor(valueInfo, valueMarshallingKnownType, c, parser, currentToken);
                 result.put(fieldName, valueFor);
                 currentToken = parser.nextToken();
             }

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/NumberToInstant.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/NumberToInstant.java
@@ -51,7 +51,7 @@ public final class NumberToInstant {
         TimestampFormatTrait.Format format = resolveTimestampFormat(field);
         switch (format) {
             case UNIX_TIMESTAMP:
-                return Instant.ofEpochMilli((long) (value.doubleValue() * 1_000d));
+                return Instant.ofEpochMilli(Math.round(value.doubleValue() * 1_000d));
             case UNIX_TIMESTAMP_MILLIS:
                 return Instant.ofEpochMilli(value.longValue());
             default:

--- a/core/protocols/protocol-core/src/test/java/software/amazon/awssdk/protocols/core/NumberToInstantTest.java
+++ b/core/protocols/protocol-core/src/test/java/software/amazon/awssdk/protocols/core/NumberToInstantTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.core.traits.TimestampFormatTrait;
+
+class NumberToInstantTest {
+
+    @Test
+    public void unixTimestampWithoutRoundingNeeded() {
+        NumberToInstant instance = instance(TimestampFormatTrait.Format.UNIX_TIMESTAMP);
+        Instant timestamp = instance.convert(1099510880.773d, instantField());
+        assertNotNull(timestamp);
+        assertEquals(Instant.ofEpochMilli(1099510880773L), timestamp);
+    }
+
+    @Test
+    public void parsingTimestampWithRoundingNeeded() {
+        NumberToInstant instance = instance(TimestampFormatTrait.Format.UNIX_TIMESTAMP);
+        // NOTE: 1099510880.771d * 1_000d == 1.0995108807709999E12
+        Instant timestamp = instance.convert(1099510880.771d, instantField());
+        assertNotNull(timestamp);
+        assertEquals(Instant.ofEpochMilli(1099510880771L), timestamp);
+    }
+
+    static NumberToInstant instance(TimestampFormatTrait.Format format) {
+        Map<MarshallLocation, TimestampFormatTrait.Format> formats = new EnumMap<>(MarshallLocation.class);
+        formats.put(MarshallLocation.PAYLOAD, format);
+
+        return NumberToInstant.create(formats);
+    }
+
+    static SdkField<Instant> instantField() {
+        return SdkField.builder(MarshallingType.INSTANT)
+            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).build())
+            .build();
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Fixes #6064 

Addresses code that is impacted by double to long casts incorrectly truncating a millisecond off of fractional seconds unix timestamp values which are rounded due to IEEE 754 double precision behavior when the source value is multiplied by 1_000d.

## Modifications
Updated current truncation behavior to utilize the configured unmarshaller that uses parses the textual using a `BigDecimal` that doesn't loose any precision.

Added to that, we fixed a bug, for collections, maps and lists, to select the correct unmarshaller we need to get the type of the value instead of the type of the collection. The bug was not discovered before because to trigger it the model would need to use a non-numeric serialization for timestamps, which none of the standard JSON protocols does by default.

## Testing
Added tests for values of both non-rounded and rounded values

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
