### PR TITLE
Add custom marshaller for pre-signed URL GET operations

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlGetObjectRequestMarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlGetObjectRequestMarshaller.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.presignedurl;
+
+import java.net.URI;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.protocols.core.OperationInfo;
+import software.amazon.awssdk.protocols.xml.AwsXmlProtocolFactory;
+import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlGetObjectRequestWrapper;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * {@link PresignedUrlGetObjectRequestWrapper} Marshaller
+ *
+ * <p>
+ * Marshalls presigned URL requests by using the complete URL directly and adding optional Range headers.
+ * Unlike regular S3 marshalers, this preserves all embedded authentication parameters in the presigned URL.
+ * </p>
+ */
+@SdkInternalApi
+public class PresignedUrlGetObjectRequestMarshaller implements Marshaller<PresignedUrlGetObjectRequestWrapper> {
+    private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
+            .requestUri("/").httpMethod(SdkHttpMethod.GET).hasExplicitPayloadMember(false).hasPayloadMembers(false)
+            .putAdditionalMetadata(AwsXmlProtocolFactory.ROOT_MARSHALL_LOCATION_ATTRIBUTE, null)
+            .putAdditionalMetadata(AwsXmlProtocolFactory.XML_NAMESPACE_ATTRIBUTE, null).build();
+
+    private final AwsXmlProtocolFactory protocolFactory;
+
+    public PresignedUrlGetObjectRequestMarshaller(AwsXmlProtocolFactory protocolFactory) {
+        this.protocolFactory = protocolFactory;
+    }
+
+    /**
+     * Marshalls the presigned URL request into an HTTP GET request.
+     *
+     * @param presignedUrlGetObjectRequestWrapper the request to marshall
+     * @return HTTP request ready for execution
+     * @throws SdkClientException if URL conversion fails
+     */
+    @Override
+    public SdkHttpFullRequest marshall(PresignedUrlGetObjectRequestWrapper presignedUrlGetObjectRequestWrapper) {
+        Validate.paramNotNull(presignedUrlGetObjectRequestWrapper, "presignedUrlGetObjectRequestWrapper");
+        try {
+            URI uri = presignedUrlGetObjectRequestWrapper.url().toURI();
+            SdkHttpFullRequest.Builder httpRequestBuilder = SdkHttpFullRequest.builder()
+                    .method(SdkHttpMethod.GET)
+                    .uri(uri);
+
+            if (presignedUrlGetObjectRequestWrapper.range() != null && 
+                !presignedUrlGetObjectRequestWrapper.range().isEmpty()) {
+                httpRequestBuilder.putHeader("Range", presignedUrlGetObjectRequestWrapper.range());
+            }
+            
+            return httpRequestBuilder.build();
+        } catch (Exception e) {
+            throw SdkClientException.builder()
+                    .message("Unable to marshall pre-signed URL Request: " + e.getMessage())
+                    .cause(e).build();
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlGetObjectRequestMarshallerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlGetObjectRequestMarshallerTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.presignedurl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import java.net.URL;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.protocols.xml.AwsXmlProtocolFactory;
+import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlGetObjectRequestWrapper;
+
+class PresignedUrlGetObjectRequestMarshallerTest {
+
+    private PresignedUrlGetObjectRequestMarshaller marshaller;
+    private AwsXmlProtocolFactory mockProtocolFactory;
+    private URL testUrl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockProtocolFactory = mock(AwsXmlProtocolFactory.class);
+        marshaller = new PresignedUrlGetObjectRequestMarshaller(mockProtocolFactory);
+        testUrl = new URL("https://test-bucket.s3.us-east-1.amazonaws.com/test-key?" +
+                "X-Amz-Date=20231215T000000Z&" +
+                "X-Amz-Signature=example-signature&" +
+                "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                "X-Amz-SignedHeaders=host&" +
+                "X-Amz-Security-Token=xxx&" +
+                "X-Amz-Credential=EXAMPLE12345678901234%2F20231215%2Fus-east-1%2Fs3%2Faws4_request&" +
+                "X-Amz-Expires=3600");
+    }
+
+    @Test
+    void marshall_withBasicRequest_shouldCreateCorrectHttpRequest() throws Exception {
+        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+                .url(testUrl)
+                .build();
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        // Verify HTTP method and URI components
+        assertThat(result.method()).isEqualTo(SdkHttpMethod.GET);
+        assertThat(result.getUri())
+                .satisfies(uri -> {
+                    assertThat(uri.getScheme()).isEqualTo("https");
+                    assertThat(uri.getHost()).isEqualTo("test-bucket.s3.us-east-1.amazonaws.com");
+                    assertThat(uri.getPath()).isEqualTo("/test-key");
+                });
+
+        // Verify query parameters are preserved
+        assertThat(result.getUri().getQuery())
+                .contains("X-Amz-Date=20231215T000000Z")
+                .contains("X-Amz-Signature=example-signature")
+                .contains("X-Amz-Algorithm=AWS4-HMAC-SHA256")
+                .contains("X-Amz-SignedHeaders=host")
+                .contains("X-Amz-Security-Token=xxx")
+                .contains("X-Amz-Credential=EXAMPLE12345678901234")
+                .contains("X-Amz-Expires=3600");
+        
+        assertThat(result.headers()).doesNotContainKey("Range");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "bytes=0-100",      // First 101 bytes
+        "bytes=100-",       // From byte 100 to end
+        "bytes=-100",       // Last 100 bytes
+        "bytes=0-0",        // Single byte
+        "bytes=100-200"     // Specific range
+    })
+    void marshall_withValidRangeFormats_shouldAddRangeHeader(String rangeValue) throws Exception {
+        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+                .url(testUrl)
+                .range(rangeValue)
+                .build();
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.headers())
+                .containsKey("Range")
+                .satisfies(headers -> assertThat(headers.get("Range")).contains(rangeValue));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void marshall_withNullOrEmptyRange_shouldNotAddRangeHeader(String rangeValue) throws Exception {
+        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+                .url(testUrl)
+                .range(rangeValue)
+                .build();
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.headers()).doesNotContainKey("Range");
+    }
+
+    @Test
+    void marshall_withNullRequest_shouldThrowException() {
+        assertThatThrownBy(() -> marshaller.marshall(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("presignedUrlGetObjectRequestWrapper must not be null");
+    }
+
+    @Test
+    void marshall_withMalformedUrl_shouldThrowSdkClientException() throws Exception {
+        URL malformedUrl = new URL("https", "test-bucket.s3.us-east-1.amazonaws.com", -1, "/test key with spaces");
+        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+                .url(malformedUrl)
+                .build();
+
+        assertThatThrownBy(() -> marshaller.marshall(request))
+                .isInstanceOf(SdkClientException.class)
+                .hasMessageContaining("Unable to marshall pre-signed URL Request");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideComplexUrls")
+    void marshall_withComplexPresignedUrl_shouldPreserveAllParameters(URL complexUrl, String[] expectedParams) 
+            throws Exception {
+        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+                .url(complexUrl)
+                .build();
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        String query = result.getUri().getQuery();
+        for (String param : expectedParams) {
+            assertThat(query).contains(param);
+        }
+    }
+
+    // JDK 8 compatible method source
+    private static Stream<Arguments> provideComplexUrls() throws Exception {
+        return Stream.of(
+            Arguments.of(
+                new URL("https://my-bucket.s3.amazonaws.com/path/to/object.txt?" +
+                    "X-Amz-Date=20231215T120000Z&" +
+                    "X-Amz-Signature=example-signature-hash&" +
+                    "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                    "X-Amz-SignedHeaders=host%3Bx-amz-content-sha256&" +
+                    "X-Amz-Security-Token=xxx&" +
+                    "X-Amz-Credential=EXAMPLE12345678901234%2F20231215%2Fus-east-1%2Fs3%2Faws4_request&" +
+                    "X-Amz-Expires=86400&" +
+                    "response-content-disposition=attachment%3B%20filename%3D%22download.txt%22"),
+                new String[] {
+                    "X-Amz-Algorithm=AWS4-HMAC-SHA256",
+                    "X-Amz-Credential=EXAMPLE12345678901234",
+                    "X-Amz-Date=20231215T120000Z",
+                    "X-Amz-Expires=86400",
+                    "X-Amz-SignedHeaders=host",
+                    "X-Amz-Security-Token=xxx",
+                    "X-Amz-Signature=example-signature-hash",
+                    "response-content-disposition=attachment"
+                }
+            ),
+            Arguments.of(
+                new URL("https://test-bucket.s3.us-west-2.amazonaws.com/folder/file.pdf?" +
+                    "X-Amz-Date=20231215T180000Z&" +
+                    "X-Amz-Signature=different-signature&" +
+                    "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                    "X-Amz-SignedHeaders=host&" +
+                    "X-Amz-Credential=EXAMPLE12345678901234%2F20231215%2Fus-west-2%2Fs3%2Faws4_request&" +
+                    "X-Amz-Expires=7200"),
+                new String[] {
+                    "X-Amz-Algorithm=AWS4-HMAC-SHA256",
+                    "X-Amz-Credential=EXAMPLE12345678901234",
+                    "X-Amz-Date=20231215T180000Z",
+                    "X-Amz-Expires=7200",
+                    "X-Amz-SignedHeaders=host",
+                    "X-Amz-Signature=different-signature"
+                }
+            )
+        );
+    }
+}


### PR DESCRIPTION
Implements custom marshaller for pre-signed URL GET operations in AWS SDK Java v2.

## Motivation and Context
Pre-signed URLs are pre-authenticated, complete HTTP URLs that can be used as is ,without SDK modifications (signing, endpoint resolution, path manipulation). The custom marshaller handles this by performing direct URL marshalling.

## Modifications
Added the custom marshaller needed for pre-signed URL Get Object Request processing

## Testing
Added unit test suite that validates Range header formats, URL preservation, and error handling for malformed requests. Tests ensure marshaller correctly handles pre-signed URL specifics without breaking authentication signatures.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
