### PR TITLE
Deprecate DefaultCredentialsProvider.create() due to singleton issues

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-c5cff7a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-c5cff7a.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "jencymaryjoseph",
+    "description": "DefaultCredentialsProvider.create() since it creates Singleton instance"
+}

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-c5cff7a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-c5cff7a.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "jencymaryjoseph",
-    "description": "DefaultCredentialsProvider.create() since it creates Singleton instance"
+    "description": "Deprecated DefaultCredentialsProvider.create() since it creates Singleton instance"
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
@@ -74,10 +74,15 @@ public final class DefaultCredentialsProvider
     }
 
     /**
-     * Returns the singleton instance of the {@link DefaultCredentialsProvider} using the default configuration. 
-     * Configuration can be specified by creating an instance using the {@link #builder()}. If you want to 
+     * Returns the singleton instance of the {@link DefaultCredentialsProvider} using the default configuration.
+     * Configuration can be specified by creating an instance using the {@link #builder()}. If you want to
      * create a new instance, use {@link #builder()} instead.
+     *
+     * @deprecated The create() method that returns a singleton instance which can cause issues if one client closes the provider
+     * while others are still using it. Use {@link #builder().build()} to create independent instances, which is the
+     * safer approach and recommended for most use cases.
      */
+    @Deprecated
     public static DefaultCredentialsProvider create() {
         return DEFAULT_CREDENTIALS_PROVIDER;
     }


### PR DESCRIPTION
* Add deprecation notice to create() method
* Update documentation to clearly explain the risks
* Recommend using builder().build() instead

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Follows up on fix implemented in #6080 which addressed this for S3 CRT client
- The `create()` method currently returns a singleton instance which can cause issues when shared between clients
- If one client closes the provider, all other clients using the same instance will fail
- Need to guide users toward using `builder().build()` for safer credential provider management

## Modifications
- Added `@Deprecated` annotation to `DefaultCredentialsProvider.create()` method
- Updated Javadoc for `create()` method to:
  - Clearly explain the singleton behavior
  - Warn about risks of shared instance
  - Recommend using `builder().build()` instead

## Testing
No additional unit tests were added as this is a documentation/deprecation change

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [] I have added tests to cover my changes
- [] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
