### PR TITLE
Add support for lambda traces via threadLocal

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptor.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptor.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.awscore.interceptor;
 
 import java.util.Optional;
+import org.slf4j.MDC;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.awscore.internal.interceptor.TracingSystemSetting;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.utils.SystemSetting;
 public class TraceIdExecutionInterceptor implements ExecutionInterceptor {
     private static final String TRACE_ID_HEADER = "X-Amzn-Trace-Id";
     private static final String LAMBDA_FUNCTION_NAME_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_FUNCTION_NAME";
+    private static final String CONCURRENT_TRACE_ID_KEY = "AWS_LAMBDA_X_TraceId";
 
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
@@ -53,6 +55,9 @@ public class TraceIdExecutionInterceptor implements ExecutionInterceptor {
     }
 
     private Optional<String> traceId() {
+        if (TracingSystemSetting.AWS_LAMBDA_MAX_CONCURRENCY.getStringValue().isPresent()) {
+            return Optional.ofNullable(MDC.get(CONCURRENT_TRACE_ID_KEY));
+        }
         return TracingSystemSetting._X_AMZN_TRACE_ID.getStringValue();
     }
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptor.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptor.java
@@ -35,7 +35,7 @@ public class TraceIdExecutionInterceptor implements ExecutionInterceptor {
     private static final String TRACE_ID_HEADER = "X-Amzn-Trace-Id";
     private static final String LAMBDA_FUNCTION_NAME_ENVIRONMENT_VARIABLE = "AWS_LAMBDA_FUNCTION_NAME";
     private static final String CONCURRENT_TRACE_ID_KEY = "AWS_LAMBDA_X_TraceId";
-    protected static final ExecutionAttribute<String> CACHED_TRACE_ID = new ExecutionAttribute<>("CachedTraceId");
+    private static final ExecutionAttribute<String> CACHED_TRACE_ID = new ExecutionAttribute<>("CachedTraceId");
 
     @Override
     public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptor.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptor.java
@@ -70,7 +70,10 @@ public class TraceIdExecutionInterceptor implements ExecutionInterceptor {
     }
 
     private static void saveTraceId(ExecutionAttributes executionAttributes) {
-        MDC.put(CONCURRENT_TRACE_ID_KEY, executionAttributes.getAttribute(TRACE_ID));
+        String traceId = executionAttributes.getAttribute(TRACE_ID);
+        if (traceId != null) {
+            MDC.put(CONCURRENT_TRACE_ID_KEY, executionAttributes.getAttribute(TRACE_ID));
+        }
     }
 
     private Optional<String> traceIdHeader(Context.ModifyHttpRequest context) {

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/interceptor/TracingSystemSetting.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/interceptor/TracingSystemSetting.java
@@ -24,7 +24,9 @@ import software.amazon.awssdk.utils.SystemSetting;
 @SdkInternalApi
 public enum TracingSystemSetting implements SystemSetting {
     // See: https://github.com/aws/aws-xray-sdk-java/issues/251
-    _X_AMZN_TRACE_ID("com.amazonaws.xray.traceHeader", null);
+    _X_AMZN_TRACE_ID("com.amazonaws.xray.traceHeader", null),
+    // Environment variable to detect Lambda multi concurrency mode ("elevator"). This value is set by the Lambda runtime.
+    AWS_LAMBDA_MAX_CONCURRENCY("aws.lambda.maxConcurrency", null);
 
     private final String systemProperty;
     private final String defaultValue;

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/interceptor/TracingSystemSetting.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/interceptor/TracingSystemSetting.java
@@ -24,9 +24,7 @@ import software.amazon.awssdk.utils.SystemSetting;
 @SdkInternalApi
 public enum TracingSystemSetting implements SystemSetting {
     // See: https://github.com/aws/aws-xray-sdk-java/issues/251
-    _X_AMZN_TRACE_ID("com.amazonaws.xray.traceHeader", null),
-    // Environment variable to detect Lambda multi concurrency mode ("elevator"). This value is set by the Lambda runtime.
-    AWS_LAMBDA_MAX_CONCURRENCY("aws.lambda.maxConcurrency", null);
+    _X_AMZN_TRACE_ID("com.amazonaws.xray.traceHeader", null);
 
     private final String systemProperty;
     private final String defaultValue;

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptorTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptorTest.java
@@ -117,7 +117,7 @@ public class TraceIdExecutionInterceptorTest {
         EnvironmentVariableHelper.run(env -> {
             resetRelevantEnvVars(env);
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
-            MDC.put("AWS_LAMBDA_X_TraceId", "mdc-trace-123");
+            MDC.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
 
             try {
                 TraceIdExecutionInterceptor interceptor = new TraceIdExecutionInterceptor();
@@ -129,7 +129,7 @@ public class TraceIdExecutionInterceptorTest {
                 SdkHttpRequest request = interceptor.modifyHttpRequest(context, executionAttributes);
                 assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
             } finally {
-                MDC.remove("AWS_LAMBDA_X_TraceId");
+                MDC.remove("AWS_LAMBDA_X_TRACE_ID");
             }
         });
     }
@@ -140,7 +140,7 @@ public class TraceIdExecutionInterceptorTest {
             resetRelevantEnvVars(env);
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
 
-            MDC.put("AWS_LAMBDA_X_TraceId", "mdc-trace-123");
+            MDC.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
             Properties props = System.getProperties();
             props.setProperty("com.amazonaws.xray.traceHeader", "sys-prop-345");
 
@@ -155,7 +155,7 @@ public class TraceIdExecutionInterceptorTest {
 
                 assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
             } finally {
-                MDC.remove("AWS_LAMBDA_X_TraceId");
+                MDC.remove("AWS_LAMBDA_X_TRACE_ID");
                 props.remove("com.amazonaws.xray.traceHeader");
             }
         });
@@ -166,7 +166,7 @@ public class TraceIdExecutionInterceptorTest {
         EnvironmentVariableHelper.run(env -> {
             resetRelevantEnvVars(env);
 
-            MDC.put("AWS_LAMBDA_X_TraceId", "should-be-ignored");
+            MDC.put("AWS_LAMBDA_X_TRACE_ID", "should-be-ignored");
 
             try {
                 TraceIdExecutionInterceptor interceptor = new TraceIdExecutionInterceptor();
@@ -179,7 +179,7 @@ public class TraceIdExecutionInterceptorTest {
 
                 assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).isEmpty();
             } finally {
-                MDC.remove("AWS_LAMBDA_X_TraceId");
+                MDC.remove("AWS_LAMBDA_X_TRACE_ID");
             }
         });
     }
@@ -206,6 +206,5 @@ public class TraceIdExecutionInterceptorTest {
     private void resetRelevantEnvVars(EnvironmentVariableHelper env) {
         env.remove("AWS_LAMBDA_FUNCTION_NAME");
         env.remove("_X_AMZN_TRACE_ID");
-        env.remove("AWS_LAMBDA_MAX_CONCURRENCY");
     }
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/TraceIdTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/TraceIdTest.java
@@ -37,8 +37,7 @@ import software.amazon.awssdk.utils.StringInputStream;
 /**
  * Verifies that the {@link TraceIdExecutionInterceptor} is actually wired up for AWS services.
  */
-public class
-TraceIdTest {
+public class TraceIdTest {
     @Test
     public void traceIdInterceptorIsEnabled() {
         EnvironmentVariableHelper.run(env -> {
@@ -130,7 +129,6 @@ TraceIdTest {
 
                 client.allTypes()
                       .thenRun(() -> {
-                          String traceId = MDC.get("AWS_LAMBDA_X_TRACE_ID");
                           client.allTypes().join();
                       })
                       .join();


### PR DESCRIPTION
## Motivation and Context

This implementation uses SLF4J MDC (which uses ThreadLocal under the hood) to read the trace ID value stored in `AWS_LAMBDA_X_TraceId` that would be set by the Lambda runtime (this would be added later, probably [here](https://github.com/aws/aws-lambda-java-libs/blob/5a0f8ad9e9b8ff61ba626e71c4b5de62134e82e4/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java#L235)).