### PR TITLE
add support for presigned head urls

### DIFF
--- a/.changes/next-release/feature-AWSS3-da364d2.json
+++ b/.changes/next-release/feature-AWSS3-da364d2.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS S3",
+    "contributor": "tmccombs",
+    "description": "Adds the ability to presign HeadObject and HeadBucket requests with the S3 Presigner"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -166,16 +166,16 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
         super(b);
 
         S3Configuration serviceConfiguration = b.serviceConfiguration != null ? b.serviceConfiguration :
-                                               S3Configuration.builder()
-                                                              .profileFile(profileFileSupplier())
-                                                              .profileName(profileName())
-                                                              .checksumValidationEnabled(false)
-                                                              .build();
+                                                S3Configuration.builder()
+                                                               .profileFile(profileFileSupplier())
+                                                               .profileName(profileName())
+                                                               .checksumValidationEnabled(false)
+                                                               .build();
         S3Configuration.Builder serviceConfigBuilder = serviceConfiguration.toBuilder();
 
         if (serviceConfiguration.checksumValidationEnabled()) {
             log.debug(() -> "The provided S3Configuration has ChecksumValidationEnabled set to true. Please note that "
-                            + "the pre-signed request can't be executed using a web browser if checksum validation is enabled.");
+                           + "the pre-signed request can't be executed using a web browser if checksum validation is enabled.");
         }
 
         if (dualstackEnabled() != null && serviceConfigBuilder.dualstackEnabled() != null) {
@@ -609,7 +609,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
      * Presign the provided HTTP request using SRA HttpSigner
      */
     private SdkHttpFullRequest sraPresignRequest(ExecutionContext execCtx, SdkHttpFullRequest request,
-                                                 Clock signingClock, Duration expirationDuration) {
+                                              Clock signingClock, Duration expirationDuration) {
         SelectedAuthScheme selectedAuthScheme = execCtx.executionAttributes().getAttribute(SELECTED_AUTH_SCHEME);
         return doSraPresign(request, selectedAuthScheme, signingClock, expirationDuration);
     }
@@ -693,7 +693,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
 
         params.put(S3ClientContextParams.USE_ARN_REGION, serviceConfiguration.useArnRegionEnabled());
         params.put(S3ClientContextParams.DISABLE_MULTI_REGION_ACCESS_POINTS,
-                   !serviceConfiguration.multiRegionEnabled());
+                                !serviceConfiguration.multiRegionEnabled());
         params.put(S3ClientContextParams.FORCE_PATH_STYLE, serviceConfiguration.pathStyleAccessEnabled());
         params.put(S3ClientContextParams.ACCELERATE, serviceConfiguration.accelerateModeEnabled());
         params.put(S3ClientContextParams.DISABLE_S3_EXPRESS_SESSION_AUTH, resolvedDisableS3ExpressSessionAuth);
@@ -706,10 +706,10 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                                      .get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT);
 
         SdkClientConfiguration config = clientConfiguration.toBuilder()
-                                                           .option(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT, legacyOption)
-                                                           .option(SdkClientOption.PROFILE_FILE_SUPPLIER, profileFileSupplier())
-                                                           .option(SdkClientOption.PROFILE_NAME, profileName())
-                                                           .build();
+            .option(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT, legacyOption)
+            .option(SdkClientOption.PROFILE_FILE_SUPPLIER, profileFileSupplier())
+            .option(SdkClientOption.PROFILE_NAME, profileName())
+            .build();
 
         return new UseGlobalEndpointResolver(config);
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -97,6 +97,8 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -105,11 +107,15 @@ import software.amazon.awssdk.services.s3.presigner.model.CompleteMultipartUploa
 import software.amazon.awssdk.services.s3.presigner.model.CreateMultipartUploadPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.DeleteObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.HeadBucketPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.HeadObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedAbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedCompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedCreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedDeleteObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadBucketRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedUploadPartRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -120,6 +126,8 @@ import software.amazon.awssdk.services.s3.transform.CompleteMultipartUploadReque
 import software.amazon.awssdk.services.s3.transform.CreateMultipartUploadRequestMarshaller;
 import software.amazon.awssdk.services.s3.transform.DeleteObjectRequestMarshaller;
 import software.amazon.awssdk.services.s3.transform.GetObjectRequestMarshaller;
+import software.amazon.awssdk.services.s3.transform.HeadBucketRequestMarshaller;
+import software.amazon.awssdk.services.s3.transform.HeadObjectRequestMarshaller;
 import software.amazon.awssdk.services.s3.transform.PutObjectRequestMarshaller;
 import software.amazon.awssdk.services.s3.transform.UploadPartRequestMarshaller;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -141,6 +149,8 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
     private final S3Configuration serviceConfiguration;
     private final List<ExecutionInterceptor> clientInterceptors;
     private final GetObjectRequestMarshaller getObjectRequestMarshaller;
+    private final HeadObjectRequestMarshaller headObjectRequestMarshaller;
+    private final HeadBucketRequestMarshaller headBucketRequestMarshaller;
     private final PutObjectRequestMarshaller putObjectRequestMarshaller;
     private final CreateMultipartUploadRequestMarshaller createMultipartUploadRequestMarshaller;
     private final UploadPartRequestMarshaller uploadPartRequestMarshaller;
@@ -156,16 +166,16 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
         super(b);
 
         S3Configuration serviceConfiguration = b.serviceConfiguration != null ? b.serviceConfiguration :
-                                                S3Configuration.builder()
-                                                               .profileFile(profileFileSupplier())
-                                                               .profileName(profileName())
-                                                               .checksumValidationEnabled(false)
-                                                               .build();
+                                               S3Configuration.builder()
+                                                              .profileFile(profileFileSupplier())
+                                                              .profileName(profileName())
+                                                              .checksumValidationEnabled(false)
+                                                              .build();
         S3Configuration.Builder serviceConfigBuilder = serviceConfiguration.toBuilder();
 
         if (serviceConfiguration.checksumValidationEnabled()) {
             log.debug(() -> "The provided S3Configuration has ChecksumValidationEnabled set to true. Please note that "
-                           + "the pre-signed request can't be executed using a web browser if checksum validation is enabled.");
+                            + "the pre-signed request can't be executed using a web browser if checksum validation is enabled.");
         }
 
         if (dualstackEnabled() != null && serviceConfigBuilder.dualstackEnabled() != null) {
@@ -192,6 +202,10 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
 
         // Copied from DefaultS3Client#getObject
         this.getObjectRequestMarshaller = new GetObjectRequestMarshaller(protocolFactory);
+
+        this.headObjectRequestMarshaller = new HeadObjectRequestMarshaller(protocolFactory);
+
+        this.headBucketRequestMarshaller = new HeadBucketRequestMarshaller(protocolFactory);
 
         // Copied from DefaultS3Client#putObject
         this.putObjectRequestMarshaller = new PutObjectRequestMarshaller(protocolFactory);
@@ -270,6 +284,28 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                        GetObjectRequest.class,
                        getObjectRequestMarshaller::marshall,
                        "GetObject")
+            .build();
+    }
+
+    @Override
+    public PresignedHeadObjectRequest presignHeadObject(HeadObjectPresignRequest request) {
+        return presign(PresignedHeadObjectRequest.builder(),
+                       request,
+                       request.headObjectRequest(),
+                       HeadObjectRequest.class,
+                       headObjectRequestMarshaller::marshall,
+                       "HeadObject")
+            .build();
+    }
+
+    @Override
+    public PresignedHeadBucketRequest presignHeadBucket(HeadBucketPresignRequest request) {
+        return presign(PresignedHeadBucketRequest.builder(),
+                       request,
+                       request.headBucketRequest(),
+                       HeadBucketRequest.class,
+                       headBucketRequestMarshaller::marshall,
+                       "HeadBucket")
             .build();
     }
 
@@ -573,7 +609,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
      * Presign the provided HTTP request using SRA HttpSigner
      */
     private SdkHttpFullRequest sraPresignRequest(ExecutionContext execCtx, SdkHttpFullRequest request,
-                                              Clock signingClock, Duration expirationDuration) {
+                                                 Clock signingClock, Duration expirationDuration) {
         SelectedAuthScheme selectedAuthScheme = execCtx.executionAttributes().getAttribute(SELECTED_AUTH_SCHEME);
         return doSraPresign(request, selectedAuthScheme, signingClock, expirationDuration);
     }
@@ -657,7 +693,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
 
         params.put(S3ClientContextParams.USE_ARN_REGION, serviceConfiguration.useArnRegionEnabled());
         params.put(S3ClientContextParams.DISABLE_MULTI_REGION_ACCESS_POINTS,
-                                !serviceConfiguration.multiRegionEnabled());
+                   !serviceConfiguration.multiRegionEnabled());
         params.put(S3ClientContextParams.FORCE_PATH_STYLE, serviceConfiguration.pathStyleAccessEnabled());
         params.put(S3ClientContextParams.ACCELERATE, serviceConfiguration.accelerateModeEnabled());
         params.put(S3ClientContextParams.DISABLE_S3_EXPRESS_SESSION_AUTH, resolvedDisableS3ExpressSessionAuth);
@@ -670,10 +706,10 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                                      .get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT);
 
         SdkClientConfiguration config = clientConfiguration.toBuilder()
-            .option(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT, legacyOption)
-            .option(SdkClientOption.PROFILE_FILE_SUPPLIER, profileFileSupplier())
-            .option(SdkClientOption.PROFILE_NAME, profileName())
-            .build();
+                                                           .option(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT, legacyOption)
+                                                           .option(SdkClientOption.PROFILE_FILE_SUPPLIER, profileFileSupplier())
+                                                           .option(SdkClientOption.PROFILE_NAME, profileName())
+                                                           .build();
 
         return new UseGlobalEndpointResolver(config);
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -40,6 +40,8 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.presigner.model.AbortMultipartUploadPresignRequest;
@@ -341,17 +343,118 @@ public interface S3Presigner extends SdkPresigner {
         return presignGetObject(builder.build());
     }
 
+    /**
+     * Presign a {@link HeadObjectRequest} so that it can be executed at a later time without requiring additional
+     * signing or authentication.
+     * <p/>
+     *
+     * <b>Example Usage</b>
+     * <p/>
+     *
+     * <pre>
+     * {@code
+     *     S3Presigner presigner = ...;
+     *
+     *     // Create a HeadObjectRequest to be pre-signed
+     *     HeadObjectRequest headObjectRequest =
+     *         HeadObjectRequest.builder()
+     *                          .bucket("my-bucket")
+     *                          .key("my-key")
+     *                          .build();
+     *
+     *     // Create a HeadObjectPresignRequest to specify the signature duration
+     *     HeadObjectPresignRequest headObjectPresignRequest =
+     *         HeadObjectPresignRequest.builder()
+     *                                .signatureDuration(Duration.ofMinutes(10))
+     *                                .headObjectRequest(headObjectRequest)
+     *                                .build();
+     *
+     *     // Generate the presigned request
+     *     PresignedHeadObjectRequest presignedHeadObjectRequest =
+     *         presigner.presignHeadObject(headObjectPresignRequest);
+     *
+     *     // The presigned URL can be used with an HTTP client to retrieve object metadata
+     *     SdkHttpClient httpClient = ApacheHttpClient.builder().build();
+     *     HttpExecuteRequest request = HttpExecuteRequest.builder()
+     *                                                   .request(presignedHeadObjectRequest.httpRequest())
+     *                                                   .build();
+     *     HttpExecuteResponse response = httpClient.prepareRequest(request).call();
+     *
+     *     // Extract metadata from response headers
+     *     String contentLength = response.httpResponse().firstMatchingHeader("Content-Length").orElse("0");
+     * }
+     * </pre>
+     */
     PresignedHeadObjectRequest presignHeadObject(HeadObjectPresignRequest request);
 
+    /**
+     * Presign a {@link HeadObjectRequest} so that it can be executed at a later time without requiring additional
+     * signing or authentication.
+     * <p />
+     * This is a shorter method of invoking {@link #presignHeadObject(HeadObjectPresignRequest)} without needing
+     * to call {@code HeadObjectPresignRequest.builder()} or {@code .build()}.
+     *
+     * @see #presignHeadObject(HeadObjectPresignRequest)
+     */
     default PresignedHeadObjectRequest presignHeadObject(Consumer<HeadObjectPresignRequest.Builder> request) {
         HeadObjectPresignRequest.Builder builder = HeadObjectPresignRequest.builder();
         request.accept(builder);
         return presignHeadObject(builder.build());
     }
 
-
+    /**
+     * Presign a {@link HeadBucketRequest} so that it can be executed at a later time without requiring additional
+     * signing or authentication.
+     * <p/>
+     *
+     * <b>Example Usage</b>
+     * <p/>
+     *
+     * <pre>
+     * {@code
+     *     S3Presigner presigner = ...;
+     *
+     *     // Create a HeadBucketRequest to be pre-signed
+     *     HeadBucketRequest headBucketRequest =
+     *         HeadBucketRequest.builder()
+     *                          .bucket("my-bucket")
+     *                          .build();
+     *
+     *     // Create a HeadBucketPresignRequest to specify the signature duration
+     *     HeadBucketPresignRequest headBucketPresignRequest =
+     *         HeadBucketPresignRequest.builder()
+     *                                .signatureDuration(Duration.ofMinutes(10))
+     *                                .headBucketRequest(headBucketRequest)
+     *                                .build();
+     *
+     *     // Generate the presigned request
+     *     PresignedHeadBucketRequest presignedHeadBucketRequest =
+     *         presigner.presignHeadBucket(headBucketPresignRequest);
+     *
+     *     // The presigned URL can be used with an HTTP client to check bucket existence and access
+     *     SdkHttpClient httpClient = ApacheHttpClient.builder().build();
+     *     HttpExecuteRequest request = HttpExecuteRequest.builder()
+     *                                                   .request(presignedHeadBucketRequest.httpRequest())
+     *                                                   .build();
+     *     HttpExecuteResponse response = httpClient.prepareRequest(request).call();
+     *
+     *     // Check if bucket exists and is accessible
+     *     boolean bucketExists = response.httpResponse().isSuccessful();
+     *     String region = response.httpResponse().firstMatchingHeader("x-amz-bucket-region").orElse("");
+     * }
+     * </pre>
+     */
     PresignedHeadBucketRequest presignHeadBucket(HeadBucketPresignRequest request);
 
+    /**
+     * Presign a {@link HeadBucketRequest} so that it can be executed at a later time without requiring additional
+     * signing or authentication.
+     * <p>
+     * This is a shorter method of invoking {@link #presignHeadBucket(HeadBucketPresignRequest)} without needing
+     * to call {@code HeadBucketPresignRequest.builder()} or {@code .build()}.
+     *
+     * @see #presignHeadBucket(HeadBucketPresignRequest)
+     */
     default PresignedHeadBucketRequest presignHeadBucket(Consumer<HeadBucketPresignRequest.Builder> request) {
         HeadBucketPresignRequest.Builder builder = HeadBucketPresignRequest.builder();
         request.accept(builder);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -385,7 +385,9 @@ public interface S3Presigner extends SdkPresigner {
      * }
      * </pre>
      */
-    PresignedHeadObjectRequest presignHeadObject(HeadObjectPresignRequest request);
+    default PresignedHeadObjectRequest presignHeadObject(HeadObjectPresignRequest request) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Presign a {@link HeadObjectRequest} so that it can be executed at a later time without requiring additional
@@ -444,7 +446,9 @@ public interface S3Presigner extends SdkPresigner {
      * }
      * </pre>
      */
-    PresignedHeadBucketRequest presignHeadBucket(HeadBucketPresignRequest request);
+    default PresignedHeadBucketRequest presignHeadBucket(HeadBucketPresignRequest request) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Presign a {@link HeadBucketRequest} so that it can be executed at a later time without requiring additional

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -47,11 +47,15 @@ import software.amazon.awssdk.services.s3.presigner.model.CompleteMultipartUploa
 import software.amazon.awssdk.services.s3.presigner.model.CreateMultipartUploadPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.DeleteObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.HeadBucketPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.HeadObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedAbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedCompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedCreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedDeleteObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadBucketRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedUploadPartRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -328,13 +332,30 @@ public interface S3Presigner extends SdkPresigner {
      * <p />
      * This is a shorter method of invoking {@link #presignGetObject(GetObjectPresignRequest)} without needing
      * to call {@code GetObjectPresignRequest.builder()} or {@code .build()}.
-     * 
+     *
      * @see #presignGetObject(GetObjectPresignRequest)
      */
     default PresignedGetObjectRequest presignGetObject(Consumer<GetObjectPresignRequest.Builder> request) {
         GetObjectPresignRequest.Builder builder = GetObjectPresignRequest.builder();
         request.accept(builder);
         return presignGetObject(builder.build());
+    }
+
+    PresignedHeadObjectRequest presignHeadObject(HeadObjectPresignRequest request);
+
+    default PresignedHeadObjectRequest presignHeadObject(Consumer<HeadObjectPresignRequest.Builder> request) {
+        HeadObjectPresignRequest.Builder builder = HeadObjectPresignRequest.builder();
+        request.accept(builder);
+        return presignHeadObject(builder.build());
+    }
+
+
+    PresignedHeadBucketRequest presignHeadBucket(HeadBucketPresignRequest request);
+
+    default PresignedHeadBucketRequest presignHeadBucket(Consumer<HeadBucketPresignRequest.Builder> request) {
+        HeadBucketPresignRequest.Builder builder = HeadBucketPresignRequest.builder();
+        request.accept(builder);
+        return presignHeadBucket(builder.build());
     }
 
     /**

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/HeadBucketPresignRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/HeadBucketPresignRequest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.presigner.model;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.presigner.PresignRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * A request to pre-sign a {@link HeadBucketRequest} so that it can be executed at a later time without requiring additional
+ * signing or authentication.
+ *
+ * @see S3Presigner#presignHeadBucket(HeadBucketPresignRequest)
+ * @see #builder()
+ */
+@SdkPublicApi
+@Immutable
+@ThreadSafe
+public final class HeadBucketPresignRequest
+    extends PresignRequest
+    implements ToCopyableBuilder<HeadBucketPresignRequest.Builder, HeadBucketPresignRequest> {
+    private final HeadBucketRequest headBucketRequest;
+
+    private HeadBucketPresignRequest(DefaultBuilder builder) {
+        super(builder);
+        this.headBucketRequest = Validate.notNull(builder.headBucketRequest, "headBucketRequest");
+    }
+
+    /**
+     * Create a builder that can be used to create a {@link HeadBucketPresignRequest}.
+     *
+     * @see S3Presigner#presignHeadBucket(HeadBucketPresignRequest)
+     */
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    /**
+     * Retrieve the {@link HeadBucketRequest} that should be presigned.
+     */
+    public HeadBucketRequest headBucketRequest() {
+        return headBucketRequest;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new DefaultBuilder(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        HeadBucketPresignRequest that = (HeadBucketPresignRequest) o;
+
+        return headBucketRequest.equals(that.headBucketRequest);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + headBucketRequest.hashCode();
+        return result;
+    }
+
+    /**
+     * A builder for a {@link HeadBucketPresignRequest}, created with {@link #builder()}.
+     */
+    @SdkPublicApi
+    @NotThreadSafe
+    public interface Builder extends PresignRequest.Builder,
+                                     CopyableBuilder<HeadBucketPresignRequest.Builder, HeadBucketPresignRequest> {
+        /**
+         * Configure the {@link HeadBucketRequest} that should be presigned.
+         */
+        Builder headBucketRequest(HeadBucketRequest headBucketRequest);
+
+        /**
+         * Configure the {@link HeadBucketRequest} that should be presigned.
+         * <p/>
+         * This is a convenience method for invoking {@link #headBucketRequest(HeadBucketRequest)} without needing to invoke
+         * {@code HeadBucketRequest.builder()} or {@code build()}.
+         */
+        default Builder headBucketRequest(Consumer<HeadBucketRequest.Builder> headBucketRequest) {
+            HeadBucketRequest.Builder builder = HeadBucketRequest.builder();
+            headBucketRequest.accept(builder);
+            return headBucketRequest(builder.build());
+        }
+
+        @Override
+        Builder signatureDuration(Duration signatureDuration);
+
+        @Override
+        HeadBucketPresignRequest build();
+    }
+
+    @SdkInternalApi
+    private static final class DefaultBuilder extends PresignRequest.DefaultBuilder<DefaultBuilder> implements Builder {
+        private HeadBucketRequest headBucketRequest;
+
+        private DefaultBuilder() {
+        }
+
+        private DefaultBuilder(HeadBucketPresignRequest request) {
+            super(request);
+            this.headBucketRequest = request.headBucketRequest;
+        }
+
+        @Override
+        public Builder headBucketRequest(HeadBucketRequest headBucketRequest) {
+            this.headBucketRequest = headBucketRequest;
+            return this;
+        }
+
+        @Override
+        public HeadBucketPresignRequest build() {
+            return new HeadBucketPresignRequest(this);
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/HeadObjectPresignRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/HeadObjectPresignRequest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.presigner.model;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.presigner.PresignRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * A request to pre-sign a {@link HeadObjectRequest} so that it can be executed at a later time without requiring additional
+ * signing or authentication.
+ *
+ * @see S3Presigner#presignHeadObject(HeadObjectPresignRequest)
+ * @see #builder()
+ */
+@SdkPublicApi
+@Immutable
+@ThreadSafe
+public final class HeadObjectPresignRequest
+    extends PresignRequest
+    implements ToCopyableBuilder<HeadObjectPresignRequest.Builder, HeadObjectPresignRequest> {
+    private final HeadObjectRequest headObjectRequest;
+
+    private HeadObjectPresignRequest(DefaultBuilder builder) {
+        super(builder);
+        this.headObjectRequest = Validate.notNull(builder.headObjectRequest, "headObjectRequest");
+    }
+
+    /**
+     * Create a builder that can be used to create a {@link HeadObjectPresignRequest}.
+     *
+     * @see S3Presigner#presignHeadObject(HeadObjectPresignRequest)
+     */
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    /**
+     * Retrieve the {@link HeadObjectRequest} that should be presigned.
+     */
+    public HeadObjectRequest headObjectRequest() {
+        return headObjectRequest;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new DefaultBuilder(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        HeadObjectPresignRequest that = (HeadObjectPresignRequest) o;
+
+        return headObjectRequest.equals(that.headObjectRequest);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + headObjectRequest.hashCode();
+        return result;
+    }
+
+    /**
+     * A builder for a {@link HeadObjectPresignRequest}, created with {@link #builder()}.
+     */
+    @SdkPublicApi
+    @NotThreadSafe
+    public interface Builder extends PresignRequest.Builder,
+                                     CopyableBuilder<HeadObjectPresignRequest.Builder, HeadObjectPresignRequest> {
+        /**
+         * Configure the {@link HeadObjectRequest} that should be presigned.
+         */
+        Builder headObjectRequest(HeadObjectRequest headObjectRequest);
+
+        /**
+         * Configure the {@link HeadObjectRequest} that should be presigned.
+         * <p/>
+         * This is a convenience method for invoking {@link #headObjectRequest(HeadObjectRequest)} without needing to invoke
+         * {@code HeadObjectRequest.builder()} or {@code build()}.
+         */
+        default Builder headObjectRequest(Consumer<HeadObjectRequest.Builder> headObjectRequest) {
+            HeadObjectRequest.Builder builder = HeadObjectRequest.builder();
+            headObjectRequest.accept(builder);
+            return headObjectRequest(builder.build());
+        }
+
+        @Override
+        Builder signatureDuration(Duration signatureDuration);
+
+        @Override
+        HeadObjectPresignRequest build();
+    }
+
+    @SdkInternalApi
+    private static final class DefaultBuilder extends PresignRequest.DefaultBuilder<DefaultBuilder> implements Builder {
+        private HeadObjectRequest headObjectRequest;
+
+        private DefaultBuilder() {
+        }
+
+        private DefaultBuilder(HeadObjectPresignRequest request) {
+            super(request);
+            this.headObjectRequest = request.headObjectRequest;
+        }
+
+        @Override
+        public Builder headObjectRequest(HeadObjectRequest headObjectRequest) {
+            this.headObjectRequest = headObjectRequest;
+            return this;
+        }
+
+        @Override
+        public HeadObjectPresignRequest build() {
+            return new HeadObjectPresignRequest(this);
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/PresignedHeadBucketRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/PresignedHeadBucketRequest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.presigner.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.presigner.PresignedRequest;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * A pre-signed a {@link HeadBucketRequest} that can be executed at a later time without requiring additional signing or
+ * authentication.
+ *
+ * @see S3Presigner#presignHeadBucket(HeadBucketPresignRequest)
+ * @see #builder()
+ */
+@SdkPublicApi
+@Immutable
+@ThreadSafe
+public class PresignedHeadBucketRequest
+    extends PresignedRequest
+    implements ToCopyableBuilder<PresignedHeadBucketRequest.Builder, PresignedHeadBucketRequest> {
+    private PresignedHeadBucketRequest(DefaultBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Create a builder that can be used to create a {@link PresignedHeadBucketRequest}.
+     *
+     * @see S3Presigner#presignHeadBucket(HeadBucketPresignRequest)
+     */
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new DefaultBuilder(this);
+    }
+
+    /**
+     * A builder for a {@link PresignedHeadBucketRequest}, created with {@link #builder()}.
+     */
+    @SdkPublicApi
+    @NotThreadSafe
+    public interface Builder extends PresignedRequest.Builder,
+                                     CopyableBuilder<PresignedHeadBucketRequest.Builder, PresignedHeadBucketRequest> {
+        @Override
+        Builder expiration(Instant expiration);
+
+        @Override
+        Builder isBrowserExecutable(Boolean isBrowserExecutable);
+
+        @Override
+        Builder signedHeaders(Map<String, List<String>> signedHeaders);
+
+        @Override
+        Builder signedPayload(SdkBytes signedPayload);
+
+        @Override
+        Builder httpRequest(SdkHttpRequest httpRequest);
+
+        @Override
+        PresignedHeadBucketRequest build();
+    }
+
+    @SdkInternalApi
+    private static final class DefaultBuilder
+        extends PresignedRequest.DefaultBuilder<DefaultBuilder>
+        implements Builder {
+        private DefaultBuilder() {
+        }
+
+        private DefaultBuilder(PresignedHeadBucketRequest request) {
+            super(request);
+        }
+
+        @Override
+        public PresignedHeadBucketRequest build() {
+            return new PresignedHeadBucketRequest(this);
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/PresignedHeadObjectRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/model/PresignedHeadObjectRequest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.presigner.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.presigner.PresignedRequest;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * A pre-signed a {@link HeadObjectRequest} that can be executed at a later time without requiring additional signing or
+ * authentication.
+ *
+ * @see S3Presigner#presignHeadObject(HeadObjectPresignRequest)
+ * @see #builder()
+ */
+@SdkPublicApi
+@Immutable
+@ThreadSafe
+public class PresignedHeadObjectRequest
+    extends PresignedRequest
+    implements ToCopyableBuilder<PresignedHeadObjectRequest.Builder, PresignedHeadObjectRequest> {
+    private PresignedHeadObjectRequest(DefaultBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Create a builder that can be used to create a {@link PresignedHeadObjectRequest}.
+     *
+     * @see S3Presigner#presignHeadObject(HeadObjectPresignRequest)
+     */
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new DefaultBuilder(this);
+    }
+
+    /**
+     * A builder for a {@link PresignedHeadObjectRequest}, created with {@link #builder()}.
+     */
+    @SdkPublicApi
+    @NotThreadSafe
+    public interface Builder extends PresignedRequest.Builder,
+                                     CopyableBuilder<PresignedHeadObjectRequest.Builder, PresignedHeadObjectRequest> {
+        @Override
+        Builder expiration(Instant expiration);
+
+        @Override
+        Builder isBrowserExecutable(Boolean isBrowserExecutable);
+
+        @Override
+        Builder signedHeaders(Map<String, List<String>> signedHeaders);
+
+        @Override
+        Builder signedPayload(SdkBytes signedPayload);
+
+        @Override
+        Builder httpRequest(SdkHttpRequest httpRequest);
+
+        @Override
+        PresignedHeadObjectRequest build();
+    }
+
+    @SdkInternalApi
+    private static final class DefaultBuilder
+        extends PresignedRequest.DefaultBuilder<DefaultBuilder>
+        implements Builder {
+        private DefaultBuilder() {
+        }
+
+        private DefaultBuilder(PresignedHeadObjectRequest request) {
+            super(request);
+        }
+
+        @Override
+        public PresignedHeadObjectRequest build() {
+            return new PresignedHeadObjectRequest(this);
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3PresignerTest.java
@@ -56,6 +56,8 @@ import software.amazon.awssdk.services.s3.model.SessionCredentials;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedDeleteObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadBucketRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -440,6 +442,55 @@ public class S3PresignerTest {
             assertThat(expires).containsOnlyDigits();
             assertThat(Integer.parseInt(expires)).isEqualTo(1234);
         });
+    }
+
+    @Test
+    public void headObject_compareWithGetObject_sameUrlDifferentMethod() {
+        PresignedHeadObjectRequest headRequest =
+            presigner.presignHeadObject(r -> r.signatureDuration(Duration.ofMinutes(5))
+                                              .headObjectRequest(ho -> ho.bucket("test-bucket")
+                                                                         .key("test-key")));
+
+        PresignedGetObjectRequest getRequest =
+            presigner.presignGetObject(r -> r.signatureDuration(Duration.ofMinutes(5))
+                                             .getObjectRequest(go -> go.bucket("test-bucket")
+                                                                       .key("test-key")));
+
+        String headUrl = headRequest.url().toString();
+        String getUrl = getRequest.url().toString();
+
+        assertThat(headUrl).contains("X-Amz-Algorithm=");
+        assertThat(getUrl).contains("X-Amz-Algorithm=");
+        assertThat(headRequest.httpRequest().method().name()).isEqualTo("HEAD");
+        assertThat(getRequest.httpRequest().method().name()).isEqualTo("GET");
+    }
+
+    @Test
+    public void headObject_withVersionId_includesVersionIdInQueryString() {
+        String versionId = "version-12345";
+
+        PresignedHeadObjectRequest presigned =
+            presigner.presignHeadObject(r -> r.signatureDuration(Duration.ofMinutes(5))
+                                              .headObjectRequest(ho -> ho.bucket("versioned-bucket")
+                                                                         .key("versioned-object")
+                                                                         .versionId(versionId)));
+
+        assertThat(presigned.url().toString()).contains("versionId=" + versionId);
+        assertThat(presigned.httpRequest().rawQueryParameters().get("versionId").get(0)).isEqualTo(versionId);
+    }
+
+    @Test
+    public void headBucket_withExpectedBucketOwner_includesHeaderInSignature() {
+        String accountId = "123456789012";
+
+        PresignedHeadBucketRequest presigned =
+            presigner.presignHeadBucket(r -> r.signatureDuration(Duration.ofMinutes(5))
+                                              .headBucketRequest(hb -> hb.bucket("owner-bucket")
+                                                                         .expectedBucketOwner(accountId)));
+
+        assertThat(presigned.isBrowserExecutable()).isFalse();
+        assertThat(presigned.signedHeaders().keySet()).containsExactlyInAnyOrder("host", "x-amz-expected-bucket-owner");
+        assertThat(presigned.signedHeaders().get("x-amz-expected-bucket-owner")).containsExactly(accountId);
     }
 
     @Test


### PR DESCRIPTION
Builds upon work done in https://github.com/aws/aws-sdk-java-v2/pull/5476
Addresses https://github.com/aws/aws-sdk-java-v2/issues/5473, https://github.com/aws/aws-sdk-java-v2/issues/5276

## Motivation and Context
This PR adds the possibility of presigning S3 head operations, a functionality that was supported in v1 and was creating a parity gap and preventing customers from migrating to v2.

### Usage Example:

```java
S3Presigner presigner = S3Presigner.create();

PresignedHeadObjectRequest presigned =
            presigner.presignHeadObject(r -> r.signatureDuration(Duration.ofMinutes(30))
                                             .headObjectRequest(hor -> hor
                                                                         .bucket(testBucket)
                                                                         .key(testGetObjectKey)));

SdkHttpClient httpClient = ApacheHttpClient.builder().build(); // or UrlConnectionHttpClient.builder().build()

HttpExecuteRequest request = HttpExecuteRequest.builder()
                                             .request(presigned.httpRequest())
                                             .build();

HttpExecuteResponse response = httpClient.prepareRequest(request).call();
String contentLength = response.httpResponse().firstMatchingHeader("Content-Length").orElse("0");
```

## Modifications
Added `presignHeadObject` and `presignHeadBucket` methods to the S3 Presigner. That includes adding model classes for request/response (`HeadObjectPresignRequest` and `PresignedHeadObjectRequest`, `HeadBucketPresignRequest` and `PresignedHeadBucketRequest`) and adding the marshalling logic for those.


## Testing

- Unit tests: Added tests to verify HEAD operations are correctly presigned, including method types, version IDs, and expected bucket owner parameters.
- Integration tests: Added tests to verify presigned HEAD URLs work against actual S3 for both object and bucket operations.

