### PR TITLE
Fix protocol dependencies for smithy-rpc-v2-cbor when creating new service module

### DIFF
--- a/release-scripts/src/main/java/software/amazon/awssdk/release/CreateNewServiceModuleMain.java
+++ b/release-scripts/src/main/java/software/amazon/awssdk/release/CreateNewServiceModuleMain.java
@@ -137,13 +137,13 @@ public class CreateNewServiceModuleMain extends Cli {
         }
 
         private String transformSpecialProtocols(String protocol) {
-            switch (protocol) {
-                case "ec2": return "aws-query";
-                case "rest-xml": return "aws-xml";
-                case "rest-json": return "aws-json";
-                case "rpc-v2-cbor": return "smithy-rpcv2";
-                default: return "aws-" + protocol;
-            }
+                switch (protocol) {
+                    case "ec2": return "aws-query";
+                    case "rest-xml": return "aws-xml";
+                    case "rest-json": return "aws-json";
+                    case "smithy-rpc-v2-cbor": return "smithy-rpcv2";
+                    default: return "aws-" + protocol;
+                }
         }
 
         public void run() throws Exception {


### PR DESCRIPTION
Fix protocol dependencies for smithy-rpc-v2-cbor when creating new service module

## Motivation and Context
When new modules are created for rpcv2 cbor services we are currently incorrectly specifing the protocol dependency in the pom.xml, example error:
```
 Could not resolve dependencies for project software.amazon.awssdk:XXXXXXX:jar:2.32.3-SNAPSHOT: Could not find artifact software.amazon.awssdk:aws-smithy-rpc-v2-cbor-protocol:jar:2.32.3-SNAPSHOT
```

This is because the protocol name used in `transformSpecialProtocols` for rpcv2 is incorrect.  The correct value for the protocol from c2j files is `smithy-rpc-v2-cbor`.

## Modifications
* Update the protocol name to match that value from the c2j model: smithy-rpc-v2-cbor.  This will now result in the correct protocol dependency: [software.amazon.awssdk:smithy-rpcv2-protocol](https://github.com/aws/aws-sdk-java-v2/blob/master/core/protocols/smithy-rpcv2-protocol/pom.xml#L27)

## Testing
Manual testing.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
