### PR TITLE
Update generator plugin to support validators

### DIFF
--- a/.changes/next-release/feature-CodeGeneratorMavenPlugin-64c91e8.json
+++ b/.changes/next-release/feature-CodeGeneratorMavenPlugin-64c91e8.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Code Generator Maven Plugin",
+    "contributor": "",
+    "description": "Update the generator plugin to support model validation during code generation. In addition, this adds the `writeValidationReport` flag to support writing the validation report to disk."
+}

--- a/codegen-maven-plugin/pom.xml
+++ b/codegen-maven-plugin/pom.xml
@@ -58,6 +58,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <artifactId>utils</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>

--- a/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
+++ b/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
@@ -21,7 +21,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -30,21 +34,23 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import software.amazon.awssdk.codegen.C2jModels;
 import software.amazon.awssdk.codegen.CodeGenerator;
+import software.amazon.awssdk.codegen.IntermediateModelBuilder;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.rules.endpoints.EndpointTestSuiteModel;
 import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
 import software.amazon.awssdk.codegen.model.service.Paginators;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Waiters;
 import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * The Maven mojo to generate Java client code using software.amazon.awssdk:codegen module.
  */
 @Mojo(name = "generate")
 public class GenerationMojo extends AbstractMojo {
-
     private static final String MODEL_FILE = "service-2.json";
     private static final String CUSTOMIZATION_CONFIG_FILE = "customization.config";
     private static final String WAITERS_FILE = "waiters-2.json";
@@ -62,6 +68,8 @@ public class GenerationMojo extends AbstractMojo {
     @Parameter(property = "writeIntermediateModel", defaultValue = "false")
     private boolean writeIntermediateModel;
 
+    @Parameter(property = "writeValidationReport", defaultValue = "false")
+    private boolean writeValidationReport;
 
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
@@ -76,20 +84,57 @@ public class GenerationMojo extends AbstractMojo {
         this.resourcesDirectory = Paths.get(outputDirectory).resolve("generated-resources").resolve("sdk-resources");
         this.testsDirectory = Paths.get(outputDirectory).resolve("generated-test-sources").resolve("sdk-tests");
 
-        findModelRoots().forEach(p -> {
-            Path modelRootPath = p.modelRoot;
-            getLog().info("Loading from: " + modelRootPath.toString());
-            generateCode(C2jModels.builder()
-                                  .customizationConfig(p.customizationConfig)
-                                  .serviceModel(loadServiceModel(modelRootPath))
-                                  .waitersModel(loadWaiterModel(modelRootPath))
-                                  .paginatorsModel(loadPaginatorModel(modelRootPath))
-                                  .endpointRuleSetModel(loadEndpointRuleSetModel(modelRootPath))
-                                  .endpointTestSuiteModel(loadEndpointTestSuiteModel(modelRootPath))
-                                  .build());
+        List<GenerationParams> generationParams = initGenerationParams();
+
+        Map<String, IntermediateModel> serviceNameToModelMap = new HashMap<>();
+
+        generationParams.forEach(
+            params -> {
+                IntermediateModel model = params.intermediateModel;
+                String lowercaseServiceName = StringUtils.lowerCase(model.getMetadata().getServiceName());
+                IntermediateModel previous = serviceNameToModelMap.put(lowercaseServiceName, model);
+                if (previous != null) {
+                    String warning = String.format("Multiple service models found with service name %s. Model validation "
+                                                   + "will likely be incorrect", lowercaseServiceName);
+                    getLog().warn(warning);
+                }
+            });
+
+        // Update each param with the intermediate model it shares models with, if any
+        generationParams.forEach(params -> {
+            CustomizationConfig customizationConfig = params.intermediateModel.getCustomizationConfig();
+
+            if (customizationConfig.getShareModelConfig() != null) {
+                String shareModelWithName = customizationConfig.getShareModelConfig().getShareModelWith();
+                params.withShareModelsTarget(serviceNameToModelMap.get(shareModelWithName));
+            }
         });
+
+        generationParams.forEach(this::generateCode);
+
         project.addCompileSourceRoot(sourcesDirectory.toFile().getAbsolutePath());
         project.addTestCompileSourceRoot(testsDirectory.toFile().getAbsolutePath());
+    }
+
+    private List<GenerationParams> initGenerationParams() throws MojoExecutionException {
+        List<ModelRoot> modelRoots = findModelRoots().collect(Collectors.toList());
+
+        return modelRoots.stream().map(r -> {
+            Path modelRootPath = r.modelRoot;
+            getLog().info("Loading from: " + modelRootPath.toString());
+            C2jModels c2jModels = C2jModels.builder()
+                                           .customizationConfig(r.customizationConfig)
+                                           .serviceModel(loadServiceModel(modelRootPath))
+                                           .waitersModel(loadWaiterModel(modelRootPath))
+                                           .paginatorsModel(loadPaginatorModel(modelRootPath))
+                                           .endpointRuleSetModel(loadEndpointRuleSetModel(modelRootPath))
+                                           .endpointTestSuiteModel(loadEndpointTestSuiteModel(modelRootPath))
+                                           .build();
+            String intermediateModelFileNamePrefix = intermediateModelFileNamePrefix(c2jModels);
+            IntermediateModel intermediateModel = new IntermediateModelBuilder(c2jModels).build();
+            return new GenerationParams().withIntermediateModel(intermediateModel)
+                                         .withIntermediateModelFileNamePrefix(intermediateModelFileNamePrefix);
+        }).collect(Collectors.toList());
     }
 
     private Stream<ModelRoot> findModelRoots() throws MojoExecutionException {
@@ -111,13 +156,15 @@ public class GenerationMojo extends AbstractMojo {
         return p.toString().endsWith(MODEL_FILE);
     }
 
-    private void generateCode(C2jModels models) {
+    private void generateCode(GenerationParams params) {
         CodeGenerator.builder()
-                     .models(models)
+                     .intermediateModel(params.intermediateModel)
+                     .shareModelsTarget(params.shareModelsTarget)
                      .sourcesDirectory(sourcesDirectory.toFile().getAbsolutePath())
                      .resourcesDirectory(resourcesDirectory.toFile().getAbsolutePath())
                      .testsDirectory(testsDirectory.toFile().getAbsolutePath())
-                     .intermediateModelFileNamePrefix(intermediateModelFileNamePrefix(models))
+                     .intermediateModelFileNamePrefix(params.intermediateModelFileNamePrefix)
+                     .emitValidationReport(writeValidationReport)
                      .build()
                      .execute();
     }
@@ -176,6 +223,27 @@ public class GenerationMojo extends AbstractMojo {
         private ModelRoot(Path modelRoot, CustomizationConfig customizationConfig) {
             this.modelRoot = modelRoot;
             this.customizationConfig = customizationConfig;
+        }
+    }
+
+    private static class GenerationParams {
+        private IntermediateModel intermediateModel;
+        private IntermediateModel shareModelsTarget;
+        private String intermediateModelFileNamePrefix;
+
+        public GenerationParams withIntermediateModel(IntermediateModel intermediateModel) {
+            this.intermediateModel = intermediateModel;
+            return this;
+        }
+
+        public GenerationParams withShareModelsTarget(IntermediateModel shareModelsTarget) {
+            this.shareModelsTarget = shareModelsTarget;
+            return this;
+        }
+
+        public GenerationParams withIntermediateModelFileNamePrefix(String intermediateModelFileNamePrefix) {
+            this.intermediateModelFileNamePrefix = intermediateModelFileNamePrefix;
+            return this;
         }
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This commit updates the generation mojo to suppport validators:

 - Add flag for controling whether the validation report is written to disk
 - Build all models to IntermediateModel upfront
 - If a service model targets another for sharing shapes, also pass in the target service IntermedidateModel

## Modifications
<!--- Describe your changes in detail -->

## Testing
### Testing report output

```
$ mvn clean install -P quick -pl :s3
$ cat services/s3/target/generated-sources/sdk/models/validation-report.json
cat: services/s3/target/generated-sources/sdk/models/validation-report.json: No such file or directory
```

```
$ mvn clean install -P quick -pl :s3 -DwriteValidationReport=true
$ cat services/s3/target/generated-sources/sdk/models/validation-report.json
{
  "validationEntries" : [ ]
}%
```
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
