### PR TITLE
Enable Netty HTTP header validation when connecting with proxy

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-904f3ec.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-904f3ec.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO HTTP Client",
+    "contributor": "",
+    "description": "Enable Netty HTTP header validation when connecting with proxy"
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandler.java
@@ -148,7 +148,7 @@ public final class ProxyTunnelInitHandler extends ChannelDuplexHandler {
     private HttpRequest connectRequest() {
         String uri = getUri();
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, uri,
-                                                         Unpooled.EMPTY_BUFFER, false);
+                                                         Unpooled.EMPTY_BUFFER);
         request.headers().add(HttpHeaderNames.HOST, uri);
 
         if (!StringUtils.isEmpty(this.username) && !StringUtils.isEmpty(this.password)) {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandlerTest.java
@@ -212,7 +212,7 @@ public class ProxyTunnelInitHandlerTest {
 
         String uri = REMOTE_HOST.getHost() + ":" + REMOTE_HOST.getPort();
         HttpRequest expectedRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, uri,
-                                                                 Unpooled.EMPTY_BUFFER, false);
+                                                                 Unpooled.EMPTY_BUFFER);
         expectedRequest.headers().add(HttpHeaderNames.HOST, uri);
 
         assertThat(requestCaptor.getValue()).isEqualTo(expectedRequest);
@@ -229,7 +229,7 @@ public class ProxyTunnelInitHandlerTest {
 
         String uri = REMOTE_HOST.getHost() + ":" + REMOTE_HOST.getPort();
         HttpRequest expectedRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, uri,
-                Unpooled.EMPTY_BUFFER, false);
+                Unpooled.EMPTY_BUFFER);
         expectedRequest.headers().add(HttpHeaderNames.HOST, uri);
 
         String authB64 = Base64.getEncoder().encodeToString(String.format("%s:%s", PROXY_USER, PROXY_PASSWORD).getBytes(CharsetUtil.UTF_8));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Enable Netty HTTP header validation when connecting with proxy