### PR TITLE
Better arn parsing

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-1408e5f.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-1408e5f.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Adding a new method of constructing ARNs without exceptions as control flow"
+}

--- a/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
+++ b/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
@@ -142,7 +142,6 @@ public final class Arn implements ToCopyableBuilder<Arn.Builder, Arn> {
      * Attempts to parse the given string into an {@link Arn}. If the input string is not a valid ARN,
      * this method returns {@link Optional#empty()} instead of throwing an exception.
      * <p>
-     * Returns an empty Optional if the input string is not a valid ARN.
      * When successful, the resource is accessible entirely as a string through
      * {@link #resourceAsString()}. Where correctly formatted, a parsed resource
      * containing resource type, resource and qualifier is available through

--- a/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
+++ b/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
@@ -149,57 +149,10 @@ public final class Arn implements ToCopyableBuilder<Arn.Builder, Arn> {
      *
      * @param arn A string containing an ARN to parse.
      * @return An {@link Optional} containing the parsed {@link Arn} if valid, or empty if invalid.
+     * @throws IllegalArgumentException if the ARN contains empty partition or service fields
      */
     public static Optional<Arn> tryFromString(String arn) {
-        if (arn == null) {
-            return Optional.empty();
-        }
-
-        int arnColonIndex = arn.indexOf(':');
-        if (arnColonIndex < 0 || !"arn".equals(arn.substring(0, arnColonIndex))) {
-            return Optional.empty();
-        }
-
-        int partitionColonIndex = arn.indexOf(':', arnColonIndex + 1);
-        if (partitionColonIndex < 0) {
-            return Optional.empty();
-        }
-
-        String partition = arn.substring(arnColonIndex + 1, partitionColonIndex);
-
-        int serviceColonIndex = arn.indexOf(':', partitionColonIndex + 1);
-        if (serviceColonIndex < 0) {
-            return Optional.empty();
-        }
-        String service = arn.substring(partitionColonIndex + 1, serviceColonIndex);
-
-        int regionColonIndex = arn.indexOf(':', serviceColonIndex + 1);
-        if (regionColonIndex < 0) {
-            return Optional.empty();
-        }
-        String region = arn.substring(serviceColonIndex + 1, regionColonIndex);
-
-        int accountColonIndex = arn.indexOf(':', regionColonIndex + 1);
-        if (accountColonIndex < 0) {
-            return Optional.empty();
-        }
-        String accountId = arn.substring(regionColonIndex + 1, accountColonIndex);
-
-        String resource = arn.substring(accountColonIndex + 1);
-        if (resource.isEmpty()) {
-            return Optional.empty();
-        }
-
-
-        Arn resultArn = builder()
-                  .partition(partition)
-                  .service(service)
-                  .region(region)
-                  .accountId(accountId)
-                  .resource(resource)
-                  .build();
-
-        return Optional.of(resultArn);
+        return parseArn(arn, false);
     }
 
     /**
@@ -212,47 +165,75 @@ public final class Arn implements ToCopyableBuilder<Arn.Builder, Arn> {
      * @return {@link Arn} - A modeled Arn.
      */
     public static Arn fromString(String arn) {
+        return parseArn(arn, true).orElseThrow(() -> new IllegalArgumentException("ARN parsing failed"));
+    }
+
+    private static Optional<Arn> parseArn(String arn, boolean throwOnError) {
+        if (arn == null) {
+            return Optional.empty();
+        }
+
         int arnColonIndex = arn.indexOf(':');
         if (arnColonIndex < 0 || !"arn".equals(arn.substring(0, arnColonIndex))) {
-            throw new IllegalArgumentException("Malformed ARN - doesn't start with 'arn:'");
+            if (throwOnError) {
+                throw new IllegalArgumentException("Malformed ARN - doesn't start with 'arn:'");
+            }
+            return Optional.empty();
         }
 
         int partitionColonIndex = arn.indexOf(':', arnColonIndex + 1);
         if (partitionColonIndex < 0) {
-            throw new IllegalArgumentException("Malformed ARN - no AWS partition specified");
+            if (throwOnError) {
+                throw new IllegalArgumentException("Malformed ARN - no AWS partition specified");
+            }
+            return Optional.empty();
         }
         String partition = arn.substring(arnColonIndex + 1, partitionColonIndex);
 
         int serviceColonIndex = arn.indexOf(':', partitionColonIndex + 1);
         if (serviceColonIndex < 0) {
-            throw new IllegalArgumentException("Malformed ARN - no service specified");
+            if (throwOnError) {
+                throw new IllegalArgumentException("Malformed ARN - no service specified");
+            }
+            return Optional.empty();
         }
         String service = arn.substring(partitionColonIndex + 1, serviceColonIndex);
 
         int regionColonIndex = arn.indexOf(':', serviceColonIndex + 1);
         if (regionColonIndex < 0) {
-            throw new IllegalArgumentException("Malformed ARN - no AWS region partition specified");
+            if (throwOnError) {
+                throw new IllegalArgumentException("Malformed ARN - no AWS region partition specified");
+            }
+            return Optional.empty();
         }
         String region = arn.substring(serviceColonIndex + 1, regionColonIndex);
 
         int accountColonIndex = arn.indexOf(':', regionColonIndex + 1);
         if (accountColonIndex < 0) {
-            throw new IllegalArgumentException("Malformed ARN - no AWS account specified");
+            if (throwOnError) {
+                throw new IllegalArgumentException("Malformed ARN - no AWS account specified");
+            }
+            return Optional.empty();
         }
         String accountId = arn.substring(regionColonIndex + 1, accountColonIndex);
 
         String resource = arn.substring(accountColonIndex + 1);
         if (resource.isEmpty()) {
-            throw new IllegalArgumentException("Malformed ARN - no resource specified");
+            if (throwOnError) {
+                throw new IllegalArgumentException("Malformed ARN - no resource specified");
+            }
+            return Optional.empty();
         }
 
-        return Arn.builder()
-                  .partition(partition)
-                  .service(service)
-                  .region(region)
-                  .accountId(accountId)
-                  .resource(resource)
-                  .build();
+        Arn resultArn = builder()
+            .partition(partition)
+            .service(service)
+            .region(region)
+            .accountId(accountId)
+            .resource(resource)
+            .build();
+
+        return Optional.of(resultArn);
     }
 
     @Override

--- a/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
+++ b/core/arns/src/main/java/software/amazon/awssdk/arns/Arn.java
@@ -139,6 +139,71 @@ public final class Arn implements ToCopyableBuilder<Arn.Builder, Arn> {
     }
 
     /**
+     * Attempts to parse the given string into an {@link Arn}. If the input string is not a valid ARN,
+     * this method returns {@link Optional#empty()} instead of throwing an exception.
+     * <p>
+     * Returns an empty Optional if the input string is not a valid ARN.
+     * When successful, the resource is accessible entirely as a string through
+     * {@link #resourceAsString()}. Where correctly formatted, a parsed resource
+     * containing resource type, resource and qualifier is available through
+     * {@link #resource()}.
+     *
+     * @param arn A string containing an ARN to parse.
+     * @return An {@link Optional} containing the parsed {@link Arn} if valid, or empty if invalid.
+     */
+    public static Optional<Arn> tryFromString(String arn) {
+        if (arn == null) {
+            return Optional.empty();
+        }
+
+        int arnColonIndex = arn.indexOf(':');
+        if (arnColonIndex < 0 || !"arn".equals(arn.substring(0, arnColonIndex))) {
+            return Optional.empty();
+        }
+
+        int partitionColonIndex = arn.indexOf(':', arnColonIndex + 1);
+        if (partitionColonIndex < 0) {
+            return Optional.empty();
+        }
+
+        String partition = arn.substring(arnColonIndex + 1, partitionColonIndex);
+
+        int serviceColonIndex = arn.indexOf(':', partitionColonIndex + 1);
+        if (serviceColonIndex < 0) {
+            return Optional.empty();
+        }
+        String service = arn.substring(partitionColonIndex + 1, serviceColonIndex);
+
+        int regionColonIndex = arn.indexOf(':', serviceColonIndex + 1);
+        if (regionColonIndex < 0) {
+            return Optional.empty();
+        }
+        String region = arn.substring(serviceColonIndex + 1, regionColonIndex);
+
+        int accountColonIndex = arn.indexOf(':', regionColonIndex + 1);
+        if (accountColonIndex < 0) {
+            return Optional.empty();
+        }
+        String accountId = arn.substring(regionColonIndex + 1, accountColonIndex);
+
+        String resource = arn.substring(accountColonIndex + 1);
+        if (resource.isEmpty()) {
+            return Optional.empty();
+        }
+
+
+        Arn resultArn = builder()
+                  .partition(partition)
+                  .service(service)
+                  .region(region)
+                  .accountId(accountId)
+                  .resource(resource)
+                  .build();
+
+        return Optional.of(resultArn);
+    }
+
+    /**
      * Parses a given string into an {@link Arn}. The resource is accessible entirely as a
      * string through {@link #resourceAsString()}. Where correctly formatted, a parsed
      * resource containing resource type, resource and qualifier is available through

--- a/core/arns/src/test/java/software/amazon/awssdk/arns/ArnTest.java
+++ b/core/arns/src/test/java/software/amazon/awssdk/arns/ArnTest.java
@@ -320,41 +320,40 @@ public class ArnTest {
 
     private static Stream<Arguments> validArnTestCases() {
         return Stream.of(
-            // Test case name, ARN string
-            Arguments.of("Basic Resource", "arn:aws:s3:us-east-1:12345678910:myresource"),
-            Arguments.of("Minimal Requirements", "arn:aws:foobar:::myresource"),
-            Arguments.of("Qualified Resource", "arn:aws:s3:us-east-1:12345678910:myresource:foobar:1"),
-            Arguments.of("Minimal Resources", "arn:aws:s3:::bucket"),
-            Arguments.of("Without Region", "arn:aws:iam::123456789012:root"),
-            Arguments.of("Resource Type And Resource", "arn:aws:s3:us-east-1:12345678910:bucket:foobar"),
-            Arguments.of("Resource Type And Resource And Qualifier", "arn:aws:s3:us-east-1:12345678910:bucket:foobar:1"),
-            Arguments.of("Resource Type And Resource With Slash", "arn:aws:s3:us-east-1:12345678910:bucket/foobar"),
-            Arguments.of("Resource Type And Resource And Qualifier With Slash", "arn:aws:s3:us-east-1:12345678910:bucket/foobar/1"),
-            Arguments.of("Without Region", "arn:aws:s3::123456789012:myresource"),
-            Arguments.of("Without AccountId", "arn:aws:s3:us-east-1::myresource"),
-            Arguments.of("Resource Containing Dots", "arn:aws:s3:us-east-1:12345678910:myresource:foobar.1")
+            Arguments.of("Basic resource", "arn:aws:s3:us-east-1:12345678910:myresource"),
+            Arguments.of("Minimal requirements", "arn:aws:foobar:::myresource"),
+            Arguments.of("Qualified resource", "arn:aws:s3:us-east-1:12345678910:myresource:foobar:1"),
+            Arguments.of("Minimal resources", "arn:aws:s3:::bucket"),
+            Arguments.of("Without region", "arn:aws:iam::123456789012:root"),
+            Arguments.of("Resource type and resource", "arn:aws:s3:us-east-1:12345678910:bucket:foobar"),
+            Arguments.of("Resource type And resource and qualifier",
+                         "arn:aws:s3:us-east-1:12345678910:bucket:foobar:1"),
+            Arguments.of("Resource type And resource with slash", "arn:aws:s3:us-east-1:12345678910:bucket/foobar"),
+            Arguments.of("Resource type and resource and qualifier slash",
+                         "arn:aws:s3:us-east-1:12345678910:bucket/foobar/1"),
+            Arguments.of("Without region", "arn:aws:s3::123456789012:myresource"),
+            Arguments.of("Without accountId", "arn:aws:s3:us-east-1::myresource"),
+            Arguments.of("Resource with dots", "arn:aws:s3:us-east-1:12345678910:myresource:foobar.1")
         );
     }
 
     private static Stream<Arguments> invalidArnTestCases() {
         return Stream.of(
-            // Test case name, ARN string
-            Arguments.of("Without Partition", "arn::s3:us-east-1:12345678910:myresource"),
-            Arguments.of("Without Service", "arn:aws::us-east-1:12345678910:myresource"),
-            Arguments.of("Without Resource", "arn:aws:s3:us-east-1:12345678910:"),
-            Arguments.of("Invalid ARN", "arn:aws:"),
-            Arguments.of("Doesn't Start With ARN", "fakearn:aws:"),
-            Arguments.of("Invalid Without Partition", "arn:"),
-            Arguments.of("Invalid Without Service", "arn:aws:"),
-            Arguments.of("Invalid Without Region", "arn:aws:s3:"),
-            Arguments.of("Invalid Without AccountId", "arn:aws:s3:us-east-1:")
+            Arguments.of("Without resource", "arn:aws:s3:us-east-1:12345678910:"),
+            Arguments.of("Invalid arn", "arn:aws:"),
+            Arguments.of("Doesn't start with arn", "fakearn:aws:"),
+            Arguments.of("Invalid without partition", "arn:"),
+            Arguments.of("Invalid without service", "arn:aws:"),
+            Arguments.of("Invalid without region", "arn:aws:s3:"),
+            Arguments.of("Invalid without accountId", "arn:aws:s3:us-east-1:"),
+            Arguments.of("Null Arn", null)
         );
     }
 
     private static Stream<Arguments> exceptionThrowingArnTestCases() {
         return Stream.of(
-            Arguments.of("Without Partition", "arn::s3:us-east-1:12345678910:myresource"),
-            Arguments.of("Without Service", "arn:aws::us-east-1:12345678910:myresource")
+            Arguments.of("Valid without partition", "arn::s3:us-east-1:12345678910:myresource"),
+            Arguments.of("Valid without service", "arn:aws::us-east-1:12345678910:myresource")
         );
     }
 
@@ -365,7 +364,6 @@ public class ArnTest {
 
         assertThat(optionalArn).isPresent();
 
-        // Compare with the original fromString implementation
         Arn expectedArn = Arn.fromString(arnString);
         Arn actualArn = optionalArn.get();
 
@@ -375,7 +373,6 @@ public class ArnTest {
         assertThat(actualArn.accountId()).isEqualTo(expectedArn.accountId());
         assertThat(actualArn.resourceAsString()).isEqualTo(expectedArn.resourceAsString());
 
-        // Verify the ARN string representation matches
         assertThat(actualArn.toString()).isEqualTo(arnString);
     }
 
@@ -392,33 +389,6 @@ public class ArnTest {
         assertThrows(IllegalArgumentException.class, () -> {
             Arn.tryFromString(arnString);
         });
-    }
-
-    @Test
-    public void optionalArnFromString_NullInput_ReturnsEmptyOptional() {
-        Optional<Arn> optionalArn = Arn.tryFromString(null);
-        assertThat(optionalArn).isEmpty();
-    }
-
-    @ParameterizedTest(name = "Resource parsing: {0}")
-    @MethodSource("validArnTestCases")
-    public void tryFromString_ResourceParsing_MatchesOriginalImplementation(String testName, String arnString) {
-        // Skip test cases that would throw exceptions in the resource parsing
-        if (arnString.contains("bucket:") || arnString.contains("bucket/")) {
-            Optional<Arn> optionalArn = Arn.tryFromString(arnString);
-            assertThat(optionalArn).isPresent();
-
-            Arn expectedArn = Arn.fromString(arnString);
-            Arn actualArn = optionalArn.get();
-
-            // Verify resource parsing
-            ArnResource expectedResource = expectedArn.resource();
-            ArnResource actualResource = actualArn.resource();
-
-            assertThat(actualResource.resourceType()).isEqualTo(expectedResource.resourceType());
-            assertThat(actualResource.resource()).isEqualTo(expectedResource.resource());
-            assertThat(actualResource.qualifier()).isEqualTo(expectedResource.qualifier());
-        }
     }
 
 }


### PR DESCRIPTION
## Motivation and Context
Addresses #6108 .

Currently the SDK uses exceptions as control flow for arn parsing. This is an anti pattern in Java and can cause performance overhead. 

## Modifications
This PR adds another arn parsing method `tryFromString(arn)` that would return an Optional of Arn when the arn is valid, and an empty when it is invalid - this avoids the hot path of throwing exceptions as control flow.

## Testing
Unit tests:
- Valid ARNs
- Invalid ARNs
- Exception throwing ARNs (valid ARNs missing a partition or service)