### PR TITLE
Fix HTTP authentication retry failures by improving RepeatableInputStreamRequestEntity repeatability

### DIFF
--- a/http-clients/apache-client/pom.xml
+++ b/http-clients/apache-client/pom.xml
@@ -92,6 +92,42 @@
             <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Added for WIRE logging details while testing-->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/RepeatableInputStreamRequestEntityTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/RepeatableInputStreamRequestEntityTest.java
@@ -26,12 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -181,6 +176,7 @@ class RepeatableInputStreamRequestEntityTest {
             public int read() {
                 return -1;
             }
+
             @Override
             public boolean markSupported() {
                 return false;
@@ -208,7 +204,7 @@ class RepeatableInputStreamRequestEntityTest {
         AtomicInteger resetCallCount = new AtomicInteger(0);
         ByteArrayInputStream trackingStream = new ByteArrayInputStream(content.getBytes()) {
             @Override
-            public synchronized void reset()  {
+            public synchronized void reset() {
                 resetCallCount.incrementAndGet();
                 super.reset();
             }
@@ -239,7 +235,7 @@ class RepeatableInputStreamRequestEntityTest {
         AtomicInteger resetCallCount = new AtomicInteger(0);
         ByteArrayInputStream trackingStream = new ByteArrayInputStream(content.getBytes()) {
             @Override
-            public synchronized void reset()  {
+            public synchronized void reset() {
                 resetCallCount.incrementAndGet();
                 super.reset();
             }
@@ -452,8 +448,8 @@ class RepeatableInputStreamRequestEntityTest {
     }
 
     @Test
-    @DisplayName("Entity should handle mixed headers correctly")
-    void constructor_WithMixedHeaders_HandlesAllCorrectly() {
+    @DisplayName("Entity should handle multiple headers correctly")
+    void constructor_WithMultiHeaders_HandlesAllCorrectly() {
         // Given
         SdkHttpRequest httpRequest = httpRequestBuilder
             .putHeader("Content-Length", "2048")
@@ -548,8 +544,8 @@ class RepeatableInputStreamRequestEntityTest {
     }
 
     @Test
-    @DisplayName("Entity should handle partial stream reads")
-    void writeTo_PartialReads_CompletesSuccessfully() throws IOException {
+    @DisplayName("Entity should handle non repeatable data arriving in chunks")
+    void writeTo_withChunkedReads_CompletesSuccessfully() throws IOException {
         // Given - Stream that returns data in small chunks
         String content = "This is a test content that will be read in chunks";
         InputStream chunkingStream = new InputStream() {
@@ -649,7 +645,6 @@ class RepeatableInputStreamRequestEntityTest {
 
         entity.writeTo(output1);
         entity.writeTo(output2);
-
 
         assertEquals(content, output1.toString());
         assertEquals(content, output2.toString());

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/RepeatableInputStreamRequestEntityTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/RepeatableInputStreamRequestEntityTest.java
@@ -1,0 +1,774 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache.internal;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+class RepeatableInputStreamRequestEntityTest {
+
+    private static final String TRANSFER_ENCODING = "Transfer-Encoding";
+    private static final String CHUNKED = "chunked";
+
+    private RepeatableInputStreamRequestEntity entity;
+    private SdkHttpRequest.Builder httpRequestBuilder;
+
+    @BeforeEach
+    void setUp() {
+        httpRequestBuilder = SdkHttpRequest.builder()
+                                           .uri(URI.create("https://example.com"))
+                                           .method(SdkHttpMethod.POST);
+    }
+
+    @Test
+    @DisplayName("Constructor should initialize with chunked transfer encoding")
+    void constructor_WithChunkedTransferEncoding_SetsChunkedTrue() {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader(TRANSFER_ENCODING, CHUNKED)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertTrue(entity.isChunked());
+    }
+
+    @Test
+    @DisplayName("Constructor should handle content length header correctly")
+    void constructor_WithContentLength_SetsContentLengthCorrectly() {
+        long expectedLength = 1024L;
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", String.valueOf(expectedLength))
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(expectedLength, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Constructor should handle invalid content length gracefully")
+    void constructor_WithInvalidContentLength_DefaultsToMinusOne() {
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", "not-a-number")
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(-1L, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Constructor should set content type when provided")
+    void constructor_WithContentType_SetsContentTypeCorrectly() {
+        String contentType = "application/json";
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Type", contentType)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(contentType, entity.getContentType().getValue());
+    }
+
+    @Test
+    @DisplayName("Constructor should use provided content stream")
+    void constructor_WithContentStreamProvider_UsesProvidedStream() {
+        String content = "test content";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes());
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertSame(inputStream, entity.getContent());
+    }
+
+    @Test
+    @DisplayName("Constructor should create empty stream when no content provider")
+    void constructor_WithoutContentStreamProvider_CreatesEmptyStream() throws IOException {
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        InputStream content = entity.getContent();
+        assertNotNull(content);
+        assertEquals(0, content.available());
+    }
+
+    @Test
+    @DisplayName("isRepeatable should return true for mark-supported streams")
+    void isRepeatable_WithMarkSupportedStream_ReturnsTrue() {
+        ByteArrayInputStream markableStream = new ByteArrayInputStream("content".getBytes());
+        ContentStreamProvider provider = () -> markableStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertTrue(entity.isRepeatable());
+        assertTrue(markableStream.markSupported());
+    }
+
+    @Test
+    @DisplayName("isRepeatable should return false for non-mark-supported streams")
+    void isRepeatable_WithNonMarkSupportedStream_ReturnsFalse() {
+        // Given
+        InputStream nonMarkableStream = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+        };
+        ContentStreamProvider provider = () -> nonMarkableStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertFalse(entity.isRepeatable());
+    }
+
+    @Test
+    @DisplayName("writeTo should not reset stream on first attempt")
+    void writeTo_FirstAttempt_DoesNotResetStream() throws IOException {
+        // Given
+        String content = "test content";
+        ByteArrayInputStream inputStream = spy(new ByteArrayInputStream(content.getBytes()));
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        entity.writeTo(output);
+
+        assertEquals(content, output.toString());
+        verify(inputStream, never()).reset();
+    }
+
+    @Test
+    @DisplayName("writeTo should reset stream on subsequent attempts if repeatable")
+    void writeTo_SubsequentAttemptWithRepeatableStream_ResetsStream() throws IOException {
+        // Given
+        String content = "test content";
+        ByteArrayInputStream inputStream = spy(new ByteArrayInputStream(content.getBytes()));
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        // First write
+        entity.writeTo(new ByteArrayOutputStream());
+        // Second write
+        ByteArrayOutputStream secondOutput = new ByteArrayOutputStream();
+        entity.writeTo(secondOutput);
+        verify(inputStream, times(1)).reset();
+        assertEquals(content, secondOutput.toString());
+    }
+
+    @Test
+    @DisplayName("writeTo should preserve original exception on first failure")
+    void writeTo_FirstAttemptThrowsException_PreservesOriginalException() throws IOException {
+        // Given
+        IOException originalException = new IOException("Original error");
+        InputStream faultyStream = mock(InputStream.class);
+        when(faultyStream.read(any(byte[].class))).thenThrow(originalException);
+        when(faultyStream.markSupported()).thenReturn(true);
+
+        ContentStreamProvider provider = () -> faultyStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> entity.writeTo(new ByteArrayOutputStream()));
+        assertSame(originalException, thrown);
+    }
+
+    @Test
+    @DisplayName("writeTo should throw original exception on subsequent failures")
+    void writeTo_SubsequentFailures_ThrowsOriginalException() throws IOException {
+        // Given
+        IOException originalException = new IOException("Original error");
+        IOException secondException = new IOException("Second error");
+
+        InputStream faultyStream = mock(InputStream.class);
+        when(faultyStream.read(any(byte[].class)))
+            .thenThrow(originalException)
+            .thenThrow(secondException);
+        when(faultyStream.markSupported()).thenReturn(true);
+
+        ContentStreamProvider provider = () -> faultyStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        // First attempt
+        IOException firstThrown = assertThrows(IOException.class,
+                                               () -> entity.writeTo(new ByteArrayOutputStream()));
+        assertEquals("Original error", firstThrown.getMessage());
+        assertSame(originalException, firstThrown);
+        // Second attempt
+        IOException secondThrown = assertThrows(IOException.class,
+                                                () -> entity.writeTo(new ByteArrayOutputStream()));
+
+        // Should still throw original exception (not the second one)
+        assertSame(originalException, secondThrown);
+        assertEquals("Original error", secondThrown.getMessage());
+        assertNotSame(secondException, secondThrown);
+    }
+
+    @Test
+    @DisplayName("writeTo should handle reset failures gracefully")
+    void writeTo_ResetThrowsException_PropagatesResetException() throws IOException {
+        // Given
+        String content = "test content";
+
+        // Create a custom stream that throws on reset after first successful read
+        InputStream problematicStream = new InputStream() {
+            private final byte[] data = content.getBytes();
+            private int position = 0;
+            private boolean hasBeenRead = false;
+
+            @Override
+            public int read() throws IOException {
+                if (position >= data.length) {
+                    hasBeenRead = true;
+                    return -1;
+                }
+                hasBeenRead = true;
+                return data[position++] & 0xFF;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                if (position >= data.length) {
+                    hasBeenRead = true;
+                    return -1;
+                }
+                int bytesToRead = Math.min(len, data.length - position);
+                System.arraycopy(data, position, b, off, bytesToRead);
+                position += bytesToRead;
+                hasBeenRead = true;
+                return bytesToRead;
+            }
+
+            @Override
+            public boolean markSupported() {
+                return true;
+            }
+
+            @Override
+            public synchronized void mark(int readlimit) {
+                // Mark at current position
+            }
+
+            @Override
+            public synchronized void reset() throws IOException {
+                if (hasBeenRead) {
+                    throw new IOException("Reset failed");
+                }
+                position = 0;
+            }
+        };
+
+        ContentStreamProvider provider = () -> problematicStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // First successful write
+        ByteArrayOutputStream firstOutput = new ByteArrayOutputStream();
+        entity.writeTo(firstOutput);
+        assertEquals(content, firstOutput.toString());
+
+        // Second write where reset should fail
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> entity.writeTo(new ByteArrayOutputStream()));
+
+
+        assertEquals("Reset failed", thrown.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"100", "0", "9223372036854775807"}) // Long.MAX_VALUE
+    @DisplayName("parseContentLength should handle valid numeric values")
+    void parseContentLength_ValidNumbers_ParsesCorrectly(String contentLength) {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", contentLength)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(Long.parseLong(contentLength), entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Multiple writes should work correctly with repeatable stream")
+    void writeTo_MultipleWrites_AllSucceed() throws IOException {
+        // Given
+        String content = "repeatable content";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes());
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // Multiple writes
+        ByteArrayOutputStream output1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output3 = new ByteArrayOutputStream();
+
+        entity.writeTo(output1);
+        entity.writeTo(output2);
+        entity.writeTo(output3);
+
+        // All outputs should contain the same content
+        assertEquals(content, output1.toString());
+        assertEquals(content, output2.toString());
+        assertEquals(content, output3.toString());
+    }
+
+    @Test
+    @DisplayName("Entity should handle mixed headers correctly")
+    void constructor_WithMixedHeaders_HandlesAllCorrectly() {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", "2048")
+            .putHeader("Content-Type", "application/xml")
+            .putHeader(TRANSFER_ENCODING, CHUNKED)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(2048L, entity.getContentLength());
+        assertEquals("application/xml", entity.getContentType().getValue());
+        assertTrue(entity.isChunked());
+    }
+
+    @Test
+    @DisplayName("Entity should handle empty content correctly")
+    void writeTo_EmptyContent_WritesNothing() throws IOException {
+        // Given
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(new byte[0]);
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        entity.writeTo(output);
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    @DisplayName("Entity should handle large content streams")
+    void writeTo_LargeContent_HandlesCorrectly() throws IOException {
+        // Given - 10MB of data
+        int size = 10 * 1024 * 1024;
+        byte[] largeContent = new byte[size];
+        new Random().nextBytes(largeContent);
+
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(largeContent);
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", String.valueOf(size))
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        entity.writeTo(output);
+        assertArrayEquals(largeContent, output.toByteArray());
+        assertEquals(size, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Entity should handle non-repeatable stream on multiple writes")
+    void writeTo_NonRepeatableStreamMultipleWrites_FailsGracefully() throws IOException {
+        InputStream nonRepeatableStream = new InputStream() {
+            private boolean hasBeenRead = false;
+
+            @Override
+            public int read() throws IOException {
+                if (hasBeenRead) {
+                    throw new IOException("Stream already consumed");
+                }
+                hasBeenRead = true;
+                return -1;
+            }
+
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+        };
+
+        ContentStreamProvider provider = () -> nonRepeatableStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // First write should succeed
+        entity.writeTo(new ByteArrayOutputStream());
+
+        // Second write should fail
+        assertThrows(IOException.class, () -> entity.writeTo(new ByteArrayOutputStream()));
+    }
+
+    @Test
+    @DisplayName("Entity should handle partial stream reads")
+    void writeTo_PartialReads_CompletesSuccessfully() throws IOException {
+        // Given - Stream that returns data in small chunks
+        String content = "This is a test content that will be read in chunks";
+        InputStream chunkingStream = new InputStream() {
+            private final byte[] data = content.getBytes();
+            private int position = 0;
+
+            @Override
+            public int read() {
+                if (position >= data.length) {
+                    return -1;
+                }
+                int i = data[position] & 0xFF;
+                position++;
+                return i;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) {
+                if (position >= data.length) {
+                    return -1;
+                }
+                // Return only 5 bytes at a time to simulate chunked reading
+                int bytesToRead = Math.min(5, Math.min(len, data.length - position));
+                System.arraycopy(data, position, b, off, bytesToRead);
+                position += bytesToRead;
+                return bytesToRead;
+            }
+
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+        };
+
+        ContentStreamProvider provider = () -> chunkingStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        entity.writeTo(output);
+
+
+        assertEquals(content, output.toString());
+    }
+
+    @Test
+    @DisplayName("Entity should handle mark/reset with limited buffer")
+    void writeTo_MarkResetWithLimitedBuffer_HandlesCorrectly() throws IOException {
+        // Given - Stream with limited mark buffer
+        String content = "Short content";
+        InputStream limitedMarkStream = new InputStream() {
+            private final ByteArrayInputStream delegate = new ByteArrayInputStream(content.getBytes());
+
+            @Override
+            public int read() throws IOException {
+                return delegate.read();
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                return delegate.read(b, off, len);
+            }
+
+            @Override
+            public boolean markSupported() {
+                return true;
+            }
+
+            @Override
+            public synchronized void mark(int readlimit) {
+                delegate.mark(5); // Very small buffer
+            }
+
+            @Override
+            public synchronized void reset() throws IOException {
+                delegate.reset();
+            }
+        };
+
+        ContentStreamProvider provider = () -> limitedMarkStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        //Multiple writes
+        ByteArrayOutputStream output1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output2 = new ByteArrayOutputStream();
+
+        entity.writeTo(output1);
+        entity.writeTo(output2);
+
+
+        assertEquals(content, output1.toString());
+        assertEquals(content, output2.toString());
+    }
+
+    @Test
+    @DisplayName("Entity should handle null content type gracefully")
+    void constructor_WithoutContentType_HandlesGracefully() {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", "100")
+            // No Content-Type header
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+
+        assertNull(entity.getContentType());
+        assertEquals(100L, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Entity should handle concurrent write attempts")
+    void writeTo_ConcurrentWrites_HandlesCorrectly() throws Exception {
+        // Given
+        String content = "Concurrent test content";
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(content.getBytes());
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // Simulate concurrent writes
+        int threadCount = 5;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        List<ByteArrayOutputStream> outputs = Collections.synchronizedList(new ArrayList<>());
+        List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                try {
+                    ByteArrayOutputStream output = new ByteArrayOutputStream();
+                    entity.writeTo(output);
+                    outputs.add(output);
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        // At least one should succeed, others may fail due to stream state
+        assertFalse(outputs.isEmpty(), "At least one write should succeed");
+        for (ByteArrayOutputStream output : outputs) {
+            if (output.size() > 0) {
+                assertEquals(content, output.toString());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Entity should handle interrupted IO operations")
+    void writeTo_InterruptedStream_ThrowsIOException() throws IOException {
+        // Given
+        InputStream interruptibleStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new InterruptedIOException("Stream interrupted");
+            }
+
+            @Override
+            public boolean markSupported() {
+                return true;
+            }
+        };
+
+        ContentStreamProvider provider = () -> interruptibleStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> entity.writeTo(new ByteArrayOutputStream()));
+        assertInstanceOf(InterruptedIOException.class, thrown);
+        assertEquals("Stream interrupted", thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("Entity should preserve state across multiple operations")
+    void multipleOperations_StatePreservation_WorksCorrectly() throws IOException {
+        // Given
+        String content = "State preservation test";
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(content.getBytes());
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", String.valueOf(content.length()))
+            .putHeader("Content-Type", "text/plain")
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // Perform multiple operations
+        boolean isRepeatable1 = entity.isRepeatable();
+        boolean isChunked1 = entity.isChunked();
+        long contentLength1 = entity.getContentLength();
+
+        // Write once
+        entity.writeTo(new ByteArrayOutputStream());
+
+        boolean isRepeatable2 = entity.isRepeatable();
+        boolean isChunked2 = entity.isChunked();
+        long contentLength2 = entity.getContentLength();
+
+        // Write again
+        entity.writeTo(new ByteArrayOutputStream());
+
+        boolean isRepeatable3 = entity.isRepeatable();
+        boolean isChunked3 = entity.isChunked();
+        long contentLength3 = entity.getContentLength();
+
+        //State should remain consistent
+        assertEquals(isRepeatable1, isRepeatable2);
+        assertEquals(isRepeatable2, isRepeatable3);
+        assertEquals(isChunked1, isChunked2);
+        assertEquals(isChunked2, isChunked3);
+        assertEquals(contentLength1, contentLength2);
+        assertEquals(contentLength2, contentLength3);
+    }
+}
+

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
@@ -148,8 +148,6 @@ public final class Apache5HttpClient implements SdkHttpClient {
         ApacheConnectionManagerFactory cmFactory = new ApacheConnectionManagerFactory();
 
         HttpClientBuilder builder = HttpClients.custom();
-        //This is done to keep backward compatibility with Apache 4.x
-        builder.disableRedirectHandling();
 
         // Note that it is important we register the original connection manager with the
         // IdleConnectionReaper as it's required for the successful deregistration of managers
@@ -166,7 +164,9 @@ public final class Apache5HttpClient implements SdkHttpClient {
                .disableContentCompression()
                .setKeepAliveStrategy(buildKeepAliveStrategy(standardOptions))
                .setUserAgent("") // SDK will set the user agent header in the pipeline. Don't let Apache waste time
-               .setConnectionManager(ClientConnectionManagerFactory.wrap(cm));
+               .setConnectionManager(ClientConnectionManagerFactory.wrap(cm))
+               //This is done to keep backward compatibility with Apache 4.x
+               .disableRedirectHandling();
 
         addProxyConfig(builder, configuration);
 

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
@@ -148,6 +148,8 @@ public final class Apache5HttpClient implements SdkHttpClient {
         ApacheConnectionManagerFactory cmFactory = new ApacheConnectionManagerFactory();
 
         HttpClientBuilder builder = HttpClients.custom();
+        //This is done to keep backward compatibility with Apache 4.x
+        builder.disableRedirectHandling();
 
         // Note that it is important we register the original connection manager with the
         // IdleConnectionReaper as it's required for the successful deregistration of managers

--- a/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/Apache5HttpClientWireMockTest.java
+++ b/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/Apache5HttpClientWireMockTest.java
@@ -115,44 +115,43 @@ public class Apache5HttpClientWireMockTest extends SdkHttpClientTestSuite {
         mockProxyServer.verify(1, RequestPatternBuilder.allRequests());
     }
 
-    //TODO : Handle this as a part of supporting CredentialsProvider for Apache 5.x
-    // @Ignore("Need to fix CredentialsProvider for Apache 5.x")
-    // @Test
-    // public void credentialPlannerIsInvoked() throws Exception {
-    //     mockProxyServer.addStubMapping(any(urlPathEqualTo("/"))
-    //                                            .willReturn(aResponse()
-    //                                                            .withHeader("WWW-Authenticate", "Basic realm=\"proxy server\"")
-    //                                                            .withStatus(401))
-    //                                            .build());
-    //
-    //     mockProxyServer.addStubMapping(any(urlPathEqualTo("/"))
-    //                                            .withBasicAuth("foo", "bar")
-    //                                            .willReturn(aResponse()
-    //                                                            .proxiedFrom("http://localhost:" + mockServer.port()))
-    //                                            .build());
-    //
-    //     CredentialsProvider credentialsProvider = CredentialsProviderBuilder.create()
-    //                                                                         .add(new AuthScope(null, 0),
-    //                                                                              new UsernamePasswordCredentials("foo",
-    //                                                                                                              "bar".toCharArray()))
-    //                                                                         .build();
-    //
-    //
-    //     SdkHttpClient client = Apache5HttpClient.builder()
-    //                                             .credentialsProvider(credentialsProvider)
-    //                                             .httpRoutePlanner(
-    //                                                 (request, context) ->
-    //                                                     new HttpRoute(
-    //                                                         new HttpHost("https", "localhost", mockProxyServer.httpsPort())
-    //
-    //                                                     ))
-    //                                             .buildWithDefaults(AttributeMap.builder()
-    //                                                                            .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
-    //                                                                            .build());
-    //     testForResponseCodeUsingHttps(client, HttpURLConnection.HTTP_OK);
-    //
-    //     mockProxyServer.verify(2, RequestPatternBuilder.allRequests());
-    // }
+    @Test
+    public void credentialPlannerIsInvoked() throws Exception {
+
+        mockProxyServer.addStubMapping(any(urlPathEqualTo("/"))
+                                               .willReturn(aResponse()
+                                                               .withHeader("WWW-Authenticate", "Basic realm=\"proxy server\"")
+                                                               .withStatus(401))
+                                               .build());
+
+        mockProxyServer.addStubMapping(any(urlPathEqualTo("/"))
+                                               .withBasicAuth("foo", "bar")
+                                               .willReturn(aResponse()
+                                                               .proxiedFrom("http://localhost:" + mockServer.port()))
+                                               .build());
+
+        CredentialsProvider credentialsProvider = CredentialsProviderBuilder.create()
+                                                                            .add(new AuthScope("localhost", -1),
+                                                                                 new UsernamePasswordCredentials("foo", "bar".toCharArray()))
+                                                                            .build();
+
+
+
+        SdkHttpClient client = Apache5HttpClient.builder()
+                                                .credentialsProvider(credentialsProvider)
+                                                .httpRoutePlanner(
+                                                    (request, context) ->
+                                                        new HttpRoute(
+                                                            new HttpHost("https", "localhost", mockProxyServer.httpsPort())
+
+                                                        ))
+                                                .buildWithDefaults(AttributeMap.builder()
+                                                                               .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
+                                                                               .build());
+        testForResponseCodeUsingHttps(client, HttpURLConnection.HTTP_OK);
+
+        mockProxyServer.verify(2, RequestPatternBuilder.allRequests());
+    }
 
 
     @Override

--- a/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/internal/RepeatableInputStreamRequestEntityTest.java
+++ b/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/internal/RepeatableInputStreamRequestEntityTest.java
@@ -448,8 +448,8 @@ class RepeatableInputStreamRequestEntityTest {
     }
 
     @Test
-    @DisplayName("Entity should handle mixed headers correctly")
-    void constructor_WithMixedHeaders_HandlesAllCorrectly() {
+    @DisplayName("Entity should handle multiple headers correctly")
+    void constructor_WithMultiHeaders_HandlesAllCorrectly() {
         // Given
         SdkHttpRequest httpRequest = httpRequestBuilder
             .putHeader("Content-Length", "2048")
@@ -548,8 +548,8 @@ class RepeatableInputStreamRequestEntityTest {
     }
 
     @Test
-    @DisplayName("Entity should handle partial stream reads")
-    void writeTo_PartialReads_CompletesSuccessfully() throws IOException {
+    @DisplayName("Entity should handle non repeatable data arriving in chunks")
+    void writeTo_withChunkedReads_CompletesSuccessfully() throws IOException {
         // Given - Stream that returns data in small chunks
         String content = "This is a test content that will be read in chunks";
         InputStream chunkingStream = new InputStream() {
@@ -594,10 +594,7 @@ class RepeatableInputStreamRequestEntityTest {
         entity = new RepeatableInputStreamRequestEntity(request);
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-
         entity.writeTo(output);
-
-
         assertEquals(content, output.toString());
     }
 

--- a/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/internal/RepeatableInputStreamRequestEntityTest.java
+++ b/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/internal/RepeatableInputStreamRequestEntityTest.java
@@ -1,0 +1,778 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache5.internal;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+class RepeatableInputStreamRequestEntityTest {
+
+    private static final String TRANSFER_ENCODING = "Transfer-Encoding";
+    private static final String CHUNKED = "chunked";
+
+    private RepeatableInputStreamRequestEntity entity;
+    private SdkHttpRequest.Builder httpRequestBuilder;
+
+    @BeforeEach
+    void setUp() {
+        httpRequestBuilder = SdkHttpRequest.builder()
+                                           .uri(URI.create("https://example.com"))
+                                           .method(SdkHttpMethod.POST);
+    }
+
+    @Test
+    @DisplayName("Constructor should initialize with chunked transfer encoding")
+    void constructor_WithChunkedTransferEncoding_SetsChunkedTrue() {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader(TRANSFER_ENCODING, CHUNKED)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertTrue(entity.isChunked());
+    }
+
+    @Test
+    @DisplayName("Constructor should handle content length header correctly")
+    void constructor_WithContentLength_SetsContentLengthCorrectly() {
+        long expectedLength = 1024L;
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", String.valueOf(expectedLength))
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(expectedLength, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Constructor should handle invalid content length gracefully")
+    void constructor_WithInvalidContentLength_DefaultsToMinusOne() {
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", "not-a-number")
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(-1L, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Constructor should set content type when provided")
+    void constructor_WithContentType_SetsContentTypeCorrectly() {
+        String contentType = "application/json";
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Type", contentType)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(contentType, entity.getContentType().toString());
+    }
+
+    @Test
+    @DisplayName("Constructor should use provided content stream")
+    void constructor_WithContentStreamProvider_UsesProvidedStream() throws IOException {
+        String content = "test content";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes());
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertSame(inputStream, entity.getContent());
+    }
+
+    @Test
+    @DisplayName("Constructor should create empty stream when no content provider")
+    void constructor_WithoutContentStreamProvider_CreatesEmptyStream() throws IOException {
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        InputStream content = entity.getContent();
+        assertNotNull(content);
+        assertEquals(0, content.available());
+    }
+
+    @Test
+    @DisplayName("isRepeatable should return true for mark-supported streams")
+    void isRepeatable_WithMarkSupportedStream_ReturnsTrue() {
+        ByteArrayInputStream markableStream = new ByteArrayInputStream("content".getBytes());
+        ContentStreamProvider provider = () -> markableStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertTrue(entity.isRepeatable());
+        assertTrue(markableStream.markSupported());
+    }
+
+    @Test
+    @DisplayName("isRepeatable should return false for non-mark-supported streams")
+    void isRepeatable_WithNonMarkSupportedStream_ReturnsFalse() {
+        // Given
+        InputStream nonMarkableStream = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+        };
+        ContentStreamProvider provider = () -> nonMarkableStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        assertFalse(entity.isRepeatable());
+    }
+
+    @Test
+    @DisplayName("writeTo should not reset stream on first attempt")
+    void writeTo_FirstAttempt_DoesNotResetStream() throws IOException {
+        // Given
+        String content = "test content";
+        ByteArrayInputStream inputStream = spy(new ByteArrayInputStream(content.getBytes()));
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        entity.writeTo(output);
+        assertEquals(content, output.toString());
+        verify(inputStream, never()).reset();
+    }
+
+    @Test
+    @DisplayName("writeTo should reset stream on subsequent attempts if repeatable")
+    void writeTo_SubsequentAttemptWithRepeatableStream_ResetsStream() throws IOException {
+        // Given
+        String content = "test content";
+        ByteArrayInputStream inputStream = spy(new ByteArrayInputStream(content.getBytes()));
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // First write
+        entity.writeTo(new ByteArrayOutputStream());
+
+        //Second write
+        ByteArrayOutputStream secondOutput = new ByteArrayOutputStream();
+        entity.writeTo(secondOutput);
+
+        verify(inputStream, times(1)).reset();
+        assertEquals(content, secondOutput.toString());
+    }
+
+    @Test
+    @DisplayName("writeTo should preserve original exception on first failure")
+    void writeTo_FirstAttemptThrowsException_PreservesOriginalException() throws IOException {
+        // Given
+        IOException originalException = new IOException("Original error");
+        InputStream faultyStream = mock(InputStream.class);
+        when(faultyStream.read(any(byte[].class))).thenThrow(originalException);
+        when(faultyStream.markSupported()).thenReturn(true);
+
+        ContentStreamProvider provider = () -> faultyStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> entity.writeTo(new ByteArrayOutputStream()));
+        assertSame(originalException, thrown);
+    }
+
+    @Test
+    @DisplayName("writeTo should throw original exception on subsequent failures")
+    void writeTo_SubsequentFailures_ThrowsOriginalException() throws IOException {
+        // Given
+        IOException originalException = new IOException("Original error");
+        IOException secondException = new IOException("Second error");
+
+        InputStream faultyStream = mock(InputStream.class);
+        when(faultyStream.read(any(byte[].class)))
+            .thenThrow(originalException)
+            .thenThrow(secondException);
+        when(faultyStream.markSupported()).thenReturn(true);
+
+        ContentStreamProvider provider = () -> faultyStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // First attempt
+        IOException firstThrown = assertThrows(IOException.class,
+                                               () -> entity.writeTo(new ByteArrayOutputStream()));
+        assertEquals("Original error", firstThrown.getMessage());
+        assertSame(originalException, firstThrown);
+
+        //Second attempt
+        IOException secondThrown = assertThrows(IOException.class,
+                                                () -> entity.writeTo(new ByteArrayOutputStream()));
+
+        // Should still throw original exception (not the second one)
+        assertSame(originalException, secondThrown);
+        assertEquals("Original error", secondThrown.getMessage());
+        assertNotSame(secondException, secondThrown);
+    }
+
+    @Test
+    @DisplayName("writeTo should handle reset failures gracefully")
+    void writeTo_ResetThrowsException_PropagatesResetException() throws IOException {
+        // Given
+        String content = "test content";
+
+        // Create a custom stream that throws on reset after first successful read
+        InputStream problematicStream = new InputStream() {
+            private final byte[] data = content.getBytes();
+            private int position = 0;
+            private boolean hasBeenRead = false;
+
+            @Override
+            public int read() throws IOException {
+                if (position >= data.length) {
+                    hasBeenRead = true;
+                    return -1;
+                }
+                hasBeenRead = true;
+                return data[position++] & 0xFF;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                if (position >= data.length) {
+                    hasBeenRead = true;
+                    return -1;
+                }
+                int bytesToRead = Math.min(len, data.length - position);
+                System.arraycopy(data, position, b, off, bytesToRead);
+                position += bytesToRead;
+                hasBeenRead = true;
+                return bytesToRead;
+            }
+
+            @Override
+            public boolean markSupported() {
+                return true;
+            }
+
+            @Override
+            public synchronized void mark(int readlimit) {
+                // Mark at current position
+            }
+
+            @Override
+            public synchronized void reset() throws IOException {
+                if (hasBeenRead) {
+                    throw new IOException("Reset failed");
+                }
+                position = 0;
+            }
+        };
+
+        ContentStreamProvider provider = () -> problematicStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // First successful write
+        ByteArrayOutputStream firstOutput = new ByteArrayOutputStream();
+        entity.writeTo(firstOutput);
+        assertEquals(content, firstOutput.toString());
+
+        //Second write where reset should fail
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> entity.writeTo(new ByteArrayOutputStream()));
+
+
+        assertEquals("Reset failed", thrown.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"100", "0", "9223372036854775807"}) // Long.MAX_VALUE
+    @DisplayName("parseContentLength should handle valid numeric values")
+    void parseContentLength_ValidNumbers_ParsesCorrectly(String contentLength) {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", contentLength)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+        entity = new RepeatableInputStreamRequestEntity(request);
+        assertEquals(Long.parseLong(contentLength), entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Multiple writes should work correctly with repeatable stream")
+    void writeTo_MultipleWrites_AllSucceed() throws IOException {
+        // Given
+        String content = "repeatable content";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes());
+        ContentStreamProvider provider = () -> inputStream;
+
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // Multiple writes
+        ByteArrayOutputStream output1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output3 = new ByteArrayOutputStream();
+
+        entity.writeTo(output1);
+        entity.writeTo(output2);
+        entity.writeTo(output3);
+
+        // All outputs should contain the same content
+        assertEquals(content, output1.toString());
+        assertEquals(content, output2.toString());
+        assertEquals(content, output3.toString());
+    }
+
+    @Test
+    @DisplayName("Entity should handle mixed headers correctly")
+    void constructor_WithMixedHeaders_HandlesAllCorrectly() {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", "2048")
+            .putHeader("Content-Type", "application/xml")
+            .putHeader(TRANSFER_ENCODING, CHUNKED)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        assertEquals(2048L, entity.getContentLength());
+        assertEquals("application/xml", entity.getContentType().toString());
+        assertTrue(entity.isChunked());
+    }
+
+    @Test
+    @DisplayName("Entity should handle empty content correctly")
+    void writeTo_EmptyContent_WritesNothing() throws IOException {
+        // Given
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(new byte[0]);
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        entity.writeTo(output);
+
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    @DisplayName("Entity should handle large content streams")
+    void writeTo_LargeContent_HandlesCorrectly() throws IOException {
+        // Given - 10MB of data
+        int size = 10 * 1024 * 1024;
+        byte[] largeContent = new byte[size];
+        new Random().nextBytes(largeContent);
+
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(largeContent);
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", String.valueOf(size))
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        entity.writeTo(output);
+        assertArrayEquals(largeContent, output.toByteArray());
+        assertEquals(size, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Entity should handle non-repeatable stream on multiple writes")
+    void writeTo_NonRepeatableStreamMultipleWrites_FailsGracefully() throws IOException {
+        // Given
+        InputStream nonRepeatableStream = new InputStream() {
+            private boolean hasBeenRead = false;
+
+            @Override
+            public int read() throws IOException {
+                if (hasBeenRead) {
+                    throw new IOException("Stream already consumed");
+                }
+                hasBeenRead = true;
+                return -1;
+            }
+
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+        };
+
+        ContentStreamProvider provider = () -> nonRepeatableStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // First write should succeed
+        entity.writeTo(new ByteArrayOutputStream());
+
+        assertThrows(IOException.class, () -> entity.writeTo(new ByteArrayOutputStream()));
+    }
+
+    @Test
+    @DisplayName("Entity should handle partial stream reads")
+    void writeTo_PartialReads_CompletesSuccessfully() throws IOException {
+        // Given - Stream that returns data in small chunks
+        String content = "This is a test content that will be read in chunks";
+        InputStream chunkingStream = new InputStream() {
+            private final byte[] data = content.getBytes();
+            private int position = 0;
+
+            @Override
+            public int read() {
+                if (position >= data.length) {
+                    return -1;
+                }
+                int i = data[position] & 0xFF;
+                position++;
+                return i;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) {
+                if (position >= data.length) {
+                    return -1;
+                }
+                // Return only 5 bytes at a time to simulate chunked reading
+                int bytesToRead = Math.min(5, Math.min(len, data.length - position));
+                System.arraycopy(data, position, b, off, bytesToRead);
+                position += bytesToRead;
+                return bytesToRead;
+            }
+
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+        };
+
+        ContentStreamProvider provider = () -> chunkingStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+
+        entity.writeTo(output);
+
+
+        assertEquals(content, output.toString());
+    }
+
+    @Test
+    @DisplayName("Entity should handle mark/reset with limited buffer")
+    void writeTo_MarkResetWithLimitedBuffer_HandlesCorrectly() throws IOException {
+        // Given - Stream with limited mark buffer
+        String content = "Short content";
+        InputStream limitedMarkStream = new InputStream() {
+            private final ByteArrayInputStream delegate = new ByteArrayInputStream(content.getBytes());
+
+            @Override
+            public int read() throws IOException {
+                return delegate.read();
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                return delegate.read(b, off, len);
+            }
+
+            @Override
+            public boolean markSupported() {
+                return true;
+            }
+
+            @Override
+            public synchronized void mark(int readlimit) {
+                delegate.mark(5); // Very small buffer
+            }
+
+            @Override
+            public synchronized void reset() throws IOException {
+                delegate.reset();
+            }
+        };
+
+        ContentStreamProvider provider = () -> limitedMarkStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        ByteArrayOutputStream output1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output2 = new ByteArrayOutputStream();
+
+        entity.writeTo(output1);
+        entity.writeTo(output2);
+
+
+        assertEquals(content, output1.toString());
+        assertEquals(content, output2.toString());
+    }
+
+    @Test
+    @DisplayName("Entity should handle null content type gracefully")
+    void constructor_WithoutContentType_HandlesGracefully() {
+        // Given
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", "100")
+            // No Content-Type header
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        assertNull(entity.getContentType());
+        assertEquals(100L, entity.getContentLength());
+    }
+
+    @Test
+    @DisplayName("Entity should handle concurrent write attempts")
+    void writeTo_ConcurrentWrites_HandlesCorrectly() throws Exception {
+        // Given
+        String content = "Concurrent test content";
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(content.getBytes());
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        // Simulate concurrent writes
+        int threadCount = 5;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        List<ByteArrayOutputStream> outputs = Collections.synchronizedList(new ArrayList<>());
+        List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                try {
+                    ByteArrayOutputStream output = new ByteArrayOutputStream();
+                    entity.writeTo(output);
+                    outputs.add(output);
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        // At least one should succeed, others may fail due to stream state
+        assertFalse(outputs.isEmpty(), "At least one write should succeed");
+        for (ByteArrayOutputStream output : outputs) {
+            if (output.size() > 0) {
+                assertEquals(content, output.toString());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Entity should handle interrupted IO operations")
+    void writeTo_InterruptedStream_ThrowsIOException() throws IOException {
+        // Given
+        InputStream interruptibleStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new InterruptedIOException("Stream interrupted");
+            }
+
+            @Override
+            public boolean markSupported() {
+                return true;
+            }
+        };
+
+        ContentStreamProvider provider = () -> interruptibleStream;
+        SdkHttpRequest httpRequest = httpRequestBuilder.build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> entity.writeTo(new ByteArrayOutputStream()));
+        assertInstanceOf(InterruptedIOException.class, thrown);
+        assertEquals("Stream interrupted", thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("Entity should preserve state across multiple operations")
+    void multipleOperations_StatePreservation_WorksCorrectly() throws IOException {
+        // Given
+        String content = "State preservation test";
+        ContentStreamProvider provider = () -> new ByteArrayInputStream(content.getBytes());
+        SdkHttpRequest httpRequest = httpRequestBuilder
+            .putHeader("Content-Length", String.valueOf(content.length()))
+            .putHeader("Content-Type", "text/plain")
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .contentStreamProvider(provider)
+                                                       .build();
+
+        entity = new RepeatableInputStreamRequestEntity(request);
+
+        //Perform multiple operations
+        boolean isRepeatable1 = entity.isRepeatable();
+        boolean isChunked1 = entity.isChunked();
+        long contentLength1 = entity.getContentLength();
+
+        // Write once
+        entity.writeTo(new ByteArrayOutputStream());
+
+        boolean isRepeatable2 = entity.isRepeatable();
+        boolean isChunked2 = entity.isChunked();
+        long contentLength2 = entity.getContentLength();
+
+        // Write again
+        entity.writeTo(new ByteArrayOutputStream());
+
+        boolean isRepeatable3 = entity.isRepeatable();
+        boolean isChunked3 = entity.isChunked();
+        long contentLength3 = entity.getContentLength();
+
+        // State should remain consistent
+        assertEquals(isRepeatable1, isRepeatable2);
+        assertEquals(isRepeatable2, isRepeatable3);
+        assertEquals(isChunked1, isChunked2);
+        assertEquals(isChunked2, isChunked3);
+        assertEquals(contentLength1, contentLength2);
+        assertEquals(contentLength2, contentLength3);
+    }
+}


### PR DESCRIPTION

## Fix HTTP authentication retry failures by improving RepeatableInputStreamRequestEntity repeatability

### Problem
- HTTP authentication retry scenarios failing with: `Cannot retry non-repeatable request`
- Occurs when initial request receives 401 Unauthorized and retry attempt fails
- Authentication challenges not handled properly
- Test cases for HTTP 301/302 responses failing due to Apache 5.x auto-redirect behavior

### Root Cause
- RepeatableInputStreamRequestEntity implementation not properly integrated with Apache 5.x
- Inconsistent repeatability detection logic
- Apache 5.x follows redirects by default, while Apache 4.x returns redirect responses to client
  - Tests expect to receive 301/302 responses for validation
  - Apache 5.x auto-follows redirects, preventing test validation

### Modifications
1. Improved Stream Repeatability
   - Changed inheritance to implement HttpEntity directly
   - Enhanced repeatability detection logic
   - Proper mark/reset support

2. Enhanced Content Handling
   - Better ContentType parsing
   - Improved chunked transfer encoding support
   - Proper resource cleanup

3. Disabled Default Redirect Handling
   - Added `builder.disableRedirectHandling()` in client creation
   - Maintains backward compatibility with Apache 4.x behavior
   - Allows tests to properly validate redirect responses:
     ```java
     @Test
     public void supportsResponseCode301() throws Exception {
         testForResponseCode(HttpURLConnection.HTTP_MOVED_PERM);
     }

     @Test
     public void supportsResponseCode302() throws Exception {
         testForResponseCode(HttpURLConnection.HTTP_MOVED_TEMP);
     }
     ```

## Testing
- Added a test  in Apache 4.x to test RepeatableInputStreamRequestEntity as it is and then ported the same test to Apache 5.x to make sure its functionality is same.
- Redirect response handling (301/302)

## Impact
- Reliable authentication retry handling
- Consistent redirect behavior with Apache 4.x
- Improved resource management

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
