### PR TITLE
Add back the option to enable/disable the fast unmarshaller

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -81,6 +81,7 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
+import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
 import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -506,6 +507,11 @@ public class BaseClientBuilderClass implements ClassSpec {
                .addCode("    .dualstackEnabled(c.get($T.DUALSTACK_ENDPOINT_ENABLED))", AwsClientOption.class)
                .addCode("    .fipsEnabled(c.get($T.FIPS_ENDPOINT_ENABLED))", AwsClientOption.class)
                .addCode("    .build());");
+
+        if (model.getMetadata().isJsonProtocol()) {
+            builder.addStatement("builder.option($1T.ENABLE_FAST_UNMARSHALLER, true)",
+                                 SdkClientJsonProtocolAdvancedOption.class);
+        }
 
         if (hasRequestAlgorithmMember(model) || hasResponseAlgorithms(model)) {
             builder.addStatement("$T clientConfig = config", SdkClientConfiguration.class);

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
@@ -53,6 +53,7 @@ import software.amazon.awssdk.protocols.json.internal.unmarshall.AwsJsonResponse
 import software.amazon.awssdk.protocols.json.internal.unmarshall.JsonProtocolUnmarshaller;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.JsonResponseHandler;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.ProtocolUnmarshallDependencies;
+import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
 
 @SdkProtectedApi
 public abstract class BaseAwsJsonProtocolFactory {
@@ -87,7 +88,16 @@ public abstract class BaseAwsJsonProtocolFactory {
         this.customErrorCodeFieldName = builder.customErrorCodeFieldName;
         this.hasAwsQueryCompatible = builder.hasAwsQueryCompatible;
         this.clientConfiguration = builder.clientConfiguration;
+        Boolean enableFastUnmarshalling = false;
+        if (clientConfiguration != null) {
+            enableFastUnmarshalling =
+                clientConfiguration.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER);
+            if (enableFastUnmarshalling == null) {
+                enableFastUnmarshalling = false;
+            }
+        }
         this.protocolUnmarshaller = JsonProtocolUnmarshaller.builder()
+                                                            .enableFastUnmarshalling(enableFastUnmarshalling)
                                                             .protocolUnmarshallDependencies(
                                                                 builder.protocolUnmarshallDependencies.get())
                                                             .build();

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.protocols.json.internal.AwsStructuredPlainJsonFact
 import software.amazon.awssdk.protocols.json.internal.MarshallerUtil;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.document.DocumentUnmarshaller;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
 import software.amazon.awssdk.protocols.jsoncore.JsonValueNodeFactory;
 import software.amazon.awssdk.utils.Lazy;
 import software.amazon.awssdk.utils.builder.Buildable;
@@ -58,24 +59,42 @@ import software.amazon.awssdk.utils.builder.Buildable;
  */
 @SdkInternalApi
 @ThreadSafe
-public final class JsonProtocolUnmarshaller {
+public class JsonProtocolUnmarshaller {
     private static final Lazy<DefaultProtocolUnmarshallDependencies> DEFAULT_DEPENDENCIES =
         new Lazy<>(JsonProtocolUnmarshaller::newProtocolUnmarshallDependencies);
 
     private final JsonUnmarshallerRegistry registry;
     private final JsonUnmarshallingParser unmarshallingParser;
+    private final JsonNodeParser parser;
 
     private JsonProtocolUnmarshaller(Builder builder) {
         ProtocolUnmarshallDependencies dependencies = builder.protocolUnmarshallDependencies;
         this.registry = dependencies.jsonUnmarshallerRegistry();
-        this.unmarshallingParser = JsonUnmarshallingParser.builder()
-                                                          .jsonValueNodeFactory(dependencies.nodeValueFactory())
-                                                          .jsonFactory(dependencies.jsonFactory())
-                                                          .unmarshallerRegistry(dependencies.jsonUnmarshallerRegistry())
-                                                          .defaultTimestampFormat(dependencies.timestampFormats()
-                                                                                              .get(MarshallLocation.PAYLOAD))
+        if (builder.enableFastUnmarshalling) {
+            this.unmarshallingParser = JsonUnmarshallingParser.builder()
+                                                              .jsonValueNodeFactory(dependencies.nodeValueFactory())
+                                                              .jsonFactory(dependencies.jsonFactory())
+                                                              .unmarshallerRegistry(dependencies.jsonUnmarshallerRegistry())
+                                                              .defaultTimestampFormat(dependencies.timestampFormats()
+                                                                                                  .get(MarshallLocation.PAYLOAD))
 
-                                                          .build();
+                                                              .build();
+            this.parser = null;
+        } else {
+            this.unmarshallingParser = null;
+            this.parser = createParser(builder, dependencies);
+        }
+    }
+
+    private JsonNodeParser createParser(Builder builder, ProtocolUnmarshallDependencies dependencies) {
+        if (builder.parser != null) {
+            return builder.parser;
+        }
+        return JsonNodeParser
+            .builder()
+            .jsonFactory(dependencies.jsonFactory())
+            .jsonValueNodeFactory(dependencies.nodeValueFactory())
+            .build();
     }
 
     public static DefaultProtocolUnmarshallDependencies defaultProtocolUnmarshallDependencies() {
@@ -219,6 +238,15 @@ public final class JsonProtocolUnmarshaller {
     }
 
     public <TypeT extends SdkPojo> TypeT unmarshall(SdkPojo sdkPojo,
+                                                    SdkHttpFullResponse response) throws IOException {
+        if (this.unmarshallingParser != null) {
+            return fastUnmarshall(sdkPojo, response);
+        }
+        JsonNode jsonNode = hasJsonPayload(sdkPojo, response) ? parser.parse(response.content().get()) : null;
+        return unmarshall(sdkPojo, response, jsonNode);
+    }
+
+    private <TypeT extends SdkPojo> TypeT fastUnmarshall(SdkPojo sdkPojo,
                                                     SdkHttpFullResponse response) throws IOException {
         if (!hasJsonPayload(sdkPojo, response)) {
             return unmarshallResponse(sdkPojo, response);
@@ -425,9 +453,21 @@ public final class JsonProtocolUnmarshaller {
      * Builder for {@link JsonProtocolUnmarshaller}.
      */
     public static final class Builder {
+
+        private JsonNodeParser parser;
         private ProtocolUnmarshallDependencies protocolUnmarshallDependencies;
+        private boolean enableFastUnmarshalling = false;
 
         private Builder() {
+        }
+
+        /**
+         * @param parser JSON parser to use.
+         * @return This builder for method chaining.
+         */
+        public Builder parser(JsonNodeParser parser) {
+            this.parser = parser;
+            return this;
         }
 
         /**
@@ -448,6 +488,15 @@ public final class JsonProtocolUnmarshaller {
             ProtocolUnmarshallDependencies protocolUnmarshallDependencies
         ) {
             this.protocolUnmarshallDependencies = protocolUnmarshallDependencies;
+            return this;
+        }
+
+        /**
+         * @param enableFastUnmarshalling Whether to enable the fast unmarshalling codepath. Default to {@code false}.
+         * @return This builder for method chaining.
+         */
+        public Builder enableFastUnmarshalling(boolean enableFastUnmarshalling) {
+            this.enableFastUnmarshalling = enableFastUnmarshalling;
             return this;
         }
 

--- a/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/InternalApiBoundaryTest.java
+++ b/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/InternalApiBoundaryTest.java
@@ -32,12 +32,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.awscore.internal.AwsProtocolMetadata;
 import software.amazon.awssdk.awscore.internal.AwsServiceProtocol;
 import software.amazon.awssdk.core.internal.interceptor.trait.RequestCompression;
 import software.amazon.awssdk.core.internal.util.MetricUtils;
 import software.amazon.awssdk.core.internal.waiters.WaiterAttribute;
 import software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil;
+import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
 import software.amazon.awssdk.utils.internal.EnumUtils;
 import software.amazon.awssdk.utils.internal.SystemSettingUtils;
 
@@ -55,7 +57,7 @@ public class InternalApiBoundaryTest {
     private static final Set<Class<?>> ALLOWED_INTERNAL_API_ACROSS_MODULE_SUPPRESSION = new HashSet<>(
         Arrays.asList(WaiterAttribute.class, RequestCompression.class, RequestCompression.Builder.class, EnumUtils.class,
                       AwsServiceProtocol.class, AwsProtocolMetadata.class, MetricUtils.class, SystemSettingUtils.class,
-                      ChecksumUtil.class));
+                      ChecksumUtil.class, SdkClientJsonProtocolAdvancedOption.class));
 
     @Test
     void internalApi_shouldNotUsedAcrossModule() {

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/protocol/JsonCodec.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/protocol/JsonCodec.java
@@ -67,6 +67,7 @@ public final class JsonCodec {
             JsonProtocolUnmarshaller unmarshaller =
                 JsonProtocolUnmarshaller
                     .builder()
+                    .enableFastUnmarshalling(true)
                     .protocolUnmarshallDependencies(behavior.protocolUnmarshallDependencies())
                     .build();
             SdkHttpFullResponse response = SdkHttpFullResponse

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/marshaller/dynamodb/V2DynamoDbAttributeValue.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/marshaller/dynamodb/V2DynamoDbAttributeValue.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.protocols.core.ExceptionMetadata;
 import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
 import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
+import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BackupInUseException;
 import software.amazon.awssdk.services.dynamodb.model.BackupNotFoundException;
@@ -79,6 +80,7 @@ public class V2DynamoDbAttributeValue {
         .clientConfiguration(SdkClientConfiguration
                                  .builder()
                                  .option(SdkClientOption.ENDPOINT, URI.create("https://localhost"))
+                                 .option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true)
                                  .build())
         .defaultServiceExceptionSupplier(DynamoDbException::builder)
         .protocol(AwsJsonProtocol.AWS_JSON)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Adds back the option to enable/disable the fast unmarshaller code-path. The only difference is that this is enabled by default without any codegen consideration for JSON based protocols.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
