### PR TITLE
Fix a bug in ConstructorCache when classes are GC'ed but not removed from cache

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavaV2-a136845.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavaV2-a136845.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java V2",
+    "contributor": "",
+    "description": "Fix a bug in ConstructorCache when classes are GC'ed but not removed from cache"
+}

--- a/core/checksums/src/main/java/software/amazon/awssdk/checksums/internal/ConstructorCache.java
+++ b/core/checksums/src/main/java/software/amazon/awssdk/checksums/internal/ConstructorCache.java
@@ -63,12 +63,17 @@ public final class ConstructorCache {
                 return Optional.empty();
             }
         });
+
         // if the WeakReference to the class has been garbage collected, remove it from the cache and try again
-        if (classRef.isPresent() && classRef.get().get() == null) {
+        if (classRef.isPresent()) {
+            Class<?> clazz = classRef.get().get();
+            if (clazz != null) {
+                return Optional.of(clazz);
+            }
             classesByClassLoader.remove(classLoader);
             return getClass(className);
         }
-        return classRef.map(WeakReference::get);
+        return Optional.empty();
     }
 
     /**

--- a/core/checksums/src/main/java/software/amazon/awssdk/checksums/internal/ConstructorCache.java
+++ b/core/checksums/src/main/java/software/amazon/awssdk/checksums/internal/ConstructorCache.java
@@ -63,6 +63,11 @@ public final class ConstructorCache {
                 return Optional.empty();
             }
         });
+        // if the WeakReference to the class has been garbage collected, remove it from the cache and try again
+        if (classRef.isPresent() && classRef.get().get() == null) {
+            classesByClassLoader.remove(classLoader);
+            return getClass(className);
+        }
         return classRef.map(WeakReference::get);
     }
 


### PR DESCRIPTION
Fix a bug in ConstructorCache when classes are GC'ed but not removed from cache

## Motivation and Context
The ConstructorCache uses WeakReferences to hold Class objects, which can be garbage-collected, leading to Optional.empty() results even though the class may still be load-able.  The ConstructorCache is using a [WeakHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/WeakHashMap.html) which handles GC of the keys only, but not when values (the class Objects in this case) are cleaned up.  

The current design of the constructor cache was introduced to store the classloader and class with a weak reference, so that we don't prevent them from being unloaded.  It was intended to follow We do something similar in DynamoDB enhanced's [BeanTableSchema](https://github.com/aws/aws-sdk-java-v2/blob/master/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchema.java) but, unlike the BeanTableSchema, this cache *also* uses weakreferences to the values being cached.

## Modifications
Adds an additional check in the `getClass` method to check if the referent in the WeakReference has been garbage collected and if so, remove it from the cache.

**Q: Why not use a `ReferenceQueue` to handle removals as in the implementation of WeakHashMap?**
Short answer: it increases complexity more than is justified to handle an edge case error.  Long answer: The schema of the cache (specially `Map<String, Map<ClassLoader, Optional<WeakReference<Class<?>>>>>`) makes this more difficult to track - we would need to create a new entry class that extends WeakReference and stores the className and classLoader and would need to ensure the reference to classLoader is also a weak reference in this entry.  We would then need to add synchronization around check the reference queue and logic to remove cache entries from the nested cache correctly. 

## Testing
Testing this edge case is extremely difficult - I was able to manually reproduce the issue with a hacked custom class loader + multiple threads, but its not consistently reproducible, so I have not added an automated unit test to cover this case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
