### PR TITLE
Create new DefaultCredentialsProvider instance every time instead of …

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTbasedS3Client-8185886.json
+++ b/.changes/next-release/bugfix-AWSCRTbasedS3Client-8185886.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT-based S3 Client",
+    "contributor": "",
+    "description": "Fixed \"Connection pool shut down\" error thrown when a default AWS CRT-based S3 client is created and closed per request. See [#5881](https://github.com/aws/aws-sdk-java-v2/issues/5881)"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -35,6 +35,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
@@ -124,6 +126,10 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
 
         if (builder.executionInterceptors != null) {
             builder.executionInterceptors.forEach(overrideConfigurationBuilder::addExecutionInterceptor);
+        }
+
+        if (builder.credentialsProvider == null) {
+            builder = builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
         }
 
         DefaultS3CrtClientBuilder finalBuilder = resolveChecksumConfiguration(builder);
@@ -227,6 +233,13 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         private Long thresholdInBytes;
         private Executor futureCompletionExecutor;
         private Boolean disableS3ExpressSessionAuth;
+
+
+        @Override
+        public DefaultS3CrtClientBuilder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+            return this;
+        }
 
         @Override
         public DefaultS3CrtClientBuilder credentialsProvider(

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -21,7 +21,6 @@ import static software.amazon.awssdk.crtcore.CrtConfigurationUtils.resolveProxy;
 import java.net.URI;
 import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.crt.auth.credentials.CredentialsProvider;
 import software.amazon.awssdk.crt.http.HttpMonitoringOptions;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
@@ -36,6 +35,7 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * Internal client configuration resolver
@@ -80,10 +80,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
             clientTlsContextOptions.withVerifyPeer(!builder.httpConfiguration.trustAllCertificatesEnabled());
         }
         this.tlsContext = new TlsContext(clientTlsContextOptions);
-        this.credentialProviderAdapter =
-            builder.credentialsProvider == null ?
-            new CrtCredentialsProviderAdapter(DefaultCredentialsProvider.create()) :
-            new CrtCredentialsProviderAdapter(builder.credentialsProvider);
+        this.credentialProviderAdapter = new CrtCredentialsProviderAdapter(
+            Validate.paramNotNull(builder.credentialsProvider, "credentialsProvider"));
 
         this.credentialsProvider = credentialProviderAdapter.crtCredentials();
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClientTest.java
@@ -133,6 +133,8 @@ class DefaultS3CrtAsyncClientTest {
             assertThat(identityProvider)
                 .isNotEqualTo(identityProviderFromAnotherClient);
             assertThat(identityProvider)
+                .isInstanceOf(DefaultCredentialsProvider.class);
+            assertThat(identityProvider)
                 .isNotEqualTo(DefaultCredentialsProvider.create());
             assertThat(identityProviderFromAnotherClient)
                 .isNotEqualTo(DefaultCredentialsProvider.create());

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
@@ -287,7 +287,8 @@ public class S3CrtAsyncHttpClientTest {
 
         s3NativeClientConfiguration = S3NativeClientConfiguration.builder()
                                                                  .endpointOverride(DEFAULT_ENDPOINT)
-                                                                 .credentialsProvider(null)
+                                                                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test",
+                                                                                                                                                  "test")))
                                                                  .build();
 
         asyncHttpClient = new S3CrtAsyncHttpClient(s3Client, S3CrtAsyncHttpClient.builder()
@@ -312,7 +313,8 @@ public class S3CrtAsyncHttpClientTest {
 
         s3NativeClientConfiguration = S3NativeClientConfiguration.builder()
                                                                  .endpointOverride(DEFAULT_ENDPOINT)
-                                                                 .credentialsProvider(null)
+                                                                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test",
+                                                                                                                       "test")))
                                                                  .build();
 
         asyncHttpClient = new S3CrtAsyncHttpClient(s3Client, S3CrtAsyncHttpClient.builder()
@@ -425,6 +427,8 @@ public class S3CrtAsyncHttpClientTest {
                                        .signingRegion(signingRegion)
                                        .thresholdInBytes(1024L)
                                        .targetThroughputInGbps(3.5)
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test",
+                                                                                                                        "test")))
                                        .maxNativeMemoryLimitInBytes(5L * 1024 * 1024 * 1024)
                                        .standardRetryOptions(
                                            new StandardRetryOptions()
@@ -466,6 +470,8 @@ public class S3CrtAsyncHttpClientTest {
         long partSizeInBytes = 1024 * 8L;
         S3NativeClientConfiguration configuration =
             S3NativeClientConfiguration.builder()
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test",
+                                                                                                                        "test")))
                                        .partSizeInBytes(partSizeInBytes)
                                        .build();
         try (S3CrtAsyncHttpClient client =
@@ -480,6 +486,8 @@ public class S3CrtAsyncHttpClientTest {
     void build_nullHttpConfiguration() {
         S3NativeClientConfiguration configuration =
             S3NativeClientConfiguration.builder()
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test",
+                                                                                                                        "test")))
                                        .build();
         try (S3CrtAsyncHttpClient client =
                  (S3CrtAsyncHttpClient) S3CrtAsyncHttpClient.builder().s3ClientConfiguration(configuration).build()) {
@@ -539,6 +547,8 @@ public class S3CrtAsyncHttpClientTest {
         S3NativeClientConfiguration configuration =
             S3NativeClientConfiguration.builder()
                                        .httpConfiguration(s3CrtHttpConfiguration)
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test",
+                                                                                                                        "test")))
                                        .build();
         try(S3CrtAsyncHttpClient client =
             (S3CrtAsyncHttpClient) S3CrtAsyncHttpClient.builder().s3ClientConfiguration(configuration).build()) {


### PR DESCRIPTION
…using single instance

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix #5881 

Currently, if credentials provider is not provided in AWS CRT-based S3 client, DefaultCredentialsProvider will be created by `DefaultCredentialsProvider.create()`. However, it returns a singleton instance. This means that if a customers is creating and closing a new client per request, the singleton instance may get closed and all subsequent requests would fail, causing `Connection pool shut down` to be thrown

## Modifications
Use `DefaultCredentialsProvider.builder().build()` (new instance) instead of `DefaultCredentialsProvider.create()` (singleton) to initialize credentials provider if it's not provided.

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
