### PR TITLE
Fix bug in MultipartS3AsyncClient GetObject

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-61abc5c.json
+++ b/.changes/next-release/bugfix-AmazonS3-61abc5c.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fix a bug in the Java based multipart client with GetObject incorrect retry behavior"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
@@ -281,11 +281,8 @@ public class SplittingTransformer<ResponseT, ResultT> implements SdkPublisher<As
                     return;
                 }
 
-                // This isn't necessary, might be good for debugging? Or can just log error
-                /*e.addSuppressed(NonRetryableException.create(
-                    "Error occurred during multipart download. Request will not be retried."));*/
-
-                individualFuture.completeExceptionally(e);
+                individualFuture.completeExceptionally(NonRetryableException.create(
+                    "Error occurred during multipart download. Request will not be retried.", e));
             });
             individualFuture.whenComplete((r, e) -> {
                 if (isCancelled.get()) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingTransformer.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SplittingTransformerConfiguration;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -279,6 +280,11 @@ public class SplittingTransformer<ResponseT, ResultT> implements SdkPublisher<As
                 if (e == null) {
                     return;
                 }
+
+                // This isn't necessary, might be good for debugging? Or can just log error
+                /*e.addSuppressed(NonRetryableException.create(
+                    "Error occurred during multipart download. Request will not be retried."));*/
+
                 individualFuture.completeExceptionally(e);
             });
             individualFuture.whenComplete((r, e) -> {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientGetObjectWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientGetObjectWiremockTest.java
@@ -57,7 +57,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @WireMockTest
-@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@Timeout(value = 45, unit = TimeUnit.SECONDS)
 public class S3MultipartClientGetObjectWiremockTest {
     private static final String BUCKET = "Example-Bucket";
     private static final String KEY = "Key";
@@ -72,7 +72,7 @@ public class S3MultipartClientGetObjectWiremockTest {
                                        .multipartEnabled(true)
                                        .httpClientBuilder(NettyNioAsyncHttpClient.builder()
                                                                                  .maxConcurrency(100)
-                                                                                 .connectionAcquisitionTimeout(Duration.ofSeconds(100)))
+                                                                                 .connectionAcquisitionTimeout(Duration.ofSeconds(60)))
                                        .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")))
                                        .build();
     }
@@ -81,8 +81,7 @@ public class S3MultipartClientGetObjectWiremockTest {
         return Stream.of(
             AsyncResponseTransformer::toBytes,
             AsyncResponseTransformer::toBlockingInputStream,
-            // TODO - hanging
-            //AsyncResponseTransformer::toPublisher,
+            AsyncResponseTransformer::toPublisher,
             () -> {
                 try {
                     Path tempDir = Files.createTempDirectory("s3-test");
@@ -106,7 +105,7 @@ public class S3MultipartClientGetObjectWiremockTest {
     public void getObject_single500WithinMany200s_shouldNotRetryError(TransformerFactory transformerFactory) {
         List<CompletableFuture<?>> futures = new ArrayList<>();
 
-        int numRuns = 1000;
+        int numRuns = 100;
         for (int i = 0; i < numRuns; i++) {
             CompletableFuture<?> resp = mock200Response(multipartClient, i, transformerFactory);
             futures.add(resp);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientGetObjectWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientGetObjectWiremockTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.multipart;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@WireMockTest
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+public class S3MultipartClientGetObjectWiremockTest {
+    public static final String BUCKET = "Example-Bucket";
+    public static final String KEY = "Key";
+    private static final int MAX_ATTEMPTS = 7;
+    private S3AsyncClient multipartClient;
+
+    @BeforeEach
+    public void setup(WireMockRuntimeInfo wm) {
+        multipartClient = S3AsyncClient.builder()
+                                       .region(Region.US_EAST_1)
+                                       .endpointOverride(URI.create(wm.getHttpBaseUrl()))
+                                       .multipartEnabled(true)
+                                       .httpClientBuilder(NettyNioAsyncHttpClient.builder()
+                                                                                 .maxConcurrency(100)
+                                                                                 .connectionAcquisitionTimeout(Duration.ofSeconds(100)))
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")))
+                                       .build();
+    }
+
+    @Test
+    public void getObject_single500WithinMany200s_shouldNotRetryError() {
+        List<CompletableFuture<ResponseBytes<GetObjectResponse>>> futures = new ArrayList<>();
+
+        int numRuns = 1000;
+        for (int i = 0; i < numRuns; i++) {
+            CompletableFuture<ResponseBytes<GetObjectResponse>> resp = mock200Response(multipartClient, i);
+            futures.add(resp);
+        }
+
+        String errorKey = "ErrorKey";
+        stubFor(get(urlEqualTo(String.format("/%s/%s?partNumber=1", BUCKET, errorKey)))
+                    .inScenario("RetryableError")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(aResponse()
+                                    .withHeader("x-amz-request-id", String.valueOf(UUID.randomUUID()))
+                                    .withStatus(500)
+                                    .withBody(internalErrorBody())
+                    )
+                    .willSetStateTo("RetryAttempt"));
+
+        stubFor(get(urlEqualTo(String.format("/%s/%s?partNumber=1", BUCKET, errorKey)))
+                    .inScenario("RetryableError")
+                    .whenScenarioStateIs("RetryAttempt")
+                    .willReturn(aResponse().withStatus(200)
+                                           .withHeader("x-amz-request-id", String.valueOf(UUID.randomUUID()))
+                                           .withBody("Hello World")));
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> requestWithRetryableError =
+            multipartClient.getObject(r -> r.bucket(BUCKET).key(errorKey), AsyncResponseTransformer.toBytes());
+        futures.add(requestWithRetryableError);
+
+        for (int i = 0; i < numRuns; i++) {
+            CompletableFuture<ResponseBytes<GetObjectResponse>> resp = mock200Response(multipartClient, i + 1000);
+            futures.add(resp);
+        }
+
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+            fail("Expecting 500 error to fail request.");
+        } catch (CompletionException e) {
+            assertThat(e.getCause()).isInstanceOf(S3Exception.class);
+        }
+
+        verify(1, getRequestedFor(urlEqualTo(String.format("/%s/%s?partNumber=1", BUCKET, errorKey))));
+    }
+
+    private String errorBody(String errorCode, String errorMessage) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+               + "<Error>\n"
+               + "  <Code>" + errorCode + "</Code>\n"
+               + "  <Message>" + errorMessage + "</Message>\n"
+               + "</Error>";
+    }
+
+    private String internalErrorBody() {
+        return errorBody("InternalError", "We encountered an internal error. Please try again.");
+    }
+
+    private CompletableFuture<ResponseBytes<GetObjectResponse>> mock200Response(S3AsyncClient s3Client, int runNumber) {
+        String runId = runNumber + " success";
+
+        stubFor(any(anyUrl())
+                    .withHeader("RunNum", matching(runId))
+                    .inScenario(runId)
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(aResponse().withStatus(200)
+                                           .withHeader("x-amz-request-id", String.valueOf(UUID.randomUUID()))
+                                           .withBody("Hello World")));
+
+        return s3Client.getObject(r -> r.bucket(BUCKET).key("key")
+                                        .overrideConfiguration(c -> c.putHeader("RunNum", runId)),
+                                  AsyncResponseTransformer.toBytes());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This PR fixes a bug in the Java-based multipart S3 client (MultipartS3AsyncClient) that causes duplicate request logging when a retryable error occurs during many concurrent GetObject operations 

Currently, when a retryable error, e.g., 503 Slowdown, is returned by S3, the SDK may do one of two things:

1. Fail the request right away instead of retrying
2. Retry the error, but incorrectly process subsequent responses. A successful 200 response returned by the sever will be ignored. Instead, the SDK will log the initial error, and continue to retry until retry attempts are exhausted. This may happen instead of scenario 1 (failing right away), if many concurrent requests are in progress and a race condition occurs.

This PR fixes 2), a follow up PR will fix 1)

## Modifications
<!--- Describe your changes in detail -->

`SplittingTransformer`
- When completing the `individualFuture` exceptionally in the `IndividualTransformer`, wrap the exception with `NonRetryableException`

`MultipartDownloaderSubscriber`
- Keep track of each part GET request and cancel all in-flight ones if `onError()` is invoked

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added mock tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
