### PR TITLE
Add AsyncPresignedUrlManager for S3 GetObject operations with presigned URLs

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManager.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManager.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.presignedurl;
+
+import static software.amazon.awssdk.core.client.config.SdkClientOption.SIGNER_OVERRIDDEN;
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.awscore.internal.AwsProtocolMetadata;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.AsyncResponseTransformerUtils;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.core.signer.NoOpSigner;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+import software.amazon.awssdk.protocols.xml.AwsS3ProtocolFactory;
+import software.amazon.awssdk.protocols.xml.XmlOperationMetadata;
+import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlGetObjectRequestWrapper;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlManager;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlGetObjectRequest;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Pair;
+
+/**
+ * Default implementation of {@link AsyncPresignedUrlManager} for executing S3 operations asynchronously using presigned URLs.
+ */
+@SdkInternalApi
+public final class DefaultAsyncPresignedUrlManager implements AsyncPresignedUrlManager {
+    private static final Logger log = LoggerFactory.getLogger(DefaultAsyncPresignedUrlManager.class);
+
+    private final AsyncClientHandler clientHandler;
+    private final AwsS3ProtocolFactory protocolFactory;
+    private final SdkClientConfiguration clientConfiguration;
+    private final AwsProtocolMetadata protocolMetadata;
+    
+    public DefaultAsyncPresignedUrlManager(AsyncClientHandler clientHandler,
+                                           AwsS3ProtocolFactory protocolFactory,
+                                           SdkClientConfiguration clientConfiguration,
+                                           AwsProtocolMetadata protocolMetadata) {
+        this.clientHandler = clientHandler;
+        this.protocolFactory = protocolFactory;
+        this.clientConfiguration = clientConfiguration;
+        this.protocolMetadata = protocolMetadata;
+    }
+
+    @Override
+    public <ReturnT> CompletableFuture<ReturnT> getObject(
+            PresignedUrlGetObjectRequest presignedUrlGetObjectRequest,
+            AsyncResponseTransformer<GetObjectResponse, ReturnT> asyncResponseTransformer)
+            throws NoSuchKeyException, InvalidObjectStateException,
+                   AwsServiceException, SdkClientException, S3Exception {
+
+        PresignedUrlGetObjectRequestWrapper internalRequest = PresignedUrlGetObjectRequestWrapper.builder()
+                .url(presignedUrlGetObjectRequest.presignedUrl())
+                .range(presignedUrlGetObjectRequest.range())
+                .build();
+
+        SdkClientConfiguration updatedClientConfiguration = updateSdkClientConfiguration(this.clientConfiguration);
+        List<MetricPublisher> metricPublishers = Optional.ofNullable(
+            updatedClientConfiguration.option(SdkClientOption.METRIC_PUBLISHERS))
+            .orElse(Collections.emptyList());
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ?
+            NoOpMetricCollector.create() : MetricCollector.create("ApiCall");
+        
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "S3");
+            //TODO: Discuss if we need to change OPERATION_NAME as part of Surface API Review
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "GetObject");
+
+            Pair<AsyncResponseTransformer<GetObjectResponse, ReturnT>, CompletableFuture<Void>> pair =
+                    AsyncResponseTransformerUtils.wrapWithEndOfStreamFuture(asyncResponseTransformer);
+            asyncResponseTransformer = pair.left();
+            CompletableFuture<Void> endOfStreamFuture = pair.right();
+
+            HttpResponseHandler<GetObjectResponse> responseHandler = protocolFactory.createResponseHandler(
+                GetObjectResponse::builder, new XmlOperationMetadata().withHasStreamingSuccessResponse(true));
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+            CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
+                    new ClientExecutionParams<PresignedUrlGetObjectRequestWrapper, GetObjectResponse>()
+                            .withOperationName("PresignedUrlGetObject")
+                            .withProtocolMetadata(protocolMetadata)
+                            .withResponseHandler(responseHandler)
+                            .withErrorResponseHandler(errorResponseHandler)
+                            .withRequestConfiguration(updatedClientConfiguration)
+                            .withInput(internalRequest)
+                            .withMetricCollector(apiCallMetricCollector)
+                            // TODO: Deprecate IS_DISCOVERED_ENDPOINT, use new SKIP_ENDPOINT_RESOLUTION for better semantics
+                            .putExecutionAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT, true)
+                            .withMarshaller(new PresignedUrlGetObjectRequestMarshaller(protocolFactory)),
+                                                                                        asyncResponseTransformer);
+            CompletableFuture<ReturnT> whenCompleteFuture = null;
+            AsyncResponseTransformer<GetObjectResponse, ReturnT> finalAsyncResponseTransformer = asyncResponseTransformer;
+            whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
+                if (e != null) {
+                    runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                                   () -> finalAsyncResponseTransformer.exceptionOccurred(e));
+                }
+                endOfStreamFuture.whenComplete((r2, e2) -> {
+                    metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+                });
+            });
+            return CompletableFutureUtils.forwardExceptionTo(whenCompleteFuture, executeFuture);
+        } catch (Throwable t) {
+            AsyncResponseTransformer<GetObjectResponse, ReturnT> finalAsyncResponseTransformer = asyncResponseTransformer;
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                           () -> finalAsyncResponseTransformer.exceptionOccurred(t));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+    
+    private SdkClientConfiguration updateSdkClientConfiguration(SdkClientConfiguration clientConfiguration) {
+        SdkClientConfiguration.Builder configBuilder = clientConfiguration.toBuilder();
+        configBuilder.option(SdkAdvancedClientOption.SIGNER, new NoOpSigner());
+        configBuilder.option(SIGNER_OVERRIDDEN, true);
+        return configBuilder.build();
+    }
+
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManager.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManager.java
@@ -113,7 +113,7 @@ public final class DefaultAsyncPresignedUrlManager implements AsyncPresignedUrlM
 
             CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
                     new ClientExecutionParams<PresignedUrlGetObjectRequestWrapper, GetObjectResponse>()
-                            .withOperationName("PresignedUrlGetObject")
+                            .withOperationName("GetObject")
                             .withProtocolMetadata(protocolMetadata)
                             .withResponseHandler(responseHandler)
                             .withErrorResponseHandler(errorResponseHandler)

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlManager.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlManager.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.presignedurl;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlGetObjectRequest;
+
+/**
+ * Interface for executing S3 operations asynchronously using presigned URLs. This can be accessed using
+ * {@link S3AsyncClient#presignedUrlManager()}.
+ */
+@SdkPublicApi
+public interface AsyncPresignedUrlManager {
+    /**
+     * <p>
+     * Downloads an S3 object asynchronously using a presigned URL.
+     * </p>
+     * <p>
+     * This operation uses a presigned URL that contains all necessary authentication information, eliminating the
+     * need for AWS credentials at request time. The presigned URL must be valid and not expired.
+     * </p>
+     * <dl>
+     * <dt>Range Requests</dt>
+     * <dd>
+     * <p>
+     * Supports partial object downloads using HTTP Range headers. Specify the range parameter
+     * in the request to download only a portion of the object (e.g., "bytes=0-1023").
+     * </p>
+     * </dd>
+     * </dl>
+     *
+     * @param request             The presigned URL request containing the URL and optional range parameters
+     * @param responseTransformer Transforms the response to the desired return type. See
+     *                            {@link software.amazon.awssdk.core.async.AsyncResponseTransformer} for pre-built
+     *                            implementations like downloading to a file or converting to bytes.
+     * @param <ReturnT>           The type of the transformed response
+     * @return A {@link CompletableFuture} containing the transformed result of the AsyncResponseTransformer
+     * @throws software.amazon.awssdk.services.s3.model.NoSuchKeyException          The specified object does not exist
+     * @throws software.amazon.awssdk.services.s3.model.InvalidObjectStateException Object is archived and must be restored before
+     *                                                                              retrieval
+     * @throws software.amazon.awssdk.core.exception.SdkClientException             If any client side error occurs such as
+     *                                                                              network failures or invalid presigned URL
+     * @throws S3Exception                                                          Base class for all S3 service exceptions.
+     *                                                                              Unknown exceptions will be thrown as an
+     *                                                                              instance of this type.
+     */
+    default <ReturnT> CompletableFuture<ReturnT> getObject(PresignedUrlGetObjectRequest request,
+                                                            AsyncResponseTransformer<GetObjectResponse,
+                                                                ReturnT> responseTransformer) throws NoSuchKeyException,
+                                                                                                     InvalidObjectStateException,
+                                                                                                     SdkClientException,
+                                                                                                     S3Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    // TODO: Add convenience methods :
+    //   - getObject(Consumer<Builder>, AsyncResponseTransformer) - consumer-based request building
+    //   - getObject(PresignedUrlGetObjectRequest, Path) - direct file download
+    //   - getObject(Consumer<Builder>, Path) - consumer + file download
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManagerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManagerTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.presignedurl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.awscore.client.config.AwsAdvancedClientOption;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
+import software.amazon.awssdk.awscore.internal.AwsProtocolMetadata;
+import software.amazon.awssdk.awscore.internal.AwsServiceProtocol;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.protocols.core.ExceptionMetadata;
+import software.amazon.awssdk.protocols.xml.AwsS3ProtocolFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlGetObjectRequest;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+
+/**
+ * Tests for {@link DefaultAsyncPresignedUrlManager} using MockAsyncHttpClient to verify HTTP interactions.
+ */
+class DefaultAsyncPresignedUrlManagerTest {
+
+    private static final String TEST_CONTENT = "test-content";
+    private static final URI DEFAULT_ENDPOINT = URI.create("https://defaultendpoint.com");
+    private static final String TEST_URL = "https://test-bucket.s3.us-east-1.amazonaws.com/test-key?" +
+                                           "X-Amz-Date=20250707T000000Z&" +
+                                           "X-Amz-Signature=test-signature-value&" +
+                                           "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                           "X-Amz-SignedHeaders=host&" +
+                                           "X-Amz-Security-Token=test-session-token&" +
+                                           "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20250707%2Fus-east-1%2Fs3%2Faws4_request&" +
+                                           "X-Amz-Expires=86400";
+
+    private MockAsyncHttpClient mockHttpClient;
+    private DefaultAsyncPresignedUrlManager presignedUrlManager;
+    private PresignedUrlGetObjectRequest testRequest;
+    private AwsProtocolMetadata protocolMetadata;
+    private AwsS3ProtocolFactory protocolFactory;
+    private AsyncClientHandler clientHandler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockHttpClient = new MockAsyncHttpClient();
+        URL testPresignedUrl = new URL(TEST_URL);
+        testRequest = PresignedUrlGetObjectRequest.builder()
+                                                  .presignedUrl(testPresignedUrl)
+                                                  .build();
+
+        SdkClientConfiguration clientConfiguration = getDefaultSdkConfigs();
+        protocolMetadata = AwsProtocolMetadata.builder()
+                                              .serviceProtocol(AwsServiceProtocol.REST_XML)
+                                              .build();
+        protocolFactory = initProtocolFactory(clientConfiguration);
+        clientHandler = new AwsAsyncClientHandler(clientConfiguration);
+
+        presignedUrlManager = new DefaultAsyncPresignedUrlManager(
+            clientHandler, protocolFactory, clientConfiguration, protocolMetadata);
+    }
+
+    private static Stream<Arguments> httpResponseTestCases() {
+        return Stream.of(
+            Arguments.of(
+                "Success response",
+                createSuccessResponse(),
+                true,
+                null
+            ),
+            Arguments.of(
+                "404 Not Found response",
+                createErrorResponse(404, "NoSuchKey", "The specified key does not exist."),
+                false,
+                NoSuchKeyException.class
+            ),
+            Arguments.of(
+                "403 Invalid Object State response",
+                createErrorResponse(403, "InvalidObjectState", "The operation is not valid for the object's storage class."),
+                false,
+                InvalidObjectStateException.class
+            ),
+            Arguments.of(
+                "Generic error response",
+                createErrorResponse(500, "InternalError", "We encountered an internal error. Please try again."),
+                false,
+                S3Exception.class
+            )
+        );
+    }
+
+    private static Stream<Arguments> requestConfigurationTestCases() {
+        return Stream.of(
+            Arguments.of(
+                "Basic request",
+                (Consumer<PresignedUrlGetObjectRequest.Builder>) builder ->
+                    builder.presignedUrl(createTestUrl()),
+                null
+            ),
+            Arguments.of(
+                "Request with range header",
+                (Consumer<PresignedUrlGetObjectRequest.Builder>) builder ->
+                    builder.presignedUrl(createTestUrl()).range("bytes=0-1024"),
+                "bytes=0-1024"
+            )
+        );
+    }
+
+    private static Stream<Arguments> additionalTestCases() {
+        return Stream.of(
+            Arguments.of("Custom transformer test", "CUSTOM_TRANSFORMER"),
+            Arguments.of("Metrics collection test", "METRICS_COLLECTION")
+        );
+    }
+
+    private static Stream<Arguments> invalidUrlTestCases() {
+        return Stream.of(
+            Arguments.of("Invalid URL format", "not-a-url"),
+            Arguments.of("Empty HTTP URL", "http://"),
+            Arguments.of("Empty HTTPS URL", "https://"),
+            Arguments.of("Empty string", "")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("httpResponseTestCases")
+    void given_AsyncPresignedUrlManager_when_GetObjectWithDifferentHttpResponses_then_ShouldHandleSuccessAndErrorsCorrectly(
+            String testName,
+            HttpExecuteResponse response,
+            boolean expectSuccess,
+            Class<? extends Exception> expectedExceptionType) {
+        
+        mockHttpClient.stubNextResponse(response);
+        
+        if (expectSuccess) {
+            assertSuccessfulGetObject(testRequest);
+        } else {
+            CompletableFuture<ResponseBytes<GetObjectResponse>> future = 
+                presignedUrlManager.getObject(testRequest, AsyncResponseTransformer.toBytes());
+            
+            assertThatThrownBy(future::join)
+                .hasCauseInstanceOf(expectedExceptionType);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("requestConfigurationTestCases")
+    void given_AsyncPresignedUrlManager_when_GetObjectWithDifferentRequestConfigurations_then_ShouldSetCorrectHeaders(
+            String testName,
+            Consumer<PresignedUrlGetObjectRequest.Builder> requestCustomizer,
+            String expectedRangeHeader) throws ExecutionException, InterruptedException {
+        
+        mockHttpClient.stubNextResponse(createSuccessResponse());
+        
+        PresignedUrlGetObjectRequest.Builder builder = PresignedUrlGetObjectRequest.builder();
+        requestCustomizer.accept(builder);
+        PresignedUrlGetObjectRequest request = builder.build();
+        
+        CompletableFuture<ResponseBytes<GetObjectResponse>> future = 
+            presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+        ResponseBytes<GetObjectResponse> result = future.get();
+        
+        assertThat(result).isNotNull();
+        assertThat(result.asUtf8String()).isEqualTo(TEST_CONTENT);
+        
+        SdkHttpRequest lastRequest = mockHttpClient.getLastRequest();
+        assertThat(lastRequest.method()).isEqualTo(SdkHttpMethod.GET);
+        
+        if (expectedRangeHeader != null) {
+            assertThat(lastRequest.firstMatchingHeader("Range"))
+                .isPresent()
+                .contains(expectedRangeHeader);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("additionalTestCases")
+    void given_AsyncPresignedUrlManager_when_ExecutingDifferentScenarios_then_ShouldBehaveCorrectly(
+            String testName, String testType) throws Exception {
+        
+        switch (testType) {
+            case "CUSTOM_TRANSFORMER":
+                mockHttpClient.stubNextResponse(createSuccessResponse());
+                CompletableFuture<ResponseBytes<GetObjectResponse>> future = 
+                    presignedUrlManager.getObject(testRequest, AsyncResponseTransformer.toBytes());
+                ResponseBytes<GetObjectResponse> result = future.get();
+                assertThat(result.asUtf8String()).isEqualTo(TEST_CONTENT);
+                break;
+                
+            case "METRICS_COLLECTION":
+                MetricPublisher mockPublisher = mock(MetricPublisher.class);
+                SdkClientConfiguration clientConfigWithMetrics = getDefaultSdkConfigs().toBuilder()
+                    .option(SdkClientOption.METRIC_PUBLISHERS, Collections.singletonList(mockPublisher))
+                    .build();
+                DefaultAsyncPresignedUrlManager managerWithMetrics = new DefaultAsyncPresignedUrlManager(
+                    clientHandler, protocolFactory, clientConfigWithMetrics, protocolMetadata);
+                mockHttpClient.stubNextResponse(createSuccessResponse());
+                CompletableFuture<ResponseBytes<GetObjectResponse>> metricsFuture = 
+                    managerWithMetrics.getObject(testRequest, AsyncResponseTransformer.toBytes());
+                metricsFuture.get();
+                
+                verify(mockPublisher, atLeastOnce()).publish(any(MetricCollection.class));
+                ArgumentCaptor<MetricCollection> metricsCaptor = ArgumentCaptor.forClass(MetricCollection.class);
+                verify(mockPublisher).publish(metricsCaptor.capture());
+                MetricCollection capturedMetrics = metricsCaptor.getValue();
+                assertThat(capturedMetrics.metricValues(CoreMetric.SERVICE_ID)).contains("S3");
+                assertThat(capturedMetrics.metricValues(CoreMetric.OPERATION_NAME)).contains("GetObject");
+                break;
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidUrlTestCases")
+    void given_AsyncPresignedUrlManager_when_GetObjectWithInvalidUrl_then_ShouldThrowException(
+            String testName, String invalidUrlString) {
+        assertThatThrownBy(() -> {
+            URL invalidUrl = new URL(invalidUrlString);
+            PresignedUrlGetObjectRequest invalidRequest = PresignedUrlGetObjectRequest.builder()
+                                                                                     .presignedUrl(invalidUrl)
+                                                                                     .build();
+            presignedUrlManager.getObject(invalidRequest, AsyncResponseTransformer.toBytes()).join();
+        }).satisfiesAnyOf(
+            ex -> assertThat(ex).isInstanceOf(java.net.MalformedURLException.class),
+            ex -> assertThat(ex).isInstanceOf(SdkClientException.class),
+            ex -> assertThat(ex).isInstanceOf(java.util.concurrent.CompletionException.class)
+                    .extracting(Throwable::getCause)
+                    .isInstanceOf(SdkClientException.class)
+        );
+    }
+
+    private SdkClientConfiguration getDefaultSdkConfigs() {
+        return SdkClientConfiguration.builder()
+                                     .option(SdkClientOption.ASYNC_HTTP_CLIENT, mockHttpClient)
+                                     .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, Collections.emptyMap())
+                                     .option(SdkClientOption.EXECUTION_INTERCEPTORS, Collections.emptyList())
+                                     .option(SdkClientOption.RETRY_STRATEGY, AwsRetryStrategy.doNotRetry())
+                                     .option(SdkAdvancedClientOption.USER_AGENT_PREFIX, "")
+                                     .option(SdkAdvancedClientOption.USER_AGENT_SUFFIX, "")
+                                     .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
+                                     .option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER, AnonymousCredentialsProvider.create())
+                                     .option(AwsClientOption.AWS_REGION, Region.US_EAST_2)
+                                     .option(AwsClientOption.SIGNING_REGION, Region.US_EAST_2)
+                                     .option(AwsClientOption.SERVICE_SIGNING_NAME, Region.AP_EAST_2.toString())
+                                     .option(AwsAdvancedClientOption.ENABLE_DEFAULT_REGION_DETECTION, false)
+                                     .option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE, Executors.newScheduledThreadPool(1))
+                                     .option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run)
+                                     .option(SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
+                                             software.amazon.awssdk.core.ClientEndpointProvider.forEndpointOverride(DEFAULT_ENDPOINT))
+                                     .build();
+    }
+
+    private AwsS3ProtocolFactory initProtocolFactory(SdkClientConfiguration configuration) {
+        return AwsS3ProtocolFactory.builder()
+                                   .registerModeledException(
+                                       ExceptionMetadata.builder().errorCode("NoSuchKey")
+                                                        .exceptionBuilderSupplier(NoSuchKeyException::builder)
+                                                        .httpStatusCode(404).build())
+                                   .registerModeledException(
+                                       ExceptionMetadata.builder().errorCode("InvalidObjectState")
+                                                        .exceptionBuilderSupplier(InvalidObjectStateException::builder)
+                                                        .httpStatusCode(403).build())
+                                   .clientConfiguration(configuration)
+                                   .defaultServiceExceptionSupplier(S3Exception::builder)
+                                   .build();
+    }
+
+    private static URL createTestUrl() {
+        try {
+            return new URL(TEST_URL);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertSuccessfulGetObject(PresignedUrlGetObjectRequest request) {
+        try {
+            CompletableFuture<ResponseBytes<GetObjectResponse>> future = 
+                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+            ResponseBytes<GetObjectResponse> result = future.get();
+            
+            assertThat(result).isNotNull();
+            assertThat(result.asUtf8String()).isEqualTo(TEST_CONTENT);
+
+            SdkHttpRequest lastRequest = mockHttpClient.getLastRequest();
+            assertThat(lastRequest.method()).isEqualTo(SdkHttpMethod.GET);
+            assertThat(lastRequest.getUri().toString()).contains("test-bucket.s3.us-east-1.amazonaws.com/test-key");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static HttpExecuteResponse createSuccessResponse() {
+        SdkHttpFullResponse httpResponse = SdkHttpFullResponse.builder()
+                                                              .statusCode(200)
+                                                              .putHeader("Content-Length", "12")
+                                                              .putHeader("ETag", "\"test-etag\"")
+                                                              .putHeader("Content-Type", "text/plain")
+                                                              .build();
+        return HttpExecuteResponse.builder()
+                                  .response(httpResponse)
+                                  .responseBody(AbortableInputStream.create(
+                                      new ByteArrayInputStream(TEST_CONTENT.getBytes(StandardCharsets.UTF_8))))
+                                  .build();
+    }
+
+    private static HttpExecuteResponse createErrorResponse(int statusCode, String errorCode, String errorMessage) {
+        String errorContent = String.format(
+            "<e><Code>%s</Code><Message>%s</Message></e>",
+            errorCode, errorMessage);
+        SdkHttpFullResponse httpResponse = SdkHttpFullResponse.builder()
+                                                              .statusCode(statusCode)
+                                                              .putHeader("x-amz-request-id", "test-request-id")
+                                                              .putHeader("x-amz-id-2", "test-extended-request-id")
+                                                              .build();
+        return HttpExecuteResponse.builder()
+                                  .response(httpResponse)
+                                  .responseBody(AbortableInputStream.create(
+                                      new ByteArrayInputStream(errorContent.getBytes(StandardCharsets.UTF_8))))
+                                  .build();
+    }
+}


### PR DESCRIPTION
Implements `DefaultAsyncPresignedUrlManager` to support asynchronous GetObject operations using presigned URLs.

## Motivation and Context
Enables async S3 GetObject operations via presigned URLs, addressing the need for non-blocking presigned URL operations.

## Modifications
Added  async API `AsyncPresignedUrlManager` and its implementation `DefaultAsyncPresignedUrlManager` 

## Testing
Added comprehensive unit tests covering success responses, error handling, request configuration with range headers, and invalid URL scenarios using MockAsyncHttpClient.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
