### PR TITLE
Use a compiled pattern instead of parsing it every time

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-b051142.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-b051142.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Small optimization for endpoint rules. Lazily compile the region pattern instead of parsing it every time. This will pay the penalty of parsing it just once at the cost of using a bit more of memory to keep the parsed pattern."
+}

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/Partition.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/Partition.java.resource
@@ -1,5 +1,6 @@
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.utils.ToString;
@@ -15,6 +16,7 @@ public class Partition {
     private final String regionRegex;
     private final Map<String, RegionOverride> regions;
     private final Outputs outputs;
+    private Pattern regionPattern;
 
     private Partition(Builder builder) {
         this.id = builder.id;
@@ -29,6 +31,13 @@ public class Partition {
 
     public String regionRegex() {
         return regionRegex;
+    }
+
+    public boolean regionMatches(String region) {
+        if (regionPattern == null) {
+            regionPattern = Pattern.compile(regionRegex);
+        }
+        return regionPattern.matcher(region).matches();
     }
 
     public Map<String, RegionOverride> regions() {

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules2/RulesFunctions.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules2/RulesFunctions.java.resource
@@ -90,8 +90,7 @@ public class RulesFunctions {
         if (matchedPartition == null) {
             // try matching on region name pattern
             for (Partition p : data.partitions) {
-                Pattern regex = Pattern.compile(p.regionRegex());
-                if (regex.matcher(regionName).matches()) {
+                if (p.regionMatches(regionName)) {
                     matchedPartition = p;
                     break;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Small optimization. Lazily compile the region pattern instead of parsing it every time. This will pay the penalty of parsing it just once at the cost of using a bit more of memory to keep the parsed pattern.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
