### PR TITLE
Invalid link link in deprecated message of DefaultCredentialsProvider replaced to @code

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
@@ -79,7 +79,7 @@ public final class DefaultCredentialsProvider
      * create a new instance, use {@link #builder()} instead.
      *
      * @deprecated The create() method that returns a singleton instance which can cause issues if one client closes the provider
-     * while others are still using it. Use {@link #builder().build()} to create independent instances, which is the
+     * while others are still using it. Use {@code builder().build()} to create independent instances, which is the
      * safer approach and recommended for most use cases.
      */
     @Deprecated


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Java doc for https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html#create() not rendered correctly for the link used inside deprecated message.

## Modifications
<!--- Describe your changes in detail -->
- Changed to @code to simplify representation

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
