### PR TITLE
Fix S3 event parsing when eventName is present but eventTime is not

### DIFF
--- a/.changes/next-release/bugfix-AWSS3EventNotifications-3774889.json
+++ b/.changes/next-release/bugfix-AWSS3EventNotifications-3774889.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS S3 Event Notifications",
+    "contributor": "reifiedbeans",
+    "description": "Fixes parsing of S3 event notifications to allow eventTime to be null when eventName is not"
+}

--- a/.changes/next-release/bugfix-AWSS3EventNotifications-3774889.json
+++ b/.changes/next-release/bugfix-AWSS3EventNotifications-3774889.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS S3 Event Notifications",
     "contributor": "reifiedbeans",
-    "description": "Fixes parsing of S3 event notifications to allow eventTime to be null when eventName is not"
+    "description": "Fixed parsing of S3 event notifications to allow eventTime to be null when eventName is not"
 }

--- a/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/internal/DefaultS3EventNotificationReader.java
+++ b/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/internal/DefaultS3EventNotificationReader.java
@@ -101,7 +101,7 @@ public final class DefaultS3EventNotificationReader implements S3EventNotificati
         eventNotificationRecord.setEventSource(eventSource);
 
         String eventTime = expectStringOrNull(recordNode, "eventTime");
-        eventNotificationRecord.setEventTime(eventName != null ? Instant.parse(eventTime) : null);
+        eventNotificationRecord.setEventTime(eventTime != null ? Instant.parse(eventTime) : null);
 
         RequestParameters requestParameters = readRequestParameters(recordNode.get("requestParameters"));
         eventNotificationRecord.setRequestParameters(requestParameters);

--- a/services-custom/s3-event-notifications/src/test/java/software/amazon/awssdk/eventnotifications/s3/model/S3EventNotificationReaderTest.java
+++ b/services-custom/s3-event-notifications/src/test/java/software/amazon/awssdk/eventnotifications/s3/model/S3EventNotificationReaderTest.java
@@ -443,6 +443,53 @@ class S3EventNotificationReaderTest {
     }
 
     @Test
+    void eventTimeIsNullWhenEventNamePresent_shouldSucceed() {
+        String json = "{\n"
+                      + "  \"Records\" : [ {\n"
+                      + "    \"eventVersion\" : \"2.1\",\n"
+                      + "    \"eventSource\" : \"aws:s3\",\n"
+                      + "    \"awsRegion\" : \"us-west-2\",\n"
+                      // missing eventTime
+                      + "    \"eventName\" : \"ObjectCreated:Put\",\n"
+                      + "    \"userIdentity\" : {\n"
+                      + "      \"principalId\" : \"AIDAJDPLRKLG7UEXAMUID\"\n"
+                      + "    },\n"
+                      + "    \"requestParameters\" : {\n"
+                      + "      \"sourceIPAddress\" : \"127.1.2.3\"\n"
+                      + "    },\n"
+                      + "    \"responseElements\":{\n"
+                      + "      \"x-amz-request-id\":\"C3D13FE58DE4C810\",\n"
+                      + "      \"x-amz-id-2\":\"FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD\"\n"
+                      + "    },\n"
+                      + "    \"s3\" : {\n"
+                      + "      \"s3SchemaVersion\" : \"1.0\",\n"
+                      + "      \"configurationId\" : \"testConfigRule\",\n"
+                      + "      \"bucket\" : {\n"
+                      + "        \"name\" : \"mybucket-test\",\n"
+                      + "        \"ownerIdentity\" : {\n"
+                      + "          \"principalId\" : \"A3NL1KOZZKExample\"\n"
+                      + "        },\n"
+                      + "        \"arn\" : \"arn:aws:s3:::mybucket\"\n"
+                      + "      },\n"
+                      + "      \"object\" : {\n"
+                      + "        \"key\" : \"HappyFace-test.jpg\",\n"
+                      + "        \"size\" : 2048,\n"
+                      + "        \"eTag\" : \"d41d8cd98f00b204e9800998ecf8etag\",\n"
+                      + "        \"versionId\" : \"096fKKXTRTtl3on89fVO.nfljtsv6vid\",\n"
+                      + "        \"sequencer\" : \"0055AED6DCD9028SEQ\"\n"
+                      + "      }\n"
+                      + "    }\n"
+                      + "  } ]\n"
+                      + "}";
+
+        S3EventNotification event = S3EventNotification.fromJson(json);
+        S3EventNotificationRecord rec = event.getRecords().get(0);
+        assertThat(rec).isNotNull();
+        assertThat(rec.getEventName()).isEqualTo("ObjectCreated:Put");
+        assertThat(rec.getEventTime()).isNull();
+    }
+
+    @Test
     void extraFields_areIgnored() {
         String json = "{\"Records\":[], \"toto\":123}";
         S3EventNotification event = S3EventNotification.fromJson(json);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Currently, `S3EventNotification::fromJson` throws an exception when `eventTime` is `null`. This is problematic, since the code intends to allow for this field to be `null`, but [it uses the wrong variable when performing a guard](https://github.com/aws/aws-sdk-java-v2/blob/cb7f5c5d692ecf657e9545a48b02e78d7a132b2c/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/internal/DefaultS3EventNotificationReader.java#L104).

## Modifications
This patch fixes the `null` guard by using the correct variable, `eventTime`, before attempting to parse it as an `Instant`.

## Testing
Built the project locally (couldn't build some modules locally, so I just built the one modified)

```shell
./mvnw --projects :s3-event-notifications --also-make install
```


## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
