### PR TITLE
Fix: Respect aws.endpointUrlSTS system property in StsCredentialsProvider

### DIFF
--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsCredentialsProviderSystemSetting.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsCredentialsProviderSystemSetting.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.internal;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.utils.SystemSetting;
+
+/**
+ * STS credentials provider specific system setting
+ */
+@SdkProtectedApi
+public enum StsCredentialsProviderSystemSetting implements SystemSetting {
+
+    /**
+     * Configure the custom STS endpoint
+     */
+    AWS_ENDPOINT_URL_STS("aws.endpointSTS", null);
+
+    private final String systemProperty;
+    private final String defaultValue;
+
+    StsCredentialsProviderSystemSetting(String systemProperty, String defaultValue) {
+        this.systemProperty = systemProperty;
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public String property() {
+        return systemProperty;
+    }
+
+    @Override
+    public String environmentVariable() {
+        return name();
+    }
+
+    @Override
+    public String defaultValue() {
+        return defaultValue;
+    }
+}

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsProfileCredentialsProviderFactory.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsProfileCredentialsProviderFactory.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sts.internal;
 
+import static software.amazon.awssdk.services.sts.internal.StsCredentialsProviderSystemSetting.AWS_ENDPOINT_URL_STS;
+
 import java.net.URI;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -95,6 +97,12 @@ public final class StsProfileCredentialsProviderFactory implements ChildProfileC
             } else {
                 stsClientBuilder.region(Region.US_EAST_1);
                 stsClientBuilder.endpointOverride(URI.create("https://sts.amazonaws.com"));
+            }
+
+            // Set custom STS endpoint if it's specified
+            if (AWS_ENDPOINT_URL_STS.getStringValue().isPresent()) {
+                stsClientBuilder.endpointOverride(URI.create(
+                    AWS_ENDPOINT_URL_STS.getStringValue().get()));
             }
         }
 

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityCredentialsProviderFactory.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityCredentialsProviderFactory.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sts.internal;
 
+import static software.amazon.awssdk.services.sts.internal.StsCredentialsProviderSystemSetting.AWS_ENDPOINT_URL_STS;
+
 import java.net.URI;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
@@ -128,6 +130,12 @@ public final class StsWebIdentityCredentialsProviderFactory implements WebIdenti
             } else {
                 stsClientBuilder.region(Region.US_EAST_1);
                 stsClientBuilder.endpointOverride(URI.create("https://sts.amazonaws.com"));
+            }
+
+            // Set custom STS endpoint if it's specified
+            if (AWS_ENDPOINT_URL_STS.getStringValue().isPresent()) {
+                stsClientBuilder.endpointOverride(URI.create(
+                    AWS_ENDPOINT_URL_STS.getStringValue().get()));
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a fix for https://github.com/aws/aws-sdk-java-v2/issues/6252


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

StsWebIdentityCredentialsProvider does not support properties to configure custom STS endpoint (like aws.endpointUrlSTS and AWS_ENDPOINT_URL_STS). Due to this problem, StsWebIdentityCredentialsProvider cannot access custom STS endpoint even if it is configured using those properties.

## Modifications
<!--- Describe your changes in detail -->

Respect aws.endpointUrlSTS system property

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally and confirmed it works as expected

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md) ... No. Because 1.x does not support the service specific environment variable/property.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
