### PR TITLE
Fix EC2 DescribeInstances query use locale-dependent formatting

### DIFF
--- a/.changes/next-release/bugfix-AWSQueryProtocol-1398d13.json
+++ b/.changes/next-release/bugfix-AWSQueryProtocol-1398d13.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS Query Protocol",
+    "contributor": "",
+    "description": "Fixed the bug that EC2 DescribeInstances query uses locale-dependent formatting"
+}

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/marshall/ListQueryMarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/marshall/ListQueryMarshaller.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.protocols.query.internal.marshall;
 
 import java.util.List;
+import java.util.Locale;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.traits.ListTrait;
@@ -31,7 +32,8 @@ public class ListQueryMarshaller implements QueryMarshaller<List<?>> {
         listTrait.isFlattened() ?
         String.format("%s.%d", path, i + 1) :
         String.format("%s.%s.%d", path, listTrait.memberFieldInfo().locationName(), i + 1);
-    private static final PathResolver EC2_QUERY_PATH_RESOLVER = (path, i, listTrait) -> String.format("%s.%d", path, i + 1);
+    private static final PathResolver EC2_QUERY_PATH_RESOLVER = (path, i, listTrait) -> String.format(Locale.ROOT, "%s.%d", path
+        , i + 1);
 
     private static final EmptyListMarshaller AWS_QUERY_EMPTY_LIST_MARSHALLER =
         (context, path) -> context.request().putRawQueryParameter(path, "");

--- a/core/protocols/aws-query-protocol/src/test/java/software/amazon/awssdk/protocols/query/ListQueryMarshallerTest.java
+++ b/core/protocols/aws-query-protocol/src/test/java/software/amazon/awssdk/protocols/query/ListQueryMarshallerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.query;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.ListTrait;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.protocols.query.internal.marshall.ListQueryMarshaller;
+import software.amazon.awssdk.protocols.query.internal.marshall.QueryMarshaller;
+import software.amazon.awssdk.protocols.query.internal.marshall.QueryMarshallerContext;
+import software.amazon.awssdk.protocols.query.internal.marshall.QueryMarshallerRegistry;
+
+
+public class ListQueryMarshallerTest {
+
+    @Test
+    public void localeSetAsNe_ParsedCorrectly() {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("ne"));
+
+        ListQueryMarshaller marshaller = ListQueryMarshaller.ec2Query();
+
+        QueryMarshallerContext context = createTestContext();
+        List<String> testList = Arrays.asList("value1", "value2");
+        SdkField<List<?>> field = createTestField();
+
+        marshaller.marshall(context, "TestParam", testList, field);
+
+        Map<String, List<String>> params = context.request().rawQueryParameters();
+
+        assertEquals(Collections.singletonList("value1"), params.get("TestParam.1"));
+        assertEquals(Collections.singletonList("value2"), params.get("TestParam.2"));
+        Locale.setDefault(defaultLocale);
+    }
+
+    private QueryMarshallerContext createTestContext() {
+
+        QueryMarshaller<String> stringMarshaller = (context, path, val, field) ->
+            context.request().putRawQueryParameter(path, val);
+
+        QueryMarshallerRegistry registry = QueryMarshallerRegistry.builder()
+                                                                  .marshaller(MarshallingType.STRING, stringMarshaller)
+                                                                  .build();
+
+        return QueryMarshallerContext.builder()
+                                     .request(SdkHttpFullRequest.builder())
+                                     .marshallerRegistry(registry)
+                                     .build();
+    }
+
+
+
+    private SdkField<List<?>> createTestField() {
+        SdkField<?> memberField = SdkField.builder(MarshallingType.STRING)
+                                          .memberName("item")
+                                          .traits(LocationTrait.builder()
+                                                               .location(MarshallLocation.PAYLOAD)
+                                                               .locationName("item")
+                                                               .build())
+                                          .build();
+
+        ListTrait listTrait = ListTrait.builder()
+                                       .memberFieldInfo(memberField)
+                                       .memberLocationName("item")
+                                       .isFlattened(true)
+                                       .build();
+
+        return SdkField.builder(MarshallingType.LIST)
+                       .memberName("TestParam")
+                       .traits(LocationTrait.builder()
+                                            .location(MarshallLocation.QUERY_PARAM)
+                                            .locationName("TestParam")
+                                            .build(),listTrait)
+                       .build();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
User reported the issue https://github.com/aws/aws-sdk-java-v2/issues/5968. Currently we are render the filters using locale-dependent numerals, UTF-8-encoded. For example, for instance running in the ne (Nepalese) local the query uses ``Filter.%E0%A5%A7.Name`` rather than ``Filter.1.Name``, where ``%E0%A5%A7`` is the UTF-8 encoding for ``U+0967 DEVANAGARI DIGIT ONE`` which is the rendering for the integer 1 in this locale. The expected behavior is in all locales, we should render the filters using ASCII digits 0 to 9 only.  
## Modifications
<!--- Describe your changes in detail -->
The current code uses ``String.format("%s.%d", path, i + 1``) which is locale-dependent. When formatting the ``%d`` (decimal integer), Java uses the system's default locale to determine how to display numbers.  
``Locale.ROOT`` is Java's locale-neutral locale. By adding that to String.format, it will always produce ASCII digits regardless of system locale.  This issue only appear for Java version 9 and above. 
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test for ListQueryMarshaller class and also did a local integration test using the self-repro code provided in the original issue. 
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
