### PR TITLE
Add synchronization around use of JDT code formatter to prevent NPE/race condition

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavaV2-e335804.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavaV2-e335804.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java V2",
+    "contributor": "",
+    "description": "Add synchronization around use of JDT code formatter to prevent NPE/race condition during code generation."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/JavaCodeFormatter.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/JavaCodeFormatter.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.codegen.internal.Constant;
 public class JavaCodeFormatter implements CodeTransformer {
 
     private static final Map<String, Object> DEFAULT_FORMATTER_OPTIONS;
+    private static final Object lock = new Object();
 
     static {
         DEFAULT_FORMATTER_OPTIONS = DefaultCodeFormatterConstants.getEclipseDefaultSettings();
@@ -90,10 +91,16 @@ public class JavaCodeFormatter implements CodeTransformer {
 
     @Override
     public String apply(String contents) {
-        TextEdit edit = codeFormatter.format(
+        TextEdit edit;
+        // There is a race condition in the org.eclipse.jdt.internal.formatter.DefaultCodeFormatter in version 3.10.0.
+        // The static PROBING_SCANNER can have its state changed by multiple threads.
+        // Synchronize our usage of that class to ensure we don't hit this.
+        synchronized (lock) {
+            edit = codeFormatter.format(
                 CodeFormatter.K_COMPILATION_UNIT
                 | CodeFormatter.F_INCLUDE_COMMENTS, contents, 0,
                 contents.length(), 0, Constant.LF);
+        }
 
         if (edit == null) {
             // TODO log a fatal or warning here. Throwing an exception is causing the actual freemarker error to be lost


### PR DESCRIPTION
Add synchronization around use of JDT code formatter to prevent NPE/race condition.

## Motivation and Context
Occasionally a NullPointerException (NPE) is raised during code generation with stack traces point to
the [JavaCodeFormatte#L93r](https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/JavaCodeFormatter.java#L93). The NPE is happening deep in the eclipse JDT code (in the scanner created by the DefaultCodeFormatter).

It appears there is a race condition in the `org.eclipse.jdt.internal.formatter.DefaultCodeFormatter` in the `probeFormatting` method (see the stack trace).  The decompiled .class file has this code (simplified to highlight issue):
```java
public class DefaultCodeFormatter extends CodeFormatter {
  private static Scanner PROBING_SCANNER;  // NOTE: static

  private TextEdit probeFormatting(String source, int indentationLevel, String lineSeparator, IRegion[] regions, boolean includeComments) {
    if (PROBING_SCANNER == null) {
        PROBING_SCANNER = new Scanner(true, false, false, 3276800L, 3276800L, (char[][])null, (char[][])null, true);
    }
    PROBING_SCANNER.setSource(source.toCharArray());
    // .... Do work [skipping for brevity], calling `PROBING_SCANNER.getNextToken()` many times.
    PROBING_SCANNER.setSource((char[])null); // Cleanup at the end - Sets the source to null
  }
}
```

Since the `PROBING_SCANNER` is static and shared across all instances of the class, its possible for one thread to complete the work and call `setSource(null)` while another thread is in the working section and trying to call `getNextToken()`, which will fail with the NPE we are seeing in stack traces with the message: `Cannot load from char array because "this.source" is null`.

We currently depend on [org.eclipse.jdt.core at 3.10.0](https://github.com/aws/aws-sdk-java-v2/blob/d0ccf56503eca09a18d9b92d808fc0990b93a7bf/pom.xml#L124) which is ~10 years old, but we cannot easily upgrade this dependency - newer versions of the library require later versions of the JDK.

```

## Modifications
Adds a synchronization block around the use of the JDT code formatter.  This should prevent multiple threads for executing the problematic block of code above concurrently. Manual benchmarking has shown no performance degradation from adding this synchronization.

NOTE: The lock Object MUST be a static/class level object to ensure that all usages of the formatter are synchronized. 

## Testing
Manual testing of class build with many threads to reproduce the issue + re-running test with synchronization fix. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
