### PR TITLE
Stream retry support part 1: Add BufferingAsyncRequestBody that buffers the entire content and sup…

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/BufferingAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/BufferingAsyncRequestBody.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * An implementation of {@link AsyncRequestBody} that buffers the entire content and supports multiple concurrent subscribers.
+ * 
+ * <p>This class allows data to be sent incrementally via the {@link #send(ByteBuffer)} method, buffered internally,
+ * and then replayed to multiple subscribers independently. Each subscriber receives a complete copy of all buffered data
+ * when they subscribe and request it.
+ * 
+ * <p>Usage Pattern:
+ * {@snippet :
+ * BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(contentLength);
+ * 
+ * // Send data incrementally
+ * body.send(ByteBuffer.wrap("Hello ".getBytes()));
+ * body.send(ByteBuffer.wrap("World".getBytes()));
+ * 
+ * // Mark data as complete and ready for subscription
+ * body.complete();
+ * 
+ * // Multiple subscribers can now consume the buffered data
+ * body.subscribe(subscriber1);
+ * body.subscribe(subscriber2);
+ * }
+ * 
+ * <h3>Thread Safety:</h3>
+ * This class is thread-safe and supports concurrent operations:
+ * <ul>
+ *   <li>Multiple threads can call {@link #send(ByteBuffer)} concurrently</li>
+ *   <li>Multiple subscribers can be added concurrently</li>
+ *   <li>Each subscriber operates independently with its own state</li>
+ * </ul>
+ * 
+ * <h3>Subscription Behavior:</h3>
+ * <ul>
+ *   <li>Subscribers can only subscribe after {@link #complete()} has been called</li>
+ *   <li>Each subscriber receives a read-only view of the buffered data</li>
+ *   <li>Subscribers receive data independently based on their own demand signaling</li>
+ *   <li>If the body is closed, new subscribers will receive an error immediately</li>
+ * </ul>
+ * 
+ * <h3>Resource Management:</h3>
+ * The body should be closed when no longer needed to free buffered data and notify active subscribers.
+ * Closing the body will:
+ * <ul>
+ *   <li>Clear all buffered data</li>
+ *   <li>Send error notifications to all active subscribers</li>
+ *   <li>Prevent new subscriptions</li>
+ * </ul>
+ *
+ */
+@ThreadSafe
+@SdkInternalApi
+public final class BufferingAsyncRequestBody implements AsyncRequestBody, SdkAutoCloseable {
+    private static final Logger log = Logger.loggerFor(BufferingAsyncRequestBody.class);
+
+    private final Long length;
+    private final List<ByteBuffer> bufferedData = new ArrayList<>();
+    private boolean dataReady;
+    private boolean closed;
+    private final Set<ReplayableByteBufferSubscription> subscriptions;
+    private final Object lock = new Object();
+
+    /**
+     * Creates a new BufferingAsyncRequestBody with the specified content length.
+     * 
+     * @param length the total content length in bytes, or null if unknown
+     */
+    BufferingAsyncRequestBody(Long length) {
+        this.length = length;
+        this.subscriptions = ConcurrentHashMap.newKeySet();
+    }
+
+    /**
+     * Sends a chunk of data to be buffered for later consumption by subscribers.
+     * 
+     * @param data the data to buffer, must not be null
+     * @throws NullPointerException if data is null
+     */
+    public void send(ByteBuffer data) {
+        Validate.paramNotNull(data, "data");
+        synchronized (lock) {
+            if (closed) {
+                throw new IllegalStateException("Cannot send data to closed body");
+            }
+            if (dataReady) {
+                throw new IllegalStateException("Request body has already been completed");
+            }
+            bufferedData.add(data);
+        }
+    }
+
+    /**
+     * Marks the request body as complete and ready for subscription.
+     * 
+     * <p>This method must be called before any subscribers can successfully subscribe
+     * to this request body. After calling this method, no more data should be sent
+     * via {@link #send(ByteBuffer)}.
+     * 
+     * <p>Once complete, multiple subscribers can subscribe and will each receive
+     * the complete buffered content independently.
+     */
+    public void complete() {
+        synchronized (lock) {
+            if (dataReady) {
+                return;
+            }
+            if (closed) {
+                throw new IllegalStateException("The AsyncRequestBody has been closed");
+            }
+            dataReady = true;
+        }
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.ofNullable(length);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        Validate.paramNotNull(subscriber, "subscriber");
+
+        synchronized (lock) {
+            if (!dataReady) {
+                subscriber.onSubscribe(new NoopSubscription(subscriber));
+                subscriber.onError(NonRetryableException.create(
+                    "Unexpected error occurred. Data is not ready to be subscribed"));
+                return;
+            }
+
+            if (closed) {
+                subscriber.onSubscribe(new NoopSubscription(subscriber));
+                subscriber.onError(NonRetryableException.create(
+                    "AsyncRequestBody has been closed"));
+                return;
+            }
+        }
+
+        ReplayableByteBufferSubscription replayableByteBufferSubscription =
+            new ReplayableByteBufferSubscription(subscriber, bufferedData);
+        subscriber.onSubscribe(replayableByteBufferSubscription);
+        subscriptions.add(replayableByteBufferSubscription);
+    }
+
+    @Override
+    public String body() {
+        return BodyType.BYTES.getName();
+    }
+
+    /**
+     * <p>Closes this request body and releases all resources. This will:
+     * <ul>
+     *   <li>Clear all buffered data to free memory</li>
+     *   <li>Notify all active subscribers with an error</li>
+     *   <li>Prevent new subscriptions from succeeding</li>
+     * </ul>
+     * 
+     * <p>This method is idempotent - calling it multiple times has no additional effect.
+     * It is safe to call this method concurrently from multiple threads.
+     */
+    @Override
+    public void close() {
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+
+            closed = true;
+            bufferedData.clear();
+            subscriptions.forEach(s -> s.notifyError(new IllegalStateException("The publisher has been closed")));
+            subscriptions.clear();
+        }
+
+    }
+
+    @SdkTestInternalApi
+    List<ByteBuffer> bufferedData() {
+        return Collections.unmodifiableList(bufferedData);
+    }
+
+    private class ReplayableByteBufferSubscription implements Subscription {
+        private final AtomicInteger index = new AtomicInteger(0);
+        private final AtomicBoolean done = new AtomicBoolean(false);
+        private final List<ByteBuffer> buffers;
+        private final AtomicBoolean processingRequest = new AtomicBoolean(false);
+        private Subscriber<? super ByteBuffer> currentSubscriber;
+        private final AtomicLong outstandingDemand = new AtomicLong();
+
+        private ReplayableByteBufferSubscription(Subscriber<? super ByteBuffer> subscriber, List<ByteBuffer> buffers) {
+            this.buffers = buffers;
+            this.currentSubscriber = subscriber;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                currentSubscriber.onError(new IllegalArgumentException("§3.9: non-positive requests are not allowed!"));
+                currentSubscriber = null;
+                return;
+            }
+
+            if (done.get()) {
+                return;
+            }
+
+            outstandingDemand.updateAndGet(current -> {
+                if (Long.MAX_VALUE - current < n) {
+                    return Long.MAX_VALUE;
+                }
+
+                return current + n;
+            });
+            processRequest();
+        }
+
+        private void processRequest() {
+            do {
+                if (!processingRequest.compareAndSet(false, true)) {
+                    // Some other thread is processing the queue, so we don't need to.
+                    return;
+                }
+
+                try {
+                    doProcessRequest();
+                } catch (Throwable e) {
+                    notifyError(new IllegalStateException("Encountered fatal error in publisher", e));
+                    subscriptions.remove(this);
+                    break;
+                } finally {
+                    processingRequest.set(false);
+                }
+
+            } while (shouldProcessRequest());
+        }
+
+        private boolean shouldProcessRequest() {
+            return !done.get() && outstandingDemand.get() > 0 && index.get() < buffers.size();
+        }
+
+        private void doProcessRequest() {
+            while (true) {
+                if (!shouldProcessRequest()) {
+                    return;
+                }
+
+                int currentIndex = this.index.getAndIncrement();
+
+                if (currentIndex >= buffers.size()) {
+                    // This should never happen, but defensive programming
+                    notifyError(new IllegalStateException("Index out of bounds"));
+                    subscriptions.remove(this);
+                    return;
+                }
+
+                ByteBuffer buffer = buffers.get(currentIndex);
+                currentSubscriber.onNext(buffer.asReadOnlyBuffer());
+                outstandingDemand.decrementAndGet();
+
+                if (currentIndex == buffers.size() - 1) {
+                    done.set(true);
+                    currentSubscriber.onComplete();
+                    subscriptions.remove(this);
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            done.set(true);
+            subscriptions.remove(this);
+        }
+
+        public void notifyError(Exception exception) {
+            if (currentSubscriber != null) {
+                done.set(true);
+                currentSubscriber.onError(exception);
+                currentSubscriber = null;
+            }
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/BufferingAsyncRequestBodyTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/BufferingAsyncRequestBodyTckTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+
+import java.nio.ByteBuffer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.core.SdkBytes;
+
+public class BufferingAsyncRequestBodyTckTest extends org.reactivestreams.tck.PublisherVerification<ByteBuffer> {
+    public BufferingAsyncRequestBodyTckTest() {
+        super(new TestEnvironment(true));
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long elements) {
+        BufferingAsyncRequestBody bufferingAsyncRequestBody = new BufferingAsyncRequestBody(1024 * elements);
+        for (int i = 0; i < elements; i++) {
+            bufferingAsyncRequestBody.send(SdkBytes.fromUtf8String(RandomStringUtils.randomAscii(1024)).asByteBuffer());
+        }
+
+        bufferingAsyncRequestBody.complete();
+        return bufferingAsyncRequestBody;
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        BufferingAsyncRequestBody bufferingAsyncRequestBody = new BufferingAsyncRequestBody(1024L);
+        bufferingAsyncRequestBody.close();
+        return null;
+    }
+
+    public long maxElementsFromPublisher() {
+        return 100;
+    }
+
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/BufferingAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/BufferingAsyncRequestBodyTest.java
@@ -1,0 +1,384 @@
+package software.amazon.awssdk.core.internal.async;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.utils.BinaryUtils;
+
+public class BufferingAsyncRequestBodyTest {
+
+    private static final ByteBuffer TEST_DATA_SET_1 =
+        ByteBuffer.wrap(RandomStringUtils.randomAscii(1024).getBytes(StandardCharsets.UTF_8));
+    private static final ByteBuffer TEST_DATA_SET_2 =
+        ByteBuffer.wrap(RandomStringUtils.randomAscii(1024).getBytes(StandardCharsets.UTF_8));
+
+    @Test
+    public void body_whenCalled_shouldReturnConstantBytes() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        assertEquals("Bytes", body.body());
+    }
+
+    @Test
+    public void close_whenCalledMultipleTimes_shouldExecuteOnlyOnce() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        Subscriber<Object> mockSubscriber = mock(Subscriber.class);
+
+        body.subscribe(mockSubscriber);
+
+        body.close();
+        assertThat(body.bufferedData()).isEmpty();
+        body.close();
+        body.close();
+
+        verify(mockSubscriber, times(1)).onError(any(NonRetryableException.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("contentLengthTestCases")
+    public void contentLength_withVariousInputs_shouldReturnExpectedResult(Long inputLength, boolean shouldBePresent,
+                                                                           Long expectedValue) {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(inputLength);
+        Optional<Long> result = body.contentLength();
+
+        assertThat(result.isPresent()).isEqualTo(shouldBePresent);
+        if (shouldBePresent) {
+            assertThat(result.get()).isEqualTo(expectedValue);
+        }
+    }
+
+    private static Stream<Arguments> contentLengthTestCases() {
+        return Stream.of(
+            Arguments.of(null, false, null),
+            Arguments.of(100L, true, 100L),
+            Arguments.of(0L, true, 0L)
+        );
+    }
+
+    @Test
+    public void send_whenByteBufferIsNull_shouldThrowNullPointerException() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+
+        assertThatThrownBy(() -> body.send(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("data must not be null");
+    }
+
+    @Test
+    public void subscribe_whenBodyIsClosed_shouldNotifySubscriberWithError() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.complete(); // Set dataReady to true
+        body.close(); // Set closed to true
+        Subscriber<Object> mockSubscriber = mock(Subscriber.class);
+
+        body.subscribe(mockSubscriber);
+
+        verify(mockSubscriber).onSubscribe(any());
+        verify(mockSubscriber).onError(argThat(e ->
+                                                   e instanceof NonRetryableException &&
+                                                   e.getMessage().equals("AsyncRequestBody has been closed")
+        ));
+    }
+
+    @Test
+    public void subscribe_whenDataNotReady_shouldNotifySubscriberWithError() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        Subscriber<Object> mockSubscriber = mock(Subscriber.class);
+
+        body.subscribe(mockSubscriber);
+
+        verify(mockSubscriber).onSubscribe(any());
+        verify(mockSubscriber).onError(argThat(e ->
+                                                   e instanceof NonRetryableException &&
+                                                   e.getMessage().equals("Unexpected error occurred. Data is not ready to be "
+                                                                         + "subscribed")
+        ));
+    }
+
+    @Test
+    public void subscribe_whenMultipleSubscribers_shouldSupportConcurrentSubscriptions() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.send(TEST_DATA_SET_1);
+        body.send(TEST_DATA_SET_2);
+        body.complete();
+
+        Subscriber<ByteBuffer> firstSubscriber = mock(Subscriber.class);
+        Subscriber<ByteBuffer> secondSubscriber = mock(Subscriber.class);
+
+        ArgumentCaptor<Subscription> firstSubscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+        ArgumentCaptor<Subscription> secondSubscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+
+        body.subscribe(firstSubscriber);
+        body.subscribe(secondSubscriber);
+
+        verify(firstSubscriber).onSubscribe(firstSubscriptionCaptor.capture());
+        verify(secondSubscriber).onSubscribe(secondSubscriptionCaptor.capture());
+
+        Subscription firstSubscription = firstSubscriptionCaptor.getValue();
+        Subscription secondSubscription = secondSubscriptionCaptor.getValue();
+
+        firstSubscription.request(2);
+        secondSubscription.request(2);
+        verifyData(firstSubscriber);
+        verifyData(secondSubscriber);
+        verify(firstSubscriber).onComplete();
+        verify(secondSubscriber).onComplete();
+    }
+
+    private static void verifyData(Subscriber<ByteBuffer> subscriber) {
+        verify(subscriber).onNext(
+            argThat(buffer -> Arrays.equals(BinaryUtils.copyBytesFrom(buffer), TEST_DATA_SET_1.array())));
+        verify(subscriber).onNext(
+            argThat(buffer -> Arrays.equals(BinaryUtils.copyBytesFrom(buffer), TEST_DATA_SET_2.array())));
+        verify(subscriber).onComplete();
+    }
+
+    @Test
+    public void send_afterClose_shouldThrowIllegalStateException() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.close();
+
+        assertThatThrownBy(() -> body.send(ByteBuffer.wrap("test".getBytes())))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Cannot send data to closed body");
+    }
+
+    @Test
+    public void send_afterComplete_shouldThrowIllegalStateException() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.complete();
+
+        assertThatThrownBy(() -> body.send(ByteBuffer.wrap("test".getBytes())))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Request body has already been completed");
+    }
+
+    @Test
+    public void complete_afterClose_shouldThrowIllegalStateException() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.close();
+
+        assertThatThrownBy(() -> body.complete())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("The AsyncRequestBody has been closed");
+    }
+
+    @Test
+    public void complete_calledMultipleTimes_shouldNotThrow() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.complete();
+        
+        // Should not throw - method returns early if already completed
+        body.complete();
+        body.complete();
+        
+        // Verify it's still in completed state
+        Subscriber<ByteBuffer> mockSubscriber = mock(Subscriber.class);
+        body.subscribe(mockSubscriber);
+        verify(mockSubscriber).onSubscribe(any());
+    }
+
+    @Test
+    public void close_withActiveSubscriptions_shouldNotifyAllSubscribers() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.send(ByteBuffer.wrap("test".getBytes()));
+        body.complete();
+
+        Subscriber<ByteBuffer> subscriber1 = mock(Subscriber.class);
+        Subscriber<ByteBuffer> subscriber2 = mock(Subscriber.class);
+        Subscriber<ByteBuffer> subscriber3 = mock(Subscriber.class);
+
+        body.subscribe(subscriber1);
+        body.subscribe(subscriber2);
+        body.subscribe(subscriber3);
+
+        body.close();
+
+        verify(subscriber1).onError(argThat(e ->
+            e instanceof IllegalStateException &&
+            e.getMessage().contains("The publisher has been closed")
+        ));
+        verify(subscriber2).onError(argThat(e ->
+            e instanceof IllegalStateException &&
+            e.getMessage().contains("The publisher has been closed")
+        ));
+        verify(subscriber3).onError(argThat(e ->
+            e instanceof IllegalStateException &&
+            e.getMessage().contains("The publisher has been closed")
+        ));
+    }
+
+    @Test
+    public void bufferedData_afterClose_shouldBeEmpty() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.send(ByteBuffer.wrap("test1".getBytes()));
+        body.send(ByteBuffer.wrap("test2".getBytes()));
+        
+        assertThat(body.bufferedData()).hasSize(2);
+        
+        body.close();
+        
+        assertThat(body.bufferedData()).isEmpty();
+    }
+
+    @Test
+    public void send_withEmptyByteBuffer_shouldStoreEmptyBuffer() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        ByteBuffer emptyBuffer = ByteBuffer.allocate(0);
+        
+        body.send(emptyBuffer);
+        body.complete();
+
+        Subscriber<ByteBuffer> mockSubscriber = mock(Subscriber.class);
+        ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+
+        body.subscribe(mockSubscriber);
+        verify(mockSubscriber).onSubscribe(subscriptionCaptor.capture());
+
+        Subscription subscription = subscriptionCaptor.getValue();
+        subscription.request(1);
+
+        verify(mockSubscriber).onNext(argThat(buffer -> buffer.remaining() == 0));
+        verify(mockSubscriber).onComplete();
+    }
+
+    @Test
+    public void concurrentSendAndComplete_shouldBeThreadSafe() throws InterruptedException {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(10);
+        AtomicInteger successfulSends = new AtomicInteger(0);
+
+        // Start multiple threads sending data
+        for (int i = 0; i < 10; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    body.send(ByteBuffer.wrap(("data" + threadId).getBytes()));
+                    successfulSends.incrementAndGet();
+                } catch (IllegalStateException e) {
+                    // Expected if complete() was called first
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Complete after a short delay
+        Thread.sleep(10);
+        body.complete();
+
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // Should have some successful sends and the body should be complete
+        assertThat(successfulSends.get()).isGreaterThan(0);
+        assertThat(body.bufferedData().size()).isEqualTo(successfulSends.get());
+    }
+
+    @Test
+    public void concurrentSubscribeAndClose_shouldBeThreadSafe() throws InterruptedException {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        body.send(ByteBuffer.wrap("test".getBytes()));
+        body.complete();
+
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(10);
+        AtomicInteger successfulSubscriptions = new AtomicInteger(0);
+        AtomicInteger errorNotifications = new AtomicInteger(0);
+
+        // Start multiple threads subscribing
+        for (int i = 0; i < 10; i++) {
+            executor.submit(() -> {
+                try {
+                    Subscriber<ByteBuffer> subscriber = new Subscriber<ByteBuffer>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            successfulSubscriptions.incrementAndGet();
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(ByteBuffer byteBuffer) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            errorNotifications.incrementAndGet();
+                        }
+
+                        @Override
+                        public void onComplete() {}
+                    };
+                    body.subscribe(subscriber);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Close after a short delay
+        Thread.sleep(10);
+        body.close();
+
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // All subscribers should have been notified
+        assertThat(successfulSubscriptions.get()).isEqualTo(10);
+    }
+
+    @Test
+    public void subscription_readOnlyBuffers_shouldNotAffectOriginalData() {
+        BufferingAsyncRequestBody body = new BufferingAsyncRequestBody(null);
+        ByteBuffer originalBuffer = ByteBuffer.wrap("test".getBytes());
+        int originalPosition = originalBuffer.position();
+        
+        body.send(originalBuffer);
+        body.complete();
+
+        Subscriber<ByteBuffer> mockSubscriber = mock(Subscriber.class);
+        ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+
+        body.subscribe(mockSubscriber);
+        verify(mockSubscriber).onSubscribe(subscriptionCaptor.capture());
+
+        Subscription subscription = subscriptionCaptor.getValue();
+        subscription.request(1);
+
+        verify(mockSubscriber).onNext(bufferCaptor.capture());
+        ByteBuffer receivedBuffer = bufferCaptor.getValue();
+
+        // Verify the received buffer is read-only
+        assertThat(receivedBuffer.isReadOnly()).isTrue();
+        
+        // Verify original buffer position is unchanged
+        assertThat(originalBuffer.position()).isEqualTo(originalPosition);
+    }
+}


### PR DESCRIPTION
…ports multiple concurrent subscribers

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
https://github.com/aws/aws-sdk-java-v2/issues/6198

This is the first PR to support retry in stream based transfer in s3 multipart client.

This PR adds `BufferingAsyncRequestBody` that is essentially a multicast publisher and can be subscribed multiple times until it's been closed