### PR TITLE
Fix NPE in ProfileFileSupplier.defaultSupplier

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-30203bb.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-30203bb.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix NPE in `ProfileFileSupplier.defaultSupplier` when both credentials and config files do not exist."
+}

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
@@ -317,12 +317,10 @@ public final class ProfileFile {
 
         @Override
         public ProfileFile build() {
-            InputStream stream = null;
-            if (content != null) {
-                stream = content;
-            } else if (contentLocation != null) {
-                stream = FunctionalUtils.invokeSafely(() -> Files.newInputStream(contentLocation));
-            }
+            Validate.isTrue(content != null || contentLocation != null,
+                            "content or contentLocation must be set.");
+            InputStream stream = content != null ? content :
+                                  FunctionalUtils.invokeSafely(() -> Files.newInputStream(contentLocation));
 
             Validate.paramNotNull(type, "type");
             Validate.paramNotNull(stream, "content");

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
@@ -86,6 +86,13 @@ public final class ProfileFile {
     }
 
     /**
+     * Create an empty profile file.
+     */
+    static ProfileFile empty() {
+        return new ProfileFile(Collections.emptyMap());
+    }
+
+    /**
      * Get the default profile file, using the credentials file from "~/.aws/credentials", the config file from "~/.aws/config"
      * and the "default" profile. This default behavior can be customized using the
      * {@link ProfileFileSystemSetting#AWS_SHARED_CREDENTIALS_FILE}, {@link ProfileFileSystemSetting#AWS_CONFIG_FILE} and
@@ -310,8 +317,12 @@ public final class ProfileFile {
 
         @Override
         public ProfileFile build() {
-            InputStream stream = content != null ? content :
-                                 FunctionalUtils.invokeSafely(() -> Files.newInputStream(contentLocation));
+            InputStream stream = null;
+            if (content != null) {
+                stream = content;
+            } else if (contentLocation != null) {
+                stream = FunctionalUtils.invokeSafely(() -> Files.newInputStream(contentLocation));
+            }
 
             Validate.paramNotNull(type, "type");
             Validate.paramNotNull(stream, "content");

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileSupplier.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileSupplier.java
@@ -55,13 +55,15 @@ public interface ProfileFileSupplier extends Supplier<ProfileFile> {
             = ProfileFileLocation.configurationFileLocation()
                                  .map(path -> reloadWhenModified(path, ProfileFile.Type.CONFIGURATION));
 
-        ProfileFileSupplier supplier = () -> ProfileFile.builder().build();
+        ProfileFileSupplier supplier;
         if (credentialsSupplierOptional.isPresent() && configurationSupplierOptional.isPresent()) {
             supplier = aggregate(credentialsSupplierOptional.get(), configurationSupplierOptional.get());
         } else if (credentialsSupplierOptional.isPresent()) {
             supplier = credentialsSupplierOptional.get();
         } else if (configurationSupplierOptional.isPresent()) {
             supplier = configurationSupplierOptional.get();
+        } else {
+            supplier = fixedProfileFile(ProfileFile.empty());
         }
 
         return supplier;

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.Pair;
 import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.awssdk.testutils.LogCaptor;
@@ -581,6 +582,15 @@ class ProfileFileSupplierTest {
         }
     }
 
+    @Test
+    public void defaultSupplier_noCredentialsFiles_returnsEmptyProvider() {
+        EnvironmentVariableHelper.run(environmentVariableHelper -> {
+            environmentVariableHelper.set(ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE, "no-such-file");
+            environmentVariableHelper.set(ProfileFileSystemSetting.AWS_CONFIG_FILE, "no-such-file");
+            ProfileFileSupplier supplier = ProfileFileSupplier.defaultSupplier();
+            assertThat(supplier.get().profiles()).isEmpty();
+        });
+    }
 
     private Path writeTestFile(String contents, Path path) {
         try {

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
@@ -570,6 +570,13 @@ public class ProfileFileTest {
         assertThat(missingProfile.profiles()).isInstanceOf(Map.class);
     }
 
+    @Test
+    public void builderValidatesContentRequired() {
+        assertThatThrownBy(() -> ProfileFile.builder().type(ProfileFile.Type.CONFIGURATION).build())
+            .hasMessageContaining("content must not be null.");
+
+    }
+
     private ProfileFile configFile(String configFile) {
         return ProfileFile.builder()
                           .content(configFile)

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
@@ -573,7 +573,8 @@ public class ProfileFileTest {
     @Test
     public void builderValidatesContentRequired() {
         assertThatThrownBy(() -> ProfileFile.builder().type(ProfileFile.Type.CONFIGURATION).build())
-            .hasMessageContaining("content must not be null.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("content or contentLocation must be set.");
 
     }
 


### PR DESCRIPTION
Fix NPE in `ProfileFileSupplier.defaultSupplier` when both credentials and config files do not exist.

Fixes #5635 

## Motivation and Context
When neither credentials or config files exist, calling `ProfileFileSupplier.defaultSupplier()` will return a supplier that raises an NPE when the value is accessed through `get` because the `ProfileFile.Builder` requires that both content and type are set. Note that `ProfileFile.defaultProfileFile()` will effectively return an empty ProfileFile in this case.

## Modifications
* Adds a package private `ProfileFile.empty()` method to create empty profile files.
* When When neither credentials or config files exist, `defaultSupplier` will return a static supplier with an empty profileFile - matching the behavior of `ProfileFile.defaultProfileFile()`.
* Improve the error message in `ProfileFile.Builder.build()` when content is missing.


## Testing
Add new test case, fails without the change and now passes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
