### PR TITLE
Add ability to specify transferDirectoryMaxConcurrency in S3TransferManager

### DIFF
--- a/.changes/next-release/feature-S3TransferManager-ca5314b.json
+++ b/.changes/next-release/feature-S3TransferManager-ca5314b.json
@@ -2,5 +2,5 @@
     "type": "feature",
     "category": "S3 Transfer Manager",
     "contributor": "AndreKurait",
-    "description": "Extend [#5031](https://github.com/aws/aws-sdk-java-v2/pull/5031) by allowing user configuration of directoryTransferMaxConcurrency during construction of S3TransferManager. This allows for more control of upper limits on JVM Heap memory allocation. See [#6330](https://github.com/aws/aws-sdk-java-v2/issues/6330)."
+    "description": "Extend [#5031](https://github.com/aws/aws-sdk-java-v2/pull/5031) by allowing user configuration of transferDirectoryMaxConcurrency during construction of S3TransferManager. This allows for more control of upper limits on JVM Heap memory allocation. See [#6330](https://github.com/aws/aws-sdk-java-v2/issues/6330)."
 }

--- a/.changes/next-release/feature-S3TransferManager-ca5314b.json
+++ b/.changes/next-release/feature-S3TransferManager-ca5314b.json
@@ -2,5 +2,5 @@
     "type": "feature",
     "category": "S3 Transfer Manager",
     "contributor": "AndreKurait",
-    "description": "Extend [#5031](https://github.com/aws/aws-sdk-java-v2/pull/5031) by allowing user configuration of directoryTransferMaxConcurrency during construction of S3TransferManager. This allows for more control of upper limits on JVM Heap memory allocation. See [#6330](https://github.com/aws/aws-sdk-java-v2/issues/6330)"
+    "description": "Extend [#5031](https://github.com/aws/aws-sdk-java-v2/pull/5031) by allowing user configuration of directoryTransferMaxConcurrency during construction of S3TransferManager. This allows for more control of upper limits on JVM Heap memory allocation. See [#6330](https://github.com/aws/aws-sdk-java-v2/issues/6330)."
 }

--- a/.changes/next-release/feature-S3TransferManager-ca5314b.json
+++ b/.changes/next-release/feature-S3TransferManager-ca5314b.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "S3 Transfer Manager",
+    "contributor": "AndreKurait",
+    "description": "Extend [#5031](https://github.com/aws/aws-sdk-java-v2/pull/5031) by allowing user configuration of directoryTransferMaxConcurrency during construction of S3TransferManager. This allows for more control of upper limits on JVM Heap memory allocation. See [#6330](https://github.com/aws/aws-sdk-java-v2/issues/6330)"
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
@@ -787,10 +787,10 @@ public interface S3TransferManager extends SdkAutoCloseable {
          * <p>
          * Default to 100
          *
-         * @param directoryTransferMaxConcurrency the maximum number of concurrent file transfers
+         * @param transferDirectoryMaxConcurrency the maximum number of concurrent file transfers
          * @return This builder for method chaining.
          */
-        Builder directoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency);
+        Builder transferDirectoryMaxConcurrency(Integer transferDirectoryMaxConcurrency);
 
         /**
          * Builds an instance of {@link S3TransferManager} based on the settings supplied to this builder

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
@@ -781,6 +781,18 @@ public interface S3TransferManager extends SdkAutoCloseable {
         Builder uploadDirectoryMaxDepth(Integer uploadDirectoryMaxDepth);
 
         /**
+         * Specifies the maximum number of concurrent file transfers that will be performed when
+         * uploading or downloading a directory. This setting controls the concurrency for an individual
+         * call to {@link S3TransferManager#uploadDirectory} or {@link S3TransferManager#downloadDirectory}.
+         * <p>
+         * Default to 100
+         *
+         * @param directoryTransferMaxConcurrency the maximum number of concurrent file transfers
+         * @return This builder for method chaining.
+         */
+        Builder directoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency);
+
+        /**
          * Builds an instance of {@link S3TransferManager} based on the settings supplied to this builder
          *
          * @return an instance of {@link S3TransferManager}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.transfer.s3.internal;
 
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_DELIMITER;
-import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_DIRECTORY_TRANSFER_MAX_CONCURRENCY;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_PREFIX;
 
 import java.io.IOException;
@@ -110,7 +109,7 @@ public class DownloadDirectoryHelper {
             new AsyncBufferingSubscriber<>(downloadSingleFile(downloadDirectoryRequest, request,
                                                               failedFileDownloads),
                                            allOfFutures,
-                                           DEFAULT_DIRECTORY_TRANSFER_MAX_CONCURRENCY);
+                                           transferConfiguration.option(TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY));
         listObjectsHelper.listS3ObjectsRecursively(request)
                          .filter(downloadDirectoryRequest.filter())
                          .subscribe(asyncBufferingSubscriber);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
@@ -109,7 +109,9 @@ public class DownloadDirectoryHelper {
             new AsyncBufferingSubscriber<>(downloadSingleFile(downloadDirectoryRequest, request,
                                                               failedFileDownloads),
                                            allOfFutures,
-                                           transferConfiguration.option(TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY));
+                                           transferConfiguration.option(
+                                               TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY
+                                           ));
         listObjectsHelper.listS3ObjectsRecursively(request)
                          .filter(downloadDirectoryRequest.filter())
                          .subscribe(asyncBufferingSubscriber);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferConfigurationOption.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferConfigurationOption.java
@@ -32,6 +32,9 @@ public final class TransferConfigurationOption<T> extends AttributeMap.Key<T> {
     public static final TransferConfigurationOption<Boolean> UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS =
         new TransferConfigurationOption<>("UploadDirectoryFileVisitOption", Boolean.class);
 
+    public static final TransferConfigurationOption<Integer> DIRECTORY_TRANSFER_MAX_CONCURRENCY =
+        new TransferConfigurationOption<>("DirectoryTransferMaxConcurrency", Integer.class);
+
     public static final TransferConfigurationOption<Executor> EXECUTOR =
         new TransferConfigurationOption<>("Executor", Executor.class);
 
@@ -45,6 +48,7 @@ public final class TransferConfigurationOption<T> extends AttributeMap.Key<T> {
         .builder()
         .put(UPLOAD_DIRECTORY_MAX_DEPTH, DEFAULT_UPLOAD_DIRECTORY_MAX_DEPTH)
         .put(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS, false)
+        .put(DIRECTORY_TRANSFER_MAX_CONCURRENCY, DEFAULT_DIRECTORY_TRANSFER_MAX_CONCURRENCY)
         .build();
 
     private final String name;
@@ -69,4 +73,3 @@ public final class TransferConfigurationOption<T> extends AttributeMap.Key<T> {
         return name;
     }
 }
-

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferConfigurationOption.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferConfigurationOption.java
@@ -33,7 +33,7 @@ public final class TransferConfigurationOption<T> extends AttributeMap.Key<T> {
         new TransferConfigurationOption<>("UploadDirectoryFileVisitOption", Boolean.class);
 
     public static final TransferConfigurationOption<Integer> DIRECTORY_TRANSFER_MAX_CONCURRENCY =
-        new TransferConfigurationOption<>("DirectoryTransferMaxConcurrency", Integer.class);
+        new TransferConfigurationOption<>("TransferDirectoryMaxConcurrency", Integer.class);
 
     public static final TransferConfigurationOption<Executor> EXECUTOR =
         new TransferConfigurationOption<>("Executor", Executor.class);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfiguration.java
@@ -43,7 +43,7 @@ public class TransferManagerConfiguration implements SdkAutoCloseable {
         AttributeMap.Builder standardOptions = AttributeMap.builder();
         standardOptions.put(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS, builder.uploadDirectoryFollowSymbolicLinks);
         standardOptions.put(UPLOAD_DIRECTORY_MAX_DEPTH, builder.uploadDirectoryMaxDepth);
-        standardOptions.put(DIRECTORY_TRANSFER_MAX_CONCURRENCY, builder.directoryTransferMaxConcurrency);
+        standardOptions.put(DIRECTORY_TRANSFER_MAX_CONCURRENCY, builder.transferDirectoryMaxConcurrency);
         finalizeExecutor(builder, standardOptions);
         options = standardOptions.build().merge(TRANSFER_MANAGER_DEFAULTS);
     }
@@ -99,7 +99,7 @@ public class TransferManagerConfiguration implements SdkAutoCloseable {
 
         private Boolean uploadDirectoryFollowSymbolicLinks;
         private Integer uploadDirectoryMaxDepth;
-        private Integer directoryTransferMaxConcurrency;
+        private Integer transferDirectoryMaxConcurrency;
         private Executor executor;
 
 
@@ -113,8 +113,8 @@ public class TransferManagerConfiguration implements SdkAutoCloseable {
             return this;
         }
 
-        public Builder directoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency) {
-            this.directoryTransferMaxConcurrency = directoryTransferMaxConcurrency;
+        public Builder transferDirectoryMaxConcurrency(Integer transferDirectoryMaxConcurrency) {
+            this.transferDirectoryMaxConcurrency = transferDirectoryMaxConcurrency;
             return this;
         }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfiguration.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.transfer.s3.internal;
 
+import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.TRANSFER_MANAGER_DEFAULTS;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.UPLOAD_DIRECTORY_MAX_DEPTH;
@@ -42,6 +43,7 @@ public class TransferManagerConfiguration implements SdkAutoCloseable {
         AttributeMap.Builder standardOptions = AttributeMap.builder();
         standardOptions.put(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS, builder.uploadDirectoryFollowSymbolicLinks);
         standardOptions.put(UPLOAD_DIRECTORY_MAX_DEPTH, builder.uploadDirectoryMaxDepth);
+        standardOptions.put(DIRECTORY_TRANSFER_MAX_CONCURRENCY, builder.directoryTransferMaxConcurrency);
         finalizeExecutor(builder, standardOptions);
         options = standardOptions.build().merge(TRANSFER_MANAGER_DEFAULTS);
     }
@@ -97,6 +99,7 @@ public class TransferManagerConfiguration implements SdkAutoCloseable {
 
         private Boolean uploadDirectoryFollowSymbolicLinks;
         private Integer uploadDirectoryMaxDepth;
+        private Integer directoryTransferMaxConcurrency;
         private Executor executor;
 
 
@@ -107,6 +110,11 @@ public class TransferManagerConfiguration implements SdkAutoCloseable {
 
         public Builder uploadDirectoryMaxDepth(Integer uploadDirectoryMaxDepth) {
             this.uploadDirectoryMaxDepth = uploadDirectoryMaxDepth;
+            return this;
+        }
+
+        public Builder directoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency) {
+            this.directoryTransferMaxConcurrency = directoryTransferMaxConcurrency;
             return this;
         }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerFactory.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerFactory.java
@@ -86,7 +86,7 @@ public final class TransferManagerFactory {
         TransferManagerConfiguration.Builder transferConfigBuilder = TransferManagerConfiguration.builder();
         transferConfigBuilder.uploadDirectoryFollowSymbolicLinks(tmBuilder.uploadDirectoryFollowSymbolicLinks);
         transferConfigBuilder.uploadDirectoryMaxDepth(tmBuilder.uploadDirectoryMaxDepth);
-        transferConfigBuilder.directoryTransferMaxConcurrency(tmBuilder.directoryTransferMaxConcurrency);
+        transferConfigBuilder.transferDirectoryMaxConcurrency(tmBuilder.transferDirectoryMaxConcurrency);
         transferConfigBuilder.executor(tmBuilder.executor);
         return transferConfigBuilder.build();
     }
@@ -96,7 +96,7 @@ public final class TransferManagerFactory {
         private Executor executor;
         private Boolean uploadDirectoryFollowSymbolicLinks;
         private Integer uploadDirectoryMaxDepth;
-        private Integer directoryTransferMaxConcurrency;
+        private Integer transferDirectoryMaxConcurrency;
 
         @Override
         public DefaultBuilder s3Client(S3AsyncClient s3AsyncClient) {
@@ -139,17 +139,17 @@ public final class TransferManagerFactory {
         }
 
         @Override
-        public DefaultBuilder directoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency) {
-            this.directoryTransferMaxConcurrency = directoryTransferMaxConcurrency;
+        public DefaultBuilder transferDirectoryMaxConcurrency(Integer transferDirectoryMaxConcurrency) {
+            this.transferDirectoryMaxConcurrency = transferDirectoryMaxConcurrency;
             return this;
         }
 
-        public void setDirectoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency) {
-            directoryTransferMaxConcurrency(directoryTransferMaxConcurrency);
+        public void setTransferDirectoryMaxConcurrency(Integer transferDirectoryMaxConcurrency) {
+            transferDirectoryMaxConcurrency(transferDirectoryMaxConcurrency);
         }
 
-        public Integer getDirectoryTransferMaxConcurrency() {
-            return directoryTransferMaxConcurrency;
+        public Integer getTransferDirectoryMaxConcurrency() {
+            return transferDirectoryMaxConcurrency;
         }
 
         @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerFactory.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerFactory.java
@@ -86,6 +86,7 @@ public final class TransferManagerFactory {
         TransferManagerConfiguration.Builder transferConfigBuilder = TransferManagerConfiguration.builder();
         transferConfigBuilder.uploadDirectoryFollowSymbolicLinks(tmBuilder.uploadDirectoryFollowSymbolicLinks);
         transferConfigBuilder.uploadDirectoryMaxDepth(tmBuilder.uploadDirectoryMaxDepth);
+        transferConfigBuilder.directoryTransferMaxConcurrency(tmBuilder.directoryTransferMaxConcurrency);
         transferConfigBuilder.executor(tmBuilder.executor);
         return transferConfigBuilder.build();
     }
@@ -95,6 +96,7 @@ public final class TransferManagerFactory {
         private Executor executor;
         private Boolean uploadDirectoryFollowSymbolicLinks;
         private Integer uploadDirectoryMaxDepth;
+        private Integer directoryTransferMaxConcurrency;
 
         @Override
         public DefaultBuilder s3Client(S3AsyncClient s3AsyncClient) {
@@ -134,6 +136,20 @@ public final class TransferManagerFactory {
 
         public Integer getUploadDirectoryMaxDepth() {
             return uploadDirectoryMaxDepth;
+        }
+
+        @Override
+        public DefaultBuilder directoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency) {
+            this.directoryTransferMaxConcurrency = directoryTransferMaxConcurrency;
+            return this;
+        }
+
+        public void setDirectoryTransferMaxConcurrency(Integer directoryTransferMaxConcurrency) {
+            directoryTransferMaxConcurrency(directoryTransferMaxConcurrency);
+        }
+
+        public Integer getDirectoryTransferMaxConcurrency() {
+            return directoryTransferMaxConcurrency;
         }
 
         @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelper.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.transfer.s3.internal;
 
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_DELIMITER;
-import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_DIRECTORY_TRANSFER_MAX_CONCURRENCY;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DEFAULT_PREFIX;
 
 import java.io.IOException;
@@ -102,7 +101,8 @@ public class UploadDirectoryHelper {
 
         AsyncBufferingSubscriber<Path> bufferingSubscriber =
             new AsyncBufferingSubscriber<>(path -> uploadSingleFile(uploadDirectoryRequest, failedFileUploads, path),
-                                           allOfFutures, DEFAULT_DIRECTORY_TRANSFER_MAX_CONCURRENCY);
+                                           allOfFutures, 
+                                           transferConfiguration.option(TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY));
 
         iterablePublisher.subscribe(bufferingSubscriber);
         CompletableFutureUtils.forwardExceptionTo(returnFuture, allOfFutures);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelper.java
@@ -102,7 +102,9 @@ public class UploadDirectoryHelper {
         AsyncBufferingSubscriber<Path> bufferingSubscriber =
             new AsyncBufferingSubscriber<>(path -> uploadSingleFile(uploadDirectoryRequest, failedFileUploads, path),
                                            allOfFutures, 
-                                           transferConfiguration.option(TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY));
+                                           transferConfiguration.option(
+                                               TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY
+                                           ));
 
         iterablePublisher.subscribe(bufferingSubscriber);
         CompletableFutureUtils.forwardExceptionTo(returnFuture, allOfFutures);

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
@@ -586,10 +586,10 @@ public class DownloadDirectoryHelperTest {
         });
         
         // Configure with our expected limit
-        // To verify test works as intended, verify test failure when directoryTransferMaxConcurrency is
+        // To verify test works as intended, verify test failure when transferDirectoryMaxConcurrency is
         // configuredMaxConcurrency + 1 or configuredMaxConcurrency - 1
         TransferManagerConfiguration customConfig = TransferManagerConfiguration.builder()
-            .directoryTransferMaxConcurrency(configuredMaxConcurrency)
+            .transferDirectoryMaxConcurrency(configuredMaxConcurrency)
             .build();
         
         DownloadDirectoryHelper customHelper = new DownloadDirectoryHelper(

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
@@ -35,13 +35,18 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -520,6 +525,114 @@ public class DownloadDirectoryHelperTest {
                                                                               .build());
 
         assertThatThrownBy(downloadDirectory.completionFuture()::join).hasCause(exception);
+    }
+    @Test
+    void downloadDirectory_customMaxConcurrency_shouldLimitConcurrentOperations() throws Exception {
+        // Create many S3 objects to test concurrency
+        int totalFiles = 50;
+        String[] keys = new String[totalFiles];
+        for (int i = 0; i < totalFiles; i++) {
+            keys[i] = "file" + i + ".txt";
+        }
+        stubSuccessfulListObjects(listObjectsHelper, keys);
+        
+        // Configuration with expected concurrency limit
+        int configuredMaxConcurrency = 5;
+        
+        // Track concurrent operations
+        AtomicInteger currentlyActive = new AtomicInteger(0);
+        AtomicInteger peakConcurrency = new AtomicInteger(0);
+        
+        // Use a Phaser to coordinate phases
+        Phaser phaser = new Phaser(1); // Start with test thread
+        
+        // Mock the single download function to track concurrent operations
+        when(singleDownloadFunction.apply(any())).thenAnswer(invocation -> {
+            phaser.register(); // Each operation registers
+            
+            CompletableFuture<CompletedFileDownload> future = new CompletableFuture<>();
+            
+            CompletableFuture.runAsync(() -> {
+                try {
+                    // Track entry
+                    int current = currentlyActive.incrementAndGet();
+                    peakConcurrency.updateAndGet(max -> Math.max(max, current));
+                    
+                    // Wait at barrier - this forces all operations to be active simultaneously
+                    phaser.arriveAndAwaitAdvance();
+                    
+                    // Complete
+                    future.complete(CompletedFileDownload.builder()
+                        .response(GetObjectResponse.builder().eTag("test").build())
+                        .build());
+                    
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                } finally {
+                    currentlyActive.decrementAndGet();
+                    phaser.arriveAndDeregister();
+                }
+            });
+            
+            return new DefaultFileDownload(future,
+                new DefaultTransferProgress(DefaultTransferProgressSnapshot.builder()
+                                               .transferredBytes(0L)
+                                               .build()),
+                () -> DownloadFileRequest.builder()
+                         .getObjectRequest(GetObjectRequest.builder().build())
+                         .destination(Paths.get("."))
+                         .build(),
+                null);
+        });
+        
+        // Configure with our expected limit
+        // To verify test works as intended, verify test failure when directoryTransferMaxConcurrency is
+        // configuredMaxConcurrency + 1 or configuredMaxConcurrency - 1
+        TransferManagerConfiguration customConfig = TransferManagerConfiguration.builder()
+            .directoryTransferMaxConcurrency(configuredMaxConcurrency)
+            .build();
+        
+        DownloadDirectoryHelper customHelper = new DownloadDirectoryHelper(
+            customConfig, listObjectsHelper, singleDownloadFunction);
+        
+        // Start download asynchronously
+        CompletableFuture<Void> downloadTask = CompletableFuture.runAsync(() -> {
+            DirectoryDownload download = customHelper.downloadDirectory(
+                DownloadDirectoryRequest.builder()
+                    .destination(directory)
+                    .bucket("bucket")
+                    .build()
+            );
+            download.completionFuture().join();
+        });
+        
+        // Wait for operations to register (but not complete the phase)
+        // We wait for more than the configured limit to ensure we'd catch violations
+        Duration maxWait = Duration.ofSeconds(5);
+        long deadline = System.nanoTime() + maxWait.toNanos();
+        int current = phaser.getRegisteredParties() - 1; // Subtract 1 for main thread
+        while (current < configuredMaxConcurrency) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError(
+                    "Timed out waiting for registrations: current=" + current +
+                    ", configuredMaxConcurrency=" + configuredMaxConcurrency);
+            }
+            LockSupport.parkNanos(10_000_000L); // ~10 ms
+            current = phaser.getRegisteredParties() - 1;
+        }
+
+        // Check peak BEFORE releasing the phase
+        int observedPeak = peakConcurrency.get();
+        assertThat(observedPeak)
+            .as("Implementation allowed %d concurrent operations but was configured for %d", 
+                observedPeak, configuredMaxConcurrency)
+            .isEqualTo(configuredMaxConcurrency);
+
+        // Release the phase to let operations complete
+        phaser.arriveAndDeregister();
+        
+        // Complete the test
+        downloadTask.get(2, TimeUnit.SECONDS);
     }
 
     private static DefaultFileDownload completedDownload() {

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
@@ -59,18 +59,32 @@ public class TransferManagerConfigurationTest {
     }
 
     @Test
-    public void noOverride_shouldUseDefaults() {
-        transferManagerConfiguration = TransferManagerConfiguration.builder().build();
-        assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS)).isFalse();
-        assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_MAX_DEPTH)).isEqualTo(Integer.MAX_VALUE);
-        assertThat(transferManagerConfiguration.option(DIRECTORY_TRANSFER_MAX_CONCURRENCY)).isEqualTo(100);
-        assertThat(transferManagerConfiguration.option(EXECUTOR)).isNotNull();
+    public void noOverride_orNullOverride_shouldUseDefaults() {
+        assertDefaultTransferManagerConfiguration(
+            TransferManagerConfiguration.builder().build()
+        );
+
+        assertDefaultTransferManagerConfiguration(
+            TransferManagerConfiguration.builder()
+                .transferDirectoryMaxConcurrency(null)
+                .executor(null)
+                .uploadDirectoryFollowSymbolicLinks(null)
+                .uploadDirectoryMaxDepth(null)
+                .build()
+        );
+    }
+
+    private void assertDefaultTransferManagerConfiguration(TransferManagerConfiguration config) {
+        assertThat(config.option(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS)).isFalse();
+        assertThat(config.option(UPLOAD_DIRECTORY_MAX_DEPTH)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(config.option(DIRECTORY_TRANSFER_MAX_CONCURRENCY)).isEqualTo(100);
+        assertThat(config.option(EXECUTOR)).isNotNull();
     }
 
     @Test
-    public void directoryTransferMaxConcurrency_customValue_shouldBeStored() {
+    public void transferDirectoryMaxConcurrency_customValue_shouldBeStored() {
         transferManagerConfiguration = TransferManagerConfiguration.builder()
-                                                                   .directoryTransferMaxConcurrency(50)
+                                                                   .transferDirectoryMaxConcurrency(50)
                                                                    .build();
         assertThat(transferManagerConfiguration.option(DIRECTORY_TRANSFER_MAX_CONCURRENCY)).isEqualTo(50);
     }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.transfer.s3.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.DIRECTORY_TRANSFER_MAX_CONCURRENCY;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.EXECUTOR;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS;
 import static software.amazon.awssdk.transfer.s3.internal.TransferConfigurationOption.UPLOAD_DIRECTORY_MAX_DEPTH;
@@ -62,7 +63,22 @@ public class TransferManagerConfigurationTest {
         transferManagerConfiguration = TransferManagerConfiguration.builder().build();
         assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS)).isFalse();
         assertThat(transferManagerConfiguration.option(UPLOAD_DIRECTORY_MAX_DEPTH)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(transferManagerConfiguration.option(DIRECTORY_TRANSFER_MAX_CONCURRENCY)).isEqualTo(100);
         assertThat(transferManagerConfiguration.option(EXECUTOR)).isNotNull();
+    }
+
+    @Test
+    public void directoryTransferMaxConcurrency_customValue_shouldBeStored() {
+        transferManagerConfiguration = TransferManagerConfiguration.builder()
+                                                                   .directoryTransferMaxConcurrency(50)
+                                                                   .build();
+        assertThat(transferManagerConfiguration.option(DIRECTORY_TRANSFER_MAX_CONCURRENCY)).isEqualTo(50);
+    }
+
+    @Test
+    public void directoryTransferMaxConcurrency_noOverride_shouldUseDefault() {
+        transferManagerConfiguration = TransferManagerConfiguration.builder().build();
+        assertThat(transferManagerConfiguration.option(DIRECTORY_TRANSFER_MAX_CONCURRENCY)).isEqualTo(100);
     }
 
     @Test

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfigurationTest.java
@@ -76,12 +76,6 @@ public class TransferManagerConfigurationTest {
     }
 
     @Test
-    public void directoryTransferMaxConcurrency_noOverride_shouldUseDefault() {
-        transferManagerConfiguration = TransferManagerConfiguration.builder().build();
-        assertThat(transferManagerConfiguration.option(DIRECTORY_TRANSFER_MAX_CONCURRENCY)).isEqualTo(100);
-    }
-
-    @Test
     public void close_noCustomExecutor_shouldCloseDefaultOne() {
         transferManagerConfiguration = TransferManagerConfiguration.builder().build();
         transferManagerConfiguration.close();

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperTest.java
@@ -522,10 +522,10 @@ public class UploadDirectoryHelperTest {
         });
         
         // Configure with our expected limit
-        // To verify test works as intended, verify test failure when directoryTransferMaxConcurrency is
+        // To verify test works as intended, verify test failure when transferDirectoryMaxConcurrency is
         // configuredMaxConcurrency + 1 or configuredMaxConcurrency - 1
         TransferManagerConfiguration customConfig = TransferManagerConfiguration.builder()
-            .directoryTransferMaxConcurrency(configuredMaxConcurrency)
+            .transferDirectoryMaxConcurrency(configuredMaxConcurrency)
             .build();
         
         UploadDirectoryHelper customHelper = new UploadDirectoryHelper(customConfig, singleUploadFunction);


### PR DESCRIPTION
## Motivation and Context

Currently there is a hardcoded value for DEFAULT_DIRECTORY_TRANSFER_MAX_CONCURRENCY in TransferConfigurationOption of `100` added in #5031. When using the S3TransferManager with limited java heap allocation, this can cause OutOfMemory errors due to number of concurrent file downloads.

https://github.com/aws/aws-sdk-java-v2/issues/6330

## Modifications

Updated TransferConfigurationOption to define TransferDirectoryMaxConcurrency and S3TransferManager to use it during upload and download directory with option to specify it in the builder.

## Testing

Primary test is the `integration` style test in Download/Upload DirectoryHelperTest.

While it's difficult to ensure the upper limit is observed without adding arbitrary test time duration to the tests, i've verified locally by modifying the test to use 
```
            .transferDirectoryMaxConcurrency(configuredMaxConcurrency - 1)
```
and observed it timed out after 5 seconds, and with
```
            .transferDirectoryMaxConcurrency(configuredMaxConcurrency + 1)
```
that it completed very quickly and failed the assertion.

The change makes no behavior change to the default and current behavior

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
