### PR TITLE
Add validations for upload in s3 mulitpart client

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-6522f77.json
+++ b/.changes/next-release/bugfix-AmazonS3-6522f77.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Add additional validations for multipart upload operations in the Java multipart S3 client."
+}

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -239,6 +239,7 @@
                 <groupId>io.reactivex.rxjava3</groupId>
                 <artifactId>rxjava</artifactId>
                 <version>${rxjava3.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <artifactId>commons-lang3</artifactId>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -236,6 +236,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>io.reactivex.rxjava3</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>${rxjava3.version}</version>
+            </dependency>
+            <dependency>
                 <artifactId>commons-lang3</artifactId>
                 <groupId>org.apache.commons</groupId>
                 <version>${commons.lang.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <org.eclipse.jdt.version>3.10.0</org.eclipse.jdt.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
         <rxjava.version>2.2.21</rxjava.version>
+        <rxjava3.version>3.1.5</rxjava3.version>
         <commons-codec.verion>1.17.1</commons-codec.verion>
         <jmh.version>1.37</jmh.version>
         <awscrt.version>0.38.1</awscrt.version>

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -230,5 +230,10 @@
             <artifactId>jimfs</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
@@ -32,6 +32,7 @@ import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.listener.PublisherListener;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -54,10 +55,10 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     private final AtomicBoolean failureActionInitiated = new AtomicBoolean(false);
     private final AtomicInteger partNumber = new AtomicInteger(1);
     private final MultipartUploadHelper multipartUploadHelper;
-    private final long contentLength;
+    private final long totalSize;
     private final long partSize;
-    private final int partCount;
-    private final int numExistingParts;
+    private final int expectedNumParts;
+    private final int existingNumParts;
     private final String uploadId;
     private final Collection<CompletableFuture<CompletedPart>> futures = new ConcurrentLinkedQueue<>();
     private final PutObjectRequest putObjectRequest;
@@ -77,23 +78,19 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     KnownContentLengthAsyncRequestBodySubscriber(MpuRequestContext mpuRequestContext,
                                                  CompletableFuture<PutObjectResponse> returnFuture,
                                                  MultipartUploadHelper multipartUploadHelper) {
-        this.contentLength = mpuRequestContext.contentLength();
+        this.totalSize = mpuRequestContext.contentLength();
         this.partSize = mpuRequestContext.partSize();
-        this.partCount = determinePartCount(contentLength, partSize);
+        this.expectedNumParts = mpuRequestContext.expectedNumParts();
         this.putObjectRequest = mpuRequestContext.request().left();
         this.returnFuture = returnFuture;
         this.uploadId = mpuRequestContext.uploadId();
         this.existingParts = mpuRequestContext.existingParts() == null ? new HashMap<>() : mpuRequestContext.existingParts();
-        this.numExistingParts = NumericUtils.saturatedCast(mpuRequestContext.numPartsCompleted());
-        this.completedParts = new AtomicReferenceArray<>(partCount);
+        this.existingNumParts = NumericUtils.saturatedCast(mpuRequestContext.numPartsCompleted());
+        this.completedParts = new AtomicReferenceArray<>(expectedNumParts);
         this.multipartUploadHelper = multipartUploadHelper;
         this.progressListener = putObjectRequest.overrideConfiguration().map(c -> c.executionAttributes()
                                                                                    .getAttribute(JAVA_PROGRESS_LISTENER))
                                                 .orElseGet(PublisherListener::noOp);
-    }
-
-    private int determinePartCount(long contentLength, long partSize) {
-        return (int) Math.ceil(contentLength / (double) partSize);
     }
 
     public S3ResumeToken pause() {
@@ -119,8 +116,8 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
         return S3ResumeToken.builder()
                             .uploadId(uploadId)
                             .partSize(partSize)
-                            .totalNumParts((long) partCount)
-                            .numPartsCompleted(numPartsCompleted + numExistingParts)
+                            .totalNumParts((long) expectedNumParts)
+                            .numPartsCompleted(numPartsCompleted + existingNumParts)
                             .build();
     }
 
@@ -145,21 +142,23 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
 
     @Override
     public void onNext(AsyncRequestBody asyncRequestBody) {
-        if (isPaused) {
+        if (isPaused || isDone) {
             return;
         }
 
-        if (existingParts.containsKey(partNumber.get())) {
-            partNumber.getAndIncrement();
+        int currentPartNum = partNumber.getAndIncrement();
+        if (existingParts.containsKey(currentPartNum)) {
             asyncRequestBody.subscribe(new CancelledSubscriber<>());
             subscription.request(1);
             asyncRequestBody.contentLength().ifPresent(progressListener::subscriberOnNext);
             return;
         }
 
+        validatePart(asyncRequestBody, currentPartNum);
+
         asyncRequestBodyInFlight.incrementAndGet();
         UploadPartRequest uploadRequest = SdkPojoConversionUtils.toUploadPartRequest(putObjectRequest,
-                                                                                     partNumber.getAndIncrement(),
+                                                                                     currentPartNum,
                                                                                      uploadId);
 
         Consumer<CompletedPart> completedPartConsumer = completedPart -> completedParts.set(completedPart.partNumber() - 1,
@@ -179,6 +178,49 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
         subscription.request(1);
     }
 
+    private void validatePart(AsyncRequestBody asyncRequestBody, int currentPartNum) {
+        if (!asyncRequestBody.contentLength().isPresent()) {
+            SdkClientException e = SdkClientException.create("Content length must be present on the AsyncRequestBody");
+            multipartUploadHelper.failRequestsElegantly(futures, e, uploadId, returnFuture, putObjectRequest);
+            return;
+        }
+
+        Long currentPartSize = asyncRequestBody.contentLength().get();
+        if (currentPartNum > expectedNumParts) {
+            SdkClientException exception = SdkClientException.create(String.format("The number of parts divided is "
+                                                                                   + "not equal to the expected number of "
+                                                                                   + "parts. Expected: %d, Actual: %d",
+                                                                                   expectedNumParts, currentPartNum));
+            multipartUploadHelper.failRequestsElegantly(futures, exception, uploadId, returnFuture, putObjectRequest);
+            return;
+        }
+
+        if (currentPartNum == expectedNumParts) {
+            validateLastPartSize(currentPartSize);
+            return;
+        }
+
+        if (currentPartSize != partSize) {
+            SdkClientException e = SdkClientException.create(String.format("Content length must be equal to the "
+                                                                           + "part size. Expected: %d, Actual: %d",
+                                                                           partSize,
+                                                                           currentPartSize));
+            multipartUploadHelper.failRequestsElegantly(futures, e, uploadId, returnFuture, putObjectRequest);
+        }
+    }
+
+    private void validateLastPartSize(Long currentPartSize) {
+        long remainder = totalSize % partSize;
+        long expectedLastPartSize = remainder == 0 ? partSize : remainder;
+        if (currentPartSize != expectedLastPartSize) {
+            SdkClientException exception =
+                SdkClientException.create("Content length of the last part must be equal to the "
+                                          + "expected last part size. Expected: " + expectedLastPartSize
+                                          + ", Actual: " + currentPartSize);
+            multipartUploadHelper.failRequestsElegantly(futures, exception, uploadId, returnFuture, putObjectRequest);
+        }
+    }
+
     private boolean shouldFailRequest() {
         return failureActionInitiated.compareAndSet(false, true) && !isPaused;
     }
@@ -187,6 +229,7 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     public void onError(Throwable t) {
         log.debug(() -> "Received onError ", t);
         if (failureActionInitiated.compareAndSet(false, true)) {
+            isDone = true;
             multipartUploadHelper.failRequestsElegantly(futures, t, uploadId, returnFuture, putObjectRequest);
         }
     }
@@ -203,6 +246,7 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     private void completeMultipartUploadIfFinished(int requestsInFlight) {
         if (isDone && requestsInFlight == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
             CompletedPart[] parts;
+
             if (existingParts.isEmpty()) {
                 parts =
                     IntStream.range(0, completedParts.length())
@@ -213,14 +257,14 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
                 parts = mergeCompletedParts();
             }
             completeMpuFuture = multipartUploadHelper.completeMultipartUpload(returnFuture, uploadId, parts, putObjectRequest,
-                                                                              contentLength);
+                                                                              totalSize);
         }
     }
 
     private CompletedPart[] mergeCompletedParts() {
-        CompletedPart[] merged = new CompletedPart[partCount];
+        CompletedPart[] merged = new CompletedPart[expectedNumParts];
         int currPart = 1;
-        while (currPart < partCount + 1) {
+        while (currPart < expectedNumParts + 1) {
             CompletedPart completedPart = existingParts.containsKey(currPart) ? existingParts.get(currPart) :
                                           completedParts.get(currPart - 1);
             merged[currPart - 1] = completedPart;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MpuRequestContext.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MpuRequestContext.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.utils.Pair;
+import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public class MpuRequestContext {
@@ -32,6 +33,7 @@ public class MpuRequestContext {
     private final Long numPartsCompleted;
     private final String uploadId;
     private final Map<Integer, CompletedPart> existingParts;
+    private final int expectedNumParts;
 
     protected MpuRequestContext(Builder builder) {
         this.request = builder.request;
@@ -40,6 +42,8 @@ public class MpuRequestContext {
         this.uploadId = builder.uploadId;
         this.existingParts = builder.existingParts;
         this.numPartsCompleted = builder.numPartsCompleted;
+        this.expectedNumParts = Validate.paramNotNull(builder.expectedNumParts,
+                                                      "expectedNumParts");
     }
 
     public static Builder builder() {
@@ -56,9 +60,13 @@ public class MpuRequestContext {
         }
         MpuRequestContext that = (MpuRequestContext) o;
 
-        return Objects.equals(request, that.request) && Objects.equals(contentLength, that.contentLength)
-               && Objects.equals(partSize, that.partSize) && Objects.equals(numPartsCompleted, that.numPartsCompleted)
-               && Objects.equals(uploadId, that.uploadId) && Objects.equals(existingParts, that.existingParts);
+        return expectedNumParts == that.expectedNumParts
+               && Objects.equals(request, that.request) 
+               && Objects.equals(contentLength, that.contentLength)
+               && Objects.equals(partSize, that.partSize) 
+               && Objects.equals(numPartsCompleted, that.numPartsCompleted)
+               && Objects.equals(uploadId, that.uploadId) 
+               && Objects.equals(existingParts, that.existingParts);
     }
 
     @Override
@@ -69,6 +77,7 @@ public class MpuRequestContext {
         result = 31 * result + (contentLength != null ? contentLength.hashCode() : 0);
         result = 31 * result + (partSize != null ? partSize.hashCode() : 0);
         result = 31 * result + (numPartsCompleted != null ? numPartsCompleted.hashCode() : 0);
+        result = 31 * result + expectedNumParts;
         return result;
     }
 
@@ -92,6 +101,10 @@ public class MpuRequestContext {
         return uploadId;
     }
 
+    public int expectedNumParts() {
+        return expectedNumParts;
+    }
+
     public Map<Integer, CompletedPart> existingParts() {
         return existingParts;
     }
@@ -103,6 +116,7 @@ public class MpuRequestContext {
         private Long numPartsCompleted;
         private String uploadId;
         private Map<Integer, CompletedPart> existingParts;
+        private Integer expectedNumParts;
 
         private Builder() {
         }
@@ -134,6 +148,11 @@ public class MpuRequestContext {
 
         public Builder existingParts(Map<Integer, CompletedPart> existingParts) {
             this.existingParts = existingParts;
+            return this;
+        }
+
+        public Builder expectedNumParts(Integer expectedNumParts) {
+            this.expectedNumParts = expectedNumParts;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
@@ -137,6 +137,7 @@ public final class UploadWithKnownContentLengthHelper {
                                                                .partSize(partSize)
                                                                .uploadId(uploadId)
                                                                .numPartsCompleted(numPartsCompleted)
+                                                               .expectedNumParts(partCount)
                                                                .build();
 
         splitAndSubscribe(mpuRequestContext, returnFuture);
@@ -170,6 +171,7 @@ public final class UploadWithKnownContentLengthHelper {
                                                                    .partSize(resumeToken.partSize())
                                                                    .uploadId(uploadId)
                                                                    .existingParts(existingParts)
+                                                                   .expectedNumParts(Math.toIntExact(resumeToken.totalNumParts()))
                                                                    .numPartsCompleted(resumeToken.numPartsCompleted())
                                                                    .build();
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
@@ -62,7 +62,7 @@ public final class UploadWithKnownContentLengthHelper {
                                                                    SdkPojoConversionUtils::toPutObjectResponse);
         this.maxMemoryUsageInBytes = maxMemoryUsageInBytes;
         this.multipartUploadThresholdInBytes = multipartUploadThresholdInBytes;
-        this.multipartUploadHelper = new MultipartUploadHelper(s3AsyncClient, partSizeInBytes, multipartUploadThresholdInBytes,
+        this.multipartUploadHelper = new MultipartUploadHelper(s3AsyncClient, multipartUploadThresholdInBytes,
                                                                maxMemoryUsageInBytes);
     }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
@@ -17,18 +17,32 @@ package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
@@ -46,10 +60,15 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     private static final int TOTAL_NUM_PARTS = 4;
     private static final String UPLOAD_ID = "1234";
     private static RandomTempFile testFile;
+    
     private AsyncRequestBody asyncRequestBody;
     private PutObjectRequest putObjectRequest;
     private S3AsyncClient s3AsyncClient;
     private MultipartUploadHelper multipartUploadHelper;
+    private CompletableFuture<PutObjectResponse> returnFuture;
+    private KnownContentLengthAsyncRequestBodySubscriber subscriber;
+    private Collection<CompletableFuture<CompletedPart>> futures;
+    private Subscription subscription;
 
     @BeforeAll
     public static void beforeAll() throws IOException {
@@ -67,13 +86,98 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         multipartUploadHelper = mock(MultipartUploadHelper.class);
         asyncRequestBody = AsyncRequestBody.fromFile(testFile);
         putObjectRequest = PutObjectRequest.builder().bucket("bucket").key("key").build();
+
+        returnFuture = new CompletableFuture<>();
+        futures = new ConcurrentLinkedQueue<>();
+        subscription = mock(Subscription.class);
+
+        when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(CompletedPart.builder().build()));
+
+        subscriber = createSubscriber(createDefaultMpuRequestContext());
+        subscriber.onSubscribe(subscription);
+    }
+
+    @Test
+    void validatePart_withMissingContentLength_shouldFailRequest() {
+        subscriber.onNext(createMockAsyncRequestBodyWithEmptyContentLength());
+        verifyFailRequestsElegantly("Content length must be present on the AsyncRequestBody");
+    }
+
+    @Test
+    void validatePart_withPartSizeExceedingLimit_shouldFailRequest() {
+        subscriber.onNext(createMockAsyncRequestBody(PART_SIZE + 1));
+        verifyFailRequestsElegantly("Content length must be equal to the part size");
+    }
+
+    @Test
+    void validateLastPartSize_withIncorrectSize_shouldFailRequest() {
+        long expectedLastPartSize = MPU_CONTENT_SIZE % PART_SIZE;
+        long incorrectLastPartSize = expectedLastPartSize + 1;
+        
+        KnownContentLengthAsyncRequestBodySubscriber lastPartSubscriber = createSubscriber(createDefaultMpuRequestContext());
+        lastPartSubscriber.onSubscribe(subscription);
+
+        for (int i = 0; i < TOTAL_NUM_PARTS - 1; i++) {
+            lastPartSubscriber.onNext(createMockAsyncRequestBody(PART_SIZE));
+        }
+
+        lastPartSubscriber.onNext(createMockAsyncRequestBody(incorrectLastPartSize));
+
+        verifyFailRequestsElegantly("Content length of the last part must be equal to the expected last part size");
+    }
+
+    @Test
+    void validateTotalPartNum_receivedMoreParts_shouldFail() {
+        long expectedLastPartSize = MPU_CONTENT_SIZE % PART_SIZE;
+        
+        KnownContentLengthAsyncRequestBodySubscriber lastPartSubscriber = createSubscriber(createDefaultMpuRequestContext());
+        lastPartSubscriber.onSubscribe(subscription);
+
+        for (int i = 0; i < TOTAL_NUM_PARTS - 1; i++) {
+            AsyncRequestBody regularPart = createMockAsyncRequestBody(PART_SIZE);
+            when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+            lastPartSubscriber.onNext(regularPart);
+        }
+
+        when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        lastPartSubscriber.onNext(createMockAsyncRequestBody(expectedLastPartSize));
+        lastPartSubscriber.onNext(createMockAsyncRequestBody(expectedLastPartSize));
+        lastPartSubscriber.onComplete();
+
+        verifyFailRequestsElegantly("The number of parts divided is not equal to the expected number of parts");
+    }
+
+    @Test
+    void validateLastPartSize_withCorrectSize_shouldNotFail() {
+        long expectedLastPartSize = MPU_CONTENT_SIZE % PART_SIZE;
+
+        KnownContentLengthAsyncRequestBodySubscriber subscriber = createSubscriber(createDefaultMpuRequestContext());
+        subscriber.onSubscribe(subscription);
+
+        for (int i = 0; i < TOTAL_NUM_PARTS - 1; i++) {
+            AsyncRequestBody regularPart = createMockAsyncRequestBody(PART_SIZE);
+            when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+            subscriber.onNext(regularPart);
+        }
+
+        when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        subscriber.onNext(createMockAsyncRequestBody(expectedLastPartSize));
+        subscriber.onComplete();
+
+        assertThat(returnFuture).isNotCompletedExceptionally();
     }
 
     @Test
     void pause_withOngoingCompleteMpuFuture_shouldReturnTokenAndCancelFuture() {
         CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture = new CompletableFuture<>();
         int numExistingParts = 2;
-        S3ResumeToken resumeToken = configureSubscriberAndPause(numExistingParts, completeMpuFuture);
+        
+        S3ResumeToken resumeToken = testPauseScenario(numExistingParts, completeMpuFuture);
 
         verifyResumeToken(resumeToken, numExistingParts);
         assertThat(completeMpuFuture).isCancelled();
@@ -84,56 +188,91 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture =
             CompletableFuture.completedFuture(CompleteMultipartUploadResponse.builder().build());
         int numExistingParts = 2;
-        S3ResumeToken resumeToken = configureSubscriberAndPause(numExistingParts, completeMpuFuture);
+        
+        S3ResumeToken resumeToken = testPauseScenario(numExistingParts, completeMpuFuture);
 
         assertThat(resumeToken).isNull();
     }
 
     @Test
     void pause_withUninitiatedCompleteMpuFuture_shouldReturnToken() {
-        CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture = null;
         int numExistingParts = 2;
-        S3ResumeToken resumeToken = configureSubscriberAndPause(numExistingParts, completeMpuFuture);
+        
+        S3ResumeToken resumeToken = testPauseScenario(numExistingParts, null);
 
         verifyResumeToken(resumeToken, numExistingParts);
     }
-
-    private S3ResumeToken configureSubscriberAndPause(int numExistingParts,
-                                                      CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture) {
-        Map<Integer, CompletedPart> existingParts = existingParts(numExistingParts);
-        KnownContentLengthAsyncRequestBodySubscriber subscriber = subscriber(putObjectRequest, asyncRequestBody, existingParts,
-                                                                             new CompletableFuture<>());
+    
+    private S3ResumeToken testPauseScenario(int numExistingParts, 
+                                           CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture) {
+        KnownContentLengthAsyncRequestBodySubscriber subscriber = 
+            createSubscriber(createMpuRequestContextWithExistingParts(numExistingParts));
 
         when(multipartUploadHelper.completeMultipartUpload(any(CompletableFuture.class), any(String.class),
-                                                           any(CompletedPart[].class), any(PutObjectRequest.class),
-                                                           any(Long.class)))
+                                                         any(CompletedPart[].class), any(PutObjectRequest.class),
+                                                         any(Long.class)))
             .thenReturn(completeMpuFuture);
+
+        simulateOnNextForAllParts(subscriber);
         subscriber.onComplete();
+        assertThat(returnFuture).isNotCompletedExceptionally();
         return subscriber.pause();
     }
 
-    private KnownContentLengthAsyncRequestBodySubscriber subscriber(PutObjectRequest putObjectRequest,
-                                                                    AsyncRequestBody asyncRequestBody,
-                                                                    Map<Integer, CompletedPart> existingParts,
-                                                                    CompletableFuture<PutObjectResponse> returnFuture) {
+    private MpuRequestContext createDefaultMpuRequestContext() {
+        return MpuRequestContext.builder()
+                                .request(Pair.of(putObjectRequest, AsyncRequestBody.fromFile(testFile)))
+                                .contentLength(MPU_CONTENT_SIZE)
+                                .partSize(PART_SIZE)
+                                .uploadId(UPLOAD_ID)
+                                .numPartsCompleted(0L)
+                                .expectedNumParts(TOTAL_NUM_PARTS)
+                                .build();
+    }
 
-        MpuRequestContext mpuRequestContext = MpuRequestContext.builder()
-                                                               .request(Pair.of(putObjectRequest, asyncRequestBody))
-                                                               .contentLength(MPU_CONTENT_SIZE)
-                                                               .partSize(PART_SIZE)
-                                                               .uploadId(UPLOAD_ID)
-                                                               .existingParts(existingParts)
-                                                               .numPartsCompleted((long) existingParts.size())
-                                                               .build();
+    private MpuRequestContext createMpuRequestContextWithExistingParts(int numExistingParts) {
+        Map<Integer, CompletedPart> existingParts = createExistingParts(numExistingParts);
+        return MpuRequestContext.builder()
+                                .request(Pair.of(putObjectRequest, asyncRequestBody))
+                                .contentLength(MPU_CONTENT_SIZE)
+                                .partSize(PART_SIZE)
+                                .uploadId(UPLOAD_ID)
+                                .existingParts(existingParts)
+                                .expectedNumParts(TOTAL_NUM_PARTS)
+                                .numPartsCompleted((long) existingParts.size())
+                                .build();
+    }
 
+    private KnownContentLengthAsyncRequestBodySubscriber createSubscriber(MpuRequestContext mpuRequestContext) {
         return new KnownContentLengthAsyncRequestBodySubscriber(mpuRequestContext, returnFuture, multipartUploadHelper);
     }
 
-    private Map<Integer, CompletedPart> existingParts(int numExistingParts) {
-        Map<Integer, CompletedPart> existingParts = new ConcurrentHashMap<>();
-        for (int i = 1; i <= numExistingParts; i++) {
-            existingParts.put(i, CompletedPart.builder().partNumber(i).build());
-        }
+    private AsyncRequestBody createMockAsyncRequestBody(long contentLength) {
+        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+        when(mockBody.contentLength()).thenReturn(Optional.of(contentLength));
+        return mockBody;
+    }
+
+    private AsyncRequestBody createMockAsyncRequestBodyWithEmptyContentLength() {
+        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+        when(mockBody.contentLength()).thenReturn(Optional.empty());
+        return mockBody;
+    }
+
+    private void verifyFailRequestsElegantly(String expectedErrorMessage) {
+        ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(multipartUploadHelper).failRequestsElegantly(any(), exceptionCaptor.capture(), eq(UPLOAD_ID), eq(returnFuture), eq(putObjectRequest));
+
+        Throwable exception = exceptionCaptor.getValue();
+        assertThat(exception).isInstanceOf(SdkClientException.class);
+        assertThat(exception.getMessage()).contains(expectedErrorMessage);
+    }
+
+    private Map<Integer, CompletedPart> createExistingParts(int numExistingParts) {
+        Map<Integer, CompletedPart> existingParts =
+            IntStream.range(0, numExistingParts)
+                     .boxed().collect(Collectors.toMap(Function.identity(),
+                                                       i -> CompletedPart.builder().partNumber(i).build(), (a, b) -> b));
         return existingParts;
     }
 
@@ -144,4 +283,13 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         assertThat(s3ResumeToken.totalNumParts()).isEqualTo(TOTAL_NUM_PARTS);
         assertThat(s3ResumeToken.numPartsCompleted()).isEqualTo(numExistingParts);
     }
+
+    private void simulateOnNextForAllParts(KnownContentLengthAsyncRequestBodySubscriber subscriber) {
+        subscriber.onSubscribe(subscription);
+
+        for (int i = 0; i < TOTAL_NUM_PARTS; i++) {
+            subscriber.onNext(createMockAsyncRequestBody(PART_SIZE));
+        }
+    }
+
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
@@ -101,13 +101,13 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     @Test
     void validatePart_withMissingContentLength_shouldFailRequest() {
         subscriber.onNext(createMockAsyncRequestBodyWithEmptyContentLength());
-        verifyFailRequestsElegantly("Content length must be present on the AsyncRequestBody");
+        verifyFailRequestsElegantly("Content length is missing on the AsyncRequestBody");
     }
 
     @Test
     void validatePart_withPartSizeExceedingLimit_shouldFailRequest() {
         subscriber.onNext(createMockAsyncRequestBody(PART_SIZE + 1));
-        verifyFailRequestsElegantly("Content length must be equal to the part size");
+        verifyFailRequestsElegantly("Content length must not be greater than part size");
     }
 
     @Test
@@ -145,7 +145,6 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
             .thenReturn(CompletableFuture.completedFuture(null));
         lastPartSubscriber.onNext(createMockAsyncRequestBody(expectedLastPartSize));
         lastPartSubscriber.onNext(createMockAsyncRequestBody(expectedLastPartSize));
-        lastPartSubscriber.onComplete();
 
         verifyFailRequestsElegantly("The number of parts divided is not equal to the expected number of parts");
     }
@@ -266,6 +265,7 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         Throwable exception = exceptionCaptor.getValue();
         assertThat(exception).isInstanceOf(SdkClientException.class);
         assertThat(exception.getMessage()).contains(expectedErrorMessage);
+        verify(subscription).cancel();
     }
 
     private Map<Integer, CompletedPart> createExistingParts(int numExistingParts) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MpuRequestContextTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MpuRequestContextTest.java
@@ -34,6 +34,7 @@ public class MpuRequestContextTest {
     private static final long NUM_PARTS_COMPLETED = 3;
     private static final String UPLOAD_ID = "55555";
     private static final Map<Integer, CompletedPart> EXISTING_PARTS = new ConcurrentHashMap<>();
+    public static final int EXPECTED_NUM_PARTS = 10;
 
     @Test
     public void mpuRequestContext_withValues_buildsCorrectly() {
@@ -44,6 +45,7 @@ public class MpuRequestContextTest {
                                                                .uploadId(UPLOAD_ID)
                                                                .existingParts(EXISTING_PARTS)
                                                                .numPartsCompleted(NUM_PARTS_COMPLETED)
+                                                               .expectedNumParts(EXPECTED_NUM_PARTS)
                                                                .build();
 
         assertThat(mpuRequestContext.request()).isEqualTo(REQUEST);
@@ -52,11 +54,14 @@ public class MpuRequestContextTest {
         assertThat(mpuRequestContext.uploadId()).isEqualTo(UPLOAD_ID);
         assertThat(mpuRequestContext.existingParts()).isEqualTo(EXISTING_PARTS);
         assertThat(mpuRequestContext.numPartsCompleted()).isEqualTo(NUM_PARTS_COMPLETED);
+        assertThat(mpuRequestContext.expectedNumParts()).isEqualTo(EXPECTED_NUM_PARTS);
     }
 
     @Test
     public void mpuRequestContext_default_buildsCorrectly() {
-        MpuRequestContext mpuRequestContext = MpuRequestContext.builder().build();
+        MpuRequestContext mpuRequestContext = MpuRequestContext.builder()
+                                                               .expectedNumParts(1)
+                                                               .build();
 
         assertThat(mpuRequestContext.request()).isNull();
         assertThat(mpuRequestContext.contentLength()).isNull();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientPutObjectWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientPutObjectWiremockTest.java
@@ -26,25 +26,40 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.reactivex.rxjava3.core.Flowable;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
 import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.utils.async.SimplePublisher;
 
 @WireMockTest
-@Timeout(10)
+@Timeout(100)
 public class S3MultipartClientPutObjectWiremockTest {
 
     private static final String BUCKET = "Example-Bucket";
@@ -56,9 +71,25 @@ public class S3MultipartClientPutObjectWiremockTest {
                                                            + "</InitiateMultipartUploadResult>";
     private S3AsyncClient s3AsyncClient;
 
+    public static Stream<Arguments> invalidAsyncRequestBodies() {
+        return Stream.of(
+            Arguments.of("knownContentLength_nullPartSize", new TestPublisherWithIncorrectSplitImpl(20L, null),
+                         "Content length is missing on the AsyncRequestBody for part number"),
+            Arguments.of("unknownContentLength_nullPartSize", new TestPublisherWithIncorrectSplitImpl(null, null),
+                         "Content length is missing on the AsyncRequestBody for part number"),
+            Arguments.of("knownContentLength_partSizeIncorrect", new TestPublisherWithIncorrectSplitImpl(20L, 11L),
+                         "Content length must not be greater than part size"),
+            Arguments.of("unknownContentLength_partSizeIncorrect", new TestPublisherWithIncorrectSplitImpl(null, 11L),
+                         "Content length must not be greater than part size"),
+            Arguments.of("knownContentLength_sendMoreParts", new TestPublisherWithIncorrectSplitImpl(20L, 10L, 3),
+                         "The number of parts divided is not equal to the expected number of parts"),
+            Arguments.of("knownContentLength_sendFewerParts", new TestPublisherWithIncorrectSplitImpl(20L, 10L, 1),
+                     "The number of parts divided is not equal to the expected number of parts"));
+    }
+
     @BeforeEach
     public void setup(WireMockRuntimeInfo wiremock) {
-        stubPutObjectCalls();
+        stubFailedPutObjectCalls();
         s3AsyncClient = S3AsyncClient.builder()
                                      .region(Region.US_EAST_1)
                                      .endpointOverride(URI.create("http://localhost:" + wiremock.getHttpPort()))
@@ -66,16 +97,22 @@ public class S3MultipartClientPutObjectWiremockTest {
                                          StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")))
                                      .multipartEnabled(true)
                                      .multipartConfiguration(b -> b.minimumPartSizeInBytes(10L).apiCallBufferSizeInBytes(10L))
-            .httpClientBuilder(AwsCrtAsyncHttpClient.builder())
+                                     .httpClientBuilder(AwsCrtAsyncHttpClient.builder())
                                      .build();
     }
 
-    private void stubPutObjectCalls() {
+    private void stubFailedPutObjectCalls() {
         stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody(CREATE_MULTIPART_PAYLOAD)));
         stubFor(put(anyUrl()).willReturn(aResponse().withStatus(404)));
         stubFor(put(urlEqualTo("/Example-Bucket/Example-Object?partNumber=1&uploadId=string")).willReturn(aResponse().withStatus(200)));
         stubFor(delete(anyUrl()).willReturn(aResponse().withStatus(200)));
     }
+
+    private void stubSuccessfulPutObjectCalls() {
+        stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody(CREATE_MULTIPART_PAYLOAD)));
+        stubFor(put(anyUrl()).willReturn(aResponse().withStatus(200)));
+    }
+
 
     // https://github.com/aws/aws-sdk-java-v2/issues/4801
     @Test
@@ -110,6 +147,19 @@ public class S3MultipartClientPutObjectWiremockTest {
         assertThatThrownBy(() -> putObjectResponse.join()).hasRootCauseInstanceOf(S3Exception.class);
     }
 
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("invalidAsyncRequestBodies")
+    void uploadWithIncorrectAsyncRequestBodySplit_contentLengthMismatch_shouldThrowException(String description,
+                                                                                             TestPublisherWithIncorrectSplitImpl asyncRequestBody,
+                                                                                             String errorMsg) {
+        stubSuccessfulPutObjectCalls();
+        CompletableFuture<PutObjectResponse> putObjectResponse = s3AsyncClient.putObject(
+            r -> r.bucket(BUCKET).key(KEY), asyncRequestBody);
+
+        assertThatThrownBy(() -> putObjectResponse.join()).hasMessageContaining(errorMsg)
+                                                          .hasRootCauseInstanceOf(SdkClientException.class);
+    }
+
     private InputStream createUnlimitedInputStream() {
         return new InputStream() {
             @Override
@@ -117,5 +167,66 @@ public class S3MultipartClientPutObjectWiremockTest {
                 return 1;
             }
         };
+    }
+
+    private static class TestPublisherWithIncorrectSplitImpl implements AsyncRequestBody {
+        private SimplePublisher<ByteBuffer> simplePublisher = new SimplePublisher<>();
+        private Long totalSize;
+        private Long partSize;
+        private Integer numParts;
+
+        private TestPublisherWithIncorrectSplitImpl(Long totalSize, Long partSize) {
+            this.totalSize = totalSize;
+            this.partSize = partSize;
+        }
+
+        private TestPublisherWithIncorrectSplitImpl(Long totalSize, long partSize, int numParts) {
+            this.totalSize = totalSize;
+            this.partSize = partSize;
+            this.numParts = numParts;
+        }
+
+        @Override
+        public Optional<Long> contentLength() {
+            return Optional.ofNullable(totalSize);
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super ByteBuffer> s) {
+            simplePublisher.subscribe(s);
+        }
+
+        @Override
+        public SdkPublisher<AsyncRequestBody> split(AsyncRequestBodySplitConfiguration splitConfiguration) {
+            List<AsyncRequestBody> requestBodies = new ArrayList<>();
+            int numAsyncRequestBodies = numParts == null ? 1 : numParts;
+            for (int i = 0; i < numAsyncRequestBodies; i++) {
+                requestBodies.add(new TestAsyncRequestBody(partSize));
+            }
+
+            return SdkPublisher.adapt(Flowable.fromArray(requestBodies.toArray(new AsyncRequestBody[requestBodies.size()])));
+        }
+    }
+
+    private static class TestAsyncRequestBody implements AsyncRequestBody {
+        private Long partSize;
+        private SimplePublisher<ByteBuffer> simplePublisher = new SimplePublisher<>();
+
+        public TestAsyncRequestBody(Long partSize) {
+            this.partSize = partSize;
+        }
+
+        @Override
+        public Optional<Long> contentLength() {
+            return Optional.ofNullable(partSize);
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super ByteBuffer> s) {
+            simplePublisher.subscribe(s);
+            simplePublisher.send(ByteBuffer.wrap(
+                RandomStringUtils.randomAscii(Math.toIntExact(partSize)).getBytes()));
+            simplePublisher.complete();
+        }
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
@@ -116,14 +116,14 @@ public class UploadWithUnknownContentLengthHelperTest {
     void uploadObject_withMissingContentLength_shouldFailRequest() {
         AsyncRequestBody asyncRequestBody = createMockAsyncRequestBodyWithEmptyContentLength();
         CompletableFuture<PutObjectResponse> future = setupAndTriggerUploadFailure(asyncRequestBody);
-        verifyFailureWithMessage(future, "Content length must be present on the AsyncRequestBody");
+        verifyFailureWithMessage(future, "Content length is missing on the AsyncRequestBody for part number");
     }
 
     @Test
     void uploadObject_withPartSizeExceedingLimit_shouldFailRequest() {
         AsyncRequestBody asyncRequestBody = createMockAsyncRequestBody(PART_SIZE + 1);
         CompletableFuture<PutObjectResponse> future = setupAndTriggerUploadFailure(asyncRequestBody);
-        verifyFailureWithMessage(future, "Content length must not be greater than the part size");
+        verifyFailureWithMessage(future, "Content length must not be greater than part size");
     }
 
     private PutObjectRequest createPutObjectRequest() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
@@ -16,17 +16,25 @@
 package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.services.s3.internal.multipart.MpuTestUtils.stubSuccessfulCompleteMultipartCall;
 import static software.amazon.awssdk.services.s3.internal.multipart.MpuTestUtils.stubSuccessfulCreateMultipartCall;
 import static software.amazon.awssdk.services.s3.internal.multipart.MpuTestUtils.stubSuccessfulUploadPartCalls;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterAll;
@@ -35,24 +43,29 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.utils.StringInputStream;
 
 public class UploadWithUnknownContentLengthHelperTest {
     private static final String BUCKET = "bucket";
     private static final String KEY = "key";
     private static final String UPLOAD_ID = "1234";
-
-    // Should contain 126 parts
     private static final long MPU_CONTENT_SIZE = 1005 * 1024;
     private static final long PART_SIZE = 8 * 1024;
+    private static final int NUM_TOTAL_PARTS = 126;
 
     private UploadWithUnknownContentLengthHelper helper;
     private S3AsyncClient s3AsyncClient;
@@ -81,55 +94,115 @@ public class UploadWithUnknownContentLengthHelperTest {
         stubSuccessfulCompleteMultipartCall(BUCKET, KEY, s3AsyncClient);
 
         BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(null);
-
-        CompletableFuture<PutObjectResponse> future = helper.uploadObject(putObjectRequest(), body);
-
+        CompletableFuture<PutObjectResponse> future = helper.uploadObject(createPutObjectRequest(), body);
         body.writeInputStream(new FileInputStream(testFile));
-
         future.join();
 
         ArgumentCaptor<UploadPartRequest> requestArgumentCaptor = ArgumentCaptor.forClass(UploadPartRequest.class);
         ArgumentCaptor<AsyncRequestBody> requestBodyArgumentCaptor = ArgumentCaptor.forClass(AsyncRequestBody.class);
-        int numTotalParts = 126;
-        verify(s3AsyncClient, times(numTotalParts)).uploadPart(requestArgumentCaptor.capture(),
-                                                   requestBodyArgumentCaptor.capture());
+        verify(s3AsyncClient, times(NUM_TOTAL_PARTS)).uploadPart(requestArgumentCaptor.capture(),
+                requestBodyArgumentCaptor.capture());
 
         List<UploadPartRequest> actualRequests = requestArgumentCaptor.getAllValues();
         List<AsyncRequestBody> actualRequestBodies = requestBodyArgumentCaptor.getAllValues();
-        assertThat(actualRequestBodies).hasSize(numTotalParts);
-        assertThat(actualRequests).hasSize(numTotalParts);
+        assertThat(actualRequestBodies).hasSize(NUM_TOTAL_PARTS);
+        assertThat(actualRequests).hasSize(NUM_TOTAL_PARTS);
 
+        verifyUploadPartRequests(actualRequests, actualRequestBodies);
+        verifyCompleteMultipartUploadRequest();
+    }
+
+    @Test
+    void uploadObject_withMissingContentLength_shouldFailRequest() {
+        AsyncRequestBody asyncRequestBody = createMockAsyncRequestBodyWithEmptyContentLength();
+        CompletableFuture<PutObjectResponse> future = setupAndTriggerUploadFailure(asyncRequestBody);
+        verifyFailureWithMessage(future, "Content length must be present on the AsyncRequestBody");
+    }
+
+    @Test
+    void uploadObject_withPartSizeExceedingLimit_shouldFailRequest() {
+        AsyncRequestBody asyncRequestBody = createMockAsyncRequestBody(PART_SIZE + 1);
+        CompletableFuture<PutObjectResponse> future = setupAndTriggerUploadFailure(asyncRequestBody);
+        verifyFailureWithMessage(future, "Content length must not be greater than the part size");
+    }
+
+    private PutObjectRequest createPutObjectRequest() {
+        return PutObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(KEY)
+                .build();
+    }
+
+    private List<CompletedPart> createCompletedParts(int totalNumParts) {
+        return IntStream.range(1, totalNumParts + 1)
+                .mapToObj(i -> CompletedPart.builder().partNumber(i).build())
+                .collect(Collectors.toList());
+    }
+
+    private AsyncRequestBody createMockAsyncRequestBody(long contentLength) {
+        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+        when(mockBody.contentLength()).thenReturn(Optional.of(contentLength));
+        return mockBody;
+    }
+
+    private AsyncRequestBody createMockAsyncRequestBodyWithEmptyContentLength() {
+        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+        when(mockBody.contentLength()).thenReturn(Optional.empty());
+        return mockBody;
+    }
+
+    private CompletableFuture<PutObjectResponse> setupAndTriggerUploadFailure(AsyncRequestBody asyncRequestBody) {
+        SdkPublisher<AsyncRequestBody> mockPublisher = mock(SdkPublisher.class);
+        when(asyncRequestBody.split(any(Consumer.class))).thenReturn(mockPublisher);
+
+        ArgumentCaptor<Subscriber<AsyncRequestBody>> subscriberCaptor = ArgumentCaptor.forClass(Subscriber.class);
+        CompletableFuture<PutObjectResponse> future = helper.uploadObject(createPutObjectRequest(), asyncRequestBody);
+
+        verify(mockPublisher).subscribe(subscriberCaptor.capture());
+        Subscriber<AsyncRequestBody> subscriber = subscriberCaptor.getValue();
+
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(asyncRequestBody);
+
+        stubSuccessfulCreateMultipartCall(UPLOAD_ID, s3AsyncClient);
+        subscriber.onNext(asyncRequestBody);
+
+        return future;
+    }
+
+    private void verifyFailureWithMessage(CompletableFuture<PutObjectResponse> future, String expectedErrorMessage) {
+        assertThat(future).isCompletedExceptionally();
+        future.exceptionally(throwable -> {
+            assertThat(throwable).isInstanceOf(SdkClientException.class);
+            assertThat(throwable.getMessage()).contains(expectedErrorMessage);
+            return null;
+        }).join();
+    }
+
+    private void verifyUploadPartRequests(List<UploadPartRequest> actualRequests,
+            List<AsyncRequestBody> actualRequestBodies) {
         for (int i = 0; i < actualRequests.size(); i++) {
             UploadPartRequest request = actualRequests.get(i);
             AsyncRequestBody requestBody = actualRequestBodies.get(i);
-            assertThat(request.partNumber()).isEqualTo( i + 1);
+            assertThat(request.partNumber()).isEqualTo(i + 1);
             assertThat(request.bucket()).isEqualTo(BUCKET);
             assertThat(request.key()).isEqualTo(KEY);
 
             if (i == actualRequests.size() - 1) {
                 assertThat(requestBody.contentLength()).hasValue(5120L);
-            } else{
+            } else {
                 assertThat(requestBody.contentLength()).hasValue(PART_SIZE);
             }
         }
+    }
 
-        ArgumentCaptor<CompleteMultipartUploadRequest> completeMpuArgumentCaptor = ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+    private void verifyCompleteMultipartUploadRequest() {
+        ArgumentCaptor<CompleteMultipartUploadRequest> completeMpuArgumentCaptor = ArgumentCaptor
+                .forClass(CompleteMultipartUploadRequest.class);
         verify(s3AsyncClient).completeMultipartUpload(completeMpuArgumentCaptor.capture());
 
         CompleteMultipartUploadRequest actualRequest = completeMpuArgumentCaptor.getValue();
-        assertThat(actualRequest.multipartUpload().parts()).isEqualTo(completedParts(numTotalParts));
-
+        assertThat(actualRequest.multipartUpload().parts()).isEqualTo(createCompletedParts(NUM_TOTAL_PARTS));
     }
-
-    private static PutObjectRequest putObjectRequest() {
-        return PutObjectRequest.builder()
-                               .bucket(BUCKET)
-                               .key(KEY)
-                               .build();
-    }
-
-    private List<CompletedPart> completedParts(int totalNumParts) {
-        return IntStream.range(1, totalNumParts + 1).mapToObj(i -> CompletedPart.builder().partNumber(i).build()).collect(Collectors.toList());
-    }
-
 }

--- a/test/ruleset-testing-core/pom.xml
+++ b/test/ruleset-testing-core/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
-            <version>3.1.5</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
The S3 multipart upload client lacked proper validation of upload parameters, which could lead to runtime failures or incorrect behavior when publishers provide malformed data. This addresses potential issues where:
• AsyncRequestBody parts lack content length information
• Individual parts exceed the configured part size
• The actual number of parts doesn't match expected calculations
• Publisher implementations continue sending data after completion

### Changes Made

#### Validation Enhancements
• **Content Length Validation**: Ensure all AsyncRequestBody parts have content length present
• **Part Size Validation**: Verify each part (except the last) matches the expected part size exactly
• **Last Part Size Validation**: Validate the final part size matches the calculated remainder or full part size
• **Part Count Validation**: Ensure the total number of parts received matches the expected count
• **Publisher State Guards**: Add isDone checks in onNext to prevent processing after completion

#### Code Structure Improvements
• **Enhanced MpuRequestContext**: Added expectedNumParts field to track anticipated part count
• **Improved Error Handling**: Better exception chaining in MultipartUploadHelper.failRequestsElegantly
• **Consistent Naming**: Renamed variables for clarity (contentLength → totalSize, partCount → expectedNumParts)

## Testing
Added tests 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
