### PR TITLE
Use Ec2MetadataClient in defaults mode

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-8c69562.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-8c69562.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Updated AutoDefaultsModeDiscovery from using EC2MetadataUtils to Ec2MetadataClient"
+}

--- a/core/aws-core/pom.xml
+++ b/core/aws-core/pom.xml
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>imds</artifactId>
-            <version>2.31.73-SNAPSHOT</version>
+            <version>${awsjavasdk.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/core/aws-core/pom.xml
+++ b/core/aws-core/pom.xml
@@ -206,6 +206,12 @@
             <artifactId>rxjava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>imds</artifactId>
+            <version>2.31.73-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscovery.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscovery.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode;
 import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.imds.Ec2MetadataClient;
 import software.amazon.awssdk.imds.Ec2MetadataRetryPolicy;
 import software.amazon.awssdk.imds.internal.Ec2MetadataSharedClient;
@@ -96,7 +97,7 @@ public class AutoDefaultsModeDiscovery {
 
             String ec2InstanceRegion = client.get(EC2_METADATA_REGION_PATH).asString();
             return Optional.ofNullable(ec2InstanceRegion);
-        } catch (Exception exception) {
+        } catch (SdkClientException e) {
             return Optional.empty();
         } finally {
             if (client != null) {

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscovery.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscovery.java
@@ -88,15 +88,20 @@ public class AutoDefaultsModeDiscovery {
             return Optional.empty();
         }
 
+        Ec2MetadataClient client = null;
         try {
-            Ec2MetadataClient client = Ec2MetadataSharedClient.builder()
-                                                              .retryPolicy(Ec2MetadataRetryPolicy.none())
-                                                              .build();
+            client = Ec2MetadataSharedClient.builder()
+                                            .retryPolicy(Ec2MetadataRetryPolicy.none())
+                                            .build();
 
             String ec2InstanceRegion = client.get(EC2_METADATA_REGION_PATH).asString();
             return Optional.ofNullable(ec2InstanceRegion);
         } catch (Exception exception) {
             return Optional.empty();
+        } finally {
+            if (client != null) {
+                Ec2MetadataSharedClient.decrementAndClose();
+            }
         }
     }
 

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscoveryEc2MetadataClientTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscoveryEc2MetadataClientTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.internal.defaultsmode;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.lang.reflect.Field;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.imds.internal.Ec2MetadataSharedClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.Lazy;
+
+/**
+ * Tests specifically for AutoDefaultsModeDiscovery's migration to use Ec2MetadataClient.
+ * These tests verify that the migration from EC2MetadataUtils to Ec2MetadataClient works correctly.
+ */
+public class AutoDefaultsModeDiscoveryEc2MetadataClientTest {
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(0);
+
+    @Before
+    public void setup() {
+        System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property(),
+                           "http://localhost:" + wireMock.port());
+        ENVIRONMENT_VARIABLE_HELPER.remove(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.environmentVariable());
+    }
+
+    @After
+    public void cleanup() {
+        wireMock.resetAll();
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+        System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property());
+    }
+
+    @Test
+    public void autoDefaultsModeDiscovery_shouldUseSharedHttpClient() throws Exception {
+        // Stub successful IMDS responses
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(200).withBody("test-token")));
+        stubFor(get("/latest/meta-data/placement/region")
+                    .willReturn(aResponse().withStatus(200).withBody("us-east-1")));
+
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+        AutoDefaultsModeDiscovery discovery = new AutoDefaultsModeDiscovery();
+        DefaultsMode result = discovery.discover(Region.US_EAST_1);
+
+        // Should return IN_REGION since client region (us-east-1) matches IMDS region (us-east-1)
+        assertThat(result).isEqualTo(DefaultsMode.IN_REGION);
+
+        // Verify that the shared HTTP client was used
+        Field sharedClientField = Ec2MetadataSharedClient.class.getDeclaredField("SHARED_HTTP_CLIENT");
+        sharedClientField.setAccessible(true);
+        Lazy<SdkHttpClient> sharedHttpClient = (Lazy<SdkHttpClient>) sharedClientField.get(null);
+
+        // Verify the shared HTTP client was initialized
+        assertThat(sharedHttpClient.hasValue()).isTrue();
+
+        // Verify IMDS requests were made
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region")));
+    }
+
+    @Test
+    public void multipleDiscoveryInstances_shouldShareSameHttpClient() throws Exception {
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(200).withBody("test-token")));
+        stubFor(get("/latest/meta-data/placement/region")
+                    .willReturn(aResponse().withStatus(200).withBody("us-west-2")));
+
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+        // Create multiple discovery instances
+        AutoDefaultsModeDiscovery discovery1 = new AutoDefaultsModeDiscovery();
+        AutoDefaultsModeDiscovery discovery2 = new AutoDefaultsModeDiscovery();
+
+        // Both should use the same shared HTTP client
+        DefaultsMode result1 = discovery1.discover(Region.US_EAST_1);
+        DefaultsMode result2 = discovery2.discover(Region.US_EAST_1);
+
+        // Both should return CROSS_REGION (client: us-east-1, IMDS: us-west-2)
+        assertThat(result1).isEqualTo(DefaultsMode.CROSS_REGION);
+        assertThat(result2).isEqualTo(DefaultsMode.CROSS_REGION);
+
+        // Verify shared HTTP client was used
+        Field sharedClientField = Ec2MetadataSharedClient.class.getDeclaredField("SHARED_HTTP_CLIENT");
+        sharedClientField.setAccessible(true);
+        Lazy<SdkHttpClient> sharedHttpClient = (Lazy<SdkHttpClient>) sharedClientField.get(null);
+
+        assertThat(sharedHttpClient.hasValue()).isTrue();
+
+        // Verify IMDS requests were made
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region")));
+    }
+
+    @Test
+    public void awsEc2MetadataDisabled_shouldSkipImdsAndUseStandardMode() {
+        // Disable IMDS
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.environmentVariable(), "true");
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+
+        AutoDefaultsModeDiscovery discovery = new AutoDefaultsModeDiscovery();
+        DefaultsMode result = discovery.discover(Region.US_EAST_1);
+
+        // Should return STANDARD mode without making IMDS calls
+        assertThat(result).isEqualTo(DefaultsMode.STANDARD);
+
+        // Verify no IMDS requests were made
+        wireMock.verify(0, putRequestedFor(urlEqualTo("/latest/api/token")));
+        wireMock.verify(0, getRequestedFor(urlEqualTo("/latest/meta-data/placement/region")));
+    }
+
+    @Test
+    public void imdsFailure_shouldFallbackToStandardMode() {
+        // Stub IMDS to fail
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+        stubFor(get("/latest/meta-data/placement/region")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+        AutoDefaultsModeDiscovery discovery = new AutoDefaultsModeDiscovery();
+        DefaultsMode result = discovery.discover(Region.US_EAST_1);
+
+        // Should fall back to STANDARD mode when IMDS fails
+        assertThat(result).isEqualTo(DefaultsMode.STANDARD);
+
+        // Verify IMDS requests were attempted
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+    }
+
+    @Test
+    public void noRetryPolicy_shouldBeUsedByDefault() {
+        // Stub token to succeed but region to fail with retryable error
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(200).withBody("test-token")));
+        stubFor(get("/latest/meta-data/placement/region")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+        AutoDefaultsModeDiscovery discovery = new AutoDefaultsModeDiscovery();
+        DefaultsMode result = discovery.discover(Region.US_EAST_1);
+
+        // Should fail immediately without retries and fallback to STANDARD
+        assertThat(result).isEqualTo(DefaultsMode.STANDARD);
+
+        // Verify requests were made but no retries
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region")));
+    }
+
+
+    @Test
+    public void imdsV1Fallback_shouldWorkWhenTokenFails() {
+        // Stub token request to fail
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+        // Stub successful IMDSv1 request
+        stubFor(get("/latest/meta-data/placement/region")
+                    .willReturn(aResponse().withStatus(200).withBody("us-east-1")));
+
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+        AutoDefaultsModeDiscovery discovery = new AutoDefaultsModeDiscovery();
+        DefaultsMode result = discovery.discover(Region.US_EAST_1);
+
+        // Should fall back to IMDSv1 and succeed, returning IN_REGION
+        assertThat(result).isEqualTo(DefaultsMode.IN_REGION);
+
+        // Verify both token request (failed) and region request (succeeded) were made
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region")));
+    }
+
+    @Test
+    public void imdsV1Fallback_shouldNotWorkWhenV1Disabled() {
+        // Disable IMDSv1 fallback
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.environmentVariable(), "true");
+
+        // Stub token request to fail
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+        AutoDefaultsModeDiscovery discovery = new AutoDefaultsModeDiscovery();
+        DefaultsMode result = discovery.discover(Region.US_EAST_1);
+
+        // Should fail without fallback to IMDSv1 and return STANDARD
+        assertThat(result).isEqualTo(DefaultsMode.STANDARD);
+
+        // Verify only token request was made
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+    }
+
+    @Test
+    public void tokenRequest400Error_shouldNotFallbackToV1() {
+        // Stub token request to fail with 400
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(400).withBody("Bad Request")));
+
+        ENVIRONMENT_VARIABLE_HELPER.set("AWS_DEFAULT_REGION", "us-west-2");
+
+        AutoDefaultsModeDiscovery discovery = new AutoDefaultsModeDiscovery();
+        DefaultsMode result = discovery.discover(Region.US_EAST_1);
+
+        // Should fail without attempting IMDSv1 fallback and return STANDARD
+        assertThat(result).isEqualTo(DefaultsMode.STANDARD);
+
+        // Verify only token request was made (no region request)
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+    }
+}

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscoveryEc2MetadataClientTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscoveryEc2MetadataClientTest.java
@@ -28,7 +28,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +56,11 @@ public class AutoDefaultsModeDiscoveryEc2MetadataClientTest {
     static void setupClass() {
         System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property(),
                            "http://localhost:" + wireMock.getPort());
+    }
+
+    @AfterAll
+    static void cleanupClass() {
+        System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property());
     }
 
     @BeforeEach

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/BaseEc2MetadataClient.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/BaseEc2MetadataClient.java
@@ -60,6 +60,10 @@ public abstract class BaseEc2MetadataClient {
         this(builder.getRetryPolicy(), builder.getTokenTtl(), builder.getEndpoint(), builder.getEndpointMode());
     }
 
+    protected BaseEc2MetadataClient(DefaultEc2MetadataClientWithFallback.Ec2MetadataBuilder builder) {
+        this(builder.getRetryPolicy(), builder.getTokenTtl(), builder.getEndpoint(), builder.getEndpointMode());
+    }
+
     private URI getEndpoint(URI builderEndpoint, EndpointMode builderEndpointMode) {
         Validate.mutuallyExclusive("Only one of 'endpoint' or 'endpointMode' must be specified, but not both",
                                    builderEndpoint, builderEndpointMode);

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/BaseEc2MetadataClient.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/BaseEc2MetadataClient.java
@@ -44,8 +44,8 @@ public abstract class BaseEc2MetadataClient {
     protected final RequestMarshaller requestMarshaller;
     protected final Duration tokenTtl;
 
-    private BaseEc2MetadataClient(Ec2MetadataRetryPolicy retryPolicy, Duration tokenTtl, URI endpoint,
-                                  EndpointMode endpointMode) {
+    protected BaseEc2MetadataClient(Ec2MetadataRetryPolicy retryPolicy, Duration tokenTtl, URI endpoint,
+                                    EndpointMode endpointMode) {
         this.retryPolicy = Validate.getOrDefault(retryPolicy, Ec2MetadataRetryPolicy.builder()::build);
         this.tokenTtl = Validate.getOrDefault(tokenTtl, () -> DEFAULT_TOKEN_TTL);
         this.endpoint = getEndpoint(endpoint, endpointMode);
@@ -60,9 +60,6 @@ public abstract class BaseEc2MetadataClient {
         this(builder.getRetryPolicy(), builder.getTokenTtl(), builder.getEndpoint(), builder.getEndpointMode());
     }
 
-    protected BaseEc2MetadataClient(DefaultEc2MetadataClientWithFallback.Ec2MetadataBuilder builder) {
-        this(builder.getRetryPolicy(), builder.getTokenTtl(), builder.getEndpoint(), builder.getEndpointMode());
-    }
 
     private URI getEndpoint(URI builderEndpoint, EndpointMode builderEndpointMode) {
         Validate.mutuallyExclusive("Only one of 'endpoint' or 'endpointMode' must be specified, but not both",

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
@@ -70,7 +70,7 @@ public final class DefaultEc2MetadataClientWithFallback extends BaseEc2MetadataC
     private final boolean imdsV1FallbackEnabled;
 
     private DefaultEc2MetadataClientWithFallback(Ec2MetadataBuilder builder) {
-        super(builder);
+        super(builder.getRetryPolicy(), builder.getTokenTtl(), builder.getEndpoint(), builder.getEndpointMode());
 
         Validate.isTrue(builder.httpClient == null || builder.httpClientBuilder == null,
                         "The httpClient and the httpClientBuilder can't both be configured.");

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
@@ -124,7 +124,7 @@ public final class DefaultEc2MetadataClientWithFallback extends BaseEc2MetadataC
                 if (token == null || token.isExpired()) {
                     token = tokenCache.get();
                 }
-                return sendRequest(path, token != null ? token.value() : null);
+                return sendRequest(path, token == null ? null : token.value());
             } catch (UncheckedIOException | RetryableException e) {
                 lastCause = e;
                 int currentTry = attempt;

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
@@ -17,6 +17,8 @@ package software.amazon.awssdk.imds.internal;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -326,8 +328,8 @@ public final class DefaultEc2MetadataClientWithFallback extends BaseEc2MetadataC
     protected static final class Ec2MetadataBuilder implements Ec2MetadataClient.Builder {
 
         private Ec2MetadataRetryPolicy retryPolicy;
-        private java.net.URI endpoint;
-        private java.time.Duration tokenTtl;
+        private URI endpoint;
+        private Duration tokenTtl;
         private EndpointMode endpointMode;
         private SdkHttpClient httpClient;
         private SdkHttpClient.Builder<?> httpClientBuilder;

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallback.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.imds.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.HttpStatusFamily;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.imds.Ec2MetadataClient;
+import software.amazon.awssdk.imds.Ec2MetadataClientException;
+import software.amazon.awssdk.imds.Ec2MetadataResponse;
+import software.amazon.awssdk.imds.Ec2MetadataRetryPolicy;
+import software.amazon.awssdk.imds.EndpointMode;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.utils.Either;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.OptionalUtils;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.cache.CachedSupplier;
+import software.amazon.awssdk.utils.cache.RefreshResult;
+
+/**
+ * An Implementation of the Ec2Metadata Interface with IMDSv1 fallback support.
+ * This client is identical to DefaultEc2MetadataClient but provides automatic fallback
+ * to IMDSv1 when IMDSv2 token retrieval fails (except for 400 errors).
+ */
+@SdkInternalApi
+@Immutable
+@ThreadSafe
+public final class DefaultEc2MetadataClientWithFallback extends BaseEc2MetadataClient implements Ec2MetadataClient {
+
+    private static final Logger log = Logger.loggerFor(DefaultEc2MetadataClientWithFallback.class);
+
+    private final SdkHttpClient httpClient;
+    private final Supplier<Token> tokenCache;
+    private final boolean httpClientIsInternal;
+    private final boolean imdsV1FallbackEnabled;
+
+    private DefaultEc2MetadataClientWithFallback(Ec2MetadataBuilder builder) {
+        super(builder);
+
+        Validate.isTrue(builder.httpClient == null || builder.httpClientBuilder == null,
+                        "The httpClient and the httpClientBuilder can't both be configured.");
+        this.httpClient = Either
+            .fromNullable(builder.httpClient, builder.httpClientBuilder)
+            .map(e -> e.map(Function.identity(), SdkHttpClient.Builder::build))
+            .orElseGet(() -> new DefaultSdkHttpClientBuilder().buildWithDefaults(imdsHttpDefaults()));
+        this.httpClientIsInternal = builder.httpClient == null;
+
+        this.imdsV1FallbackEnabled = !resolveImdsV1Disabled();
+
+        this.tokenCache = CachedSupplier.builder(() -> RefreshResult.builder(this.getToken())
+                                                                    .staleTime(Instant.now().plus(tokenTtl))
+                                                                    .build())
+                                        .cachedValueName(toString())
+                                        .build();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.create("Ec2MetadataClientWithFallback");
+    }
+
+    @Override
+    public void close() {
+        if (httpClientIsInternal) {
+            httpClient.close();
+        }
+    }
+
+    public static Ec2MetadataBuilder builder() {
+        return new DefaultEc2MetadataClientWithFallback.Ec2MetadataBuilder();
+    }
+
+    /**
+     * Gets the specified instance metadata value by the given path with IMDSv1 fallback support.
+     * Will retry based on the {@link Ec2MetadataRetryPolicy retry policy} provided.
+     * Follows the same behavior as EC2MetadataUtils: if IMDSv2 token retrieval fails with 400 error,
+     * throws exception; otherwise falls back to IMDSv1 (null token).
+     *
+     * @param path Input path of the resource to get.
+     * @return Instance metadata value as part of MetadataResponse Object
+     * @throws SdkClientException if the request fails after all retries and fallback attempts
+     */
+    @Override
+    public Ec2MetadataResponse get(String path) {
+        Throwable lastCause = null;
+        // 3 retries means 4 total attempts
+        Token token = null;
+        for (int attempt = 0; attempt < retryPolicy.numRetries() + 1; attempt++) {
+            RetryPolicyContext retryPolicyContext = RetryPolicyContext.builder().retriesAttempted(attempt).build();
+            try {
+                if (token == null || token.isExpired()) {
+                    token = getTokenWithFallback();
+                }
+                return sendRequest(path, token != null ? token.value() : null);
+            } catch (UncheckedIOException | RetryableException e) {
+                lastCause = e;
+                int currentTry = attempt;
+                log.debug(() -> "Error while executing EC2Metadata request, attempting retry. Current attempt: " + currentTry);
+            } catch (SdkClientException sdkClientException) {
+                int totalTries = attempt + 1;
+                log.debug(() -> String.format("Error while executing EC2Metadata request. Total attempts: %d. %s",
+                                              totalTries,
+                                              sdkClientException.getMessage()));
+                throw sdkClientException;
+            } catch (IOException ioe) {
+                lastCause = new UncheckedIOException(ioe);
+                int currentTry = attempt;
+                log.debug(() -> "Error while executing EC2Metadata request, attempting retry. Current attempt: " + currentTry);
+            }
+            pauseBeforeRetryIfNeeded(retryPolicyContext);
+        }
+
+        SdkClientException.Builder sdkClientExceptionBuilder = SdkClientException
+            .builder()
+            .message("Exceeded maximum number of retries. Total retry attempts: " + retryPolicy.numRetries());
+        if (lastCause != null) {
+            String msg = sdkClientExceptionBuilder.message();
+            sdkClientExceptionBuilder.cause(lastCause).message(msg);
+        }
+        throw sdkClientExceptionBuilder.build();
+    }
+
+    /**
+     * Gets token with fallback logic that matches EC2MetadataUtils behavior.
+     * If token retrieval fails with 400 error, throws exception.
+     * Otherwise, returns null to indicate fallback to IMDSv1.
+     */
+    private Token getTokenWithFallback() {
+        try {
+            return tokenCache.get();
+        } catch (Exception e) {
+            boolean is400ServiceException = e instanceof Ec2MetadataClientException
+                    && ((Ec2MetadataClientException) e).statusCode() == 400;
+
+            // metadata resolution must not continue to the token-less flow for a 400
+            if (is400ServiceException) {
+                throw SdkClientException.builder()
+                        .message("Unable to fetch metadata token")
+                        .cause(e)
+                        .build();
+            }
+            return handleTokenErrorResponse(e);
+        }
+    }
+
+    /**
+     * Handles token error response following EC2MetadataUtils pattern.
+     */
+    private Token handleTokenErrorResponse(Exception e) {
+        if (!imdsV1FallbackEnabled) {
+            String message = String.format("Failed to retrieve IMDS token, and fallback to IMDS v1 is disabled via the "
+                                           + "%s system property, %s environment variable, or %s configuration file profile"
+                                           + " setting.",
+                                           SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.environmentVariable(),
+                                           SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.property(),
+                                           ProfileProperty.EC2_METADATA_V1_DISABLED);
+            throw SdkClientException.builder()
+                                    .message(message)
+                                    .cause(e)
+                                    .build();
+        }
+        return null; // null token indicates fallback to IMDSv1
+    }
+
+
+    /**
+     * Resolves whether IMDSv1 is disabled from system settings and profile file.
+     */
+    private boolean resolveImdsV1Disabled() {
+        return OptionalUtils.firstPresent(
+                            fromSystemSettingsMetadataV1Disabled(),
+                            () -> fromProfileFileMetadataV1Disabled()
+                        )
+                        .orElse(false);
+    }
+
+    private Optional<Boolean> fromSystemSettingsMetadataV1Disabled() {
+        return SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.getStringValue()
+                                                            .map(Boolean::parseBoolean);
+    }
+
+    private Optional<Boolean> fromProfileFileMetadataV1Disabled() {
+        return Ec2MetadataConfigProvider.instance()
+                                       .resolveProfile()
+                                       .flatMap(p -> p.property(ProfileProperty.EC2_METADATA_V1_DISABLED))
+                                       .map(Boolean::parseBoolean);
+    }
+
+    private void handleUnsuccessfulResponse(int statusCode, Optional<AbortableInputStream> responseBody,
+                                            HttpExecuteResponse response, Supplier<String> errorMessageSupplier) {
+        String responseContent = responseBody.map(BaseEc2MetadataClient::uncheckedInputStreamToUtf8)
+                                             .orElse("");
+
+        throw Ec2MetadataClientException.builder()
+                                        .statusCode(statusCode)
+                                        .sdkHttpResponse(response.httpResponse())
+                                        .rawResponse(SdkBytes.fromUtf8String(responseContent))
+                                        .message(errorMessageSupplier.get())
+                                        .build();
+    }
+
+    private Ec2MetadataResponse sendRequest(String path, String token) throws IOException {
+        HttpExecuteRequest httpExecuteRequest =
+            HttpExecuteRequest.builder()
+                              .request(requestMarshaller.createDataRequest(path, token, tokenTtl))
+                              .build();
+        HttpExecuteResponse response = httpClient.prepareRequest(httpExecuteRequest).call();
+
+        int statusCode = response.httpResponse().statusCode();
+        Optional<AbortableInputStream> responseBody = response.responseBody();
+
+        if (HttpStatusFamily.of(statusCode).isOneOf(HttpStatusFamily.SERVER_ERROR)) {
+            responseBody.map(BaseEc2MetadataClient::uncheckedInputStreamToUtf8)
+                        .ifPresent(str -> log.debug(() -> "Metadata request response body: " + str));
+            throw RetryableException
+                .builder()
+                .message(String.format("The requested metadata at path '%s' returned Http code %s", path, statusCode))
+                .build();
+        }
+
+        if (!HttpStatusFamily.of(statusCode).isOneOf(HttpStatusFamily.SUCCESSFUL)) {
+            handleUnsuccessfulResponse(statusCode, responseBody, response,
+                () -> String.format("The requested metadata at path '%s' returned Http code %s", path, statusCode)
+            );
+        }
+
+        AbortableInputStream abortableInputStream = responseBody.orElseThrow(
+            SdkClientException.builder().message("Response body empty with Status Code " + statusCode)::build);
+        String data = uncheckedInputStreamToUtf8(abortableInputStream);
+        return Ec2MetadataResponse.create(data);
+    }
+
+    private void pauseBeforeRetryIfNeeded(RetryPolicyContext retryPolicyContext) {
+        long backoffTimeMillis = retryPolicy.backoffStrategy()
+                                            .computeDelayBeforeNextRetry(retryPolicyContext)
+                                            .toMillis();
+        if (backoffTimeMillis > 0) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(backoffTimeMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw SdkClientException.builder().message("Thread interrupted while trying to sleep").cause(e).build();
+            }
+        }
+    }
+
+    private Token getToken() {
+        HttpExecuteRequest httpExecuteRequest = HttpExecuteRequest.builder()
+                                                                  .request(requestMarshaller.createTokenRequest(tokenTtl))
+                                                                  .build();
+        HttpExecuteResponse response = null;
+        try {
+            response = httpClient.prepareRequest(httpExecuteRequest).call();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        int statusCode = response.httpResponse().statusCode();
+
+        if (HttpStatusFamily.of(statusCode).isOneOf(HttpStatusFamily.SERVER_ERROR)) {
+            response.responseBody().map(BaseEc2MetadataClient::uncheckedInputStreamToUtf8)
+                    .ifPresent(str -> log.debug(() -> "Metadata request response body: " + str));
+            throw RetryableException.builder()
+                                    .message("Could not retrieve token, " + statusCode + " error occurred").build();
+        }
+
+        if (!HttpStatusFamily.of(statusCode).isOneOf(HttpStatusFamily.SUCCESSFUL)) {
+            handleUnsuccessfulResponse(statusCode, response.responseBody(), response,
+                () -> String.format("Could not retrieve token, %d error occurred", statusCode)
+            );
+        }
+
+        String ttl = response.httpResponse()
+                             .firstMatchingHeader(RequestMarshaller.EC2_METADATA_TOKEN_TTL_HEADER)
+                             .orElseThrow(() -> SdkClientException
+                                 .builder()
+                                 .message(RequestMarshaller.EC2_METADATA_TOKEN_TTL_HEADER + " header not found in token response")
+                                 .build());
+        java.time.Duration ttlDuration;
+        try {
+            ttlDuration = java.time.Duration.ofSeconds(Long.parseLong(ttl));
+        } catch (NumberFormatException nfe) {
+            throw SdkClientException.create("Invalid token format received from IMDS server", nfe);
+        }
+
+        AbortableInputStream abortableInputStream = response.responseBody().orElseThrow(
+            SdkClientException.builder().message("Empty response body")::build);
+
+        String value = uncheckedInputStreamToUtf8(abortableInputStream);
+        return new Token(value, ttlDuration);
+    }
+
+    protected static final class Ec2MetadataBuilder implements Ec2MetadataClient.Builder {
+
+        private Ec2MetadataRetryPolicy retryPolicy;
+        private java.net.URI endpoint;
+        private java.time.Duration tokenTtl;
+        private EndpointMode endpointMode;
+        private SdkHttpClient httpClient;
+        private SdkHttpClient.Builder<?> httpClientBuilder;
+
+        private Ec2MetadataBuilder() {
+        }
+
+        @Override
+        public Ec2MetadataBuilder retryPolicy(Ec2MetadataRetryPolicy retryPolicy) {
+            this.retryPolicy = retryPolicy;
+            return this;
+        }
+
+        @Override
+        public Builder retryPolicy(java.util.function.Consumer<Ec2MetadataRetryPolicy.Builder> builderConsumer) {
+            Validate.notNull(builderConsumer, "builderConsumer must not be null");
+            Ec2MetadataRetryPolicy.Builder builder = Ec2MetadataRetryPolicy.builder();
+            builderConsumer.accept(builder);
+            return retryPolicy(builder.build());
+        }
+
+        @Override
+        public Ec2MetadataBuilder endpoint(java.net.URI endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        @Override
+        public Ec2MetadataBuilder tokenTtl(java.time.Duration tokenTtl) {
+            this.tokenTtl = tokenTtl;
+            return this;
+        }
+
+        @Override
+        public Ec2MetadataBuilder endpointMode(EndpointMode endpointMode) {
+            this.endpointMode = endpointMode;
+            return this;
+        }
+
+        @Override
+        public Ec2MetadataBuilder httpClient(SdkHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        @Override
+        public Builder httpClient(SdkHttpClient.Builder<?> builder) {
+            this.httpClientBuilder = builder;
+            return this;
+        }
+
+        public Ec2MetadataRetryPolicy getRetryPolicy() {
+            return this.retryPolicy;
+        }
+
+        public java.net.URI getEndpoint() {
+            return this.endpoint;
+        }
+
+        public java.time.Duration getTokenTtl() {
+            return this.tokenTtl;
+        }
+
+        public EndpointMode getEndpointMode() {
+            return this.endpointMode;
+        }
+
+        @Override
+        public Ec2MetadataClient build() {
+            return new DefaultEc2MetadataClientWithFallback(this);
+        }
+    }
+}

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/Ec2MetadataSharedClient.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/Ec2MetadataSharedClient.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.imds.internal;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.imds.Ec2MetadataClient;
+import software.amazon.awssdk.imds.Ec2MetadataRetryPolicy;
+import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.Lazy;
+
+/**
+ * Creates Ec2MetadataClient instances using a shared HTTP client internally.
+ * This provides resource efficiency by sharing a single HTTP client across all IMDS-backed providers
+ */
+@SdkInternalApi
+public final class Ec2MetadataSharedClient {
+    // Singleton HTTP client shared across all Ec2MetadataClient instances
+    private static final Lazy<SdkHttpClient> SHARED_HTTP_CLIENT = new Lazy<>(() -> createImdsHttpClient());
+    
+    private Ec2MetadataSharedClient() {
+        // Prevent instantiation
+    }
+    
+    /**
+     * Creates a builder for configuring Ec2MetadataClient with shared HTTP client.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    /**
+     * Creates a new Ec2MetadataClient instance using the shared HTTP client
+     * with default configuration.
+     */
+    public static Ec2MetadataClient create() {
+        return builder().build();
+    }
+    
+    private static SdkHttpClient createImdsHttpClient() {
+        Duration metadataServiceTimeout = Ec2MetadataConfigProvider.instance().resolveServiceTimeout();
+        AttributeMap imdsHttpDefaults = AttributeMap.builder()
+                .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, metadataServiceTimeout)
+                .put(SdkHttpConfigurationOption.READ_TIMEOUT, metadataServiceTimeout)
+                .build();
+
+        return new DefaultSdkHttpClientBuilder().buildWithDefaults(imdsHttpDefaults);
+    }
+    
+    public static final class Builder {
+        private Ec2MetadataRetryPolicy retryPolicy;
+        
+        private Builder() {
+        }
+        
+        public Builder retryPolicy(Ec2MetadataRetryPolicy retryPolicy) {
+            this.retryPolicy = retryPolicy;
+            return this;
+        }
+        
+        public Ec2MetadataClient build() {
+            return DefaultEc2MetadataClientWithFallback.builder()
+                .httpClient(SHARED_HTTP_CLIENT.getValue())
+                .retryPolicy(retryPolicy)
+                .build();
+        }
+    }
+}

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/RequestMarshaller.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/RequestMarshaller.java
@@ -50,7 +50,7 @@ public class RequestMarshaller {
     }
 
     public SdkHttpFullRequest createTokenRequest(Duration tokenTtl) {
-        return defaulttHttpBuilder()
+        return defaultHttpBuilder()
             .method(SdkHttpMethod.PUT)
             .uri(tokenPath)
             .putHeader(EC2_METADATA_TOKEN_TTL_HEADER, String.valueOf(tokenTtl.getSeconds()))
@@ -59,7 +59,7 @@ public class RequestMarshaller {
 
     public SdkHttpFullRequest createDataRequest(String path, String token, Duration tokenTtl) {
         URI resourcePath = URI.create(basePath + path);
-        SdkHttpFullRequest.Builder builder = defaulttHttpBuilder()
+        SdkHttpFullRequest.Builder builder = defaultHttpBuilder()
             .method(SdkHttpMethod.GET)
             .uri(resourcePath)
             .putHeader(EC2_METADATA_TOKEN_TTL_HEADER, String.valueOf(tokenTtl.getSeconds()));
@@ -69,7 +69,7 @@ public class RequestMarshaller {
         return builder.build();
     }
 
-    private SdkHttpFullRequest.Builder defaulttHttpBuilder() {
+    private SdkHttpFullRequest.Builder defaultHttpBuilder() {
         return SdkHttpFullRequest.builder()
                              .putHeader(USER_AGENT, SystemUserAgent.getOrCreate().userAgentString())
                              .putHeader(ACCEPT, "*/*")

--- a/core/imds/src/main/java/software/amazon/awssdk/imds/internal/RequestMarshaller.java
+++ b/core/imds/src/main/java/software/amazon/awssdk/imds/internal/RequestMarshaller.java
@@ -59,12 +59,14 @@ public class RequestMarshaller {
 
     public SdkHttpFullRequest createDataRequest(String path, String token, Duration tokenTtl) {
         URI resourcePath = URI.create(basePath + path);
-        return defaulttHttpBuilder()
+        SdkHttpFullRequest.Builder builder = defaulttHttpBuilder()
             .method(SdkHttpMethod.GET)
             .uri(resourcePath)
-            .putHeader(EC2_METADATA_TOKEN_TTL_HEADER, String.valueOf(tokenTtl.getSeconds()))
-            .putHeader(TOKEN_HEADER, token)
-            .build();
+            .putHeader(EC2_METADATA_TOKEN_TTL_HEADER, String.valueOf(tokenTtl.getSeconds()));
+        if (token != null) {
+            builder.putHeader(TOKEN_HEADER, token);
+        }
+        return builder.build();
     }
 
     private SdkHttpFullRequest.Builder defaulttHttpBuilder() {

--- a/core/imds/src/test/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallbackTest.java
+++ b/core/imds/src/test/java/software/amazon/awssdk/imds/internal/DefaultEc2MetadataClientWithFallbackTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.imds.internal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.imds.Ec2MetadataClient;
+import software.amazon.awssdk.imds.Ec2MetadataResponse;
+import software.amazon.awssdk.imds.Ec2MetadataRetryPolicy;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+/**
+ * Tests for DefaultEc2MetadataClientWithFallback to verify IMDSv1 fallback behavior.
+ */
+public class DefaultEc2MetadataClientWithFallbackTest {
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+                                                               .options(wireMockConfig().dynamicPort().dynamicPort())
+                                                               .configureStaticDsl(true)
+                                                               .build();
+
+    private Ec2MetadataClient client;
+
+    @BeforeEach
+    public void setup() {
+        clearEnvironmentVariable(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.environmentVariable());
+        
+        // Create client with WireMock endpoint
+        client = DefaultEc2MetadataClientWithFallback.builder()
+                .endpoint(URI.create("http://localhost:" + wireMock.getPort()))
+                .retryPolicy(Ec2MetadataRetryPolicy.builder().numRetries(0).build())
+                .tokenTtl(Duration.ofSeconds(21600))
+                .build();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        if (client != null) {
+            client.close();
+        }
+        wireMock.resetAll();
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+    }
+
+    private void clearEnvironmentVariable(String name) {
+        try {
+            ENVIRONMENT_VARIABLE_HELPER.set(name, null);
+        } catch (Exception e) {
+            //Ignore
+        }
+    }
+
+    @Test
+    public void imdsV2Success_shouldUseTokenAndReturnData() {
+        // Stub successful IMDSv2 flow
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("x-aws-ec2-metadata-token-ttl-seconds", "21600")
+                                    .withBody("test-token")));
+        
+        stubFor(get("/latest/meta-data/placement/region")
+                    .withHeader("x-aws-ec2-metadata-token", matching("test-token"))
+                    .willReturn(aResponse().withStatus(200).withBody("us-east-1")));
+
+        Ec2MetadataResponse response = client.get("/latest/meta-data/placement/region");
+
+        assertThat(response.asString()).isEqualTo("us-east-1");
+
+        // Verify both token and data requests were made
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region"))
+                .withHeader("x-aws-ec2-metadata-token", matching("test-token")));
+    }
+
+    @Test
+    public void imdsV1Fallback_shouldWorkWhenTokenFails() {
+        // Stub token request to fail with 500
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+        // Stub successful IMDSv1 request
+        stubFor(get("/latest/meta-data/placement/region")
+                    .willReturn(aResponse().withStatus(200).withBody("us-west-2")));
+
+        Ec2MetadataResponse response = client.get("/latest/meta-data/placement/region");
+
+        assertThat(response.asString()).isEqualTo("us-west-2");
+
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region"))
+                .withoutHeader("x-aws-ec2-metadata-token"));
+        
+        // Verify no IMDSv2 requests were made
+        verify(0, getRequestedFor(urlEqualTo("/latest/meta-data/placement/region"))
+                .withHeader("x-aws-ec2-metadata-token", matching(".*")));
+    }
+
+    @Test
+    public void imdsV1Fallback_shouldNotWorkWith400Error() {
+        // Stub token request to fail with 400
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(400).withBody("Bad Request")));
+
+        assertThatThrownBy(() -> client.get("/latest/meta-data/placement/region"))
+                .isInstanceOf(SdkClientException.class)
+                .hasMessageContaining("Unable to fetch metadata token");
+
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(0, getRequestedFor(urlEqualTo("/latest/meta-data/placement/region")));
+    }
+
+    @Test
+    public void imdsV1Fallback_shouldNotWorkWhenDisabled() {
+        // Disable IMDSv1 fallback
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_EC2_METADATA_V1_DISABLED.environmentVariable(), "true");
+
+        // Recreate client to pick up environment variable
+        client.close();
+        client = DefaultEc2MetadataClientWithFallback.builder()
+                .endpoint(URI.create("http://localhost:" + wireMock.getPort()))
+                .retryPolicy(Ec2MetadataRetryPolicy.builder().numRetries(0).build())
+                .tokenTtl(Duration.ofSeconds(21600))
+                .build();
+
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+        // Should throw exception without attempting IMDSv1 fallback
+        assertThatThrownBy(() -> client.get("/latest/meta-data/placement/region"))
+                .isInstanceOf(SdkClientException.class)
+                .hasMessageContaining("fallback to IMDS v1 is disabled");
+
+
+        verify(putRequestedFor(urlEqualTo("/latest/api/token")));
+        verify(0, getRequestedFor(urlEqualTo("/latest/meta-data/placement/region")));
+    }
+
+    @Test
+    public void tokenCaching_shouldReuseValidToken() {
+        // Stub successful token request
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("x-aws-ec2-metadata-token-ttl-seconds", "21600")
+                                    .withBody("cached-token")));
+        
+        // Stub successful data requests
+        stubFor(get("/latest/meta-data/placement/region")
+                    .withHeader("x-aws-ec2-metadata-token", matching("cached-token"))
+                    .willReturn(aResponse().withStatus(200).withBody("us-east-1")));
+        
+        stubFor(get("/latest/meta-data/instance-id")
+                    .withHeader("x-aws-ec2-metadata-token", matching("cached-token"))
+                    .willReturn(aResponse().withStatus(200).withBody("i1234")));
+
+        // Make two requests
+        Ec2MetadataResponse response1 = client.get("/latest/meta-data/placement/region");
+        Ec2MetadataResponse response2 = client.get("/latest/meta-data/instance-id");
+
+        assertThat(response1.asString()).isEqualTo("us-east-1");
+        assertThat(response2.asString()).isEqualTo("i1234");
+
+        // Verify token was requested only once
+        verify(1, putRequestedFor(urlEqualTo("/latest/api/token")));
+        
+        // Verify both data requests were made with the same token
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region"))
+                .withHeader("x-aws-ec2-metadata-token", matching("cached-token")));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/instance-id"))
+                .withHeader("x-aws-ec2-metadata-token", matching("cached-token")));
+    }
+
+    @Test
+    public void fallbackAfterTokenFailure_shouldUseImdsV1ForSubsequentRequests() {
+        // Stub token request to fail
+        stubFor(put("/latest/api/token")
+                    .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+        // Stub successful IMDSv1 requests
+        stubFor(get("/latest/meta-data/placement/region")
+                    .willReturn(aResponse().withStatus(200).withBody("us-west-2")));
+        
+        stubFor(get("/latest/meta-data/instance-id")
+                    .willReturn(aResponse().withStatus(200).withBody("i-123")));
+
+        // Make two requests - both should use IMDSv1 fallback
+        Ec2MetadataResponse response1 = client.get("/latest/meta-data/placement/region");
+        Ec2MetadataResponse response2 = client.get("/latest/meta-data/instance-id");
+
+        assertThat(response1.asString()).isEqualTo("us-west-2");
+        assertThat(response2.asString()).isEqualTo("i-123");
+
+        // Verify token was requested only once
+        verify(1, putRequestedFor(urlEqualTo("/latest/api/token")));
+        
+
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/placement/region"))
+                .withoutHeader("x-aws-ec2-metadata-token"));
+        verify(getRequestedFor(urlEqualTo("/latest/meta-data/instance-id"))
+                .withoutHeader("x-aws-ec2-metadata-token"));
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/DefaultSdkHttpClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/DefaultSdkHttpClientBuilder.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.core.internal.http.loader;
 
-import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpService;
@@ -24,7 +24,7 @@ import software.amazon.awssdk.utils.AttributeMap;
 /**
  * Utility to load the default HTTP client factory and create an instance of {@link SdkHttpClient}.
  */
-@SdkInternalApi
+@SdkProtectedApi
 public final class DefaultSdkHttpClientBuilder implements SdkHttpClient.Builder {
 
     private static final SdkHttpServiceProvider<SdkHttpService> DEFAULT_CHAIN = new CachingSdkHttpServiceProvider<>(

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/DefaultSdkHttpClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/DefaultSdkHttpClientBuilder.java
@@ -23,6 +23,9 @@ import software.amazon.awssdk.utils.AttributeMap;
 
 /**
  * Utility to load the default HTTP client factory and create an instance of {@link SdkHttpClient}.
+ *
+ * Implementation notes: this class should've been outside internal package,
+ * but we can't fix it due to backwards compatibility reasons.
  */
 @SdkProtectedApi
 public final class DefaultSdkHttpClientBuilder implements SdkHttpClient.Builder {

--- a/test/architecture-tests/archunit_store/c898eee1-aeb5-4355-bb3b-ea56bf58cacb
+++ b/test/architecture-tests/archunit_store/c898eee1-aeb5-4355-bb3b-ea56bf58cacb
@@ -27,3 +27,5 @@ Class <software.amazon.awssdk.utils.internal.Base16Lower> does not reside outsid
 Class <software.amazon.awssdk.utils.internal.EnumUtils> does not reside outside of package '..internal..' in (EnumUtils.java:0)
 Class <software.amazon.awssdk.utils.internal.MappingSubscriber> does not reside outside of package '..internal..' in (MappingSubscriber.java:0)
 Class <software.amazon.awssdk.utils.internal.SystemSettingUtils> does not reside outside of package '..internal..' in (SystemSettingUtils.java:0)
+Class <software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder> does not reside outside of package '..internal..' in (DefaultSdkHttpClientBuilder.java:0)
+Class <software.amazon.awssdk.imds.internal.Ec2MetadataSharedClient> does not reside outside of package '..internal..' in (Ec2MetadataSharedClient.java:0)


### PR DESCRIPTION
AutoDefaultsModeDiscovery changes to use Ec2MetadataClient

## Motivation and Context

This change migrates IMDS-backed providers from using internal utilities to the public Ec2MetadataClient API.

- AutoDefaultsModeDiscovery currently uses the internal EC2MetadataUtils class via HttpResourcesUtils, which doesn't respect certain IMDS client configurations 
- Lacks features like IMDS session token caching and auto-refresh 
- It replaces the basic HttpURLConnection with a HTTP client that offers much better debugging capabilities
- Uses separate IMDS implementation instead of the public Ec2MetadataClient

This PR specifically addresses the Auto defaults mode discovery component, which is one of three planned migrations (along with InstanceProfileCredentialsProvider and InstanceProfileRegionProvider).

Github Feature Request: https://github.com/aws/aws-sdk-java-v2/issues/5876

## Modifications

- Migrated AutoDefaultsModeDiscovery class to use Ec2MetadataClient from EC2MetadataUtils.
- Created Ec2MetadataSharedClient, which creates a shared HTTP client that is shared among the providers.
- Added DefaultEc2MetadataClientWithFallback for IMDSv1 compatibility.
- Added imds module dependency to aws-core module's pom.xml

## Testing

- All existing tests pass - AutoDefaultsModeDiscoveryTest continues to validate original functionality
- Added "AutoDefaultsModeDiscoveryEc2MetadataClientTest" which has unit tests that test the migration from EC2MetadataUtils to Ec2MetadataClient.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
