### PR TITLE
Separate migration tests from regular builds

### DIFF
--- a/.changes/next-release/removal-AWSSDKforJavav2-c58118f.json
+++ b/.changes/next-release/removal-AWSSDKforJavav2-c58118f.json
@@ -1,0 +1,6 @@
+{
+    "type": "removal",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Separate migration tests from normal builds"
+}

--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -139,3 +139,17 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: aws-sdk-java-v2-endpoints-test
+  migration-tests:
+    if: github.repository == 'aws/aws-sdk-java-v2'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+          role-duration-seconds: 7200
+      - name: Run migration test
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: aws-sdk-java-v2-migration-test

--- a/buildspecs/migration-test.yml
+++ b/buildspecs/migration-test.yml
@@ -7,7 +7,8 @@ phases:
 
   build:
     commands:
-      - mvn clean install -pl :v2-migration-tests -P quick -am && mvn install -pl :v2-migration-tests -P migration-tests -T1C $MAVEN_OPTIONS
+      - mvn clean install -pl :v2-migration-tests,:bom-internal -am -P quick $MAVEN_OPTIONS
+      - mvn install -pl :v2-migration-tests -P migration-tests -T2C $MAVEN_OPTIONS
     finally:
       - mkdir -p codebuild-test-reports
       - find ./ -name 'TEST-*.xml' -type f -exec cp {} codebuild-test-reports/ \;

--- a/buildspecs/migration-test.yml
+++ b/buildspecs/migration-test.yml
@@ -7,7 +7,7 @@ phases:
 
   build:
     commands:
-      - mvn clean install -pl :v2-migration-tests -am -P migration-tests -T1C $MAVEN_OPTIONS
+      - mvn clean install -pl :v2-migration-tests -P quick -am && mvn install -pl :v2-migration-tests -P migration-tests -T1C $MAVEN_OPTIONS
     finally:
       - mkdir -p codebuild-test-reports
       - find ./ -name 'TEST-*.xml' -type f -exec cp {} codebuild-test-reports/ \;

--- a/buildspecs/migration-test.yml
+++ b/buildspecs/migration-test.yml
@@ -1,0 +1,17 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      java: "$JAVA_RUNTIME"
+
+  build:
+    commands:
+      - mvn clean install -pl :v2-migration-tests -P migration-tests -T1C $MAVEN_OPTIONS
+    finally:
+      - mkdir -p codebuild-test-reports
+      - find ./ -name 'TEST-*.xml' -type f -exec cp {} codebuild-test-reports/ \;
+reports:
+  IntegTests:
+    files:
+      - 'codebuild-test-reports/**/*'

--- a/buildspecs/migration-test.yml
+++ b/buildspecs/migration-test.yml
@@ -7,7 +7,7 @@ phases:
 
   build:
     commands:
-      - mvn clean install -pl :v2-migration-tests -P migration-tests -T1C $MAVEN_OPTIONS
+      - mvn clean install -pl :v2-migration-tests -am -P migration-tests -T1C $MAVEN_OPTIONS
     finally:
       - mkdir -p codebuild-test-reports
       - find ./ -name 'TEST-*.xml' -type f -exec cp {} codebuild-test-reports/ \;

--- a/buildspecs/resources/ci.cloudformation.yml
+++ b/buildspecs/resources/ci.cloudformation.yml
@@ -57,6 +57,7 @@ Resources:
                   - !Sub arn:aws:codebuild:${ AWS::Region }:${ AWS::AccountId }:project/aws-sdk-java-v2-native-image-test
                   - !Sub arn:aws:codebuild:${ AWS::Region }:${ AWS::AccountId }:project/aws-sdk-java-v2-sonar
                   - !Sub arn:aws:codebuild:${ AWS::Region }:${ AWS::AccountId }:project/aws-sdk-java-v2-endpoints-test
+                  - !Sub arn:aws:codebuild:${ AWS::Region }:${ AWS::AccountId }:project/aws-sdk-java-v2-migration-test
               - Effect: Allow
                 Action:
                   - logs:GetLogEvents
@@ -69,6 +70,7 @@ Resources:
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/aws-sdk-java-v2-native-image-test:*
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/aws-sdk-java-v2-sonar:*
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/aws-sdk-java-v2-endpoints-test:*
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/aws-sdk-java-v2-migration-test:*
 
   GithubOidc:
     Type: AWS::IAM::OIDCProvider

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
         <s3accessgrants.version>2.1.0</s3accessgrants.version>
 
         <skip.unit.tests>${skipTests}</skip.unit.tests>
+        <v2.migration.tests.skip>true</v2.migration.tests.skip>
         <integTestSourceDirectory>${project.basedir}/src/it/java</integTestSourceDirectory>
         <javadoc.resourcesDir>${session.executionRootDirectory}</javadoc.resourcesDir>
         <scm.github.url>https://github.com/aws/aws-sdk-java-v2</scm.github.url>
@@ -824,6 +825,21 @@
                 <mdep.analyze.skip>true</mdep.analyze.skip>
                 <japicmp.skip>true</japicmp.skip>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>migration-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <v2.migration.tests.skip>false</v2.migration.tests.skip>
+                <checkstyle.skip>true</checkstyle.skip>
+                <spotbugs.skip>true</spotbugs.skip>
+                <mdep.analyze.skip>true</mdep.analyze.skip>
+                <japicmp.skip>true</japicmp.skip>
+                <javadoc.skip>true</javadoc.skip>
             </properties>
         </profile>
 

--- a/test/v2-migration-tests/pom.xml
+++ b/test/v2-migration-tests/pom.xml
@@ -163,6 +163,17 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Separate Codebuild for migration tests -->
+                    <skipTests>${v2.migration.tests.skip}</skipTests>
+                    <!-- Sets the VM argument line used when migration tests are run. -->
+                    <argLine>${argLine}</argLine>
+                    <trimStackTrace>false</trimStackTrace>
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Add `migration-test` Maven profile and exclude`v2-migration-tests` in regular builds. This can reduce 20+ mins and speed up the build. A separate CB will be created to run those tests in parallel.

Previous changes for endpoint tests:
https://github.com/aws/aws-sdk-java-v2/pull/3553 & https://github.com/aws/aws-sdk-java-v2/pull/4860

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally:

`mvn install -pl :v2-migration-tests`  -> tests skipped

`mvn install -pl :v2-migration-tests -P migration-test`  -> tests ran

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
