### PR TITLE
Move connection timeout configuration from RequestConfig to ConnectionConfig in Apache HttpClient 5

### DIFF
--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
@@ -44,6 +44,7 @@ import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.DefaultSchemePortResolver;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -70,6 +71,7 @@ import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.pool.PoolStats;
 import org.apache.hc.core5.ssl.SSLInitializationException;
 import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
@@ -343,7 +345,6 @@ public final class Apache5HttpClient implements SdkHttpClient {
                                                          AttributeMap resolvedOptions) {
         return Apache5HttpRequestConfig.builder()
                                        .socketTimeout(resolvedOptions.get(SdkHttpConfigurationOption.READ_TIMEOUT))
-                                       .connectionTimeout(resolvedOptions.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT))
                                        .connectionAcquireTimeout(
                                           resolvedOptions.get(SdkHttpConfigurationOption.CONNECTION_ACQUIRE_TIMEOUT))
                                        .proxyConfiguration(builder.proxyConfiguration)
@@ -728,15 +729,28 @@ public final class Apache5HttpClient implements SdkHttpClient {
                                                          .setSSLSocketFactory(sslsf)
                                                          .setSchemePortResolver(DefaultSchemePortResolver.INSTANCE)
                                                          .setDnsResolver(configuration.dnsResolver);
-            Duration connectionTtl = standardOptions.get(SdkHttpConfigurationOption.CONNECTION_TIME_TO_LIVE);
-            if (!connectionTtl.isZero()) {
-                // Skip TTL=0 to maintain backward compatibility (infinite in 4.x vs immediate expiration in 5.x)
-                builder.setConnectionTimeToLive(TimeValue.of(connectionTtl.toMillis(), TimeUnit.MILLISECONDS));
-            }
             builder.setMaxConnPerRoute(standardOptions.get(SdkHttpConfigurationOption.MAX_CONNECTIONS));
             builder.setMaxConnTotal(standardOptions.get(SdkHttpConfigurationOption.MAX_CONNECTIONS));
             builder.setDefaultSocketConfig(buildSocketConfig(standardOptions));
+            builder.setDefaultConnectionConfig(getConnectionConfig(standardOptions));
             return builder.build();
+        }
+
+        private static ConnectionConfig getConnectionConfig(AttributeMap standardOptions) {
+            ConnectionConfig.Builder connectionConfigBuilder =
+                ConnectionConfig.custom()
+                                .setConnectTimeout(
+                                    Timeout.of(standardOptions.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toMillis(),
+                                               TimeUnit.MILLISECONDS))
+                                .setSocketTimeout(
+                                    Timeout.of(standardOptions.get(SdkHttpConfigurationOption.READ_TIMEOUT).toMillis(),
+                                               TimeUnit.MILLISECONDS));
+            Duration connectionTtl = standardOptions.get(SdkHttpConfigurationOption.CONNECTION_TIME_TO_LIVE);
+            if (!connectionTtl.isZero()) {
+                // Skip TTL=0 to maintain backward compatibility (infinite in 4.x vs immediate expiration in 5.x)
+                connectionConfigBuilder.setTimeToLive(TimeValue.of(connectionTtl.toMillis(), TimeUnit.MILLISECONDS));
+            }
+            return connectionConfigBuilder.build();
         }
 
         private SSLConnectionSocketFactory getPreferredSocketFactory(Apache5HttpClient.DefaultBuilder configuration,

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/Apache5HttpClient.java
@@ -739,16 +739,14 @@ public final class Apache5HttpClient implements SdkHttpClient {
         private static ConnectionConfig getConnectionConfig(AttributeMap standardOptions) {
             ConnectionConfig.Builder connectionConfigBuilder =
                 ConnectionConfig.custom()
-                                .setConnectTimeout(
-                                    Timeout.of(standardOptions.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toMillis(),
-                                               TimeUnit.MILLISECONDS))
-                                .setSocketTimeout(
-                                    Timeout.of(standardOptions.get(SdkHttpConfigurationOption.READ_TIMEOUT).toMillis(),
-                                               TimeUnit.MILLISECONDS));
+                                .setConnectTimeout(Timeout.ofMilliseconds(
+                                    standardOptions.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toMillis()))
+                                .setSocketTimeout(Timeout.ofMilliseconds(
+                                    standardOptions.get(SdkHttpConfigurationOption.READ_TIMEOUT).toMillis()));
             Duration connectionTtl = standardOptions.get(SdkHttpConfigurationOption.CONNECTION_TIME_TO_LIVE);
             if (!connectionTtl.isZero()) {
                 // Skip TTL=0 to maintain backward compatibility (infinite in 4.x vs immediate expiration in 5.x)
-                connectionConfigBuilder.setTimeToLive(TimeValue.of(connectionTtl.toMillis(), TimeUnit.MILLISECONDS));
+                connectionConfigBuilder.setTimeToLive(TimeValue.ofMilliseconds(connectionTtl.toMillis()));
             }
             return connectionConfigBuilder.build();
         }

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/internal/Apache5HttpRequestConfig.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/internal/Apache5HttpRequestConfig.java
@@ -27,14 +27,12 @@ import software.amazon.awssdk.http.apache5.ProxyConfiguration;
 public final class Apache5HttpRequestConfig {
 
     private final Duration socketTimeout;
-    private final Duration connectionTimeout;
     private final Duration connectionAcquireTimeout;
     private final boolean expectContinueEnabled;
     private final ProxyConfiguration proxyConfiguration;
 
     private Apache5HttpRequestConfig(Builder builder) {
         this.socketTimeout = builder.socketTimeout;
-        this.connectionTimeout = builder.connectionTimeout;
         this.connectionAcquireTimeout = builder.connectionAcquireTimeout;
         this.expectContinueEnabled = builder.expectContinueEnabled;
         this.proxyConfiguration = builder.proxyConfiguration;
@@ -42,10 +40,6 @@ public final class Apache5HttpRequestConfig {
 
     public Duration socketTimeout() {
         return socketTimeout;
-    }
-
-    public Duration connectionTimeout() {
-        return connectionTimeout;
     }
 
     public Duration connectionAcquireTimeout() {
@@ -73,7 +67,6 @@ public final class Apache5HttpRequestConfig {
     public static final class Builder {
 
         private Duration socketTimeout;
-        private Duration connectionTimeout;
         private Duration connectionAcquireTimeout;
         private boolean expectContinueEnabled;
         private ProxyConfiguration proxyConfiguration;
@@ -83,11 +76,6 @@ public final class Apache5HttpRequestConfig {
 
         public Builder socketTimeout(Duration socketTimeout) {
             this.socketTimeout = socketTimeout;
-            return this;
-        }
-
-        public Builder connectionTimeout(Duration connectionTimeout) {
-            this.connectionTimeout = connectionTimeout;
             return this;
         }
 

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/internal/impl/Apache5HttpRequestFactory.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/internal/impl/Apache5HttpRequestFactory.java
@@ -52,7 +52,7 @@ public class Apache5HttpRequestFactory {
     private static final List<String> IGNORE_HEADERS = Arrays.asList(HttpHeaders.CONTENT_LENGTH, HttpHeaders.HOST,
                                                                      HttpHeaders.TRANSFER_ENCODING);
 
-    public HttpUriRequestBase create(final HttpExecuteRequest request, final Apache5HttpRequestConfig requestConfig) {
+    public HttpUriRequestBase create(HttpExecuteRequest request, Apache5HttpRequestConfig requestConfig) {
         HttpUriRequestBase base = createApacheRequest(request, sanitizeUri(request.httpRequest()));
         addHeadersToRequest(base, request.httpRequest());
         addRequestConfig(base, request.httpRequest(), requestConfig);
@@ -90,12 +90,10 @@ public class Apache5HttpRequestFactory {
     private void addRequestConfig(HttpUriRequestBase base,
                                   SdkHttpRequest request,
                                   Apache5HttpRequestConfig requestConfig) {
-        int connectTimeout = saturatedCast(requestConfig.connectionTimeout().toMillis());
         int connectAcquireTimeout = saturatedCast(requestConfig.connectionAcquireTimeout().toMillis());
         RequestConfig.Builder requestConfigBuilder = RequestConfig
             .custom()
             .setConnectionRequestTimeout(connectAcquireTimeout, TimeUnit.MILLISECONDS)
-            .setConnectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
             .setResponseTimeout(saturatedCast(requestConfig.socketTimeout().toMillis()), TimeUnit.MILLISECONDS);
 
         /*

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/internal/utils/Apache5Utils.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/internal/utils/Apache5Utils.java
@@ -79,6 +79,7 @@ public final class Apache5Utils {
      * Returns a new instance of NTCredentials used for proxy authentication.
      */
     private static Credentials newNtCredentials(ProxyConfiguration proxyConfiguration) {
+        // Deprecated NTCredentials is used to maintain backward compatibility with Apache4.
         return new NTCredentials(
             proxyConfiguration.username(),
             proxyConfiguration.password().toCharArray(),

--- a/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/MetricReportingTest.java
+++ b/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/MetricReportingTest.java
@@ -109,7 +109,6 @@ public class MetricReportingTest {
     private Apache5HttpClient newClient() {
         Apache5HttpRequestConfig config = Apache5HttpRequestConfig.builder()
                                                                   .connectionAcquireTimeout(Duration.ofDays(1))
-                                                                  .connectionTimeout(Duration.ofDays(1))
                                                                   .socketTimeout(Duration.ofDays(1))
                                                                   .proxyConfiguration(ProxyConfiguration.builder().build())
                                                                   .build();

--- a/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/internal/impl/ApacheHttpRequestFactoryTest.java
+++ b/http-clients/apache5-client/src/test/java/software/amazon/awssdk/http/apache5/internal/impl/ApacheHttpRequestFactoryTest.java
@@ -50,7 +50,6 @@ class ApacheHttpRequestFactoryTest {
         instance = new Apache5HttpRequestFactory();
         requestConfig = Apache5HttpRequestConfig.builder()
                                                 .connectionAcquireTimeout(Duration.ZERO)
-                                                .connectionTimeout(Duration.ZERO)
                                                 .socketTimeout(Duration.ZERO)
                                                 .build();
     }


### PR DESCRIPTION

## Motivation and Context
This change addresses the use of deprecated APIs in Apache HttpClient 5. The `setConnectTimeout()` method in `RequestConfig.Builder` is deprecated and should be replaced with proper connection-level timeout configuration via `ConnectionConfig`.

In Apache HttpClient 5, the architecture separates:
- **Connection-level timeouts** (connect timeout, socket timeout, TTL) → configured via `ConnectionConfig`  
- **Request-level timeouts** (connection request timeout, response timeout) → configured via `RequestConfig`

This change aligns our implementation with Apache HttpClient 5's recommended practices and eliminates deprecated API usage warnings.

## Modifications
- **Removed `connectionTimeout` from `Apache5HttpRequestConfig`** - This timeout is now managed at the connection manager level
- **Added `getConnectionConfig()` method** in `ApacheConnectionManagerFactory` to centralize connection-level timeout configuration
- **Moved connection timeout, socket timeout, and TTL configuration** to `ConnectionConfig` instead of `RequestConfig`
- **Updated `addRequestConfig()` method** in `Apache5HttpRequestFactory` to remove deprecated `setConnectTimeout()` call
- **Updated all test files** to remove references to connection timeout in request configuration
- **Added timeout validation tests** to ensure both connection and socket timeouts work correctly

## Testing
- **Added `connectionTimeout_exceedsLimit_throwsException()` test** - Validates connection timeout using non-routable IP address (192.0.2.1) with 100ms timeout
- **Added `socketTimeout_exceedsLimit_throwsException()` test** - Validates socket timeout using WireMock with 2-second delay and 500ms timeout  
- **Updated existing tests** - Removed connection timeout configuration from `MetricReportingTest` and `ApacheHttpRequestFactoryTest`
- **Verified backward compatibility** - All existing functionality continues to work, timeouts are just configured at the appropriate architectural level
- **Cross-platform compatibility** - Tests account for different exception messages across JVM implementations using multiple timeout-related keywords

The tests confirm that:
1. Connection timeouts are properly enforced when connecting to unreachable endpoints
2. Socket timeouts are properly enforced when waiting for slow server responses  
3. The timeout configuration at the ConnectionConfig level works as expected
4. No regression in existing timeout functionality
## Screenshots (if appropriate)

<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
