### PR TITLE
SigV4a: Add host header only when not already provided

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-9f69c81.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-9f69c81.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed SigV4a signing to respect pre-existing Host headers to be consistent with existing SigV4 signing behavior."
+}

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -412,4 +412,26 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-checksum-crc32"))
             .contains("some value");
     }
+
+    @Test
+    public void sign_withProvidedHostHeader_shouldRespectUserHostHeader() {
+        AwsCredentialsIdentity credentials =
+            AwsCredentialsIdentity.create("access", "secret");
+
+        String hostOverride = "virtual-host.localhost";
+        SignRequest<AwsCredentialsIdentity> request = generateBasicRequest(
+            credentials,
+            httpRequest -> httpRequest.putHeader("Host", hostOverride).port(443),
+            signRequest -> {
+
+            }
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        assertThat(signedRequest.request().firstMatchingHeader("Host")).hasValue(hostOverride);
+        assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Date")).hasValue("20200803T174823Z");
+        assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Region-Set")).hasValue("aws-global");
+        assertThat(signedRequest.request().firstMatchingHeader("Authorization")).isPresent();
+    }
 }


### PR DESCRIPTION
## Motivation and Context

This change enables host header override functionality for SigV4a signing, bringing it to parity with SigV4 signing behavior. 

**Background:** In PR #5608, we fixed SigV4 signing to respect pre-existing Host headers rather than always overriding them. This was necessary for use cases like:
- Transparent proxies that rely on the Host header for routing
- Custom routing scenarios where the Host header differs from the endpoint

**Current issue:** The same fix was not applied to the SigV4a signing path, causing host header overrides to be ignored when using SigV4a.

**Impact:**  Enhance SigV4a support such that customers expect host header override to work consistently across both signing algorithms.

## Modifications

- Added host header existence check in `CrtUtils.java` before setting the host header in SigV4a signing flow
- This mirrors the fix previously applied to SigV4 signing in PR #5608
- Ensures that if a Host header is already present in the request, it will not be overwritten during SigV4a signing

## Testing

- Reproduced the issue using the provided test case showing SigV4 works but SigV4a fails
- Verified that with this change, both SigV4 and SigV4a respect pre-existing Host headers
- Regression tested to ensure default behavior (no pre-existing Host header) continues to work

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
