### PR TITLE
Update S3 Pre-signed URL GET design with multipart download support

### DIFF
--- a/docs/design/core/presignedURL-Get/DecisionLog.md
+++ b/docs/design/core/presignedURL-Get/DecisionLog.md
@@ -53,3 +53,10 @@ The team has decided to implement functionality only for S3 async client and def
 2. Remove the consumer builder pattern from Get Request Model.
 
 3. throw UnsupportedOperationException for Multipart S3 Client and S3 CRT Client for now.
+
+## Design Review: 07/31/2025
+**Source**: Design : Multipart Download Support for Pre-signed URLs  
+**Attendees**: John Viegas, Zoe Wang, Dongie Agnir, Bole Yi, Ran Vaknin, Saranya Somepalli, David Ho, Olivier Lepage Applin
+
+### Decision Addressed
+Initially considered separate discovery request (bytes=0-0) followed by download, but decided to follow AWS Transfer Manager SEP specification using Range: bytes=0-{partSizeInBytes-1} to download first part AND discover total object size simultaneously from Content-Range header response.


### PR DESCRIPTION
Updates the existing S3 Pre-signed URL GET design document to include multipart download support for large objects.

## Motivation and Context
The original design only covered single-stream downloads. Large objects need multipart capability for optimal performance.

## Modifications
Updated design documents to include multipart download support using HTTP Range headers following AWS Transfer Manager specification for ranged GETs.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
