### PR TITLE
add non final clarification to ddb enhanced client

### DIFF
--- a/.changes/next-release/documentation-AmazonDynamoDBEnhancedClient-8964823.json
+++ b/.changes/next-release/documentation-AmazonDynamoDBEnhancedClient-8964823.json
@@ -1,0 +1,6 @@
+{
+    "type": "documentation",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Add documentation clarifying usage for ddb enhanced client"
+}

--- a/services-custom/dynamodb-enhanced/README.md
+++ b/services-custom/dynamodb-enhanced/README.md
@@ -8,6 +8,9 @@ completely made up and not part of this library. Any search or key
 values used are also completely arbitrary.
 
 ### Initialization
+**IMPORTANT**: Fields in your DynamoDbBean java class **MUST NOT** be marked as `final`. 
+The DynamoDB Enhanced Client requires fields to be mutable for the mapping to work correctly.
+
 1. Create or use a java class for mapping records to and from the
    database table. At a minimum you must annotate the class so that
    it can be used as a DynamoDb bean, and also the property that


### PR DESCRIPTION
Clarifying that Ddb entity classes must be mutable for ddb enhanced client to be able to do the mapping correctly. 