### PR TITLE
Fix DownloadFilter interface to properly return DownloadFilter type

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-ad9d4c6.json
+++ b/.changes/next-release/bugfix-S3TransferManager-ad9d4c6.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "jencymaryjoseph",
+    "description": "DownloadFilter type incompatability methods overriden from extended interface"
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
@@ -39,8 +39,32 @@ public interface DownloadFilter extends Predicate<S3Object> {
     boolean test(S3Object s3Object);
 
     /**
-     * A {@link DownloadFilter} that downloads all non-folder objects. A folder is a 0-byte object created when a customer
-     * uses S3 console to create a folder, and it always ends with "/".
+     * Returns a composed filter that performs AND operation
+     */
+    @Override
+    default DownloadFilter and(Predicate<? super S3Object> other) {
+        return s3Object -> test(s3Object) && other.test(s3Object);
+    }
+
+    /**
+     * Returns a composed filter that performs OR operation
+     */
+    @Override
+    default DownloadFilter or(Predicate<? super S3Object> other) {
+        return s3Object -> test(s3Object) || other.test(s3Object);
+    }
+
+    /**
+     * Returns a filter that negates the result
+     */
+    @Override
+    default DownloadFilter negate() {
+        return s3Object -> !test(s3Object);
+    }
+
+    /**
+     * A {@link DownloadFilter} that downloads all non-folder objects. A folder is a 0-byte object created when a customer uses S3
+     * console to create a folder, and it always ends with "/".
      *
      * <p>
      * This is the default behavior if no filter is provided.

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.transfer.s3.config;
 
+import java.util.Objects;
 import java.util.function.Predicate;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -38,24 +39,37 @@ public interface DownloadFilter extends Predicate<S3Object> {
     @Override
     boolean test(S3Object s3Object);
 
-    /**
-     * Returns a composed filter that performs AND operation
+     /*
+      * Returns a composed filter that performs AND operation
+      *
+      * @param other the predicate to AND with this predicate
+      * @return a composed predicate that performs OR operation
+      * @throws NullPointerException if other is null
      */
     @Override
     default DownloadFilter and(Predicate<? super S3Object> other) {
+        Objects.requireNonNull(other, "Other predicate cannot be null");
         return s3Object -> test(s3Object) && other.test(s3Object);
     }
 
-    /**
+    /*
      * Returns a composed filter that performs OR operation
+     *
+     * @param other the predicate to OR with this predicate
+     * @return a composed predicate that performs OR operation
+     * @throws NullPointerException if other is null
      */
     @Override
     default DownloadFilter or(Predicate<? super S3Object> other) {
+        Objects.requireNonNull(other, "Other predicate cannot be null");
         return s3Object -> test(s3Object) || other.test(s3Object);
     }
 
-    /**
-     * Returns a filter that negates the result
+    /*
+     * Returns a predicate that represents the logical negation of this predicate.
+     * If this predicate would download an object, the negated predicate will not download it, and vice versa.
+     *
+     * @return a predicate that represents the logical negation of this predicate
      */
     @Override
     default DownloadFilter negate() {

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
@@ -40,10 +40,11 @@ public interface DownloadFilter extends Predicate<S3Object> {
     boolean test(S3Object s3Object);
 
     /**
-     * Returns a predicate that represents the logical AND of this predicate and another
+     * Returns a composed filter that represents the logical AND of this filter and another.
+     * The composed filter returns true only if both this filter and the other filter return true.
      * @param other a predicate that will be logically-ANDed with this
      *              predicate
-     * @return a composed predicate that performs AND operation
+     * @return a composed filter that represents the logical AND of this filter and the other filter
      * @throws NullPointerException if other is null
      */
     @Override
@@ -53,10 +54,11 @@ public interface DownloadFilter extends Predicate<S3Object> {
     }
 
     /**
-     * Returns a predicate that represents the logical OR of this predicate and another
+     * Returns a composed filter that represents the logical OR of this filter and another.
+     * The composed filter returns true if either this filter or the other filter returns true.
      * @param other a predicate that will be logically-ORed with this
      *              predicate
-     * @return a composed predicate that performs OR operation
+     * @return a composed filter that represents the logical OR of this filter and the other filter
      * @throws NullPointerException if other is null
      */
     @Override
@@ -66,9 +68,9 @@ public interface DownloadFilter extends Predicate<S3Object> {
     }
 
     /**
-     * Returns a predicate that represents the logical negation of this
-     * predicate.
-     * @return a predicate that represents the logical negation of this
+     * Returns a filter that represents the logical negation of this predicate.
+     * The returned filter returns true when this filter returns false, and vice versa.
+     * @return a filter that represents the logical negation of this filter
      * predicate
      */
     @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
@@ -39,12 +39,12 @@ public interface DownloadFilter extends Predicate<S3Object> {
     @Override
     boolean test(S3Object s3Object);
 
-     /*
-      * Returns a composed filter that performs AND operation
-      *
-      * @param other the predicate to AND with this predicate
-      * @return a composed predicate that performs OR operation
-      * @throws NullPointerException if other is null
+    /**
+     * Returns a composed filter that performs AND operation
+     * @param other a predicate that will be logically-ANDed with this
+     *              predicate
+     * @return a composed predicate that performs AND operation
+     * @throws NullPointerException if other is null
      */
     @Override
     default DownloadFilter and(Predicate<? super S3Object> other) {
@@ -52,10 +52,10 @@ public interface DownloadFilter extends Predicate<S3Object> {
         return s3Object -> test(s3Object) && other.test(s3Object);
     }
 
-    /*
-     * Returns a composed filter that performs OR operation
-     *
-     * @param other the predicate to OR with this predicate
+    /**
+     * Returns a predicate that represents the logical OR of this predicate and another
+     * @param other a predicate that will be logically-ORed with this
+     *              predicate
      * @return a composed predicate that performs OR operation
      * @throws NullPointerException if other is null
      */
@@ -65,11 +65,11 @@ public interface DownloadFilter extends Predicate<S3Object> {
         return s3Object -> test(s3Object) || other.test(s3Object);
     }
 
-    /*
-     * Returns a predicate that represents the logical negation of this predicate.
-     * If this predicate would download an object, the negated predicate will not download it, and vice versa.
-     *
-     * @return a predicate that represents the logical negation of this predicate
+    /**
+     * Returns a predicate that represents the logical negation of this
+     * predicate.
+     * @return a predicate that represents the logical negation of this
+     * predicate
      */
     @Override
     default DownloadFilter negate() {

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/DownloadFilter.java
@@ -40,7 +40,7 @@ public interface DownloadFilter extends Predicate<S3Object> {
     boolean test(S3Object s3Object);
 
     /**
-     * Returns a composed filter that performs AND operation
+     * Returns a predicate that represents the logical AND of this predicate and another
      * @param other a predicate that will be logically-ANDed with this
      *              predicate
      * @return a composed predicate that performs AND operation

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/config/DownloadFilterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/config/DownloadFilterTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.transfer.s3.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,5 +38,161 @@ public class DownloadFilterTest {
     @MethodSource("s3Objects")
     void allObjectsFilter_shouldWork(S3Object s3Object, boolean result) {
         assertThat(DownloadFilter.allObjects().test(s3Object)).isEqualTo(result);
+    }
+
+    private static Stream<Arguments> basicOrFilterTestCases() {
+        return Stream.of(
+            Arguments.of(
+                "File in folder1 - should match",
+                S3Object.builder().key("folder1/test.txt").size(2000L).build(),
+                true
+            ),
+            Arguments.of(
+                "File in folder3 - should match",
+                S3Object.builder().key("folder3/test.txt").size(2000L).build(),
+                true
+            ),
+            Arguments.of(
+                "File in folder2 - should not match",
+                S3Object.builder().key("folder2/test.txt").size(2000L).build(),
+                false
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("basicOrFilterTestCases")
+    @DisplayName("Test OR filter combinations")
+    void testBasicOrFilter(String testName, S3Object s3Object, boolean result) {
+        DownloadFilter folder1Filter = s3Obj -> s3Obj.key().startsWith("folder1");
+        DownloadFilter folder3Filter = s3Obj -> s3Obj.key().startsWith("folder3");
+        DownloadFilter combinedFilter = folder1Filter.or(folder3Filter);
+        assertThat(combinedFilter.test(s3Object))
+            .as(testName)
+            .isEqualTo(result);
+    }
+
+    private static Stream<Arguments> basicAndFilterTestCases() {
+        return Stream.of(
+            Arguments.of(
+                "Large text file - should match",
+                S3Object.builder().key("folder1/test.txt").size(2000L).build(),
+                true
+            ),
+            Arguments.of(
+                "Small text file - should not match",
+                S3Object.builder().key("folder1/test.txt").size(500L).build(),
+                false
+            ),
+            Arguments.of(
+                "Large non-text file - should not match",
+                S3Object.builder().key("folder1/test.pdf").size(2000L).build(),
+                false
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("basicAndFilterTestCases")
+    @DisplayName("Test AND filter combinations")
+    void testBasicAndFilter(String testName, S3Object s3Object, boolean result) {
+        DownloadFilter txtFilter = s3Obj -> s3Obj.key().endsWith(".txt");
+        DownloadFilter sizeFilter = s3Obj -> s3Obj.size() > 1000L;
+        DownloadFilter combinedFilter = txtFilter.and(sizeFilter);
+        assertThat(combinedFilter.test(s3Object))
+            .as(testName)
+            .isEqualTo(result);
+    }
+
+    private static Stream<Arguments> basicNegateFilterTestCases() {
+        return Stream.of(
+            Arguments.of(
+                "File in folder1 - should not match",
+                "FOLDER",
+                S3Object.builder().key("folder1/test.txt").size(1000L).build(),
+                false
+            ),
+            Arguments.of(
+                "File not in folder1 - should match",
+                "FOLDER",
+                S3Object.builder().key("folder2/test.txt").size(1000L).build(),
+                true
+            ),
+            Arguments.of(
+                "Large file - should not match",
+                "SIZE",
+                S3Object.builder().key("test.txt").size(2000L).build(),
+                false
+            ),
+            Arguments.of(
+                "Small file - should match",
+                "SIZE",
+                S3Object.builder().key("test.txt").size(500L).build(),
+                true
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("basicNegateFilterTestCases")
+    @DisplayName("Test NEGATE filter operations")
+    void testBasicNegateFilter(String testName, String filterType, S3Object s3Object, boolean result) {
+        DownloadFilter baseFilter;
+
+        switch (filterType) {
+            case "FOLDER":
+                baseFilter = s3Obj -> s3Obj.key().startsWith("folder1");
+                break;
+            case "SIZE":
+                baseFilter = s3Obj -> s3Obj.size() > 1000L;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown filter type: " + filterType);
+        }
+
+        DownloadFilter negatedFilter = baseFilter.negate();
+        assertThat(negatedFilter.test(s3Object))
+            .as(testName)
+            .isEqualTo(result);
+    }
+
+    private static Stream<Arguments> combinedFilterTestCases() {
+        return Stream.of(
+            Arguments.of(
+                "Large file in folder1 - should match",
+                S3Object.builder().key("folder1/test.txt").size(2000L).build(),
+                true,
+                "folder1 OR folder3 AND size > 1000"
+            ),
+            Arguments.of(
+                "Small file in folder1 - should not match",
+                S3Object.builder().key("folder1/test.txt").size(500L).build(),
+                false,
+                "folder1 OR folder3 AND size > 1000"
+            ),
+            Arguments.of(
+                "Large file in folder2 - should not match",
+                S3Object.builder().key("folder2/test.txt").size(2000L).build(),
+                false,
+                "folder1 OR folder3 AND size > 1000"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("combinedFilterTestCases")
+    @DisplayName("Test combined filter operations")
+    void testCombinedFilters(String testName, S3Object s3Object, boolean result, String description) {
+        DownloadFilter folder1Filter = s3Obj -> s3Obj.key().startsWith("folder1");
+        DownloadFilter folder3Filter = s3Obj -> s3Obj.key().startsWith("folder3");
+        DownloadFilter sizeFilter = s3Obj -> s3Obj.size() > 1000L;
+
+        DownloadFilter chainedFilter = folder1Filter
+            .or(folder3Filter)
+            .and(sizeFilter);
+
+        assertThat(chainedFilter.test(s3Object))
+            .as("%s: %s", testName, description)
+            .isEqualTo(result);
     }
 }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/config/DownloadFilterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/config/DownloadFilterTest.java
@@ -43,35 +43,35 @@ public class DownloadFilterTest {
     }
 
     private static Stream<Arguments> filterOperationTestCases() {
-        Function<S3Object, DownloadFilter> folder1OrFolder3Filter = (s3Object) -> {
+        Function<S3Object, DownloadFilter> folder1OrFolder3Filter = s3Object -> {
             DownloadFilter folder1 = obj -> obj.key().startsWith("folder1");
             DownloadFilter folder3 = obj -> obj.key().startsWith("folder3");
             return folder1.or(folder3);
         };
 
-        Function<S3Object, DownloadFilter> txtAndLargeSizeFilter = (s3Object) -> {
+        Function<S3Object, DownloadFilter> txtAndLargeSizeFilter = s3Object -> {
             DownloadFilter txtFilter = obj -> obj.key().endsWith(".txt");
             DownloadFilter sizeFilter = obj -> obj.size() > 1000L;
             return txtFilter.and(sizeFilter);
         };
 
-        Function<S3Object, DownloadFilter> notFolder1Filter = (s3Object) -> {
+        Function<S3Object, DownloadFilter> notFolder1Filter = s3Object -> {
             DownloadFilter folder1 = obj -> obj.key().startsWith("folder1");
             return folder1.negate();
         };
 
-        Function<S3Object, DownloadFilter> notLargeSizeFilter = (s3Object) -> {
+        Function<S3Object, DownloadFilter> notLargeSizeFilter = s3Object -> {
             DownloadFilter largeSize = obj -> obj.size() > 1000L;
             return largeSize.negate();
         };
 
-        Function<S3Object, DownloadFilter> complexFilter = (s3Object) -> {
+        Function<S3Object, DownloadFilter> complexFilter = s3Object -> {
             DownloadFilter folder1 = obj -> obj.key().startsWith("folder1");
             DownloadFilter folder3 = obj -> obj.key().startsWith("folder3");
             DownloadFilter sizeFilter = obj -> obj.size() > 1000L;
             return folder1.or(folder3).and(sizeFilter);
         };
-        Function<S3Object, DownloadFilter> nullParameterFilter = (s3Object) -> {
+        Function<S3Object, DownloadFilter> nullParameterFilter = s3Object -> {
             DownloadFilter baseFilter = obj -> obj.key().startsWith("folder1");
             return s -> {
                 assertThrows(NullPointerException.class,


### PR DESCRIPTION
- Override Predicate default methods to return DownloadFilter
- Add comprehensive parameterized tests

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
DownloadFilter inherits from Predicate<S3Object> but doesn't override the default methods properly. This causes compilation errors when trying to chain filters because the default Predicate methods return Predicate<T> instead of DownloadFilter.
Example of current issue:
```java
DownloadFilter folder1Filter = s3Object -> s3Object.key().startsWith("folder1");
DownloadFilter folder3Filter = s3Object -> s3Object.key().startsWith("folder3");

DownloadDirectoryRequest.Builder builder = DownloadDirectoryRequest.builder();
builder.filter(folder1Filter.or(folder3Filter)); // Compilation error 
```

## Modifications
1. Modified DownloadFilter interface to override default methods:
Override and() to return DownloadFilter
Override or() to return DownloadFilter
Override negate() to return DownloadFilter
2. Enhanced test coverage with parameterized tests for better readability and maintenance 

## Testing
 **Unit Testing**
Added comprehensive parameterized tests covering:
Basic AND, OR operations
NEGATE operations
Chained filter combinations
Edge cases

**Integration Testing**
Performed extensive integration testing (not included in PR):
Tested various filter combinations with S3TransferManager
Verified correct behavior with different file types and structures
Validated nested directory handling
Confirmed proper filtering based on multiple conditions 

**Environment and Validation**
Local run of mvn install succeeds
All tests pass successfully
No performance impact observed
Backward compatibility maintained 


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
