### PR TITLE
Fix CompletableFuture hangs when RetryStrategy/MetricsCollector raise errors

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-dc851b9.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-dc851b9.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix CompletableFuture hanging when RetryStrategy/MetricsCollector raise errors"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallMetricCollectionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallMetricCollectionStage.java
@@ -57,6 +57,9 @@ public final class AsyncApiCallMetricCollectionStage<OutputT> implements Request
             } else {
                 future.complete(r);
             }
+        }).exceptionally(t -> {
+            future.completeExceptionally(t);
+            return null;
         });
 
         return CompletableFutureUtils.forwardExceptionTo(future, executeFuture);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
@@ -75,7 +75,11 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
 
         public CompletableFuture<Response<OutputT>> execute() {
             CompletableFuture<Response<OutputT>> future = new CompletableFuture<>();
-            attemptFirstExecute(future);
+            try {
+                attemptFirstExecute(future);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
             return future;
         }
 
@@ -126,6 +130,9 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
 
                 retryableStageHelper.recordAttemptSucceeded();
                 future.complete(response);
+            }).exceptionally(t -> {
+                future.completeExceptionally(t);
+                return null;
             });
         }
 
@@ -149,7 +156,11 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
 
         private void maybeRetryExecute(CompletableFuture<Response<OutputT>> future, Exception exception) {
             retryableStageHelper.setLastException(exception);
-            maybeAttemptExecute(future);
+            try {
+                maybeAttemptExecute(future);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
         }
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientMetricCollectorExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientMetricCollectorExceptionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.core.internal.util.AsyncResponseHandlerTestUtils.noOpResponseHandler;
+import static utils.HttpTestUtils.testAsyncClientBuilder;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.core.Response;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.EmptyPublisher;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.http.NoopTestRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptorChain;
+import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.internal.http.AmazonAsyncHttpClient;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.core.protocol.VoidSdkResponse;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.retries.DefaultRetryStrategy;
+import utils.ValidSdkObjects;
+
+/**
+ * Tests to verify that exceptions thrown by the MetricCollector are reported through the returned future.
+ * {@link java.util.concurrent.CompletableFuture}.
+ *
+ * @see AsyncClientHandlerExceptionTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncClientMetricCollectorExceptionTest {
+
+    public static final String MESSAGE = "test exception";
+
+    @Mock
+    private MetricCollector metricCollector;
+
+    @Mock
+    private SdkAsyncHttpClient asyncHttpClient;
+
+    @Test
+    public void exceptionInReportMetricReportedInFuture() throws Exception {
+        when(metricCollector.createChild(any())).thenReturn(metricCollector);
+        Exception exception = new RuntimeException(MESSAGE);
+        doThrow(exception).when(metricCollector).reportMetric(eq(CoreMetric.API_CALL_DURATION), any(Duration.class));
+
+        CompletableFuture<SdkResponse> responseFuture = makeRequest();
+
+        assertThatThrownBy(() -> responseFuture.get(1, TimeUnit.SECONDS)).hasRootCause(exception);
+    }
+
+    private CompletableFuture<SdkResponse> makeRequest() throws Exception {
+        when(asyncHttpClient.execute(any(AsyncExecuteRequest.class))).thenAnswer((Answer<CompletableFuture<Void>>) invocationOnMock -> {
+            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgument(0, AsyncExecuteRequest.class).responseHandler();
+            handler.onHeaders(SdkHttpFullResponse.builder()
+                                                 .statusCode(200)
+                                                 .build());
+            handler.onStream(new EmptyPublisher<>());
+            return CompletableFuture.completedFuture(null);
+        });
+
+        AmazonAsyncHttpClient asyncClient = testAsyncClientBuilder()
+            .retryStrategy(DefaultRetryStrategy.doNotRetry())
+            .asyncHttpClient(asyncHttpClient)
+            .build();
+
+        SdkHttpFullRequest httpFullRequest = ValidSdkObjects.sdkHttpFullRequest().build();
+        NoopTestRequest sdkRequest = NoopTestRequest.builder().build();
+        InterceptorContext interceptorContext = InterceptorContext
+            .builder()
+            .request(sdkRequest)
+            .httpRequest(httpFullRequest)
+            .build();
+
+        Response<SdkResponse> response =
+            Response.<SdkResponse>builder()
+                    .isSuccess(true)
+                    .response(VoidSdkResponse.builder().build())
+                    .httpResponse(SdkHttpResponse.builder().statusCode(200).build())
+                    .build();
+
+        return asyncClient
+            .requestExecutionBuilder()
+            .originalRequest(sdkRequest)
+            .request(httpFullRequest)
+            .executionContext(
+                ExecutionContext
+                    .builder()
+                    .executionAttributes(new ExecutionAttributes())
+                    .interceptorContext(interceptorContext)
+                    .metricCollector(metricCollector)
+                    .interceptorChain(new ExecutionInterceptorChain(Collections.emptyList()))
+                    .build()
+            )
+            .execute(noOpResponseHandler(response));
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientRetryStrategyExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientRetryStrategyExceptionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.core.internal.util.AsyncResponseHandlerTestUtils.noOpResponseHandler;
+import static utils.HttpTestUtils.testAsyncClientBuilder;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.http.NoopTestRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptorChain;
+import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.internal.http.AmazonAsyncHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenResponse;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.retries.api.RetryToken;
+import utils.ValidSdkObjects;
+
+/**
+ * Tests to verify that exceptions thrown by the RetryStrategy are reported through the returned future.
+ * {@link java.util.concurrent.CompletableFuture}.
+ *
+ * @see AsyncClientHandlerExceptionTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncClientRetryStrategyExceptionTest {
+
+    public static final String MESSAGE = "test exception";
+
+    @Mock
+    private RetryStrategy retryStrategy;
+
+    @Test
+    public void exceptionInInitialTokenReportedInFuture() {
+        Exception exception = new RuntimeException(MESSAGE);
+        when(retryStrategy.acquireInitialToken(any())).thenThrow(exception);
+
+        CompletableFuture<SdkResponse> responseFuture = makeRequest();
+
+        assertThatThrownBy(() -> responseFuture.get(1, TimeUnit.SECONDS)).hasRootCause(exception);
+    }
+
+    @Test
+    public void exceptionInRefreshTokenReportedInFuture() {
+        when(retryStrategy.acquireInitialToken(any())).thenReturn(
+            AcquireInitialTokenResponse.create(new RetryToken() {
+            }, Duration.ZERO)
+        );
+        Exception exception = new RuntimeException(MESSAGE);
+        when(retryStrategy.refreshRetryToken(any())).thenThrow(exception);
+
+        CompletableFuture<SdkResponse> responseFuture = makeRequest();
+
+        assertThatThrownBy(() -> responseFuture.get(1, TimeUnit.SECONDS)).hasRootCause(exception);
+    }
+
+    private CompletableFuture<SdkResponse> makeRequest() {
+        AmazonAsyncHttpClient asyncClient = testAsyncClientBuilder().retryStrategy(retryStrategy).build();
+
+        SdkHttpFullRequest httpFullRequest = ValidSdkObjects.sdkHttpFullRequest().build();
+        NoopTestRequest sdkRequest = NoopTestRequest.builder().build();
+        InterceptorContext interceptorContext = InterceptorContext
+            .builder()
+            .request(sdkRequest)
+            .httpRequest(httpFullRequest)
+            .build();
+
+        return asyncClient
+            .requestExecutionBuilder()
+            .originalRequest(sdkRequest)
+            .request(httpFullRequest)
+            .executionContext(
+                ExecutionContext
+                    .builder()
+                    .executionAttributes(new ExecutionAttributes())
+                    .interceptorContext(interceptorContext)
+                    .metricCollector(MetricCollector.create("test"))
+                    .interceptorChain(new ExecutionInterceptorChain(Collections.emptyList()))
+                    .build()
+            )
+            .execute(noOpResponseHandler());
+    }
+}


### PR DESCRIPTION
Fix #6008  - Improve error handling in futures in the async pipeline.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Errors raised by the RetryStrategy or MetricsCollector in the async request pipeline previously caused the returned future to hang indefinitely because they were never setting a completion state on the returned future.  See #6008.

## Modifications
* Improve error handling in futures in the async pipeline

## Testing
* Added new unit tests for both cases
* manual testing with the a reproduction case for #6008 with ddb client.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
