### PR TITLE
Improve error message for the error case where a request using Reques…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1c39709.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1c39709.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Improve error message for the error case where a request using RequestBody#fromInputStream failed to retry due to lack of mark and reset support. See [#6174](https://github.com/aws/aws-sdk-java-v2/issues/6174)"
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/RequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/RequestBodyTest.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
 import software.amazon.awssdk.checksums.SdkChecksum;
 import software.amazon.awssdk.core.internal.sync.BufferingContentStreamProvider;
 import software.amazon.awssdk.core.internal.util.Mimetype;
+import software.amazon.awssdk.testutils.RandomInputStream;
 import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.StringInputStream;
@@ -161,6 +162,17 @@ public class RequestBodyTest {
 
         assertThat(getCrc32(requestBody.contentStreamProvider().newStream())).isEqualTo(streamCrc32);
         assertThat(getCrc32(requestBody.contentStreamProvider().newStream())).isEqualTo(streamCrc32);
+    }
+
+    @Test
+    public void fromInputStream_streamNotSupportReset_shouldThrowException() {
+        RandomInputStream stream = new RandomInputStream(100);
+        assertThat(stream.markSupported()).isFalse();
+        RequestBody requestBody = RequestBody.fromInputStream(stream, 100);
+        IoUtils.drainInputStream(requestBody.contentStreamProvider().newStream());
+        assertThatThrownBy(() -> requestBody.contentStreamProvider().newStream())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Content input stream does not support mark/reset");
     }
 
     private static String getCrc32(InputStream inputStream) {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
#6174
## Modifications
Improve error message for the error case where a request using `RequestBody#fromInputStream` failed to retry due to lack of mark and reset support

Before:
```
java.lang.IllegalStateException: The request content has fewer bytes than the specified content-length: 14 bytes.
```
After:
```
java.lang.IllegalStateException: Content input stream does not support mark/reset
```

## Testing
Added unit test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
