### PR TITLE
Fix dependency generation for new smithy-rpc-v2-cbor services

### DIFF
--- a/release-scripts/src/main/java/software/amazon/awssdk/release/NewServiceMain.java
+++ b/release-scripts/src/main/java/software/amazon/awssdk/release/NewServiceMain.java
@@ -86,7 +86,8 @@ public class NewServiceMain extends Cli {
             this.serviceModuleName = commandLine.getOptionValue("service-module-name").trim();
             this.serviceId = commandLine.getOptionValue("service-id").trim();
             this.serviceProtocol = transformSpecialProtocols(commandLine.getOptionValue("service-protocol").trim());
-            this.internalDependencies = computeInternalDependencies(toList(commandLine
+            this.internalDependencies = computeInternalDependencies(serviceProtocol,
+                                                                    toList(commandLine
                                                                                .getOptionValues("include-internal-dependency")),
                                                                     toList(commandLine
                                                                                .getOptionValues("exclude-internal-dependency")));
@@ -98,7 +99,7 @@ public class NewServiceMain extends Cli {
                 case "ec2": return "aws-query";
                 case "rest-xml": return "aws-xml";
                 case "rest-json": return "aws-json";
-                case "rpc-v2-cbor": return "smithy-rpcv2";
+                case "smithy-rpc-v2-cbor": return "smithy-rpcv2";
                 default: return "aws-" + protocol;
             }
         }


### PR DESCRIPTION
Fix dependency generation for new smithy-rpc-v2-cbor services

## Motivation and Context
Generation of new smithy-rpc-v2-cbor services is failing with:

```
[WARNING] Used undeclared dependencies found:
[WARNING]    software.amazon.awssdk:aws-json-protocol:jar:2.32.4-SNAPSHOT:compile

org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.1:analyze-only (default) on project arcregionswitch: Dependency problems found
```

While the `aws-cbor-protocol` module does define a dependency on aws-json-protocol, the code generation *also* generates code into the service module that has direct dependencies on aws-json-protocol, causing the undeclared dependencies issue above.

## Modifications
* Adds a static map of additional dependencies per protocol that are added to the list.

## Testing
Manual testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
