### PR TITLE
Throw ModelInvalidException for bearerAuth issues

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-960b6f3.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-960b6f3.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Add validation for invalid usages of the `enableEnvironmentBearerToken` codegen customization."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -327,7 +327,7 @@ public class BaseClientBuilderClass implements ClassSpec {
             ValidationEntry entry = ValidationEntry.create(ValidationErrorId.INVALID_CODEGEN_CUSTOMIZATION,
                                                            ValidationErrorSeverity.DANGER,
                                                            "The enableEnvironmentBearerToken customization requires"
-                                                           + " the SRA Auth customization.");
+                                                           + " the useSraAuth customization but it is disabled.");
 
             throw ModelInvalidException.fromEntry(entry);
         }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -63,6 +63,10 @@ import software.amazon.awssdk.codegen.poet.model.ServiceClientConfigurationUtils
 import software.amazon.awssdk.codegen.poet.rules.EndpointParamsKnowledgeIndex;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
 import software.amazon.awssdk.codegen.utils.AuthUtils;
+import software.amazon.awssdk.codegen.validation.ModelInvalidException;
+import software.amazon.awssdk.codegen.validation.ValidationEntry;
+import software.amazon.awssdk.codegen.validation.ValidationErrorId;
+import software.amazon.awssdk.codegen.validation.ValidationErrorSeverity;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculationResolver;
@@ -320,11 +324,21 @@ public class BaseClientBuilderClass implements ClassSpec {
 
     private void configureEnvironmentBearerToken(MethodSpec.Builder builder) {
         if (!authSchemeSpecUtils.useSraAuth()) {
-            throw new IllegalStateException("The enableEnvironmentBearerToken customization requires SRA Auth.");
+            ValidationEntry entry = ValidationEntry.create(ValidationErrorId.INVALID_CODEGEN_CUSTOMIZATION,
+                                                           ValidationErrorSeverity.DANGER,
+                                                           "The enableEnvironmentBearerToken customization requires"
+                                                           + " the SRA Auth customization.");
+
+            throw ModelInvalidException.fromEntry(entry);
         }
         if (!AuthUtils.usesBearerAuth(model)) {
-            throw new IllegalStateException("The enableEnvironmentBearerToken customization requires the service to model and "
-                                            + "support smithy.api#httpBearerAuth.");
+            ValidationEntry entry =
+                ValidationEntry.create(ValidationErrorId.INVALID_CODEGEN_CUSTOMIZATION,
+                                       ValidationErrorSeverity.DANGER,
+                                        "The enableEnvironmentBearerToken customization requires the service to model"
+                                        + " and support smithy.api#httpBearerAuth.");
+
+            throw ModelInvalidException.fromEntry(entry);
         }
 
         builder.addStatement("$T tokenFromEnv = new $T().getStringValue()",

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ModelInvalidException.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ModelInvalidException.java
@@ -38,6 +38,10 @@ public class ModelInvalidException extends RuntimeException {
         return new Builder();
     }
 
+    public static ModelInvalidException fromEntry(ValidationEntry entry) {
+        return builder().validationEntries(Collections.singletonList(entry)).build();
+    }
+
     public static class Builder {
         private List<ValidationEntry> validationEntries;
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ValidationEntry.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ValidationEntry.java
@@ -61,6 +61,10 @@ public final class ValidationEntry {
         return this;
     }
 
+    public static ValidationEntry create(ValidationErrorId errorId, ValidationErrorSeverity severity, String detailMessage) {
+        return new ValidationEntry().withErrorId(errorId).withSeverity(severity).withDetailMessage(detailMessage);
+    }
+
     @Override
     public String toString() {
         return ToString.builder("ValidationEntry")

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ValidationErrorId.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ValidationErrorId.java
@@ -22,6 +22,9 @@ public enum ValidationErrorId {
     ),
     UNKNOWN_SHAPE_MEMBER("The model references an unknown shape member."),
     REQUEST_URI_NOT_FOUND("The request URI does not exist."),
+
+    INVALID_CODEGEN_CUSTOMIZATION("A customization is enabled for this service that cannot be applied for the given service "
+                                  + "model.")
     ;
 
     private final String description;


### PR DESCRIPTION
Change from IllegalStateException to ModelInvalidException for cases where the enableEnvironmentBearerToken customization is enabled but the service model does not support it.

This commit adds a new error ID `INVALID_CODEGEN_CUSTOMIZATION` for these cases.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
Tested locally with an invalid service model and ensured that 

 - the new exceptions are thrown
 - the generated `validation-report.json` contains the expected issues

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
