### PR TITLE
Add Github workflow to lock PR conversation on close

### DIFF
--- a/.github/workflows/lock-conversation-closed-pr.yml
+++ b/.github/workflows/lock-conversation-closed-pr.yml
@@ -10,7 +10,6 @@ jobs:
     name: Lock PR Conversation on Close
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - name: Lock PR conversation on Close
@@ -25,7 +24,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              body: "This pull request has been closed and the conversation has been locked. If you need more assistance, please open a new issue that references this one."
+              body: "This pull request has been closed and the conversation has been locked. Comments on closed PRs are hard for our team to see. If you need more assistance, please open a new issue that references this one."
             });
             
             await github.rest.issues.lock({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Lock conversations on closed/merged PRs, with message to open Github issue, which will provide more visibility

## Modifications
<!--- Describe your changes in detail -->
Add Github workflow

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on forked repo
