### PR TITLE
Allow default values for non-builtIn endpoint params

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-175fc73.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-175fc73.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Allow default values for non-builtIn endpoint params"
+}

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/Parameter.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/Parameter.java.resource
@@ -22,9 +22,6 @@ public final class Parameter implements ToParameterReference {
     private final boolean required;
 
     public Parameter(Builder builder) {
-        if (builder.defaultValue != null && builder.builtIn == null) {
-            throw new RuntimeException("Cannot set a default value for non-builtin parameters");
-        }
         if (builder.defaultValue != null && !builder.required) {
             throw new RuntimeException("When a default value is set, the field must also be marked as required");
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
Remove restriction, to allow default values to be set for non builtIn endpoint parameters

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled `codegen` and `codegen-generated-classes-test` locally
