### PR TITLE
Rename PresignedUrlManager to PresignedUrlExtension following API review

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -346,9 +346,9 @@ public class CustomizationConfig {
     private boolean batchManagerSupported;
 
     /**
-     * A boolean flag to indicate if Presigned URL Manager is supported.
+     * A boolean flag to indicate if Presigned URL Extension is supported.
      */
-    private boolean presignedUrlManagerSupported;
+    private boolean presignedUrlExtensionSupported;
 
     /**
      * A boolean flag to indicate if the fast unmarshaller code path is enabled.
@@ -929,12 +929,12 @@ public class CustomizationConfig {
         this.batchManagerSupported = batchManagerSupported;
     }
 
-    public boolean getPresignedUrlManagerSupported() {
-        return presignedUrlManagerSupported;
+    public boolean getPresignedUrlExtensionSupported() {
+        return presignedUrlExtensionSupported;
     }
 
-    public void setPresignedUrlManagerSupported(boolean presignedUrlManagerSupported) {
-        this.presignedUrlManagerSupported = presignedUrlManagerSupported;
+    public void setPresignedUrlExtensionSupported(boolean presignedUrlExtensionSupported) {
+        this.presignedUrlExtensionSupported = presignedUrlExtensionSupported;
     }
 
     public boolean getEnableFastUnmarshaller() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtension.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtension.java
@@ -210,7 +210,7 @@ public class PoetExtension {
                              model.getMetadata().getServiceName() + "AsyncBatchManager");
     }
     
-    public ClassName getPresignedUrlManagerAsyncInterface() {
-        return ClassName.get(model.getMetadata().getFullPresignedUrlPackageName(), "AsyncPresignedUrlManager");
+    public ClassName getPresignedUrlExtensionAsyncInterface() {
+        return ClassName.get(model.getMetadata().getFullPresignedUrlPackageName(), "AsyncPresignedUrlExtension");
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -586,12 +586,12 @@ public final class AsyncClientClass extends AsyncClientInterface {
     }
     
     @Override
-    protected void addPresignedUrlManagerMethod(Builder type) {
-        ClassName returnType = poetExtensions.getPresignedUrlManagerAsyncInterface();
+    protected void addPresignedUrlExtensionMethod(Builder type) {
+        ClassName returnType = poetExtensions.getPresignedUrlExtensionAsyncInterface();
         String internalPresignedUrlPackage = model.getMetadata().getFullInternalPackageName() + ".presignedurl";
-        ClassName implClass = ClassName.get(internalPresignedUrlPackage, "DefaultAsyncPresignedUrlManager");
+        ClassName implClass = ClassName.get(internalPresignedUrlPackage, "DefaultAsyncPresignedUrlExtension");
         
-        MethodSpec presignedUrlManager = MethodSpec.methodBuilder("presignedUrlManager")
+        MethodSpec presignedUrlExtension = MethodSpec.methodBuilder("presignedUrlExtension")
                                                   .addModifiers(PUBLIC)
                                                   .addAnnotation(Override.class)
                                                   .returns(returnType)
@@ -602,7 +602,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
                                                                 implClass)
                                                   .build();
         
-        type.addMethod(presignedUrlManager);
+        type.addMethod(presignedUrlExtension);
     }
 
     private MethodSpec resolveMetricPublishersMethod() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
@@ -99,8 +99,8 @@ public class AsyncClientInterface implements ClassSpec {
         if (model.getCustomizationConfig().getBatchManagerSupported()) {
             addBatchManagerMethod(result);
         }
-        if (model.getCustomizationConfig().getPresignedUrlManagerSupported()) {
-            addPresignedUrlManagerMethod(result);
+        if (model.getCustomizationConfig().getPresignedUrlExtensionSupported()) {
+            addPresignedUrlExtensionMethod(result);
         }
         result.addMethod(serviceClientConfigMethod());
         addAdditionalMethods(result);
@@ -178,14 +178,14 @@ public class AsyncClientInterface implements ClassSpec {
         type.addMethod(batchManagerOperationBody(builder).build());
     }
     
-    protected void addPresignedUrlManagerMethod(TypeSpec.Builder type) {
-        ClassName returnType = poetExtensions.getPresignedUrlManagerAsyncInterface();
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("presignedUrlManager")
+    protected void addPresignedUrlExtensionMethod(TypeSpec.Builder type) {
+        ClassName returnType = poetExtensions.getPresignedUrlExtensionAsyncInterface();
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("presignedUrlExtension")
                                                .addModifiers(PUBLIC)
                                                .returns(returnType)
                                                .addJavadoc("Creates an instance of {@link $T} object with the "
                                                            + "configuration set on this client.", returnType);
-        type.addMethod(presignedUrlManagerOperationBody(builder).build());
+        type.addMethod(presignedUrlExtensionOperationBody(builder).build());
     }
 
     @Override
@@ -564,7 +564,7 @@ public class AsyncClientInterface implements ClassSpec {
                       .addStatement("throw new $T()", UnsupportedOperationException.class);
     }
     
-    protected MethodSpec.Builder presignedUrlManagerOperationBody(MethodSpec.Builder builder) {
+    protected MethodSpec.Builder presignedUrlExtensionOperationBody(MethodSpec.Builder builder) {
         return builder.addModifiers(DEFAULT, PUBLIC)
                       .addStatement("throw new $T()", UnsupportedOperationException.class);
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClass.java
@@ -224,7 +224,7 @@ public class DelegatingAsyncClientClass extends AsyncClientInterface {
     }
     
     @Override
-    protected MethodSpec.Builder presignedUrlManagerOperationBody(MethodSpec.Builder builder) {
-        return builder.addAnnotation(Override.class).addStatement("return delegate.presignedUrlManager()");
+    protected MethodSpec.Builder presignedUrlExtensionOperationBody(MethodSpec.Builder builder) {
+        return builder.addAnnotation(Override.class).addStatement("return delegate.presignedUrlExtension()");
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -526,7 +526,7 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
     
-    public static IntermediateModel presignedUrlManagerModels() {
+    public static IntermediateModel presignedUrlExtensionModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/presignedurl/service-2.json").getFile());
         File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/presignedurl/customization.config").getFile());
 

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
@@ -24,7 +24,7 @@ import static software.amazon.awssdk.codegen.poet.ClientTestModels.customContent
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.customPackageModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.endpointDiscoveryModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.opsWithSigv4a;
-import static software.amazon.awssdk.codegen.poet.ClientTestModels.presignedUrlManagerModels;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.presignedUrlExtensionModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.queryServiceModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.restJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.rpcv2ServiceModels;
@@ -119,8 +119,8 @@ public class AsyncClientClassTest {
     }
     
     @Test
-    public void asyncClientPresignedUrlManager() {
-        ClassSpec asyncClientPresignedUrlManager = createAsyncClientClass(presignedUrlManagerModels());
+    public void asyncClientPresignedUrlExtension() {
+        ClassSpec asyncClientPresignedUrlManager = createAsyncClientClass(presignedUrlExtensionModels());
         assertThat(asyncClientPresignedUrlManager, generatesTo("test-presignedurl-async.java"));
     }
 

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterfaceTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterfaceTest.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.codegen.poet.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.batchManagerModels;
-import static software.amazon.awssdk.codegen.poet.ClientTestModels.presignedUrlManagerModels;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.presignedUrlExtensionModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.restJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
@@ -38,8 +38,8 @@ public class AsyncClientInterfaceTest {
     }
     
     @Test
-    public void asyncClientInterfaceWithPresignedUrlManager() {
-        ClassSpec asyncClientInterface = new AsyncClientInterface(presignedUrlManagerModels());
+    public void asyncClientInterfaceWithPresignedUrlExtension() {
+        ClassSpec asyncClientInterface = new AsyncClientInterface(presignedUrlExtensionModels());
         assertThat(asyncClientInterface, generatesTo("test-json-async-client-interface-presignedurl.java"));
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/DelegatingAsyncClientClassTest.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.codegen.poet.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static software.amazon.awssdk.codegen.poet.ClientTestModels.presignedUrlManagerModels;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.presignedUrlExtensionModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.restJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
@@ -31,9 +31,9 @@ public class DelegatingAsyncClientClassTest {
     }
     
     @Test
-    public void delegatingAsyncClientClassWithPresignedUrlManager() {
+    public void delegatingAsyncClientClassWithPresignedUrlExtension() {
         DelegatingAsyncClientClass asyncClientDecoratorAbstractClass =
-            new DelegatingAsyncClientClass(presignedUrlManagerModels());
+            new DelegatingAsyncClientClass(presignedUrlExtensionModels());
         assertThat(asyncClientDecoratorAbstractClass, generatesTo("test-abstract-async-client-class-presignedurl.java"));
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/presignedurl/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/presignedurl/customization.config
@@ -1,3 +1,3 @@
 {
-  "presignedUrlManagerSupported": true
+  "presignedUrlExtensionSupported": true
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class-presignedurl.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-abstract-async-client-class-presignedurl.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
 import software.amazon.awssdk.services.json.model.JsonRequest;
-import software.amazon.awssdk.services.json.presignedurl.AsyncPresignedUrlManager;
+import software.amazon.awssdk.services.json.presignedurl.AsyncPresignedUrlExtension;
 import software.amazon.awssdk.utils.Validate;
 
 @Generated("software.amazon.awssdk:codegen")
@@ -51,11 +51,11 @@ public abstract class DelegatingJsonAsyncClient implements JsonAsyncClient {
     }
 
     /**
-     * Creates an instance of {@link AsyncPresignedUrlManager} object with the configuration set on this client.
+     * Creates an instance of {@link AsyncPresignedUrlExtension} object with the configuration set on this client.
      */
     @Override
-    public AsyncPresignedUrlManager presignedUrlManager() {
-        return delegate.presignedUrlManager();
+    public AsyncPresignedUrlExtension presignedUrlExtension() {
+        return delegate.presignedUrlExtension();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface-presignedurl.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface-presignedurl.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.awscore.AwsClient;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
-import software.amazon.awssdk.services.json.presignedurl.AsyncPresignedUrlManager;
+import software.amazon.awssdk.services.json.presignedurl.AsyncPresignedUrlExtension;
 
 /**
  * Service client for accessing Json Service asynchronously. This can be created using the static {@link #builder()}
@@ -94,9 +94,9 @@ public interface JsonAsyncClient extends AwsClient {
     }
 
     /**
-     * Creates an instance of {@link AsyncPresignedUrlManager} object with the configuration set on this client.
+     * Creates an instance of {@link AsyncPresignedUrlExtension} object with the configuration set on this client.
      */
-    default AsyncPresignedUrlManager presignedUrlManager() {
+    default AsyncPresignedUrlExtension presignedUrlExtension() {
         throw new UnsupportedOperationException();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-presignedurl-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-presignedurl-async.java
@@ -39,12 +39,12 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.internal.JsonServiceClientConfigurationBuilder;
 import software.amazon.awssdk.services.json.internal.ServiceVersionInfo;
-import software.amazon.awssdk.services.json.internal.presignedurl.DefaultAsyncPresignedUrlManager;
+import software.amazon.awssdk.services.json.internal.presignedurl.DefaultAsyncPresignedUrlExtension;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
 import software.amazon.awssdk.services.json.model.InvalidInputException;
 import software.amazon.awssdk.services.json.model.JsonException;
-import software.amazon.awssdk.services.json.presignedurl.AsyncPresignedUrlManager;
+import software.amazon.awssdk.services.json.presignedurl.AsyncPresignedUrlExtension;
 import software.amazon.awssdk.services.json.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 
@@ -147,8 +147,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     }
 
     @Override
-    public AsyncPresignedUrlManager presignedUrlManager() {
-        return new DefaultAsyncPresignedUrlManager(clientHandler, protocolFactory, clientConfiguration, protocolMetadata);
+    public AsyncPresignedUrlExtension presignedUrlExtension() {
+        return new DefaultAsyncPresignedUrlExtension(clientHandler, protocolFactory, clientConfiguration, protocolMetadata);
     }
 
     @Override

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -74,6 +74,7 @@ import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Validate;
 
@@ -448,5 +449,11 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                             + "software.amazon.awssdk.crt:crt is a required dependency; make sure you have it "
                                             + "on the classpath.", e);
         }
+    }
+
+    @Override
+    public AsyncPresignedUrlExtension presignedUrlExtension() {
+        // TODO: Implement presigned URL extension support for CRT client
+        throw new UnsupportedOperationException("Presigned URL extension is not supported for multipart client");
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClient.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Request;
 import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
+import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -110,5 +111,11 @@ public final class MultipartS3AsyncClient extends DelegatingS3AsyncClient {
             }
         };
         return new MultipartS3AsyncClient(clientWithUserAgent, multipartConfiguration, checksumEnabled);
+    }
+
+    @Override
+    public AsyncPresignedUrlExtension presignedUrlExtension() {
+        // TODO: Implement presigned URL extension support for multipart client
+        throw new UnsupportedOperationException("Presigned URL extension is not supported for multipart client");
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
@@ -24,11 +24,11 @@ import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.protocols.core.OperationInfo;
 import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
 import software.amazon.awssdk.protocols.xml.AwsXmlProtocolFactory;
-import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlGetObjectRequestWrapper;
+import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlDownloadRequestWrapper;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * {@link PresignedUrlGetObjectRequestWrapper} Marshaller
+ * {@link PresignedUrlDownloadRequestWrapper} Marshaller
  *
  * <p>
  * Marshalls presigned URL requests by using the complete URL directly and adding optional Range headers.
@@ -36,7 +36,7 @@ import software.amazon.awssdk.utils.Validate;
  * </p>
  */
 @SdkInternalApi
-public class PresignedUrlGetObjectRequestMarshaller implements Marshaller<PresignedUrlGetObjectRequestWrapper> {
+public class PresignedUrlDownloadRequestMarshaller implements Marshaller<PresignedUrlDownloadRequestWrapper> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
             .requestUri("").httpMethod(SdkHttpMethod.GET).hasExplicitPayloadMember(false).hasPayloadMembers(false)
             .putAdditionalMetadata(AwsXmlProtocolFactory.ROOT_MARSHALL_LOCATION_ATTRIBUTE, null)
@@ -44,7 +44,7 @@ public class PresignedUrlGetObjectRequestMarshaller implements Marshaller<Presig
 
     private final AwsXmlProtocolFactory protocolFactory;
 
-    public PresignedUrlGetObjectRequestMarshaller(AwsXmlProtocolFactory protocolFactory) {
+    public PresignedUrlDownloadRequestMarshaller(AwsXmlProtocolFactory protocolFactory) {
         this.protocolFactory = protocolFactory;
     }
 
@@ -56,7 +56,7 @@ public class PresignedUrlGetObjectRequestMarshaller implements Marshaller<Presig
      * @throws SdkClientException if URL conversion fails
      */
     @Override
-    public SdkHttpFullRequest marshall(PresignedUrlGetObjectRequestWrapper presignedUrlGetObjectRequestWrapper) {
+    public SdkHttpFullRequest marshall(PresignedUrlDownloadRequestWrapper presignedUrlGetObjectRequestWrapper) {
         Validate.paramNotNull(presignedUrlGetObjectRequestWrapper, "presignedUrlGetObjectRequestWrapper");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapper.java
@@ -37,14 +37,14 @@ import software.amazon.awssdk.services.s3.model.S3Request;
  * SdkField definitions needed for custom marshalling and is not intended for direct use by SDK users.
  * </p>
  * <b>Note:</b> This is an internal implementation class and should not be used
- * directly. Use {@code PresignedUrlGetObjectRequest} for public API interactions.
+ * directly. Use {@code PresignedUrlDownloadRequest} for public API interactions.
  */
 @SdkInternalApi
-public final class PresignedUrlGetObjectRequestWrapper extends S3Request {
+public final class PresignedUrlDownloadRequestWrapper extends S3Request {
     private static final SdkField<String> RANGE_FIELD = SdkField
         .<String>builder(MarshallingType.STRING)
         .memberName("Range")
-        .getter(getter(PresignedUrlGetObjectRequestWrapper::range))
+        .getter(getter(PresignedUrlDownloadRequestWrapper::range))
         .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("Range")
                              .unmarshallLocationName("Range").build()).build();
 
@@ -56,7 +56,7 @@ public final class PresignedUrlGetObjectRequestWrapper extends S3Request {
     private final URL url;
     private final String range;
 
-    private PresignedUrlGetObjectRequestWrapper(Builder builder) {
+    private PresignedUrlDownloadRequestWrapper(Builder builder) {
         super(builder);
         this.url = builder.url;
         this.range = builder.range;
@@ -80,8 +80,8 @@ public final class PresignedUrlGetObjectRequestWrapper extends S3Request {
         return SDK_NAME_TO_FIELD;
     }
 
-    private static <T> Function<Object, T> getter(Function<PresignedUrlGetObjectRequestWrapper, T> g) {
-        return obj -> g.apply((PresignedUrlGetObjectRequestWrapper) obj);
+    private static <T> Function<Object, T> getter(Function<PresignedUrlDownloadRequestWrapper, T> g) {
+        return obj -> g.apply((PresignedUrlDownloadRequestWrapper) obj);
     }
 
     private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
@@ -110,7 +110,7 @@ public final class PresignedUrlGetObjectRequestWrapper extends S3Request {
         if (!super.equals(obj)) {
             return false;
         }
-        PresignedUrlGetObjectRequestWrapper that = (PresignedUrlGetObjectRequestWrapper) obj;
+        PresignedUrlDownloadRequestWrapper that = (PresignedUrlDownloadRequestWrapper) obj;
         return Objects.equals(url, that.url) && Objects.equals(range, that.range);
     }
 
@@ -129,7 +129,7 @@ public final class PresignedUrlGetObjectRequestWrapper extends S3Request {
         public Builder() {
         }
 
-        Builder(PresignedUrlGetObjectRequestWrapper request) {
+        Builder(PresignedUrlDownloadRequestWrapper request) {
             super(request);
             this.url = request.url();
             this.range = request.range();
@@ -146,8 +146,8 @@ public final class PresignedUrlGetObjectRequestWrapper extends S3Request {
         }
 
         @Override
-        public PresignedUrlGetObjectRequestWrapper build() {
-            return new PresignedUrlGetObjectRequestWrapper(this);
+        public PresignedUrlDownloadRequestWrapper build() {
+            return new PresignedUrlDownloadRequestWrapper(this);
         }
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtension.java
@@ -24,14 +24,14 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlGetObjectRequest;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 
 /**
  * Interface for executing S3 operations asynchronously using presigned URLs. This can be accessed using
- * {@link S3AsyncClient#presignedUrlManager()}.
+ * {@link S3AsyncClient#presignedUrlExtension()}.
  */
 @SdkPublicApi
-public interface AsyncPresignedUrlManager {
+public interface AsyncPresignedUrlExtension {
     /**
      * <p>
      * Downloads an S3 object asynchronously using a presigned URL.
@@ -52,7 +52,7 @@ public interface AsyncPresignedUrlManager {
      * @throws SdkClientException If any client side error occurs
      * @throws S3Exception        Base class for all S3 service exceptions
      */
-    default <ReturnT> CompletableFuture<ReturnT> getObject(PresignedUrlGetObjectRequest request,
+    default <ReturnT> CompletableFuture<ReturnT> getObject(PresignedUrlDownloadRequest request,
                                                            AsyncResponseTransformer<GetObjectResponse,
                                                                ReturnT> responseTransformer) {
         throw new UnsupportedOperationException();
@@ -64,20 +64,20 @@ public interface AsyncPresignedUrlManager {
      * </p>
      *
      * <p>
-     * This is a convenience method that creates a {@link PresignedUrlGetObjectRequest} using the provided consumer.
+     * This is a convenience method that creates a {@link PresignedUrlDownloadRequest} using the provided consumer.
      * </p>
      *
-     * @param requestConsumer     Consumer that will configure a {@link PresignedUrlGetObjectRequest.Builder}
+     * @param requestConsumer     Consumer that will configure a {@link PresignedUrlDownloadRequest.Builder}
      * @param responseTransformer Transforms the response to the desired return type
      * @param <ReturnT>           The type of the transformed response
      * @return A {@link CompletableFuture} containing the transformed result
      * @throws SdkClientException If any client side error occurs
      * @throws S3Exception        Base class for all S3 service exceptions
      */
-    default <ReturnT> CompletableFuture<ReturnT> getObject(Consumer<PresignedUrlGetObjectRequest.Builder> requestConsumer,
+    default <ReturnT> CompletableFuture<ReturnT> getObject(Consumer<PresignedUrlDownloadRequest.Builder> requestConsumer,
                                                            AsyncResponseTransformer<GetObjectResponse,
                                                                ReturnT> responseTransformer) {
-        return getObject(PresignedUrlGetObjectRequest.builder().applyMutation(requestConsumer).build(), responseTransformer);
+        return getObject(PresignedUrlDownloadRequest.builder().applyMutation(requestConsumer).build(), responseTransformer);
     }
 
     /**
@@ -96,7 +96,7 @@ public interface AsyncPresignedUrlManager {
      * @throws SdkClientException If any client side error occurs
      * @throws S3Exception        Base class for all S3 service exceptions
      */
-    default CompletableFuture<GetObjectResponse> getObject(PresignedUrlGetObjectRequest request,
+    default CompletableFuture<GetObjectResponse> getObject(PresignedUrlDownloadRequest request,
                                                            Path destinationPath) {
         return getObject(request, AsyncResponseTransformer.toFile(destinationPath));
     }
@@ -111,13 +111,13 @@ public interface AsyncPresignedUrlManager {
      * This is a convenience method that combines consumer-based request building with file-based response handling.
      * </p>
      *
-     * @param requestConsumer Consumer that will configure a {@link PresignedUrlGetObjectRequest.Builder}
+     * @param requestConsumer Consumer that will configure a {@link PresignedUrlDownloadRequest.Builder}
      * @param destinationPath The path where the downloaded object will be saved
      * @return A {@link CompletableFuture} containing the {@link GetObjectResponse}
      * @throws SdkClientException If any client side error occurs
      * @throws S3Exception        Base class for all S3 service exceptions
      */
-    default CompletableFuture<GetObjectResponse> getObject(Consumer<PresignedUrlGetObjectRequest.Builder> requestConsumer,
+    default CompletableFuture<GetObjectResponse> getObject(Consumer<PresignedUrlDownloadRequest.Builder> requestConsumer,
                                                            Path destinationPath) {
         return getObject(requestConsumer, AsyncResponseTransformer.toFile(destinationPath));
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequest.java
@@ -25,15 +25,15 @@ import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
- * Request object for performing GetObject operations using a presigned URL.
+ * Request object for performing download operations using a presigned URL.
  */
 @SdkPublicApi
-public final class PresignedUrlGetObjectRequest implements ToCopyableBuilder<PresignedUrlGetObjectRequest.Builder,
-    PresignedUrlGetObjectRequest> {
+public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<PresignedUrlDownloadRequest.Builder,
+    PresignedUrlDownloadRequest> {
     private final URL presignedUrl;
     private final String range;
 
-    private PresignedUrlGetObjectRequest(BuilderImpl builder) {
+    private PresignedUrlDownloadRequest(BuilderImpl builder) {
         this.presignedUrl = builder.presignedUrl;
         this.range = builder.range;
     }
@@ -76,12 +76,12 @@ public final class PresignedUrlGetObjectRequest implements ToCopyableBuilder<Pre
     }
 
     /**
-     * Create a {@code PresignedUrlGetObjectRequest} instance with the given configuration
+     * Create a {@code PresignedUrlDownloadRequest} instance with the given configuration
      *
      * @param builderConsumer the consumer that will configure the builder
-     * @return a {@code PresignedUrlGetObjectRequest} instance
+     * @return a {@code PresignedUrlDownloadRequest} instance
      */
-    public static PresignedUrlGetObjectRequest builder(Consumer<Builder> builderConsumer) {
+    public static PresignedUrlDownloadRequest builder(Consumer<Builder> builderConsumer) {
         return builder().applyMutation(builderConsumer).build();
     }
 
@@ -105,20 +105,20 @@ public final class PresignedUrlGetObjectRequest implements ToCopyableBuilder<Pre
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        PresignedUrlGetObjectRequest other = (PresignedUrlGetObjectRequest) obj;
+        PresignedUrlDownloadRequest other = (PresignedUrlDownloadRequest) obj;
         return Objects.equals(presignedUrl(), other.presignedUrl()) &&
                Objects.equals(range(), other.range());
     }
 
     @Override
     public String toString() {
-        return ToString.builder("PresignedUrlGetObjectRequest")
+        return ToString.builder("PresignedUrlDownloadRequest")
                        .add("PresignedUrl", presignedUrl())
                        .add("Range", range())
                        .build();
     }
 
-    public interface Builder extends CopyableBuilder<Builder, PresignedUrlGetObjectRequest> {
+    public interface Builder extends CopyableBuilder<Builder, PresignedUrlDownloadRequest> {
         /**
          * Sets the presigned URL for the S3 object.
          * @param presignedUrl
@@ -141,7 +141,7 @@ public final class PresignedUrlGetObjectRequest implements ToCopyableBuilder<Pre
         private BuilderImpl() {
         }
 
-        private BuilderImpl(PresignedUrlGetObjectRequest presignedUrlGetObjectRequest) {
+        private BuilderImpl(PresignedUrlDownloadRequest presignedUrlGetObjectRequest) {
             presignedUrl(presignedUrlGetObjectRequest.presignedUrl());
             range(presignedUrlGetObjectRequest.range());
         }
@@ -159,9 +159,9 @@ public final class PresignedUrlGetObjectRequest implements ToCopyableBuilder<Pre
         }
 
         @Override
-        public PresignedUrlGetObjectRequest build() {
+        public PresignedUrlDownloadRequest build() {
             Validate.paramNotNull(presignedUrl, "presignedUrl");
-            return new PresignedUrlGetObjectRequest(this);
+            return new PresignedUrlDownloadRequest(this);
         }
     }
 }

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -359,5 +359,5 @@
       "className": "software.amazon.awssdk.services.s3.internal.CustomRequestTransformerUtils"
     }
   },
-    "presignedUrlManagerSupported": true
+    "presignedUrlExtensionSupported": true
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
@@ -32,11 +32,11 @@ import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.protocols.core.OperationInfo;
 import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
 import software.amazon.awssdk.protocols.xml.AwsXmlProtocolFactory;
-import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlGetObjectRequestWrapper;
+import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlDownloadRequestWrapper;
 
-class PresignedUrlGetObjectRequestMarshallerTest {
+class PresignedUrlDownloadRequestMarshallerTest {
 
-    private PresignedUrlGetObjectRequestMarshaller marshaller;
+    private PresignedUrlDownloadRequestMarshaller marshaller;
     private AwsXmlProtocolFactory mockProtocolFactory;
     private ProtocolMarshaller<SdkHttpFullRequest> mockProtocolMarshaller;
     private URL testUrl;
@@ -47,7 +47,7 @@ class PresignedUrlGetObjectRequestMarshallerTest {
         mockProtocolMarshaller = mock(ProtocolMarshaller.class);
         when(mockProtocolFactory.createProtocolMarshaller(any(OperationInfo.class)))
             .thenReturn(mockProtocolMarshaller);
-        marshaller = new PresignedUrlGetObjectRequestMarshaller(mockProtocolFactory);
+        marshaller = new PresignedUrlDownloadRequestMarshaller(mockProtocolFactory);
 
         testUrl = new URL("https://test-bucket.s3.us-east-1.amazonaws.com/test-key?" +
                           "X-Amz-Date=20231215T000000Z&" +
@@ -67,10 +67,10 @@ class PresignedUrlGetObjectRequestMarshallerTest {
                                                            .protocol("https")
                                                            .host("example.com")
                                                            .build();
-        when(mockProtocolMarshaller.marshall(any(PresignedUrlGetObjectRequestWrapper.class)))
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
             .thenReturn(baseRequest);
 
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(testUrl)
                                                                                          .build();
         SdkHttpFullRequest result = marshaller.marshall(request);
@@ -114,10 +114,10 @@ class PresignedUrlGetObjectRequestMarshallerTest {
                                                            .putHeader("Range", rangeValue)  // Add the Range header to the mock response
                                                            .build();
 
-        when(mockProtocolMarshaller.marshall(any(PresignedUrlGetObjectRequestWrapper.class)))
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
             .thenReturn(baseRequest);
 
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(testUrl)
                                                                                          .range(rangeValue)
                                                                                          .build();
@@ -139,10 +139,10 @@ class PresignedUrlGetObjectRequestMarshallerTest {
                                                            .protocol("https")
                                                            .host("example.com")
                                                            .build();
-        when(mockProtocolMarshaller.marshall(any(PresignedUrlGetObjectRequestWrapper.class)))
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
             .thenReturn(baseRequest);
 
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(testUrl)
                                                                                          .range(rangeValue)
                                                                                          .build();
@@ -166,11 +166,11 @@ class PresignedUrlGetObjectRequestMarshallerTest {
                                                            .protocol("https")
                                                            .host("example.com")
                                                            .build();
-        when(mockProtocolMarshaller.marshall(any(PresignedUrlGetObjectRequestWrapper.class)))
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
             .thenReturn(baseRequest);
 
         URL malformedUrl = new URL("https", "test-bucket.s3.us-east-1.amazonaws.com", -1, "/test key with spaces");
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(malformedUrl)
                                                                                          .build();
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlGetObjectRequestWrapperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlGetObjectRequestWrapperTest.java
@@ -26,17 +26,17 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 
 
-class PresignedUrlGetObjectRequestWrapperTest {
+class PresignedUrlDownloadRequestWrapperTest {
     @Test
     void equalsAndHashCode_shouldFollowContract() {
-        EqualsVerifier.forClass(PresignedUrlGetObjectRequestWrapper.class)
+        EqualsVerifier.forClass(PresignedUrlDownloadRequestWrapper.class)
                       .withRedefinedSuperclass()
                       .verify();
     }
 
     @Test
     void basicProperties_shouldWork() throws Exception {
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
                                                                                          .range("bytes=0-100")
                                                                                          .build();
@@ -47,7 +47,7 @@ class PresignedUrlGetObjectRequestWrapperTest {
 
     @Test
     void sdkFields_shouldReturnExpectedFields() throws Exception {
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
                                                                                          .range("bytes=0-100")
                                                                                          .build();
@@ -66,7 +66,7 @@ class PresignedUrlGetObjectRequestWrapperTest {
 
     @Test
     void sdkFieldNameToField_shouldReturnExpectedMapping() throws Exception {
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
                                                                                          .build();
 
@@ -80,7 +80,7 @@ class PresignedUrlGetObjectRequestWrapperTest {
 
     @Test
     void rangeField_shouldMarshalCorrectly() throws Exception {
-        PresignedUrlGetObjectRequestWrapper request = PresignedUrlGetObjectRequestWrapper.builder()
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
                                                                                          .range("bytes=0-1023")
                                                                                          .build();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTest.java
@@ -52,13 +52,13 @@ import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlGetObjectRequest;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 
 @WireMockTest
-public class AsyncPresignedUrlManagerTest {
+public class AsyncPresignedUrlExtensionTest {
 
     private S3AsyncClient s3AsyncClient;
-    private AsyncPresignedUrlManager presignedUrlManager;
+    private AsyncPresignedUrlExtension presignedUrlExtension;
 
     @TempDir
     Path tempDir;
@@ -68,7 +68,7 @@ public class AsyncPresignedUrlManagerTest {
         s3AsyncClient = S3AsyncClient.builder()
                                      .endpointOverride(URI.create(wireMockRuntimeInfo.getHttpBaseUrl()))
                                      .build();
-        presignedUrlManager = s3AsyncClient.presignedUrlManager();
+        presignedUrlExtension = s3AsyncClient.presignedUrlExtension();
     }
 
     @AfterEach
@@ -82,7 +82,7 @@ public class AsyncPresignedUrlManagerTest {
     class BasicFunctionality {
         @Test
         void givenS3AsyncClient_whenPresignedUrlManagerRequested_thenReturnsNonNullInstance() {
-            assertThat(presignedUrlManager).isNotNull();
+            assertThat(presignedUrlExtension).isNotNull();
         }
 
         @Test
@@ -94,10 +94,10 @@ public class AsyncPresignedUrlManagerTest {
             stubSuccessResponse(presignedUrlPath, testContent, testETag);
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
 
             ResponseBytes<GetObjectResponse> response = result.get();
             assertSuccessfulResponse(response, testContent, testETag);
@@ -114,7 +114,7 @@ public class AsyncPresignedUrlManagerTest {
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(
+                presignedUrlExtension.getObject(
                     request -> request.presignedUrl(presignedUrl),
                     AsyncResponseTransformer.toBytes()
                 );
@@ -138,10 +138,10 @@ public class AsyncPresignedUrlManagerTest {
                                         .withBody(testContent)));
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
             
             ResponseBytes<GetObjectResponse> response = result.get();
             assertThat(response).isNotNull();
@@ -166,13 +166,13 @@ public class AsyncPresignedUrlManagerTest {
                                         .withBody(expectedContent)));
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+            PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                                .presignedUrl(presignedUrl)
                                                                                .range(range)
                                                                                .build();
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
 
             ResponseBytes<GetObjectResponse> response = result.get();
             assertThat(response).isNotNull();
@@ -191,12 +191,12 @@ public class AsyncPresignedUrlManagerTest {
             stubSuccessResponse(presignedUrlPath, testContent, testETag);
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
 
             Path downloadFile = tempDir.resolve("download-" + UUID.randomUUID() + ".txt");
 
             CompletableFuture<GetObjectResponse> result =
-                presignedUrlManager.getObject(request, downloadFile);
+                presignedUrlExtension.getObject(request, downloadFile);
 
             GetObjectResponse response = result.get();
             assertThat(response).isNotNull();
@@ -218,7 +218,7 @@ public class AsyncPresignedUrlManagerTest {
             Path downloadFile = tempDir.resolve("consumer-download-" + UUID.randomUUID() + ".txt");
 
             CompletableFuture<GetObjectResponse> result =
-                presignedUrlManager.getObject(
+                presignedUrlExtension.getObject(
                     request -> request.presignedUrl(presignedUrl),
                     downloadFile
                 );
@@ -246,10 +246,10 @@ public class AsyncPresignedUrlManagerTest {
                                         .withBody(testContent)));
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
             
             Path downloadFile = tempDir.resolve("empty-file-" + UUID.randomUUID() + ".txt");
-            CompletableFuture<GetObjectResponse> result = presignedUrlManager.getObject(request, downloadFile);
+            CompletableFuture<GetObjectResponse> result = presignedUrlExtension.getObject(request, downloadFile);
             
             GetObjectResponse response = result.get();
             assertThat(response).isNotNull();
@@ -275,10 +275,10 @@ public class AsyncPresignedUrlManagerTest {
                                         .withBody(largeContent)));
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
 
             Path downloadFile = tempDir.resolve("large-file-" + UUID.randomUUID() + ".bin");
-            CompletableFuture<GetObjectResponse> result = presignedUrlManager.getObject(request, downloadFile);
+            CompletableFuture<GetObjectResponse> result = presignedUrlExtension.getObject(request, downloadFile);
             
             GetObjectResponse response = result.get();
             assertThat(response).isNotNull();
@@ -316,10 +316,10 @@ public class AsyncPresignedUrlManagerTest {
                                         .withBody(testContent)));
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
 
             ResponseBytes<GetObjectResponse> response = result.get();
             assertSuccessfulResponse(response, testContent, testETag);
@@ -351,10 +351,10 @@ public class AsyncPresignedUrlManagerTest {
                                         .withBody(testContent)));
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
 
             ResponseBytes<GetObjectResponse> response = result.get();
             assertSuccessfulResponse(response, testContent, testETag);
@@ -373,10 +373,10 @@ public class AsyncPresignedUrlManagerTest {
                                         .withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
-            PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+            PresignedUrlDownloadRequest request = createRequest(presignedUrl);
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
             try {
                 result.get();
                 throw new AssertionError("Expected exception was not thrown");
@@ -401,12 +401,12 @@ public class AsyncPresignedUrlManagerTest {
                 throw new RuntimeException(e);
             }
 
-            PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+            PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                                .presignedUrl(presignedUrl)
                                                                                .build();
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
 
             assertThatThrownBy(() -> result.get())
                 .isInstanceOf(ExecutionException.class);
@@ -428,12 +428,12 @@ public class AsyncPresignedUrlManagerTest {
                 throw new RuntimeException(e);
             }
 
-            PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+            PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                                .presignedUrl(presignedUrl)
                                                                                .build();
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =
-                presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes());
+                presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
 
             assertThatThrownBy(() -> result.get())
                 .isInstanceOf(ExecutionException.class);
@@ -464,9 +464,9 @@ public class AsyncPresignedUrlManagerTest {
             List<CompletableFuture<ResponseBytes<GetObjectResponse>>> futures = new ArrayList<>();
             for (int i = 0; i < concurrentRequests; i++) {
                 URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, paths.get(i));
-                PresignedUrlGetObjectRequest request = createRequest(presignedUrl);
+                PresignedUrlDownloadRequest request = createRequest(presignedUrl);
                 
-                futures.add(presignedUrlManager.getObject(request, AsyncResponseTransformer.toBytes()));
+                futures.add(presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes()));
             }
             
             CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
@@ -488,8 +488,8 @@ public class AsyncPresignedUrlManagerTest {
         }
     }
 
-    private PresignedUrlGetObjectRequest createRequest(URL presignedUrl) {
-        return PresignedUrlGetObjectRequest.builder()
+    private PresignedUrlDownloadRequest createRequest(URL presignedUrl) {
+        return PresignedUrlDownloadRequest.builder()
                                            .presignedUrl(presignedUrl)
                                            .build();
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlGetObjectRequestTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlGetObjectRequestTest.java
@@ -21,18 +21,18 @@ import java.net.URL;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-class PresignedUrlGetObjectRequestTest {
+class PresignedUrlDownloadRequestTest {
 
     @Test
     void equalsAndHashCode_shouldFollowContract() {
-        EqualsVerifier.forClass(PresignedUrlGetObjectRequest.class)
+        EqualsVerifier.forClass(PresignedUrlDownloadRequest.class)
                       .verify();
     }
 
     @Test
     void builder_shouldCreateRequestWithAllFields() throws Exception {
         URL url = new URL("https://example.com");
-        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(url)
                                                                            .range("bytes=0-100")
                                                                            .build();
@@ -44,7 +44,7 @@ class PresignedUrlGetObjectRequestTest {
     @Test
     void builder_shouldCreateRequestWithOnlyRequiredFields() throws Exception {
         URL url = new URL("https://example.com");
-        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(url)
                                                                            .build();
 
@@ -55,12 +55,12 @@ class PresignedUrlGetObjectRequestTest {
     @Test
     void toBuilder_shouldCreateBuilderFromExistingRequest() throws Exception {
         URL url = new URL("https://example.com");
-        PresignedUrlGetObjectRequest original = PresignedUrlGetObjectRequest.builder()
+        PresignedUrlDownloadRequest original = PresignedUrlDownloadRequest.builder()
                                                                             .presignedUrl(url)
                                                                             .range("bytes=0-100")
                                                                             .build();
 
-        PresignedUrlGetObjectRequest copy = original.toBuilder().build();
+        PresignedUrlDownloadRequest copy = original.toBuilder().build();
 
         assertThat(copy.presignedUrl()).isEqualTo(original.presignedUrl());
         assertThat(copy.range()).isEqualTo(original.range());
@@ -70,12 +70,12 @@ class PresignedUrlGetObjectRequestTest {
     void toBuilder_shouldAllowModification() throws Exception {
         URL url1 = new URL("https://example.com");
         URL url2 = new URL("https://other.com");
-        PresignedUrlGetObjectRequest original = PresignedUrlGetObjectRequest.builder()
+        PresignedUrlDownloadRequest original = PresignedUrlDownloadRequest.builder()
                                                                             .presignedUrl(url1)
                                                                             .range("bytes=0-100")
                                                                             .build();
 
-        PresignedUrlGetObjectRequest modified = original.toBuilder()
+        PresignedUrlDownloadRequest modified = original.toBuilder()
                                                         .presignedUrl(url2)
                                                         .range("bytes=200-300")
                                                         .build();
@@ -92,7 +92,7 @@ class PresignedUrlGetObjectRequestTest {
         URL url = new URL("https://example.com");
         String range = "bytes=0-100";
 
-        PresignedUrlGetObjectRequest request = PresignedUrlGetObjectRequest.builder()
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(url)
                                                                            .range(range)
                                                                            .build();
@@ -109,7 +109,7 @@ class PresignedUrlGetObjectRequestTest {
 
     @Test
     void serializableBuilderClass_shouldReturnCorrectClass() {
-        assertThat(PresignedUrlGetObjectRequest.serializableBuilderClass())
-            .isEqualTo(PresignedUrlGetObjectRequest.BuilderImpl.class);
+        assertThat(PresignedUrlDownloadRequest.serializableBuilderClass())
+            .isEqualTo(PresignedUrlDownloadRequest.BuilderImpl.class);
     }
 }


### PR DESCRIPTION
Updates API naming from "`Manager`" to "`Extension`" pattern and "`GetObject`" to "`Download`" operations per surface API review feedback.

## Motivation and Context
Surface API review recommended consistent naming conventions across AWS SDK Java v2.
Improves API discoverability and aligns with established SDK patterns.

## Modifications
Renamed `AsyncPresignedUrlManager` → `AsyncPresignedUrlExtension` with `presignedUrlExtension`() method
Updated `PresignedUrlGetObjectRequest` → `PresignedUrlDownloadRequest` and operation name to `PresignedUrlDownloadRequest`
Modified codegen framework to support new API names
Added `UnsupportedOperationException` for CRT and multipart clients with TODO comments for future implementation

## Testing
All tests pass

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
