### PR TITLE
Make SsoCredentialsProvider builder usable

### DIFF
--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -136,7 +136,7 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
     /**
      * Get a builder for creating a custom {@link SsoCredentialsProvider}.
      */
-    public static BuilderImpl builder() {
+    public static Builder builder() {
         return new BuilderImpl();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Only the `Builder` interface in `SsoCredentialsProvider` is visible outside the package, the `BuilderImpl` is protected. 
To make the builder for `SsoCredentialsProvider` usable outside the package, the interface has to be returned.

Compare for example another `CredentialsProvider` `build()` method where also the public interface is returned: [StsAssumeRoleCredentialsProvider.java](https://github.com/aws/aws-sdk-java-v2/blob/f60abb1dbe9cc569a00b435d12067eff8a04c27c/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java#L68) 

## Modifications
<!--- Describe your changes in detail -->
Change the `builder()` method to return the public interface instead of the protected implementation.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Current workaround is to cast the returned builder into the interface:
```(SsoCredentialsProvider.Builder)SsoCredentialsProvider.builder()```

## Screenshots (if appropriate)
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
