### PR TITLE
Add initial empty module for Apache5x for seting up package

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -4,6 +4,7 @@
     "modules": {
         "annotations": { "packageName": "AwsJavaSdk-Core-Annotations" },
         "apache-client": { "packageName": "AwsJavaSdk-HttpClient-ApacheClient" },
+        "apache5-client": { "packageName": "AwsJavaSdk-HttpClient-Apache5Client" },
         "arns": { "packageName": "AwsJavaSdk-Core-Arns" },
         "auth": { "packageName": "AwsJavaSdk-Core-Auth" },
         "auth-crt": { "packageName": "AwsJavaSdk-Core-AuthCrt" },

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -194,6 +194,11 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
+                <artifactId>apache5-client</artifactId>
+                <version>${awsjavasdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
                 <artifactId>netty-nio-client</artifactId>
                 <version>${awsjavasdk.version}</version>
             </dependency>

--- a/http-clients/apache5-client/pom.xml
+++ b/http-clients/apache5-client/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<modelVersion>4.0.0</modelVersion>
+<parent>
+    <artifactId>http-clients</artifactId>
+    <groupId>software.amazon.awssdk</groupId>
+    <version>2.31.33-SNAPSHOT</version>
+</parent>
+
+<artifactId>apache5-client</artifactId>
+<name>AWS Java SDK :: HTTP Clients :: Apache5</name>
+
+<dependencies>
+    <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>http-client-spi</artifactId>
+        <version>${awsjavasdk.version}</version>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Automatic-Module-Name>software.amazon.awssdk.http.apache5</Automatic-Module-Name>
+                    </manifestEntries>
+                </archive>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+
+</project>

--- a/http-clients/apache5-client/pom.xml
+++ b/http-clients/apache5-client/pom.xml
@@ -17,15 +17,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<modelVersion>4.0.0</modelVersion>
-<parent>
-    <artifactId>http-clients</artifactId>
-    <groupId>software.amazon.awssdk</groupId>
-    <version>2.31.33-SNAPSHOT</version>
-</parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>http-clients</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.31.33-SNAPSHOT</version>
+    </parent>
 
-<artifactId>apache5-client</artifactId>
-<name>AWS Java SDK :: HTTP Clients :: Apache5</name>
+    <artifactId>apache5-client</artifactId>
+    <name>AWS Java SDK :: HTTP Clients :: Apache5</name>
 
 <dependencies>
     <dependency>

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache5;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpClient;
+
+/**
+ * An implementation of {@link SdkHttpClient} that uses Apache HTTP Client 5.x to communicate with the service. This client
+ * provides enhanced functionality over the URL connection client, including support for HTTP proxies, connection pooling,
+ * and advanced configuration options.
+ *
+ * <p>This implementation leverages Apache HttpClient 5.x, offering improved performance characteristics and better compliance
+ * with HTTP standards compared to the Apache 4.x-based.</p>
+ *
+ * <p>See software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient for a lighter alternative implementation
+ * with fewer dependencies but more limited functionality.</p>
+ *
+ */
+@SdkPublicApi
+public class Apache5HttpClient implements SdkHttpClient {
+
+    public static final String CLIENT_NAME = "Apache5";
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+        throw new UnsupportedOperationException("API implementation is in progress");
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException("API implementation is in progress");
+    }
+
+    @Override
+    public String clientName() {
+        return CLIENT_NAME;
+    }
+
+}

--- a/http-clients/pom.xml
+++ b/http-clients/pom.xml
@@ -34,6 +34,7 @@
         <module>aws-crt-client</module>
         <module>netty-nio-client</module>
         <module>url-connection-client</module>
+        <module>apache5-client</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -656,6 +656,7 @@
                             <includeModule>sdk-core</includeModule>
                             <includeModule>http-client-spi</includeModule>
                             <includeModule>apache-client</includeModule>
+                            <includeModule>apache5-client</includeModule>
                             <includeModule>netty-nio-client</includeModule>
                             <includeModule>url-connection-client</includeModule>
                             <includeModule>cloudwatch-metric-publisher</includeModule>

--- a/test/architecture-tests/pom.xml
+++ b/test/architecture-tests/pom.xml
@@ -152,6 +152,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache5-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/test/tests-coverage-reporting/pom.xml
+++ b/test/tests-coverage-reporting/pom.xml
@@ -168,6 +168,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <artifactId>apache5-client</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>aws-sdk-java</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Setting up empty Apache5x module so that implementation can be added in future PRs

| Additions | Checkbox |
|------|----------|
| Automatic-Module-Name in pom.xml | ✅ |
| Add to tests-coverage-reporting pom.xml | ✅ |
| Add to aws-sdk-java pom.xml | ❌ |
| Add to architecture-tests pom.xml | ✅ |
| Add to bom pom.xml | ✅ |
| Update japicmp plugin config | ✅ |
| Add package name mapping in .brazil.json | ✅ |



## Modifications
<!--- Describe your changes in detail -->
- Added a new module
- Specs used
Business Metrics
- The [client name](https://github.com/aws/aws-sdk-java-v2/blob/fce580e7a233a0f15e728eee86dac54f4a2ea9a3/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java#L42-L54) will be Apache5

Module Details
- module name: apache5-client
- Brazil jsonname: AwsJavaSdk-HttpClient-Apache5Client
* root package: software.amazon.awssdk.http.apache5

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
mvn clean install -pl :apache5-client  -P quick --am 
```

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
