### PR TITLE
Update Netty to 4.1.123

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-d270782.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d270782.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Update Netty to `4.1.123`."
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <equalsverifier.version>3.15.1</equalsverifier.version>
         <!-- Update netty-open-ssl-version accordingly whenever we update netty version-->
         <!-- https://github.com/netty/netty/blob/4.1/pom.xml search "tcnative.version" -->
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.123.Final</netty.version>
         <unitils.version>3.4.6</unitils.version>
         <xmlunit.version>1.3</xmlunit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -141,7 +141,7 @@
         <jimfs.version>1.1</jimfs.version>
         <testng.version>7.1.0</testng.version> <!-- TCK Tests -->
         <commons-lang.verson>2.6</commons-lang.verson>
-        <netty-open-ssl-version>2.0.70.Final</netty-open-ssl-version>
+        <netty-open-ssl-version>2.0.72.Final</netty-open-ssl-version>
         <dynamodb-local.version>1.25.0</dynamodb-local.version>
         <sqllite.version>1.0.392</sqllite.version>
         <blockhound.version>1.0.8.RELEASE</blockhound.version>


### PR DESCRIPTION
Addresses #6247. 

There is some confusion around the [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193) description where it reads "Netty (...) has a vulnerability in versions up to and including 4.1.118.Final", but in the same page the known affected versions reads "Up to (excluding) 4.1.118". The [GitHub Advisory Database](https://github.com/advisories/GHSA-389x-839f-4rhx) also shows 4.1.118 as patched version.

This updates the netty version to 4.1.123 to avoid the confusion.

I'll kick off the integration tests too.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
