### PR TITLE
DynamoDB Enhanced - support for custom AttributeConverters and StringConverters to be used in collections

### DIFF
--- a/services-custom/dynamodb-enhanced/pom.xml
+++ b/services-custom/dynamodb-enhanced/pom.xml
@@ -233,5 +233,13 @@
             <type>so</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/model/Record.java
+++ b/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/model/Record.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
+import java.util.Map;
 import java.util.Objects;
 
 public class Record {
@@ -26,6 +27,8 @@ public class Record {
     private Integer gsiSort;
 
     private String stringAttribute;
+
+    private Map<String, String> attributesMap;
 
     public String getId() {
         return id;
@@ -81,6 +84,15 @@ public class Record {
         return this;
     }
 
+    public Map<String, String> getAttributesMap() {
+        return attributesMap;
+    }
+
+    public Record setAttributesMap(Map<String, String> attributesMap) {
+        this.attributesMap = attributesMap;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -91,11 +103,12 @@ public class Record {
                Objects.equals(value, record.value) &&
                Objects.equals(gsiId, record.gsiId) &&
                Objects.equals(stringAttribute, record.stringAttribute) &&
-               Objects.equals(gsiSort, record.gsiSort);
+               Objects.equals(gsiSort, record.gsiSort) &&
+               Objects.equals(attributesMap, record.attributesMap);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, sort, value, gsiId, gsiSort, stringAttribute);
+        return Objects.hash(id, sort, value, gsiId, gsiSort, stringAttribute, attributesMap);
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/FallbackAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/FallbackAttributeConverter.java
@@ -1,0 +1,44 @@
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.GenericObjectStringConverter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A fallback {@link AttributeConverter} used when no specific converter is registered.
+ * Serializes to and from strings using {@link GenericObjectStringConverter}, and stores as {@code SS}.
+ */
+public class FallbackAttributeConverter<T> implements AttributeConverter<T> {
+
+    private final GenericObjectStringConverter<T> stringConverter;
+
+    private FallbackAttributeConverter(GenericObjectStringConverter<T> stringConverter) {
+        this.stringConverter = stringConverter;
+    }
+
+    public static <T> FallbackAttributeConverter<T> create(EnhancedType<T> type) {
+        return new FallbackAttributeConverter<>(GenericObjectStringConverter.create(type));
+    }
+
+    @Override
+    public EnhancedType<T> type() {
+        return stringConverter.type();
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.S;
+    }
+
+    @Override
+    public AttributeValue transformFrom(T input) {
+        return AttributeValue.builder().s(stringConverter.toString(input)).build();
+    }
+
+    @Override
+    public T transformTo(AttributeValue input) {
+        return stringConverter.fromString(input.s());
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/FallbackStringConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/FallbackStringConverterProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter.string;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverterProvider;
+
+/**
+ * A {@link StringConverterProvider} that delegates to a default provider and
+ * falls back to a {@link GenericObjectStringConverter} when no specific converter is found.
+ *
+ * <p>Fallback converters are cached per raw class for performance.</p>
+ */
+
+public class FallbackStringConverterProvider implements StringConverterProvider {
+
+    private final StringConverterProvider delegate;
+    private final Map<Class<?>, StringConverter<?>> cache = new ConcurrentHashMap<>();
+
+    public FallbackStringConverterProvider(StringConverterProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> StringConverter<T> converterFor(EnhancedType<T> type) {
+        try {
+            return delegate.converterFor(type);
+        } catch (IllegalArgumentException e) {
+            return (StringConverter<T>) cache.computeIfAbsent(
+                type.rawClass(),
+                cls -> GenericObjectStringConverter.create((EnhancedType<Object>) type)
+            );
+        }
+    }
+}
+
+
+

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/FallbackStringConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/FallbackStringConverterProvider.java
@@ -17,6 +17,9 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.converter.string;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverterProvider;
@@ -27,7 +30,9 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConvert
  *
  * <p>Fallback converters are cached per raw class for performance.</p>
  */
-
+@SdkInternalApi
+@ThreadSafe
+@Immutable
 public class FallbackStringConverterProvider implements StringConverterProvider {
 
     private final StringConverterProvider delegate;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/GenericObjectStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/GenericObjectStringConverter.java
@@ -32,7 +32,6 @@ import software.amazon.awssdk.utils.Logger;
  * This converter is useful for types that don't have built-in support and is typically used in fallback scenarios. If
  * serialization or deserialization fails, an error is logged and {@code null} is returned.
  */
-
 @SdkInternalApi
 @ThreadSafe
 @Immutable

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/GenericObjectStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/GenericObjectStringConverter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter.string;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * A generic fallback {@link StringConverter} that uses Jackson's ObjectMapper to serialize and deserialize arbitrary types to and
+ * from JSON.
+ * <p>
+ * This converter is useful for types that don't have built-in support and is typically used in fallback scenarios. If
+ * serialization or deserialization fails, an error is logged and {@code null} is returned.
+ */
+
+@SdkInternalApi
+@ThreadSafe
+@Immutable
+public final class GenericObjectStringConverter<T> implements StringConverter<T> {
+
+    private static final Logger log = Logger.loggerFor(GenericObjectStringConverter.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private final EnhancedType<T> type;
+
+    private GenericObjectStringConverter(EnhancedType<T> type) {
+        this.type = type;
+    }
+
+    public static <T> GenericObjectStringConverter<T> create(EnhancedType<T> type) {
+        return new GenericObjectStringConverter<>(type);
+    }
+
+    @Override
+    public EnhancedType<T> type() {
+        return type;
+    }
+
+    @Override
+    public String toString(T value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            log.error(() -> "Failed to serialize object of type " + type.rawClass().getName(), e);
+        }
+        return null;
+    }
+
+    @Override
+    public T fromString(String string) {
+        if (string == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(string, type.rawClass());
+        } catch (JsonProcessingException e) {
+            log.error(() -> "Failed to deserialize object of type " + type.rawClass().getName(), e);
+        }
+        return null;
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/CustomType.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/CustomType.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@DynamoDbBean
+public class CustomType {
+    private String stringAttribute;
+    private Boolean booleanAttribute;
+    private Integer integerAttribute;
+    private Double doubleAttribute;
+    private LocalDate localDateAttribute;
+
+    public String getStringAttribute() {
+        return stringAttribute;
+    }
+
+    public CustomType setStringAttribute(String stringAttribute) {
+        this.stringAttribute = stringAttribute;
+        return this;
+    }
+
+    public LocalDate getLocalDateAttribute() {
+        return localDateAttribute;
+    }
+
+    public CustomType setLocalDateAttribute(LocalDate localDateAttribute) {
+        this.localDateAttribute = localDateAttribute;
+        return this;
+    }
+
+    public Double getDoubleAttribute() {
+        return doubleAttribute;
+    }
+
+    public CustomType setDoubleAttribute(Double doubleAttribute) {
+        this.doubleAttribute = doubleAttribute;
+        return this;
+    }
+
+    public Integer getIntegerAttribute() {
+        return integerAttribute;
+    }
+
+    public CustomType setIntegerAttribute(Integer integerAttribute) {
+        this.integerAttribute = integerAttribute;
+        return this;
+    }
+
+    public Boolean getBooleanAttribute() {
+        return booleanAttribute;
+    }
+
+    public CustomType setBooleanAttribute(Boolean booleanAttribute) {
+        this.booleanAttribute = booleanAttribute;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CustomType that = (CustomType) o;
+        return Objects.equals(stringAttribute, that.stringAttribute) && Objects.equals(booleanAttribute, that.booleanAttribute) && Objects.equals(integerAttribute, that.integerAttribute) && Objects.equals(doubleAttribute, that.doubleAttribute) && Objects.equals(localDateAttribute, that.localDateAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stringAttribute, booleanAttribute, integerAttribute, doubleAttribute, localDateAttribute);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/FallbackStringConverterProviderTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/FallbackStringConverterProviderTest.java
@@ -1,0 +1,103 @@
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter.string;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.model.Record;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FallbackStringConverterProviderTest {
+
+    @Mock
+    private StringConverterProvider mockDelegate;
+
+    private FallbackStringConverterProvider fallbackProvider;
+
+    @Before
+    public void setUp() {
+        fallbackProvider = new FallbackStringConverterProvider(mockDelegate);
+    }
+
+    @Test
+    public void testUsesDelegateWhenAvailable() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        StringConverter<Record> mockConverter = mock(StringConverter.class);
+        when(mockConverter.toString(any())).thenReturn("mock-serialized-result");
+        when(mockDelegate.converterFor(type)).thenReturn(mockConverter);
+
+        StringConverter<Record> result = fallbackProvider.converterFor(type);
+        assertEquals("mock-serialized-result", result.toString(createRecord()));
+        verify(mockDelegate).converterFor(type);
+    }
+
+    @Test
+    public void testFallbackSerializationDeserialization() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        when(mockDelegate.converterFor(type)).thenThrow(new IllegalArgumentException("Not found"));
+
+        StringConverter<Record> converter = fallbackProvider.converterFor(type);
+        Record original = createRecord();
+        String json = converter.toString(original);
+        Record parsed = converter.fromString(json);
+
+        assertNotNull(json);
+        assertNotNull(parsed);
+        assertEquals(original.getId(), parsed.getId());
+        assertEquals(original.getAttributesMap(), parsed.getAttributesMap());
+    }
+
+    @Test
+    public void testFallbackCaching() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        when(mockDelegate.converterFor(type)).thenThrow(new IllegalArgumentException("Not found"));
+
+        StringConverter<Record> first = fallbackProvider.converterFor(type);
+        StringConverter<Record> second = fallbackProvider.converterFor(type);
+
+        assertSame(first, second);
+    }
+
+    @Test
+    public void testFallbackHandlesNull() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        when(mockDelegate.converterFor(type)).thenThrow(new IllegalArgumentException("Not found"));
+
+        StringConverter<Record> converter = fallbackProvider.converterFor(type);
+        assertNull(converter.toString(null));
+        assertNull(converter.fromString(null));
+    }
+
+    @Test
+    public void testFallbackReturnsNullOnMalformedJson() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        when(mockDelegate.converterFor(type)).thenThrow(new IllegalArgumentException("Not found"));
+
+        StringConverter<Record> converter = fallbackProvider.converterFor(type);
+        assertNull(converter.fromString("{invalid"));
+    }
+
+    private Record createRecord() {
+        return new Record()
+            .setId("123")
+            .setAttributesMap(new HashMap<String, String>() {{
+                put("mapAttribute1", "mapValue1");
+                put("mapAttribute2", "mapValue2");
+                put("mapAttribute3", "mapValue3");
+            }});
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/GenericObjectStringConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/GenericObjectStringConverterTest.java
@@ -1,0 +1,63 @@
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter.string;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.model.Record;
+
+public class GenericObjectStringConverterTest {
+
+    @Test
+    public void testSerializeAndDeserializeCustomObject() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        StringConverter<Record> converter = GenericObjectStringConverter.create(type);
+
+        Record original = createRecord();
+        String json = converter.toString(original);
+        Record result = converter.fromString(json);
+
+        assertNotNull(json);
+        assertNotNull(result);
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getAttributesMap(), result.getAttributesMap());
+    }
+
+    @Test
+    public void serializeNullObject_returnsNull() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        StringConverter<Record> converter = GenericObjectStringConverter.create(type);
+
+        assertNull(converter.toString(null));
+    }
+
+    @Test
+    public void serializeNullJsonString_returnsNull() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        StringConverter<Record> converter = GenericObjectStringConverter.create(type);
+
+        assertNull(converter.fromString(null));
+    }
+
+    @Test
+    public void deserializeMalformedJson_returnsNull() {
+        EnhancedType<Record> type = EnhancedType.of(Record.class);
+        StringConverter<Record> converter = GenericObjectStringConverter.create(type);
+
+        assertNull(converter.fromString("{malformed"));
+    }
+
+    private Record createRecord() {
+        return new Record()
+            .setId("123")
+            .setAttributesMap(new HashMap<String, String>() {{
+                put("mapAttribute1", "mapValue1");
+                put("mapAttribute2", "mapValue2");
+                put("mapAttribute3", "mapValue3");
+            }});
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/customconverter/CustomConverterBeanTableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/customconverter/CustomConverterBeanTableSchemaTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.customconverter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.CustomType;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.CustomConverterBean;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CustomConverterBeanTableSchemaTest {
+
+    @Test
+    public void serializeBean_withCustomSet_CorrectlyPerformSerialization() {
+        CustomConverterBean customConverterBean = new CustomConverterBean()
+            .setId("1")
+            .setCustomSet(buildCustomSet());
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(customConverterBean, true);
+
+        //expected result items
+        AttributeValue expectedCustomSet = AttributeValue.builder().ss("{\"stringAttribute\":\"test2\","
+                                                                       + "\"booleanAttribute\":false,\"integerAttribute\":2,"
+                                                                       + "\"doubleAttribute\":200.0,"
+                                                                       + "\"localDateAttribute\":[2025,5,5]}",
+
+                                                                       "{\"stringAttribute\":\"test1\","
+                                                                       + "\"booleanAttribute\":true,\"integerAttribute\":1,"
+                                                                       + "\"doubleAttribute\":100.0,"
+                                                                       + "\"localDateAttribute\":[2025,1,1]}").build();
+
+        assertThat(itemMap.size(), is(2));
+        assertThat(itemMap, hasEntry("id", stringValue("1")));
+        assertThat(itemMap, hasEntry("customSet", expectedCustomSet));
+    }
+
+    @Test
+    public void deserializeBean_withCustomSet_CorrectlyPerformDeserialization() {
+        AttributeValue customSetAttribute = AttributeValue.builder().ss("{\"stringAttribute\":\"test1\","
+                                                                        + "\"booleanAttribute\":true,\"integerAttribute\":1,"
+                                                                        + "\"doubleAttribute\":100.0,"
+                                                                        + "\"localDateAttribute\":[2025,1,1]}",
+
+                                                                        "{\"stringAttribute\":\"test2\","
+                                                                        + "\"booleanAttribute\":false,\"integerAttribute\":2,"
+                                                                        + "\"doubleAttribute\":200.0,"
+                                                                        + "\"localDateAttribute\":[2025,5,5]}").build();
+
+        Map<String, AttributeValue> itemMap = new HashMap<>();
+        itemMap.put("id", stringValue("1"));
+        itemMap.put("customSet", customSetAttribute);
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        CustomConverterBean result = beanTableSchema.mapToItem(itemMap);
+
+        assertThat(result.getId(), is("1"));
+        assertThat(result.getCustomSet(), equalTo(buildCustomSet()));
+    }
+
+    @Test
+    public void serializeBean_withCustomList_CorrectlyPerformSerialization() {
+        CustomConverterBean customConverterBean = new CustomConverterBean()
+            .setId("1")
+            .setCustomList(buildCustomList());
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(customConverterBean, true);
+
+        //expected result items
+        AttributeValue expectedCustomList = AttributeValue.builder().l(new ArrayList<>(Arrays.asList(
+            AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                put("booleanAttribute", AttributeValue.builder().bool(Boolean.TRUE).build());
+                put("integerAttribute", AttributeValue.builder().n("1").build());
+                put("doubleAttribute", AttributeValue.builder().n("100.0").build());
+                put("stringAttribute", AttributeValue.builder().s("test1").build());
+                put("localDateAttribute", AttributeValue.builder().s("2025-01-01").build());
+            }}).build(),
+
+            AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                put("booleanAttribute", AttributeValue.builder().bool(Boolean.FALSE).build());
+                put("integerAttribute", AttributeValue.builder().n("2").build());
+                put("doubleAttribute", AttributeValue.builder().n("200.0").build());
+                put("stringAttribute", AttributeValue.builder().s("test2").build());
+                put("localDateAttribute", AttributeValue.builder().s("2025-05-05").build());
+            }}).build()
+        ))).build();
+
+        assertThat(itemMap.size(), is(2));
+        assertThat(itemMap, hasEntry("id", stringValue("1")));
+        assertThat(itemMap, hasEntry("customList", expectedCustomList));
+    }
+
+    @Test
+    public void deserializeBean_withCustomListCorrectlyPerformDeserialization() {
+        AttributeValue customListAttribute = AttributeValue.builder().l(new ArrayList<>(Arrays.asList(
+            AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                put("booleanAttribute", AttributeValue.builder().bool(Boolean.TRUE).build());
+                put("integerAttribute", AttributeValue.builder().n("1").build());
+                put("doubleAttribute", AttributeValue.builder().n("100.0").build());
+                put("stringAttribute", AttributeValue.builder().s("test1").build());
+                put("localDateAttribute", AttributeValue.builder().s("2025-01-01").build());
+            }}).build(),
+
+            AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                put("booleanAttribute", AttributeValue.builder().bool(Boolean.FALSE).build());
+                put("integerAttribute", AttributeValue.builder().n("2").build());
+                put("doubleAttribute", AttributeValue.builder().n("200.0").build());
+                put("stringAttribute", AttributeValue.builder().s("test2").build());
+                put("localDateAttribute", AttributeValue.builder().s("2025-05-05").build());
+            }}).build()
+        ))).build();
+
+        Map<String, AttributeValue> itemMap = new HashMap<>();
+        itemMap.put("id", stringValue("1"));
+        itemMap.put("customList", customListAttribute);
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        CustomConverterBean result = beanTableSchema.mapToItem(itemMap);
+
+        assertThat(result.getId(), is("1"));
+        assertThat(result.getCustomList(), equalTo(buildCustomList()));
+    }
+
+    @Test
+    public void serializeBean_withCustomMapKey_CorrectlyPerformSerialization() {
+        CustomConverterBean customConverterBean = new CustomConverterBean()
+            .setId("1")
+            .setCustomKeyMap(buildCustomKeyMap());
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(customConverterBean, true);
+
+        //expected result items
+        AttributeValue expectedCustomKeyMap = AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+            put("{\"stringAttribute\":\"test1\",\"booleanAttribute\":true,\"integerAttribute\":1,"
+                + "\"doubleAttribute\":100.0,\"localDateAttribute\":[2025,1,1]}",
+                AttributeValue.builder().s("mapValue").build());
+        }}).build();
+
+        assertThat(itemMap.size(), is(2));
+        assertThat(itemMap, hasEntry("id", stringValue("1")));
+        assertThat(itemMap, hasEntry("customKeyMap", expectedCustomKeyMap));
+    }
+
+    @Test
+    public void deserializeBean_withCustomMapKey_CorrectlyPerformDeserialization() {
+        AttributeValue customKeyMapAttribute = AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+            put("{\"stringAttribute\":\"test1\",\"booleanAttribute\":true,\"integerAttribute\":1,"
+                + "\"doubleAttribute\":100.0,\"localDateAttribute\":[2025,1,1]}",
+                AttributeValue.builder().s("mapValue").build());
+        }}).build();
+
+        Map<String, AttributeValue> itemMap = new HashMap<>();
+        itemMap.put("id", stringValue("1"));
+        itemMap.put("customKeyMap", customKeyMapAttribute);
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        CustomConverterBean result = beanTableSchema.mapToItem(itemMap);
+
+        assertThat(result.getId(), is("1"));
+        assertThat(result.getCustomKeyMap(), equalTo(buildCustomKeyMap()));
+    }
+
+    @Test
+    public void serializeBean_withCustomMapValue_CorrectlyPerformSerialization() {
+        CustomConverterBean customConverterBean = new CustomConverterBean()
+            .setId("1")
+            .setCustomValueMap(buildCustomValueMap());
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(customConverterBean, true);
+
+        //expected result items
+        AttributeValue expectedCustomValueMap = AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+            put("mapKey",
+                AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                    put("booleanAttribute", AttributeValue.builder().bool(Boolean.TRUE).build());
+                    put("integerAttribute", AttributeValue.builder().n("1").build());
+                    put("doubleAttribute", AttributeValue.builder().n("100.0").build());
+                    put("stringAttribute", AttributeValue.builder().s("test1").build());
+                    put("localDateAttribute", AttributeValue.builder().s("2025-01-01").build());
+                }}).build());
+        }}).build();
+
+        assertThat(itemMap.size(), is(2));
+        assertThat(itemMap, hasEntry("id", stringValue("1")));
+        assertThat(itemMap, hasEntry("customValueMap", expectedCustomValueMap));
+    }
+
+    @Test
+    public void deserializeBean_withCustomMapValue_CorrectlyPerformDeserialization() {
+        AttributeValue customValueMapAttribute = AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+            put("mapKey",
+                AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                    put("booleanAttribute", AttributeValue.builder().bool(Boolean.TRUE).build());
+                    put("integerAttribute", AttributeValue.builder().n("1").build());
+                    put("doubleAttribute", AttributeValue.builder().n("100.0").build());
+                    put("stringAttribute", AttributeValue.builder().s("test1").build());
+                    put("localDateAttribute", AttributeValue.builder().s("2025-01-01").build());
+                }}).build());
+        }}).build();
+
+        Map<String, AttributeValue> itemMap = new HashMap<>();
+        itemMap.put("id", stringValue("1"));
+        itemMap.put("customValueMap", customValueMapAttribute);
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        CustomConverterBean result = beanTableSchema.mapToItem(itemMap);
+
+        assertThat(result.getId(), is("1"));
+        assertThat(result.getCustomValueMap(), equalTo(buildCustomValueMap()));
+    }
+
+    @Test
+    public void serializeBean_withStringsMap_CorrectlyPerformSerialization() {
+        CustomConverterBean customConverterBean = new CustomConverterBean()
+            .setId("1")
+            .setLocalDate(LocalDate.of(2025, 1, 1))
+            .setStringsMap(buildStringsMap());
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(customConverterBean, true);
+
+        //expected result items
+        AttributeValue expectedLocalDate = AttributeValue.builder().s("2025-01-01").build();
+
+        AttributeValue expectedStringsMap = AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+            put("stringMapAttribute1", AttributeValue.builder().s("mapValue1").build());
+            put("stringMapAttribute2", AttributeValue.builder().s("mapValue2").build());
+            put("stringMapAttribute3", AttributeValue.builder().s("mapValue3").build());
+        }}).build();
+
+        assertThat(itemMap.size(), is(3));
+        assertThat(itemMap, hasEntry("id", stringValue("1")));
+        assertThat(itemMap, hasEntry("localDate", expectedLocalDate));
+        assertThat(itemMap, hasEntry("stringsMap", expectedStringsMap));
+    }
+
+    @Test
+    public void deserializeBean_withStringsMap_CorrectlyPerformDeserialization() {
+        AttributeValue localDateAttribute = AttributeValue.builder().s("2025-01-01").build();
+        AttributeValue stringsMapAttribute = AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+            put("stringMapAttribute1", AttributeValue.builder().s("mapValue1").build());
+            put("stringMapAttribute2", AttributeValue.builder().s("mapValue2").build());
+            put("stringMapAttribute3", AttributeValue.builder().s("mapValue3").build());
+        }}).build();
+
+        Map<String, AttributeValue> itemMap = new HashMap<>();
+        itemMap.put("id", stringValue("1"));
+        itemMap.put("localDate", localDateAttribute);
+        itemMap.put("stringsMap", stringsMapAttribute);
+
+        BeanTableSchema<CustomConverterBean> beanTableSchema = BeanTableSchema.create(CustomConverterBean.class);
+        CustomConverterBean result = beanTableSchema.mapToItem(itemMap);
+
+        assertThat(result.getId(), is("1"));
+        assertThat(result.getLocalDate(), is(LocalDate.of(2025, 1,1)));
+        assertThat(result.getStringsMap(), equalTo(buildStringsMap()));
+    }
+
+    private Set<CustomType> buildCustomSet() {
+        return new HashSet<>(Arrays.asList(buildFirstCustomTypeElement(), buildSecondCustomTypeElement()));
+    }
+
+    private List<CustomType> buildCustomList() {
+        return new ArrayList<>(Arrays.asList(buildFirstCustomTypeElement(), buildSecondCustomTypeElement()));
+    }
+
+    private Map<CustomType, String> buildCustomKeyMap() {
+        return new HashMap<CustomType, String>() {{
+            put(buildFirstCustomTypeElement(), "mapValue");
+        }};
+    }
+
+    private Map<String, CustomType> buildCustomValueMap() {
+        return new HashMap<String, CustomType>() {{
+            put("mapKey", buildFirstCustomTypeElement());
+        }};
+    }
+
+    private Map<String, String> buildStringsMap() {
+        return new HashMap<String, String>() {{
+            put("stringMapAttribute1", "mapValue1");
+            put("stringMapAttribute2", "mapValue2");
+            put("stringMapAttribute3", "mapValue3");
+        }};
+    }
+
+    private CustomType buildFirstCustomTypeElement() {
+      return new CustomType()
+            .setBooleanAttribute(Boolean.TRUE)
+            .setIntegerAttribute(1)
+            .setDoubleAttribute(100.0)
+            .setStringAttribute("test1")
+            .setLocalDateAttribute(LocalDate.of(2025, 1, 1));
+    }
+
+    private CustomType buildSecondCustomTypeElement() {
+       return new CustomType()
+            .setBooleanAttribute(Boolean.FALSE)
+            .setIntegerAttribute(2)
+            .setDoubleAttribute(200.0)
+            .setStringAttribute("test2")
+            .setLocalDateAttribute(LocalDate.of(2025, 5, 5));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/CustomConverterBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/CustomConverterBean.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.CustomType;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class CustomConverterBean {
+    private String id;
+    private LocalDate localDate;
+    private Map<String, String> stringsMap;
+    private Map<CustomType, String> customKeyMap;
+    private Map<String, CustomType> customValueMap;
+    private List<CustomType> customList;
+    private Set<CustomType> customSet;
+
+    @DynamoDbPartitionKey
+    public String getId() {
+        return this.id;
+    }
+
+    public CustomConverterBean setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public LocalDate getLocalDate() {
+        return localDate;
+    }
+
+    public CustomConverterBean setLocalDate(LocalDate localDate) {
+        this.localDate = localDate;
+        return this;
+    }
+
+    public Map<String, String> getStringsMap() {
+        return stringsMap;
+    }
+
+    public CustomConverterBean setStringsMap(Map<String, String> stringsMap) {
+        this.stringsMap = stringsMap;
+        return this;
+    }
+
+    public Map<CustomType, String> getCustomKeyMap() {
+        return customKeyMap;
+    }
+
+    public CustomConverterBean setCustomKeyMap(Map<CustomType, String> customKeyMap) {
+        this.customKeyMap = customKeyMap;
+        return this;
+    }
+
+    public Map<String, CustomType> getCustomValueMap() {
+        return customValueMap;
+    }
+
+    public CustomConverterBean setCustomValueMap(Map<String, CustomType> customValueMap) {
+        this.customValueMap = customValueMap;
+        return this;
+    }
+
+    public List<CustomType> getCustomList() {
+        return customList;
+    }
+
+    public CustomConverterBean setCustomList(List<CustomType> customList) {
+        this.customList = customList;
+        return this;
+    }
+
+    public Set<CustomType> getCustomSet() {
+        return customSet;
+    }
+
+    public CustomConverterBean setCustomSet(Set<CustomType> customSet) {
+        this.customSet = customSet;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CustomConverterBean that = (CustomConverterBean) o;
+        return Objects.equals(id, that.id) && Objects.equals(localDate, that.localDate) && Objects.equals(stringsMap, that.stringsMap) && Objects.equals(customKeyMap, that.customKeyMap) && Objects.equals(customValueMap, that.customValueMap) && Objects.equals(customList, that.customList) && Objects.equals(customSet, that.customSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, localDate, stringsMap, customKeyMap, customValueMap, customList, customSet);
+    }
+}


### PR DESCRIPTION
Add support for custom AttributeConverters and StringConverters in collection types

## Motivation and Context
Currently, serializing custom types within collections (like **List<CustomType>**, **Set<CustomType>**, **Map<CustomType, Value>** or **Map<Value, CustomType>**) requires extensive boilerplate or duplication of internal SDK logic. The default converter providers do not support registering custom converters, making it difficult to handle these cases cleanly. 

This change introduces **fallback mechanisms and Jackson-based generic converters** to simplify serialization of custom types in collections, improving extensibility and developer experience.

Fixes: [#4862](https://github.com/aws/aws-sdk-java-v2/issues/4862)


## Modifications
- Added **GenericObjectStringConverter<T>**: A generic StringConverter that uses Jackson's ObjectMapper to serialize/deserialize custom types to and from JSON strings.
- Added **FallbackAttributeConverter<T>**: Wraps a StringConverter<T> to enable its use in collections (lists, sets, maps) when no specific AttributeConverter is registered.
- Added **FallbackStringConverterProvider**: A custom StringConverterProvider that first tries the default provider and falls back to GenericObjectStringConverter using ObjectMapper when needed.
- Enabled support for custom types in collections: Collection element types and map keys/values can now be serialized/deserialized using fallback converters.
- Added tests: **Unit and integration tests** verifying support for custom object types in List, Set, and Map structures.


## Testing
- **Unit Tests**: Verified the behavior of GenericObjectStringConverter, FallbackAttributeConverter, and FallbackStringConverterProvider, ensuring correct serialization and deserialization of custom types.
- **Integration Tests**: correct serialization/deserialization of:
       1. List of elements of custom type
       2. Set of elements of custom type
       3. Map with key of custom type
       4. Map with elements of custom type

- **Edge Cases**: Tested null values, empty collections, and malformed input strings to ensure robustness.


## Test Coverage Checklist

| Scenario | Done | Comments if Not Done |
|---------|:----:|---------------------|
| **1. Different TableSchema Creation Methods** | | |
| a. TableSchema.fromBean(Customer.class) | [x] | |
| b. TableSchema.fromImmutableClass(Customer.class) for immutable classes | [x] | |
| c. TableSchema.documentSchemaBuilder().build() | [ ] | |
| d. StaticTableSchema.builder(Customer.class) | [x] | |
| **2. Nesting of Different TableSchema Types** | | |
| a. @DynamoDbBean with nested @DynamoDbBean as NonNull | [x] | |
| b. @DynamoDbBean with nested @DynamoDbImmutable as NonNull | [x] | |
| c. @DynamoDbImmutable with nested @DynamoDbBean as NonNull | [x] | |
| d. @DynamoDbBean with nested @DynamoDbBean as Null | [x] | |
| e. @DynamoDbBean with nested @DynamoDbImmutable as Null| [x] | |
| f. @DynamoDbImmutable with nested @DynamoDbBean as Null | [x] | |
| **3. CRUD Operations** | | |
| a. scan() | [ ] | |
| b. query() | [x] | |
| c. updateItem() | [ ] | |
| d. putItem() | [x] | |
| e. getItem() | [x] | |
| f. deleteItem() | [ ] | |
| g. batchGetItem() | [ ] | |
| h. batchWriteItem() | [ ] | |
| i. transactGetItems() | [ ] | |
| j. transactWriteItems()  | [ ] | |
| **4. Data Types and Null Handling** | |  |
| a. top-level null attributes | [x] | |
| b. collections with null elements | [x] | |
| c. maps with null values | [x] | |
| d. conversion between null Java values and AttributeValue | [x] | |
| e. full serialization/deserialization cycle with null values | [x] | |
| **5. AsyncTable and SyncTable** | | |
| a. DynamoDbAsyncTable Testing | [ ] | |
| b. DynamoDbTable Testing | [ ] | |
| **6. New/Modification in Extensions** | | |
| a. Tables with Scenario in ScenarioSl No.1 (All table schemas are Must) | [ ] | |
| b. Test with Default Values in Annotations | [ ] | |
| c. Combination of Annotation and Builder passes extension | [ ] | |
| **7. New/Modification in Converters** | | |
| a. Tables with Scenario in ScenarioSl No.1 (All table schemas are Must) | [ ] | |
| b. Test with Default Values in Annotations | [ ] | |
| c. Test All Scenarios from 1 to 5 | [ ] | |


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
