### PR TITLE
Remove usage of `DisplayName` API from S3 integ test as S3 no longer sends it

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3ListObjectsV2IntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3ListObjectsV2IntegrationTest.java
@@ -332,7 +332,6 @@ public class S3ListObjectsV2IntegrationTest extends S3IntegrationTestBase {
 
             if (shouldIncludeOwner) {
                 assertNotNull(obj.owner());
-                assertTrue(obj.owner().displayName().length() > 1);
                 assertTrue(obj.owner().id().length() > 1);
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
```
Java.lang.NullPointerException
    at software.amazon.awssdk.services.s3.S3ListObjectsV2IntegrationTest.assertS3ObjectSummariesAreValid(S3ListObjectsV2IntegrationTest.java:335)
    at software.amazon.awssdk.services.s3.S3ListObjectsV2IntegrationTest.testListWithFetchOwner(S3ListObjectsV2IntegrationTest.java:262)
    at java.lang.reflect.Method.invoke(Method.java:498)
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://docs.aws.amazon.com/AmazonS3/latest/API/API_Owner.html
- based on this
```
Between July 15, 2025 and October 1, 2025, you will begin to see an increasing rate of missing DisplayName in the Owner object.
```

## Modifications
<!--- Describe your changes in detail -->
- Remove the usage of `DisplayName` API in iteg test , we already do check on the owner.`id` api



## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
