### PR TITLE
Add merge_group to some of the GH workflows so that they get triggere…

### DIFF
--- a/.github/workflows/api-surface-area-review-verification.yml
+++ b/.github/workflows/api-surface-area-review-verification.yml
@@ -5,6 +5,7 @@ permissions:
   pull-requests: read
 
 on:
+  merge_group:
   pull_request:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches:

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -5,6 +5,7 @@ permissions:
   pull-requests: read
 
 on:
+  merge_group:
   pull_request:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
+  merge_group:
   schedule:
     - cron: '44 14 * * 6'
 

--- a/.github/workflows/new-module-verification.yml
+++ b/.github/workflows/new-module-verification.yml
@@ -1,6 +1,7 @@
 name: New Module Verification
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:


### PR DESCRIPTION
…d when a pull request is put into merge queue

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Add merge_group to the GH workflows so that they get triggered when a pull request is added into a merge queue, which eventually allows us to mark them as required to pass before merging