### PR TITLE
Fix service version info to only register major and minor versions

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ServiceVersionInfoSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ServiceVersionInfoSpec.java
@@ -22,11 +22,14 @@ import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 import javax.lang.model.element.Modifier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.codegen.utils.VersionUtils;
 
 public class ServiceVersionInfoSpec implements ClassSpec {
     private final PoetExtension poetExtension;
@@ -37,14 +40,16 @@ public class ServiceVersionInfoSpec implements ClassSpec {
 
     @Override
     public TypeSpec poetSpec() {
+        String majorMinorVersion = VersionUtils.convertToMajorMinorX(SDK_VERSION);
+
         TypeSpec.Builder builder = TypeSpec.classBuilder("ServiceVersionInfo")
                                            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                                            .addAnnotation(PoetUtils.generatedAnnotation())
                                            .addAnnotation(SdkInternalApi.class)
                                            .addField(FieldSpec.builder(
                                                String.class, "VERSION", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                                                              .initializer("$S", SDK_VERSION)
-                                                              .addJavadoc("Returns the current version for the AWS SDK in which"
+                                                              .initializer("$S", majorMinorVersion)
+                                                              .addJavadoc("Returns the current major.minor.x version for the AWS SDK in which"
                                                                           + " this class is running.")
                                                               .build())
                                            .addMethod(privateConstructor());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ServiceVersionInfoSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ServiceVersionInfoSpec.java
@@ -22,8 +22,6 @@ import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 import javax.lang.model.element.Modifier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
@@ -49,8 +47,8 @@ public class ServiceVersionInfoSpec implements ClassSpec {
                                            .addField(FieldSpec.builder(
                                                String.class, "VERSION", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
                                                               .initializer("$S", majorMinorVersion)
-                                                              .addJavadoc("Returns the current major.minor.x version for the AWS SDK in which"
-                                                                          + " this class is running.")
+                                                              .addJavadoc("Returns the current major.minor.x version for the"
+                                                                          + " AWS SDK in which this class is running.")
                                                               .build())
                                            .addMethod(privateConstructor());
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public class VersionUtils {
+
+    private VersionUtils() {}
+
+    /**
+    * Converts a full version string to a major.minor.x format.
+    *
+    * @param version The full version string to convert (e.g., "2.32.1")
+    * @return The version string in major.minor.x format (e.g., "2.32.x"),
+    * or the original string if it doesn't match the expected version pattern
+    */
+    public static String convertToMajorMinorX(String version) {
+        Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(.*)");
+        Matcher matcher = pattern.matcher(version);
+
+        if (matcher.matches()) {
+            String major = matcher.group(1);
+            String minor = matcher.group(2);
+            String suffix = matcher.group(4);
+
+            return major + "." + minor + ".x" + suffix;
+        }
+
+        return version;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
@@ -22,7 +22,9 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 public class VersionUtils {
 
-    private VersionUtils() {}
+    private VersionUtils() {
+
+    }
 
     /**
     * Converts a full version string to a major.minor.x format.

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
@@ -28,11 +28,11 @@ public class VersionUtils {
 
     /**
     * Converts a full version string to a major.minor.x format.
-    *
-    * @param version The full version string to convert (e.g., "2.32.1")
-    * @return The version string in major.minor.x format (e.g., "2.32.x"),
-    * or the original string if it doesn't match the expected version pattern
-    */
+     *
+     * @param version The full version string to convert (e.g., "2.32.1")
+     * @return The version string in major.minor.x format (e.g., "2.32.x"),
+     * or the original string if it doesn't match the expected version pattern
+     */
     public static String convertToMajorMinorX(String version) {
         Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(.*)");
         Matcher matcher = pattern.matcher(version);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/utils/VersionUtils.java
@@ -22,20 +22,20 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 public class VersionUtils {
 
-    private VersionUtils() {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(.*)");
 
+    private VersionUtils() {
     }
 
     /**
-    * Converts a full version string to a major.minor.x format.
+     * Converts a full version string to a major.minor.x format.
      *
      * @param version The full version string to convert (e.g., "2.32.1")
      * @return The version string in major.minor.x format (e.g., "2.32.x"),
      * or the original string if it doesn't match the expected version pattern
      */
     public static String convertToMajorMinorX(String version) {
-        Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(.*)");
-        Matcher matcher = pattern.matcher(version);
+        Matcher matcher = VERSION_PATTERN.matcher(version);
 
         if (matcher.matches()) {
             String major = matcher.group(1);
@@ -47,4 +47,5 @@ public class VersionUtils {
 
         return version;
     }
+
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/ServiceVersionInfoSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/ServiceVersionInfoSpecTest.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.codegen.poet.client;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static software.amazon.awssdk.core.util.VersionInfo.SDK_VERSION;
 
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.ClientTestModels;
 import software.amazon.awssdk.codegen.poet.client.specs.ServiceVersionInfoSpec;
-import software.amazon.awssdk.core.util.VersionInfo;
+import software.amazon.awssdk.codegen.utils.VersionUtils;
 
 public class ServiceVersionInfoSpecTest {
 
@@ -36,7 +36,7 @@ public class ServiceVersionInfoSpecTest {
     // version at build time.
     @Test
     void testServiceVersionInfoClass() {
-        String currVersion = VersionInfo.SDK_VERSION;
+        String currVersion = VersionUtils.convertToMajorMinorX(SDK_VERSION);
         ClassSpec serviceVersionInfoSpec = new ServiceVersionInfoSpec(ClientTestModels.restJsonServiceModels());
 
         String expectedContent = loadFixtureFile("test-service-version-info-class.java");

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/utils/VersionUtilsTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/utils/VersionUtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class VersionUtilsTest {
+
+    @Test
+    public void serviceVersionInfo_redactPatchVersion() {
+        String currentVersion = "2.35.13";
+        String currentSnapshotVersion = "2.35.13-SNAPSHOT";
+
+        String actualVersion = VersionUtils.convertToMajorMinorX(currentVersion);
+        String actualSnapshotVersion = VersionUtils.convertToMajorMinorX(currentSnapshotVersion);
+        assertThat(actualVersion).isEqualTo("2.35.x");
+        assertThat(actualSnapshotVersion).isEqualTo("2.35.x-SNAPSHOT");
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/utils/VersionUtilsTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/utils/VersionUtilsTest.java
@@ -17,18 +17,26 @@ package software.amazon.awssdk.codegen.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class VersionUtilsTest {
 
-    @Test
-    public void serviceVersionInfo_redactPatchVersion() {
-        String currentVersion = "2.35.13";
-        String currentSnapshotVersion = "2.35.13-SNAPSHOT";
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("versionsTestCases")
+    public void serviceVersionInfo_redactPatchVersion(String testName, String versionToTruncate, String expectedVersion) {
+        String actualVersion = VersionUtils.convertToMajorMinorX(versionToTruncate);
+        assertThat(actualVersion).isEqualTo(expectedVersion);
+    }
 
-        String actualVersion = VersionUtils.convertToMajorMinorX(currentVersion);
-        String actualSnapshotVersion = VersionUtils.convertToMajorMinorX(currentSnapshotVersion);
-        assertThat(actualVersion).isEqualTo("2.35.x");
-        assertThat(actualSnapshotVersion).isEqualTo("2.35.x-SNAPSHOT");
+    private static Stream<Arguments> versionsTestCases() {
+        return Stream.of(
+            Arguments.of("valid version", "2.35.13", "2.35.x"),
+            Arguments.of("valid snapshot version", "2.35.13-SNAPSHOT", "2.35.x-SNAPSHOT"),
+            Arguments.of("different major version", "3.5.5", "3.5.x"),
+            Arguments.of("invalid version, uses version as-is", "23513", "23513")
+        );
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/specs/test-service-version-info-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/specs/test-service-version-info-class.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 public final class ServiceVersionInfo {
   /**
-   * Returns the current version for the AWS SDK in which this class is running.
+   * Returns the current major.minor.x version for the AWS SDK in which this class is running.
    */
   public static final String VERSION = "{{VERSION}}";
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/useragent/SdkUserAgentBuilderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/useragent/SdkUserAgentBuilderTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/useragent/SdkUserAgentBuilderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/useragent/SdkUserAgentBuilderTest.java
@@ -52,7 +52,7 @@ class SdkUserAgentBuilderTest {
                            Arrays.asList("Kotlin", "Scala"));
 
         SdkClientUserAgentProperties minimalProperties = sdkProperties(null, null, null, null, null);
-        SdkClientUserAgentProperties maximalProperties = sdkProperties("arbitrary", "async", "Netty", "someAppId", "DynamoDB#2.26.22-SNAPSHOT");
+        SdkClientUserAgentProperties maximalProperties = sdkProperties("arbitrary", "async", "Netty", "someAppId", "DynamoDB#2.26.x-SNAPSHOT");
 
 
         return Stream.of(
@@ -88,11 +88,11 @@ class SdkUserAgentBuilderTest {
                          sdkProperties( null, null, null, "someAppId", null),
                          maximalSysAgent),
             Arguments.of("standard sysagent, request values - apiMetadata",
-                         "aws-sdk-java/2.26.22-SNAPSHOT ua/2.1 api/DynamoDB#2.26.22-SNAPSHOT os/Mac_OS_X#14.6.1 lang/java#21.0.2 md/OpenJDK_64-Bit_Server_VM#21.0.2+13-LTS md/en_US",
-                         sdkProperties(null, null, null, null, "DynamoDB#2.26.22-SNAPSHOT"),
+                         "aws-sdk-java/2.26.22-SNAPSHOT ua/2.1 api/DynamoDB#2.26.x-SNAPSHOT os/Mac_OS_X#14.6.1 lang/java#21.0.2 md/OpenJDK_64-Bit_Server_VM#21.0.2+13-LTS md/en_US",
+                         sdkProperties(null, null, null, null, "DynamoDB#2.26.x-SNAPSHOT"),
                          standardValuesSysAgent),
             Arguments.of("standard sysagent, request values - maximal",
-                         "aws-sdk-java/2.26.22-SNAPSHOT md/io#async md/http#Netty md/internal ua/2.1 api/DynamoDB#2.26.22-SNAPSHOT"
+                         "aws-sdk-java/2.26.22-SNAPSHOT md/io#async md/http#Netty md/internal ua/2.1 api/DynamoDB#2.26.x-SNAPSHOT"
                          + " os/Mac_OS_X#14.6.1 lang/java#21.0.2 "
                          + "md/OpenJDK_64-Bit_Server_VM#21.0.2+13-LTS md/vendor#Amazon.com_Inc. md/en_US md/Kotlin md/Scala "
                          + "exec-env/lambda app/someAppId",

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BusinessMetricsUserAgentTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BusinessMetricsUserAgentTest.java
@@ -197,5 +197,9 @@ class BusinessMetricsUserAgentTest {
 
         String userAgent = assertAndGetUserAgentString();
         assertThat(userAgent).contains("AmazonProtocolRestJson#" + ServiceVersionInfo.VERSION);
+        String version = ServiceVersionInfo.VERSION;
+        assertThat(ServiceVersionInfo.VERSION.endsWith(".x") ||
+                   ServiceVersionInfo.VERSION.endsWith(".x-SNAPSHOT")).isTrue();
     }
+
 }


### PR DESCRIPTION
Follow up to #6212 
Changes `ServiceVersionInfo` to be generated with a `major.minor.x` format instead of `major.minor.patch` this is to avoid updating this file for every service for every release. 

Lowering the update cadence is done to avoid rate limiting in our release infrastructure. This comes at the cost of having less fine-grained useragent info.