### PR TITLE
Convert some codegen exceptions to ModelInvalidException

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-838b5da.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-838b5da.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Convert codegen exceptions caused by bad customization config or invalid models to ModelInvalidException."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -507,9 +507,8 @@ public class DefaultNamingStrategy implements NamingStrategy {
                     ValidationErrorSeverity.DANGER,
                     String.format(
                         "Encountered a name or identifier that the customer will see (%s in the %s) with an underscore. "
-                        + "This isn't idiomatic in Java. Please either remove the underscores or apply the "
-                        + "'underscoresInNameBehavior' customization for this service (Supported "
-                        + "'underscoresInNameBehavior' values: %s).", name, location, supportedBehaviors)
+                        + "This isn't idiomatic in Java. Please either remove the underscores",
+                        name, location, supportedBehaviors)
                 ));
             }
             if (behavior != UnderscoresInNameBehavior.ALLOW) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -43,9 +43,12 @@ import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.Metadata;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Shape;
+import software.amazon.awssdk.codegen.validation.ModelInvalidException;
+import software.amazon.awssdk.codegen.validation.ValidationEntry;
+import software.amazon.awssdk.codegen.validation.ValidationErrorId;
+import software.amazon.awssdk.codegen.validation.ValidationErrorSeverity;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.StringUtils;
-import software.amazon.awssdk.utils.Validate;
 
 /**
  * Default implementation of naming strategy respecting.
@@ -498,17 +501,36 @@ public class DefaultNamingStrategy implements NamingStrategy {
             UnderscoresInNameBehavior behavior = customizationConfig.getUnderscoresInNameBehavior();
 
             String supportedBehaviors = Arrays.toString(UnderscoresInNameBehavior.values());
-            Validate.notNull(behavior,
-                             "Encountered a name or identifier that the customer will see (%s in the %s) with an underscore. "
-                             + "This isn't idiomatic in Java. Please either remove the underscores or apply the "
-                             + "'underscoresInNameBehavior' customization for this service (Supported "
-                             + "'underscoresInNameBehavior' values: %s).", name, location, supportedBehaviors);
-            Validate.isTrue(behavior == UnderscoresInNameBehavior.ALLOW,
-                            "Unsupported underscoresInShapeNameBehavior: %s. Supported values: %s", behavior, supportedBehaviors);
+            if (behavior == null) {
+                throw ModelInvalidException.fromEntry(ValidationEntry.create(
+                    ValidationErrorId.INVALID_IDENTIFIER_NAME,
+                    ValidationErrorSeverity.DANGER,
+                    String.format(
+                        "Encountered a name or identifier that the customer will see (%s in the %s) with an underscore. "
+                        + "This isn't idiomatic in Java. Please either remove the underscores or apply the "
+                        + "'underscoresInNameBehavior' customization for this service (Supported "
+                        + "'underscoresInNameBehavior' values: %s).", name, location, supportedBehaviors)
+                ));
+            }
+            if (behavior != UnderscoresInNameBehavior.ALLOW) {
+                throw ModelInvalidException.fromEntry(ValidationEntry.create(
+                    ValidationErrorId.INVALID_CODEGEN_CUSTOMIZATION,
+                    ValidationErrorSeverity.DANGER,
+                    String.format(
+                        "Unsupported underscoresInShapeNameBehavior: %s. Supported values: %s",
+                        behavior, supportedBehaviors)
+                ));
+            }
         }
 
-        Validate.isTrue(VALID_IDENTIFIER_NAME.matcher(name).matches(),
-                        "Encountered a name or identifier that is invalid within Java (%s in %s). Please remove invalid "
-                        + "characters.", name, location);
+        if (!VALID_IDENTIFIER_NAME.matcher(name).matches()) {
+            throw ModelInvalidException.fromEntry(ValidationEntry.create(
+                ValidationErrorId.INVALID_IDENTIFIER_NAME,
+                ValidationErrorSeverity.DANGER,
+                String.format(
+                    "Encountered a name or identifier that is invalid within Java (%s in %s). Please remove invalid "
+                    + "characters.", name, location)
+            ));
+        }
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpec.java
@@ -34,6 +34,10 @@ import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.model.TypeProvider;
+import software.amazon.awssdk.codegen.validation.ModelInvalidException;
+import software.amazon.awssdk.codegen.validation.ValidationEntry;
+import software.amazon.awssdk.codegen.validation.ValidationErrorId;
+import software.amazon.awssdk.codegen.validation.ValidationErrorSeverity;
 import software.amazon.awssdk.core.util.PaginatorUtils;
 
 public abstract class PaginatorsClassSpec implements ClassSpec {
@@ -64,7 +68,12 @@ public abstract class PaginatorsClassSpec implements ClassSpec {
         this.typeProvider = new TypeProvider(model);
         this.operationModel = model.getOperation(c2jOperationName);
         if (operationModel == null) {
-            throw new IllegalArgumentException("The service model does not model an operation '" + c2jOperationName + "'");
+            throw ModelInvalidException.fromEntry(ValidationEntry.create(
+                ValidationErrorId.UNKNOWN_OPERATION,
+                ValidationErrorSeverity.DANGER,
+                "Invalid paginator definition - The service model does not model the referenced operation '" +
+                c2jOperationName + "'"
+            ));
         }
         this.paginationDocs = new PaginationDocs(model, operationModel, paginatorDefinition);
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ValidationErrorId.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/validation/ValidationErrorId.java
@@ -24,8 +24,9 @@ public enum ValidationErrorId {
     REQUEST_URI_NOT_FOUND("The request URI does not exist."),
 
     INVALID_CODEGEN_CUSTOMIZATION("A customization is enabled for this service that cannot be applied for the given service "
-                                  + "model.")
-    ;
+                                  + "model."),
+    UNKNOWN_OPERATION("The model references an unknown operation."),
+    INVALID_IDENTIFIER_NAME("The model contains an invalid or non-idiomatic name or identifier.");
 
     private final String description;
 

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpecTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
 import software.amazon.awssdk.codegen.poet.ClientTestModels;
+import software.amazon.awssdk.codegen.validation.ModelInvalidException;
 
 public class PaginatorsClassSpecTest {
     @Test
@@ -30,8 +31,9 @@ public class PaginatorsClassSpecTest {
         assertThatThrownBy(() -> new TestPaginatorSpec(ClientTestModels.awsJsonServiceModels(),
                                                        "~~DoesNotExist",
                                                        new PaginatorDefinition()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("The service model does not model an operation '~~DoesNotExist'");
+            .isInstanceOf(ModelInvalidException.class)
+            .hasMessageContaining("Invalid paginator definition - "
+                                  + "The service model does not model the referenced operation '~~DoesNotExist'");
     }
 
     private static class TestPaginatorSpec extends PaginatorsClassSpec {


### PR DESCRIPTION
Converts some codegen exceptions to ModelInvalidException.

## Motivation and Context
Related previous change: https://github.com/aws/aws-sdk-java-v2/pull/new/alexwoo/model-validations

There are a number of places we raise NPE or IllegalArgumentException, ect when there are issues with customization config or the model - this PR converts those exceptions to the new ModelInvalidException.

## Modifications


## Testing
existing test cases

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
