### PR TITLE
Add @Mutable and @NotThreadSafe to model Builders

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-26bdf69.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-26bdf69.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Add `@Mutable` and `@NotThreadSafe` to model Builders"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ModelBuilderSpecs.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ModelBuilderSpecs.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
@@ -83,6 +85,8 @@ class ModelBuilderSpecs {
     public TypeSpec builderInterface() {
         TypeSpec.Builder builder = TypeSpec.interfaceBuilder(builderInterfaceName())
                 .addSuperinterfaces(builderSuperInterfaces())
+                .addAnnotation(Mutable.class)
+                .addAnnotation(NotThreadSafe.class)
                 .addModifiers(PUBLIC);
 
         shapeModel.getNonStreamingMembers()

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -16,6 +16,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
@@ -1661,6 +1663,8 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo, CopyableBuilder<Builder, AllTypesRequest> {
         /**
          * Sets the value of the StringMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -16,6 +16,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -1660,6 +1662,8 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo, CopyableBuilder<Builder, AllTypesResponse> {
         /**
          * Sets the value of the StringMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesunionstructure.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesunionstructure.java
@@ -19,6 +19,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -2301,6 +2303,8 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, AllTypesUnionStructure> {
         /**
          * Sets the value of the StringMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/basetype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/basetype.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -163,6 +165,8 @@ public final class BaseType implements SdkPojo, Serializable, ToCopyableBuilder<
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, BaseType> {
         /**
          * Sets the value of the BaseMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenamerequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenamerequest.java
@@ -11,6 +11,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -171,6 +173,8 @@ public final class DeprecatedRenameRequest extends JsonProtocolTestsRequest impl
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo, CopyableBuilder<Builder, DeprecatedRenameRequest> {
         /**
          * Sets the value of the NewNameNoDeprecation property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenameresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenameresponse.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -158,6 +160,8 @@ public final class DeprecatedRenameResponse extends JsonProtocolTestsResponse im
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, DeprecatedRenameResponse> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -52,6 +54,8 @@ public final class EmptyModeledException extends JsonProtocolTestsException impl
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, EmptyModeledException>, JsonProtocolTestsException.Builder {
         @Override
         Builder awsErrorDetails(AwsErrorDetails awsErrorDetails);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventone.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventone.java
@@ -12,6 +12,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -148,6 +150,8 @@ public class EventOne implements SdkPojo, Serializable, ToCopyableBuilder<EventO
         throw new UnsupportedOperationException();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, EventOne> {
         /**
          * Sets the value of the Foo property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -92,6 +94,8 @@ public final class EventStreamOperationRequest extends JsonProtocolTestsRequest 
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, EventStreamOperationRequest> {
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -90,6 +92,8 @@ public final class EventStreamOperationResponse extends JsonProtocolTestsRespons
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, EventStreamOperationResponse> {
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationwithonlyinputrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationwithonlyinputrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -92,6 +94,8 @@ public final class EventStreamOperationWithOnlyInputRequest extends JsonProtocol
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, EventStreamOperationWithOnlyInputRequest> {
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationwithonlyinputresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstreamoperationwithonlyinputresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -88,6 +90,8 @@ public final class EventStreamOperationWithOnlyInputResponse extends JsonProtoco
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, EventStreamOperationWithOnlyInputResponse> {
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventtwo.java
@@ -12,6 +12,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -148,6 +150,8 @@ public class EventTwo implements SdkPojo, Serializable, ToCopyableBuilder<EventT
         throw new UnsupportedOperationException();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, EventTwo> {
         /**
          * Sets the value of the Bar property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinternalservererrorexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinternalservererrorexception.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -60,6 +62,8 @@ public final class JsonServiceInternalServerErrorException extends JsonException
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, JsonServiceInternalServerErrorException>,
                                      JsonException.Builder {
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinvalidinputexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonserviceinvalidinputexception.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -55,6 +57,8 @@ public final class JsonServiceInvalidInputException extends JsonException implem
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, JsonServiceInvalidInputException>, JsonException.Builder {
         @Override
         Builder awsErrorDetails(AwsErrorDetails awsErrorDetails);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonservicethrottlingexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/exceptions/jsonservicethrottlingexception.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -65,6 +67,8 @@ public final class JsonServiceThrottlingException extends JsonException implemen
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, JsonServiceThrottlingException>, JsonException.Builder {
         @Override
         Builder awsErrorDetails(AwsErrorDetails awsErrorDetails);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingrequest.java
@@ -12,6 +12,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -320,6 +322,8 @@ public final class ExistenceCheckNamingRequest extends JsonProtocolTestsRequest 
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, ExistenceCheckNamingRequest> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingresponse.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -318,6 +320,8 @@ public final class ExistenceCheckNamingResponse extends JsonProtocolTestsRespons
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, ExistenceCheckNamingResponse> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
@@ -13,6 +13,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -145,6 +147,8 @@ public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<Inpu
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, InputEvent> {
         /**
          * Sets the value of the ExplicitPayloadMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
@@ -13,6 +13,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -190,6 +192,8 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, InputEventTwo> {
         /**
          * Sets the value of the ImplicitPayloadMemberOne property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersrequest.java
@@ -12,6 +12,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -336,6 +338,8 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo, CopyableBuilder<Builder, NestedContainersRequest> {
         /**
          * Sets the value of the ListOfListOfStrings property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersresponse.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -334,6 +336,8 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, NestedContainersResponse> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedqueryparameteroperation.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedqueryparameteroperation.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -160,6 +162,8 @@ public final class NestedQueryParameterOperation implements SdkPojo, Serializabl
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, NestedQueryParameterOperation> {
         /**
          * Sets the value of the QueryParamOne property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberrequest.java
@@ -11,6 +11,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -220,6 +222,8 @@ public final class OperationWithDeprecatedMemberRequest extends JsonProtocolTest
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, OperationWithDeprecatedMemberRequest> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberresponse.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -188,6 +190,8 @@ public final class OperationWithDeprecatedMemberResponse extends JsonProtocolTes
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, OperationWithDeprecatedMemberResponse> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithnoinputoroutputrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithnoinputoroutputrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -90,6 +92,8 @@ public final class OperationWithNoInputOrOutputRequest extends JsonProtocolTests
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, OperationWithNoInputOrOutputRequest> {
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithnoinputoroutputresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithnoinputoroutputresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -88,6 +90,8 @@ public final class OperationWithNoInputOrOutputResponse extends JsonProtocolTest
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, OperationWithNoInputOrOutputResponse> {
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/queryparameteroperationrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/queryparameteroperationrequest.java
@@ -12,6 +12,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -352,6 +354,8 @@ public final class QueryParameterOperationRequest extends JsonProtocolTestsReque
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, QueryParameterOperationRequest> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/queryparameteroperationresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/queryparameteroperationresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -88,6 +90,8 @@ public final class QueryParameterOperationResponse extends JsonProtocolTestsResp
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, QueryParameterOperationResponse> {
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
@@ -15,6 +15,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -269,6 +271,8 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, RecursiveStructType> {
         /**
          * Sets the value of the NoRecurse property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -90,6 +92,8 @@ public final class GetRandomPersonRequest extends SharedEventStreamRequest imple
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo, CopyableBuilder<Builder, GetRandomPersonRequest> {
         @Override
         Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
@@ -12,6 +12,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -158,6 +160,8 @@ public class GetRandomPersonResponse extends SharedEventStreamResponse implement
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, GetRandomPersonResponse> {
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
@@ -13,6 +13,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -180,6 +182,8 @@ public class Person implements SdkPojo, Serializable, ToCopyableBuilder<Person.B
         throw new UnsupportedOperationException();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, Person> {
         /**
          * Sets the value of the Name property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -90,6 +92,8 @@ public final class StreamBirthsRequest extends SharedEventStreamRequest implemen
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo, CopyableBuilder<Builder, StreamBirthsRequest> {
         @Override
         Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -90,6 +92,8 @@ public final class StreamBirthsResponse extends SharedEventStreamResponse implem
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo, CopyableBuilder<Builder, StreamBirthsResponse> {
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -90,6 +92,8 @@ public final class StreamDeathsRequest extends SharedEventStreamRequest implemen
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo, CopyableBuilder<Builder, StreamDeathsRequest> {
         @Override
         Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -90,6 +92,8 @@ public final class StreamDeathsResponse extends SharedEventStreamResponse implem
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo, CopyableBuilder<Builder, StreamDeathsResponse> {
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/simplestruct.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/simplestruct.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -131,6 +133,8 @@ public final class SimpleStruct implements SdkPojo, Serializable, ToCopyableBuil
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, SimpleStruct> {
         /**
          * Sets the value of the StringMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streaminginputoperationrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streaminginputoperationrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -92,6 +94,8 @@ public final class StreamingInputOperationRequest extends JsonProtocolTestsReque
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, StreamingInputOperationRequest> {
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streaminginputoperationresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streaminginputoperationresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -88,6 +90,8 @@ public final class StreamingInputOperationResponse extends JsonProtocolTestsResp
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, StreamingInputOperationResponse> {
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streamingoutputoperationrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streamingoutputoperationrequest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -90,6 +92,8 @@ public final class StreamingOutputOperationRequest extends JsonProtocolTestsRequ
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
                                      CopyableBuilder<Builder, StreamingOutputOperationRequest> {
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streamingoutputoperationresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/streamingoutputoperationresponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -90,6 +92,8 @@ public final class StreamingOutputOperationResponse extends JsonProtocolTestsRes
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
                                      CopyableBuilder<Builder, StreamingOutputOperationResponse> {
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -134,6 +136,8 @@ public final class StructWithNestedBlobType implements SdkPojo, Serializable,
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, StructWithNestedBlobType> {
         /**
          * Sets the value of the NestedBlob property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithtimestamp.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithtimestamp.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -134,6 +136,8 @@ public final class StructWithTimestamp implements SdkPojo, Serializable,
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, StructWithTimestamp> {
         /**
          * Sets the value of the NestedTimestamp property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/subtypeone.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/subtypeone.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -132,6 +134,8 @@ public final class SubTypeOne implements SdkPojo, Serializable, ToCopyableBuilde
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, SubTypeOne> {
         /**
          * Sets the value of the SubTypeOneMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/underscore_name_type.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/underscore_name_type.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.ToString;
@@ -91,6 +93,8 @@ public final class Underscore_Name_Type implements SdkPojo, Serializable,
         return Collections.emptyMap();
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, Underscore_Name_Type> {
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespacerequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespacerequest.java
@@ -11,6 +11,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
@@ -198,6 +200,8 @@ public final class TestXmlNamespaceRequest extends ProtocolRestXmlRequest implem
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends ProtocolRestXmlRequest.Builder, SdkPojo, CopyableBuilder<Builder, TestXmlNamespaceRequest> {
         /**
          * Sets the value of the StringMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespaceresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespaceresponse.java
@@ -11,6 +11,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -197,6 +199,8 @@ public final class TestXmlNamespaceResponse extends ProtocolRestXmlResponse impl
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends ProtocolRestXmlResponse.Builder, SdkPojo, CopyableBuilder<Builder, TestXmlNamespaceResponse> {
         /**
          * Sets the value of the StringMember property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/xmlnamespacemember.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/xmlnamespacemember.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
@@ -162,6 +164,8 @@ public final class XmlNamespaceMember implements SdkPojo, Serializable,
         return (obj, val) -> s.accept((Builder) obj, val);
     }
 
+    @Mutable
+    @NotThreadSafe
     public interface Builder extends SdkPojo, CopyableBuilder<Builder, XmlNamespaceMember> {
         /**
          * Sets the value of the Type property for this object.


### PR DESCRIPTION
Add `@Mutable` and `@NotThreadSafe` to model Builders (including Request Builders)

## Motivation and Context
Fixes: #6007 

This PR adds the `@Mutable` and `@NotThreadSafe` annotations to model Builders to improve documentation and mark them as not thread safe and discourage usage in non-thread safe contexts. 

## Modifications
* Add `@Mutable` and `@NotThreadSafe` to model Builders (including Request Builders)

## Testing
Updated existing codegen test generated files - see diff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
