### PR TITLE
Add ec2InstanceProfileName configuration

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-994f3a1.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-994f3a1.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Adding ec2InstanceProfileName configuration to specify IMDS instance profile for retrieving credentials."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -215,8 +215,12 @@ public final class InstanceProfileCredentialsProvider
                         return refreshCredentials();
                     }
                 } else {
+                    String profileName = resolveProfileName();
                     throw SdkClientException.builder()
-                                           .message("Invalid profile name")
+                                           .message(String.format("Invalid EC2 instance profile name: '%s'. " +
+                                                                 "Verify that the profile exists and that your instance " +
+                                                                 "has permission to access it. ",
+                                                                 profileName))
                                            .cause(e)
                                            .build();
                 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderExtendedApiTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderExtendedApiTest.java
@@ -271,7 +271,7 @@ public class InstanceProfileCredentialsProviderExtendedApiTest {
         
         assertThatThrownBy(() -> provider.resolveCredentials())
             .isInstanceOf(SdkClientException.class)
-            .hasMessageContaining("Invalid profile name");
+            .hasMessageContaining("Invalid EC2 instance profile name");
 
         verify(putRequestedFor(urlPathEqualTo(TOKEN_RESOURCE_PATH))
                    .withHeader(EC2_METADATA_TOKEN_TTL_HEADER, equalTo("21600")));
@@ -383,7 +383,7 @@ public class InstanceProfileCredentialsProviderExtendedApiTest {
         
         assertThatThrownBy(() -> provider.resolveCredentials())
             .isInstanceOf(SdkClientException.class)
-            .hasMessageContaining("Invalid profile name");
+            .hasMessageContaining("Invalid EC2 instance profile name");
 
         verify(putRequestedFor(urlPathEqualTo(TOKEN_RESOURCE_PATH))
                    .withHeader(EC2_METADATA_TOKEN_TTL_HEADER, equalTo("21600")));

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -162,6 +162,12 @@ public final class ProfileProperty {
     public static final String EC2_METADATA_V1_DISABLED = "ec2_metadata_v1_disabled";
 
     public static final String METADATA_SERVICE_TIMEOUT = "metadata_service_timeout";
+    
+    /**
+     * Property name for specifying an IAM instance profile by name.
+     * When this is set, the provider will skip fetching a list of available instance profiles.
+     */
+    public static final String EC2_INSTANCE_PROFILE_NAME = "ec2_instance_profile_name";
 
     /**
      * Whether request compression is disabled for operations marked with the RequestCompression trait. The default value is

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -99,6 +99,14 @@ public enum SdkSystemSetting implements SystemSetting {
      * metadata service in environments with varying network conditions.
      */
     AWS_METADATA_SERVICE_TIMEOUT("aws.ec2MetadataServiceTimeout", "1"),
+    
+    /**
+     * The EC2 instance profile name to use for retrieving credentials.
+     * 
+     * When this is set, the provider will skip fetching the list of available instance profiles
+     * and use this name directly.
+     */
+    AWS_EC2_INSTANCE_PROFILE_NAME("aws.ec2InstanceProfileName", null),
 
     /**
      * The elastic container metadata service endpoint that should be called by the ContainerCredentialsProvider


### PR DESCRIPTION
Adding ec2InstanceProfileName configuration to specify IMDS instance profile.

## Motivation and Context
Adding ec2InstanceProfileName configuration to specify IMDS instance profile for retrieving credentials. This improves performance by skipping the profile discovery step, eliminating one IMDS call.

## Modifications
- Added the ec2InstanceProfileName config in provider configuration, system properties, environment variables and in configuration files.
- Modified Ec2MetadataConfigProvider to parse ec2InstanceProfileName configuration.
- Modified the credentials fetching logic in InstanceProfileCredentialsProvider to include this new configuration.
- Added unit tests to test the new config. 


## Testing
- Added unit tests for all supported configuration methods.
- Added tests in the ExtendedApiTest file to verify the new profile name works with the Extended API.
- Added few test cases from the IMDS SEP which tests with ec2InstanceProfileName config.
- Performed one-off integration testing.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
