### PR TITLE
 Modify Operation Name for Presigned URL, add  Null Check for ResolvedEndpoint, enhance AsyncPresignedUrlManager API

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -279,7 +279,7 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
 
         b.addStatement("$T resolvedEndpoint = executionAttributes.getAttribute($T.RESOLVED_ENDPOINT)",
                        Endpoint.class, SdkInternalExecutionAttribute.class);
-        b.beginControlFlow("if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty())");
+        b.beginControlFlow("if (resolvedEndpoint == null || $T.isNullOrEmpty(resolvedEndpoint.headers()))", CollectionUtils.class);
         b.addStatement("return context.httpRequest()");
         b.endControlFlow();
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -279,7 +279,8 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
 
         b.addStatement("$T resolvedEndpoint = executionAttributes.getAttribute($T.RESOLVED_ENDPOINT)",
                        Endpoint.class, SdkInternalExecutionAttribute.class);
-        b.beginControlFlow("if (resolvedEndpoint == null || $T.isNullOrEmpty(resolvedEndpoint.headers()))", CollectionUtils.class);
+        b.beginControlFlow("if (resolvedEndpoint == null || $T.isNullOrEmpty(resolvedEndpoint.headers()))",
+                           CollectionUtils.class);
         b.addStatement("return context.httpRequest()");
         b.endControlFlow();
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -279,7 +279,7 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
 
         b.addStatement("$T resolvedEndpoint = executionAttributes.getAttribute($T.RESOLVED_ENDPOINT)",
                        Endpoint.class, SdkInternalExecutionAttribute.class);
-        b.beginControlFlow("if (resolvedEndpoint.headers().isEmpty())");
+        b.beginControlFlow("if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty())");
         b.addStatement("return context.httpRequest()");
         b.endControlFlow();
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
@@ -109,7 +109,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
@@ -109,7 +109,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || CollectionUtils.isNullOrEmpty(resolvedEndpoint.headers())) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
@@ -101,7 +101,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
@@ -101,7 +101,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || CollectionUtils.isNullOrEmpty(resolvedEndpoint.headers())) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-multiauthsigv4a.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-multiauthsigv4a.java
@@ -90,7 +90,7 @@ public final class DatabaseResolveEndpointInterceptor implements ExecutionInterc
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || CollectionUtils.isNullOrEmpty(resolvedEndpoint.headers())) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-multiauthsigv4a.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-multiauthsigv4a.java
@@ -90,7 +90,7 @@ public final class DatabaseResolveEndpointInterceptor implements ExecutionInterc
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -92,7 +92,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -92,7 +92,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint == null || resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || CollectionUtils.isNullOrEmpty(resolvedEndpoint.headers())) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManager.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManager.java
@@ -98,7 +98,7 @@ public final class DefaultAsyncPresignedUrlManager implements AsyncPresignedUrlM
         try {
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "S3");
             //TODO: Discuss if we need to change OPERATION_NAME as part of Surface API Review
-            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "GetObject");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "PresignedUrlGetObject");
 
             Pair<AsyncResponseTransformer<GetObjectResponse, ReturnT>, CompletableFuture<Void>> pair =
                     AsyncResponseTransformerUtils.wrapWithEndOfStreamFuture(asyncResponseTransformer);
@@ -113,7 +113,7 @@ public final class DefaultAsyncPresignedUrlManager implements AsyncPresignedUrlM
 
             CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
                     new ClientExecutionParams<PresignedUrlGetObjectRequestWrapper, GetObjectResponse>()
-                            .withOperationName("GetObject")
+                            .withOperationName("PresignedUrlGetObject")
                             .withProtocolMetadata(protocolMetadata)
                             .withResponseHandler(responseHandler)
                             .withErrorResponseHandler(errorResponseHandler)

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManagerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlManagerTest.java
@@ -256,7 +256,7 @@ class DefaultAsyncPresignedUrlManagerTest {
                 verify(mockPublisher).publish(metricsCaptor.capture());
                 MetricCollection capturedMetrics = metricsCaptor.getValue();
                 assertThat(capturedMetrics.metricValues(CoreMetric.SERVICE_ID)).contains("S3");
-                assertThat(capturedMetrics.metricValues(CoreMetric.OPERATION_NAME)).contains("GetObject");
+                assertThat(capturedMetrics.metricValues(CoreMetric.OPERATION_NAME)).contains("PresignedUrlGetObject");
                 break;
         }
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlManagerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlManagerTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.presignedurl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlGetObjectRequest;
+
+@WireMockTest
+public class AsyncPresignedUrlManagerTest {
+
+    private S3AsyncClient s3AsyncClient;
+    private AsyncPresignedUrlManager presignedUrlManager;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setup(WireMockRuntimeInfo wireMockRuntimeInfo) {
+        // Configure retry policy for testing
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+                                             .numRetries(3)
+                                             .retryCondition(RetryCondition.defaultRetryCondition())
+                                             .backoffStrategy(BackoffStrategy.defaultStrategy())
+                                             .throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+                                             .build();
+
+        s3AsyncClient = S3AsyncClient.builder()
+                                     .endpointOverride(URI.create(wireMockRuntimeInfo.getHttpBaseUrl()))
+                                     .overrideConfiguration(ClientOverrideConfiguration.builder()
+                                                                                       .retryPolicy(retryPolicy)
+                                                                                       .apiCallTimeout(Duration.ofSeconds(10))
+                                                                                       .apiCallAttemptTimeout(Duration.ofSeconds(2))
+                                                                                       .build())
+                                     .build();
+        presignedUrlManager = s3AsyncClient.presignedUrlManager();
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (s3AsyncClient != null) {
+            s3AsyncClient.close();
+        }
+    }
+
+    @Test
+    void testGetPresignedUrlManagerFromS3AsyncClient() {
+        assertThat(presignedUrlManager).isNotNull();
+    }
+
+    // Test Method 1: getObject(PresignedUrlGetObjectRequest, AsyncResponseTransformer)
+    @Test
+    void testGetObjectWithPresignedUrl(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        String testContent = "Hello world";
+        String testETag = "\"d6eb32081c822ed572b70567826d9d9d\"";
+        String presignedUrlPath = "/presigned-test-object";
+
+        stubFor(get(urlEqualTo(presignedUrlPath))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("ETag", testETag)
+                                    .withBody(testContent)));
+
+        URL presignedUrl = new URL(wireMockRuntimeInfo.getHttpBaseUrl() + presignedUrlPath);
+        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+                                                                           .presignedUrl(presignedUrl)
+                                                                           .build();
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> result =
+            presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+
+        ResponseBytes<GetObjectResponse> response = result.get();
+        assertThat(response).isNotNull();
+        assertThat(response.asUtf8String()).isEqualTo(testContent);
+        assertThat(response.response().eTag()).isEqualTo(testETag);
+    }
+
+    // Test Method 2: getObject(Consumer<Builder>, AsyncResponseTransformer)
+    @Test
+    void testGetObjectWithConsumerBuilder(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        String testContent = "Hello consumer";
+        String testETag = "\"c1234567890abcdef1234567890abcdef\"";
+        String presignedUrlPath = "/presigned-test-consumer";
+
+        stubFor(get(urlEqualTo(presignedUrlPath))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("ETag", testETag)
+                                    .withBody(testContent)));
+
+        URL presignedUrl = new URL(wireMockRuntimeInfo.getHttpBaseUrl() + presignedUrlPath);
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> result =
+            presignedUrlManager.getObject(
+                request -> request.presignedUrl(presignedUrl),
+                AsyncResponseTransformer.toBytes()
+            );
+
+        ResponseBytes<GetObjectResponse> response = result.get();
+        assertThat(response).isNotNull();
+        assertThat(response.asUtf8String()).isEqualTo(testContent);
+        assertThat(response.response().eTag()).isEqualTo(testETag);
+    }
+
+    // Test Method 3: getObject(PresignedUrlGetObjectRequest, Path)
+    @Test
+    void testGetObjectToFile(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        String testContent = "File content for download";
+        String testETag = "\"" + UUID.randomUUID().toString().replace("-", "") + "\"";
+        String presignedUrlPath = "/presigned-test-file";
+
+        stubFor(get(urlEqualTo(presignedUrlPath))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("ETag", testETag)
+                                    .withBody(testContent)));
+
+        URL presignedUrl = new URL(wireMockRuntimeInfo.getHttpBaseUrl() + presignedUrlPath);
+        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+                                                                           .presignedUrl(presignedUrl)
+                                                                           .build();
+
+        Path downloadFile = tempDir.resolve("download-" + UUID.randomUUID() + ".txt");
+
+        CompletableFuture<GetObjectResponse> result =
+            presignedUrlManager.getObject(request, downloadFile);
+
+        GetObjectResponse response = result.get();
+        assertThat(response).isNotNull();
+        assertThat(response.eTag()).isEqualTo(testETag);
+
+        String fileContent = new String(Files.readAllBytes(downloadFile), StandardCharsets.UTF_8);
+        assertThat(fileContent).isEqualTo(testContent);
+    }
+
+    // Test Method 4: getObject(Consumer<Builder>, Path)
+    @Test
+    void testGetObjectToFileWithConsumerBuilder(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        String testContent = "Consumer file content";
+        String testETag = "\"" + UUID.randomUUID().toString().replace("-", "") + "\"";
+        String presignedUrlPath = "/presigned-test-file-consumer";
+
+        stubFor(get(urlEqualTo(presignedUrlPath))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("ETag", testETag)
+                                    .withBody(testContent)));
+
+        URL presignedUrl = new URL(wireMockRuntimeInfo.getHttpBaseUrl() + presignedUrlPath);
+        Path downloadFile = tempDir.resolve("consumer-download-" + UUID.randomUUID() + ".txt");
+
+        CompletableFuture<GetObjectResponse> result =
+            presignedUrlManager.getObject(
+                request -> request.presignedUrl(presignedUrl),
+                downloadFile
+            );
+
+        GetObjectResponse response = result.get();
+        assertThat(response).isNotNull();
+        assertThat(response.eTag()).isEqualTo(testETag);
+
+        String fileContent = new String(Files.readAllBytes(downloadFile), StandardCharsets.UTF_8);
+        assertThat(fileContent).isEqualTo(testContent);
+    }
+
+    // Test Range Requests functionality
+    @ParameterizedTest(name = "Range: ''{0}'' -> ''{1}''")
+    @MethodSource("rangeTestData")
+    void testGetObjectWithRange(String range, String expectedContent, String contentRange, WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        String presignedUrlPath = "/presigned-test-range";
+        String testETag = "\"d6eb32081c822ed572b70567826d9d9d\"";
+
+        stubFor(get(urlEqualTo(presignedUrlPath))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("ETag", testETag)
+                                    .withHeader("Content-Range", contentRange)
+                                    .withBody(expectedContent)));
+
+        URL presignedUrl = new URL(wireMockRuntimeInfo.getHttpBaseUrl() + presignedUrlPath);
+        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+                                                                           .presignedUrl(presignedUrl)
+                                                                           .range(range)
+                                                                           .build();
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> result =
+            presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+
+        ResponseBytes<GetObjectResponse> response = result.get();
+        assertThat(response).isNotNull();
+        assertThat(response.asUtf8String()).isEqualTo(expectedContent);
+    }
+
+    // Test Error Scenarios
+    @ParameterizedTest(name = "Error: HTTP {0}")
+    @MethodSource("errorScenarios")
+    void testGetObjectErrorScenarios(int httpStatus, String errorCode, String urlPath, WireMockRuntimeInfo wireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo(urlPath))
+                    .willReturn(aResponse()
+                                    .withStatus(httpStatus)
+                                    .withBody(String.format("<Error><Code>%s</Code></Error>", errorCode))));
+
+        URL presignedUrl;
+        try {
+            presignedUrl = new URL(wireMockRuntimeInfo.getHttpBaseUrl() + urlPath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+                                                                           .presignedUrl(presignedUrl)
+                                                                           .build();
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> result =
+            presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+
+        assertThatThrownBy(() -> result.get())
+            .isInstanceOf(ExecutionException.class);
+    }
+
+    // Retry test
+    @Test
+    void testRetryOnTimeout(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        String testContent = "Timeout retry success";
+        String presignedUrlPath = "/presigned-timeout";
+
+        // First call times out, second succeeds
+        stubFor(get(urlEqualTo(presignedUrlPath))
+                    .inScenario("Timeout Retry")
+                    .whenScenarioStateIs(STARTED)
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withFixedDelay(3000)) // Longer than attempt timeout
+                    .willSetStateTo("Timeout Occurred"));
+
+        stubFor(get(urlEqualTo(presignedUrlPath))
+                    .inScenario("Timeout Retry")
+                    .whenScenarioStateIs("Timeout Occurred")
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withBody(testContent)));
+
+        URL presignedUrl = new URL(wireMockRuntimeInfo.getHttpBaseUrl() + presignedUrlPath);
+        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+                                                                           .presignedUrl(presignedUrl)
+                                                                           .build();
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> result =
+            presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+
+        ResponseBytes<GetObjectResponse> response = result.get();
+        assertThat(response.asUtf8String()).isEqualTo(testContent);
+
+        verify(exactly(2), getRequestedFor(urlEqualTo(presignedUrlPath)));
+    }
+
+    static Stream<Arguments> rangeTestData() {
+        return Stream.of(
+            Arguments.of("bytes=0-4", "Hello", "bytes 0-4/11"),
+            Arguments.of("bytes=6-10", "world", "bytes 6-10/11"),
+            Arguments.of("bytes=0-0", "H", "bytes 0-0/11"),
+            Arguments.of("bytes=-5", "world", "bytes 6-10/11")
+        );
+    }
+
+    static Stream<Arguments> errorScenarios() {
+        return Stream.of(
+            Arguments.of(404, "NoSuchKey", "/nonexistent-key"),
+            Arguments.of(403, "AccessDenied", "/forbidden-key"),
+            Arguments.of(409, "InvalidObjectState", "/archived-key")
+        );
+    }
+}


### PR DESCRIPTION
Added distinct operation name for pre-signed URL requests to prevent ClassCastException, 
implemented null check for resolvedEndpoint to avoid NullPointerException, 
and enhanced `AsyncPresignedUrlManager` API with GetObject methods.

## Motivation and Context
When using `AsyncPresignedUrlManager` with presigned URLs, a ClassCastException occurs because the S3 endpoint resolution interceptor attempts to cast PresignedUrlGetObjectRequestWrapper to GetObjectRequest. 
NullPointerExceptions are thrown for presigned url get operations when resolvedEndpoint is null in the endpoint interceptor.

## Modifications
1. Added Distinct Operation Name for Pre-signed URL
   • Changed operation name from "GetObject" to "PresignedUrlGetObject" in `DefaultAsyncPresignedUrlManager`
   • Prevents invalid casting in the S3 endpoint resolution interceptor

2. Added Null Check for ResolvedEndpoint
   • Modified `EndpointResolverInterceptorSpec`.java to add null check for resolvedEndpoint
   • Updated corresponding test resources to match new expected output

3. Enhanced AsyncPresignedUrlManager API
   • Added GetObject methods to `AsyncPresignedUrlManager` API
   • Also covered unit tests for this

## Testing
• Verified fix resolves ClassCastException with `AsyncPresignedUrlManager`
• Confirmed null check properly handles cases where resolvedEndpoint is null
• Added unit tests for new `AsyncPresignedUrlManager` functionality

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
