### PR TITLE
Add ChunkedEncodedPublisher

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisher.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisher.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Pair;
+import software.amazon.awssdk.utils.async.AddingTrailingDataSubscriber;
+import software.amazon.awssdk.utils.async.DelegatingSubscriber;
+import software.amazon.awssdk.utils.async.FlatteningSubscriber;
+import software.amazon.awssdk.utils.internal.MappingSubscriber;
+
+/**
+ * An implementation of chunk-transfer encoding, but by wrapping a {@link Publisher} of {@link ByteBuffer}. This implementation
+ * supports chunk-headers, chunk-extensions.
+ * <p>
+ * Per <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-4.1">RFC-7230</a>, a chunk-transfer encoded message is
+ * defined as:
+ * <pre>
+ *     chunked-body   = *chunk
+ *                      last-chunk
+ *                      trailer-part
+ *                      CRLF
+ *     chunk          = chunk-size [ chunk-ext ] CRLF
+ *                      chunk-data CRLF
+ *     chunk-size     = 1*HEXDIG
+ *     last-chunk     = 1*("0") [ chunk-ext ] CRLF
+ *     chunk-data     = 1*OCTET ; a sequence of chunk-size octets
+ *
+ *     chunk-ext      = *( ";" chunk-ext-name [ "=" chunk-ext-val ] )
+ *     chunk-ext-name = token
+ *     chunk-ext-val  = token / quoted-string
+ * </pre>
+ *
+ * @see ChunkedEncodedInputStream
+ */
+@SdkInternalApi
+public class ChunkedEncodedPublisher implements Publisher<ByteBuffer> {
+    private static final byte[] CRLF = {'\r', '\n'};
+    private static final byte SEMICOLON = ';';
+    private static final byte EQUALS = '=';
+
+    private final Publisher<ByteBuffer> wrapped;
+    private final List<ChunkExtensionProvider> extensions = new ArrayList<>();
+    private final int chunkSize;
+    private ByteBuffer chunkBuffer;
+    private final boolean addEmptyTrailingChunk;
+
+    public ChunkedEncodedPublisher(Builder b) {
+        this.wrapped = b.publisher;
+        this.chunkSize = b.chunkSize;
+        this.extensions.addAll(b.extensions);
+        this.addEmptyTrailingChunk = b.addEmptyTrailingChunk;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        Publisher<Iterable<ByteBuffer>> chunked = chunk(wrapped);
+        Publisher<Iterable<ByteBuffer>> trailingAdded = addTrailingChunks(chunked);
+        Publisher<ByteBuffer> flattened = flatten(trailingAdded);
+        Publisher<ByteBuffer> encoded = map(flattened, this::encodeChunk);
+
+        encoded.subscribe(subscriber);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private Iterable<Iterable<ByteBuffer>> getTrailingChunks() {
+        List<ByteBuffer> trailing = new ArrayList<>();
+
+        if (chunkBuffer != null) {
+            chunkBuffer.flip();
+            if (chunkBuffer.hasRemaining()) {
+                trailing.add(chunkBuffer);
+            }
+        }
+
+        if (addEmptyTrailingChunk) {
+            trailing.add(ByteBuffer.allocate(0));
+        }
+
+        return Collections.singletonList(trailing);
+    }
+
+    private Publisher<Iterable<ByteBuffer>> chunk(Publisher<ByteBuffer> upstream) {
+        return subscriber -> {
+            upstream.subscribe(new ChunkingSubscriber(subscriber));
+        };
+    }
+
+    private Publisher<ByteBuffer> flatten(Publisher<Iterable<ByteBuffer>> upstream) {
+        return subscriber -> upstream.subscribe(new FlatteningSubscriber<>(subscriber));
+    }
+
+    public Publisher<Iterable<ByteBuffer>> addTrailingChunks(Publisher<Iterable<ByteBuffer>> upstream) {
+        return subscriber -> {
+            upstream.subscribe(new AddingTrailingDataSubscriber<>(subscriber, this::getTrailingChunks));
+        };
+    }
+
+    public Publisher<ByteBuffer> map(Publisher<ByteBuffer> upstream, Function<? super ByteBuffer, ? extends ByteBuffer> mapper) {
+        return subscriber -> upstream.subscribe(MappingSubscriber.create(subscriber, mapper));
+    }
+
+    // TODO: Trailing checksum
+    private ByteBuffer encodeChunk(ByteBuffer byteBuffer) {
+        int contentLen = byteBuffer.remaining();
+        byte[] chunkSizeHex = Integer.toHexString(contentLen).getBytes(StandardCharsets.UTF_8);
+
+        List<Pair<byte[], byte[]>> chunkExtensions = this.extensions.stream()
+                                                                    .map(e -> {
+                                                                        ByteBuffer duplicate = byteBuffer.duplicate();
+                                                                        return e.get(duplicate);
+                                                                    }).collect(Collectors.toList());
+
+        int extensionsLength = calculateExtensionsLength(chunkExtensions);
+
+        int encodedLen = chunkSizeHex.length + extensionsLength + CRLF.length + contentLen + CRLF.length;
+
+        ByteBuffer encoded = ByteBuffer.allocate(encodedLen);
+        encoded.put(chunkSizeHex);
+
+        chunkExtensions.forEach(p -> {
+            encoded.put(SEMICOLON);
+            encoded.put(p.left());
+            if (p.right() != null && p.right().length > 0) {
+                encoded.put(EQUALS);
+                encoded.put(p.right());
+            }
+        });
+
+        encoded.put(CRLF);
+        encoded.put(byteBuffer);
+        encoded.put(CRLF);
+
+        encoded.flip();
+
+        return encoded;
+    }
+
+    private int calculateExtensionsLength(List<Pair<byte[], byte[]>> chunkExtensions) {
+        return chunkExtensions.stream()
+                       .mapToInt(p -> {
+                           int keyLen = p.left().length;
+                           byte[] value = p.right();
+                           if (value.length > 0) {
+                               return 1 + keyLen + 1 + value.length; // ';ext-key=ext-value'
+                           }
+                           // ';ext-key
+                           return 1 + keyLen;
+                       }).sum();
+    }
+
+    private class ChunkingSubscriber extends DelegatingSubscriber<ByteBuffer, Iterable<ByteBuffer>> {
+        protected ChunkingSubscriber(Subscriber<? super Iterable<ByteBuffer>> subscriber) {
+            super(subscriber);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            if (chunkBuffer == null) {
+                chunkBuffer = ByteBuffer.allocate(chunkSize);
+            }
+
+            long totalBufferedBytes = (long) chunkBuffer.position() + byteBuffer.remaining();
+            int nBufferedChunks = (int) (totalBufferedBytes / chunkSize);
+
+            List<ByteBuffer> chunks = new ArrayList<>(nBufferedChunks);
+
+            if (nBufferedChunks > 0) {
+                for (int i = 0; i < nBufferedChunks; i++) {
+                    ByteBuffer slice = byteBuffer.slice();
+                    int maxBytesToCopy = Math.min(chunkBuffer.remaining(), slice.remaining());
+                    slice.limit(maxBytesToCopy);
+
+                    chunkBuffer.put(slice);
+                    if (!chunkBuffer.hasRemaining()) {
+                        chunkBuffer.flip();
+                        chunks.add(chunkBuffer);
+                        chunkBuffer = ByteBuffer.allocate(chunkSize);
+                    }
+
+                    byteBuffer.position(byteBuffer.position() + maxBytesToCopy);
+                }
+
+                if (byteBuffer.hasRemaining()) {
+                    chunkBuffer.put(byteBuffer);
+                }
+            } else {
+                chunkBuffer.put(byteBuffer);
+            }
+
+            subscriber.onNext(chunks);
+        }
+    }
+
+    public static class Builder {
+        private Publisher<ByteBuffer> publisher;
+        private int chunkSize;
+        private boolean addEmptyTrailingChunk;
+        private final List<ChunkExtensionProvider> extensions = new ArrayList<>();
+
+        public Builder publisher(Publisher<ByteBuffer> publisher) {
+            this.publisher = publisher;
+            return this;
+        }
+
+        public Builder chunkSize(int chunkSize) {
+            this.chunkSize = chunkSize;
+            return this;
+        }
+
+        public Builder addEmptyTrailingChunk(boolean addEmptyTrailingChunk) {
+            this.addEmptyTrailingChunk = addEmptyTrailingChunk;
+            return this;
+        }
+
+        public Builder addExtension(ChunkExtensionProvider extension) {
+            this.extensions.add(extension);
+            return this;
+        }
+
+        public ChunkedEncodedPublisher build() {
+            return new ChunkedEncodedPublisher(this);
+        }
+    }
+}

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisherTckTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisherTckTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+public class ChunkedEncodedPublisherTckTest extends PublisherVerification<ByteBuffer> {
+    private static final int INPUT_STREAM_ELEMENT_SIZE = 64;
+    private static final int CHUNK_SIZE = 16 * 1024;
+
+    public ChunkedEncodedPublisherTckTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long l) {
+        return createChunkedPublisher(l);
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 512;
+    }
+
+    private Publisher<ByteBuffer> createChunkedPublisher(long chunksToProduce) {
+        // max of 8 MiB
+        long totalSize = chunksToProduce * CHUNK_SIZE;
+
+        int totalElements = (int) (totalSize / INPUT_STREAM_ELEMENT_SIZE);
+
+        byte[] content = new byte[INPUT_STREAM_ELEMENT_SIZE];
+
+        List<ByteBuffer> elements = new ArrayList<>();
+        for (int i = 0; i < totalElements; i++) {
+            elements.add(ByteBuffer.wrap(content));
+        }
+
+        Publisher<ByteBuffer> inputPublisher = Flowable.fromIterable(elements);
+
+        return ChunkedEncodedPublisher.builder()
+                                      .chunkSize(CHUNK_SIZE)
+                                      .publisher(inputPublisher)
+                                      .addEmptyTrailingChunk(false)
+                                      .build();
+    }
+}

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisherTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisherTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PrimitiveIterator;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
+import software.amazon.awssdk.checksums.SdkChecksum;
+import software.amazon.awssdk.utils.Pair;
+
+public class ChunkedEncodedPublisherTest {
+    private static final int CHUNK_SIZE = 16 * 1024;
+    private final Random RNG = new Random();
+    private final SdkChecksum CRC32 = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC32);
+
+    @BeforeEach
+    public void setup() {
+        CRC32.reset();
+    }
+
+    @Test
+    void subscribe_wrappedDoesNotFillBuffer_allDataInSingleChunk() {
+        ByteBuffer element = ByteBuffer.wrap("hello world".getBytes(StandardCharsets.UTF_8));
+        Flowable<ByteBuffer> upstream = Flowable.just(element.duplicate());
+
+        ChunkedEncodedPublisher publisher = ChunkedEncodedPublisher.builder()
+                                                                   .chunkSize(CHUNK_SIZE)
+                                                                   .publisher(upstream)
+                                                                   .build();
+
+        List<ByteBuffer> chunks = getAllElements(publisher);
+
+        assertThat(chunks.size()).isEqualTo(1);
+        assertThat(stripEncoding(chunks.get(0)))
+            .isEqualTo(element);
+    }
+
+    @Test
+    void subscribe_extensionHasNoValue_formattedCorrectly() {
+        TestPublisher testPublisher = randomPublisherOfLength(8);
+
+        ChunkExtensionProvider extensionProvider = new StaticExtensionProvider("foo", "");
+
+        ChunkedEncodedPublisher chunkPublisher =
+            ChunkedEncodedPublisher.builder()
+                                   .publisher(testPublisher)
+                                   .addExtension(extensionProvider)
+                                   .chunkSize(CHUNK_SIZE)
+                                   .build();
+
+        List<ByteBuffer> chunks = getAllElements(chunkPublisher);
+
+        assertThat(getHeaderAsString(chunks.get(0))).endsWith(";foo");
+    }
+
+    @Test
+    void subscribe_multipleExtensions_formattedCorrectly() {
+        TestPublisher testPublisher = randomPublisherOfLength(8);
+
+        ChunkedEncodedPublisher.Builder chunkPublisher =
+            ChunkedEncodedPublisher.builder()
+                                   .publisher(testPublisher)
+                                   .chunkSize(CHUNK_SIZE);
+
+        Stream.of("1", "2", "3")
+              .map(v -> new StaticExtensionProvider("key" + v, "value" + v))
+              .forEach(chunkPublisher::addExtension);
+
+        List<ByteBuffer> chunks = getAllElements(chunkPublisher.build());
+
+        chunks.forEach(chunk -> assertThat(getHeaderAsString(chunk)).endsWith(";key1=value1;key2=value2;key3=value3"));
+    }
+
+    @Test
+    void subscribe_randomElementSizes_dataChunkedCorrectly() {
+        for (int i = 0; i < 512; ++i) {
+            int nChunks = 24;
+            TestPublisher byteBufferPublisher = randomPublisherOfLength(CHUNK_SIZE * 24);
+
+            ChunkedEncodedPublisher chunkedPublisher = ChunkedEncodedPublisher.builder()
+                                                                              .publisher(byteBufferPublisher)
+                                                                              .chunkSize(CHUNK_SIZE)
+                                                                              .build();
+
+            List<ByteBuffer> chunks = getAllElements(chunkedPublisher);
+
+            List<ByteBuffer> stripped = chunks.stream().map(this::stripEncoding).collect(Collectors.toList());
+            assertThat(stripped.size()).isEqualTo(nChunks);
+
+            stripped.forEach(chunk -> assertThat(chunk.remaining()).isEqualTo(CHUNK_SIZE));
+
+            CRC32.reset();
+            stripped.forEach(CRC32::update);
+
+            assertThat(CRC32.getChecksumBytes()).isEqualTo(byteBufferPublisher.wrappedChecksum);
+        }
+    }
+
+    @Test
+    void subscribe_randomElementSizes_chunksHaveExtensions_dataChunkedCorrectly() {
+        for (int i = 0; i < 512; ++i) {
+            int nChunks = 24;
+            TestPublisher byteBufferPublisher = randomPublisherOfLength(CHUNK_SIZE * 24);
+
+            StaticExtensionProvider extensionProvider = Mockito.spy(new StaticExtensionProvider("foo", "bar"));
+
+            ChunkedEncodedPublisher chunkedPublisher = ChunkedEncodedPublisher.builder()
+                                                                              .publisher(byteBufferPublisher)
+                                                                              .addExtension(extensionProvider)
+                                                                              .chunkSize(CHUNK_SIZE)
+                                                                              .build();
+
+            List<ByteBuffer> chunks = getAllElements(chunkedPublisher);
+
+            chunks.forEach(c -> {
+                String header = StandardCharsets.UTF_8.decode(getHeader(c)).toString();
+                assertThat(header).isEqualTo("4000;foo=bar");
+            });
+
+            List<ByteBuffer> stripped = chunks.stream().map(this::stripEncoding).collect(Collectors.toList());
+
+            assertThat(stripped.size()).isEqualTo(nChunks);
+
+            stripped.forEach(chunk -> assertThat(chunk.remaining()).isEqualTo(CHUNK_SIZE));
+
+            CRC32.reset();
+            stripped.forEach(CRC32::update);
+
+            assertThat(CRC32.getChecksumBytes()).isEqualTo(byteBufferPublisher.wrappedChecksum);
+        }
+    }
+
+    @Test
+    void subscribe_addTrailingChunkTrue_trailingChunkAdded() {
+        TestPublisher testPublisher = randomPublisherOfLength(CHUNK_SIZE * 2);
+
+        ChunkedEncodedPublisher chunkedPublisher = ChunkedEncodedPublisher.builder()
+                                                                          .publisher(testPublisher)
+                                                                          .chunkSize(CHUNK_SIZE)
+                                                                          .addEmptyTrailingChunk(true)
+                                                                          .build();
+
+        List<ByteBuffer> chunks = getAllElements(chunkedPublisher);
+
+        assertThat(chunks.size()).isEqualTo(3);
+
+        ByteBuffer trailing = chunks.get(chunks.size() - 1);
+        assertThat(stripEncoding(trailing).remaining()).isEqualTo(0);
+    }
+
+    @Test
+    void subscribe_addTrailingChunkTrue_upstreamEmpty_trailingChunkAdded() {
+        Publisher<ByteBuffer> empty = Flowable.empty();
+
+        ChunkedEncodedPublisher chunkedPublisher =
+            ChunkedEncodedPublisher.builder().publisher(empty).chunkSize(CHUNK_SIZE).addEmptyTrailingChunk(true).build();
+
+        List<ByteBuffer> chunks = getAllElements(chunkedPublisher);
+
+        assertThat(chunks.size()).isEqualTo(1);
+    }
+
+    @Test
+    void subscribe_extensionsPresent_extensionsInvokedForEachChunk() {
+        ChunkExtensionProvider mockProvider = Mockito.spy(new StaticExtensionProvider("foo", "bar"));
+
+        int nChunks = 16;
+        TestPublisher elements = randomPublisherOfLength(nChunks * CHUNK_SIZE);
+
+        ChunkedEncodedPublisher chunkPublisher =
+            ChunkedEncodedPublisher.builder().publisher(elements).chunkSize(CHUNK_SIZE).addExtension(mockProvider).build();
+
+        List<ByteBuffer> chunks = getAllElements(chunkPublisher);
+
+        ArgumentCaptor<ByteBuffer> chunkCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+
+        Mockito.verify(mockProvider, Mockito.times(nChunks)).get(chunkCaptor.capture());
+        List<ByteBuffer> extensionChunks = chunkCaptor.getAllValues();
+
+        for (int i = 0; i < chunks.size(); ++i) {
+            ByteBuffer chunk = chunks.get(i);
+            ByteBuffer extensionChunk = extensionChunks.get(i);
+            assertThat(stripEncoding(chunk)).isEqualTo(extensionChunk);
+        }
+    }
+
+    private TestPublisher randomPublisherOfLength(int bytes) {
+        List<ByteBuffer> elements = new ArrayList<>();
+
+        PrimitiveIterator.OfInt sizeIter = RNG.ints(16, 8192).iterator();
+
+        CRC32.reset();
+        while (bytes > 0) {
+            int elementSize = sizeIter.next();
+            elementSize = Math.min(elementSize, bytes);
+
+            bytes -= elementSize;
+
+            byte[] elementContent = new byte[elementSize];
+            RNG.nextBytes(elementContent);
+            CRC32.update(elementContent);
+            elements.add(ByteBuffer.wrap(elementContent));
+        }
+
+        Flowable<ByteBuffer> publisher = Flowable.fromIterable(elements);
+
+        return new TestPublisher(publisher, CRC32.getChecksumBytes());
+    }
+
+    private List<ByteBuffer> getAllElements(Publisher<ByteBuffer> publisher) {
+        return Flowable.fromPublisher(publisher).toList().blockingGet();
+    }
+
+    private String getHeaderAsString(ByteBuffer chunk) {
+        return StandardCharsets.UTF_8.decode(getHeader(chunk)).toString();
+    }
+
+    private ByteBuffer getHeader(ByteBuffer chunk) {
+        ByteBuffer header = chunk.duplicate();
+        byte a = header.get(0);
+        byte b = header.get(1);
+
+        int i = 2;
+        for (; i < header.limit() && a != '\r' && b != '\n'; ++i) {
+            a = b;
+            b = header.get(i);
+        }
+
+        header.limit(i - 2);
+        return header;
+    }
+
+    private ByteBuffer stripEncoding(ByteBuffer chunk) {
+        ByteBuffer header = getHeader(chunk);
+
+        ByteBuffer lengthHex = header.duplicate();
+
+        boolean semiFound = false;
+        while (lengthHex.hasRemaining()) {
+            byte b = lengthHex.get();
+            if (b == ';') {
+                semiFound = true;
+                break;
+            }
+        }
+
+        if (semiFound) {
+            lengthHex.position(lengthHex.position() - 1);
+        }
+        // assume the whole line is the length (no extensions)
+        lengthHex.flip();
+
+        int length = Integer.parseInt(StandardCharsets.UTF_8.decode(lengthHex).toString(), 16);
+
+        ByteBuffer stripped = chunk.duplicate();
+
+        int chunkStart = header.remaining() + 2;
+        stripped.position(chunkStart);
+        stripped.limit(chunkStart + length);
+
+        return stripped;
+    }
+
+    private static class TestPublisher implements Publisher<ByteBuffer> {
+        private final Publisher<ByteBuffer> wrapped;
+        private final byte[] wrappedChecksum;
+
+        public TestPublisher(Publisher<ByteBuffer> wrapped, byte[] wrappedChecksum) {
+            this.wrapped = wrapped;
+            this.wrappedChecksum = new byte[wrappedChecksum.length];
+            System.arraycopy(wrappedChecksum, 0, this.wrappedChecksum, 0, wrappedChecksum.length);
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+            wrapped.subscribe(subscriber);
+        }
+
+        public byte[] wrappedChecksum() {
+            return wrappedChecksum;
+        }
+    }
+
+    private static class StaticExtensionProvider implements ChunkExtensionProvider {
+        private final byte[] key;
+        private final byte[] value;
+
+        public StaticExtensionProvider(String key, String value) {
+            this.key = key.getBytes(StandardCharsets.UTF_8);
+            this.value = value == null ? null : value.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public Pair<byte[], byte[]> get(ByteBuffer chunk) {
+            return Pair.of(key, value);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
This publisher supports encoding binary streams using chunked encoding. This publisher fills the same purpose that ChunkedEncodedInputStream does, but for async bodies.

Note: currently unused anywhere. Will be part of supporting streaming signing.

## Modifications
<!--- Describe your changes in detail -->

## Testing
 - New unit tests
 - TCK test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
