### PR TITLE
fix regression tests in merge queue

### DIFF
--- a/.github/workflows/s3-regression-tests.yml
+++ b/.github/workflows/s3-regression-tests.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Check for changes related to s3
         id: check-changes
         run: |
-          git fetch origin ${{ github.base_ref || github.event.merge_group.base_ref }} --depth 1
-          CHANGED_FILES=$(git diff remotes/origin/${{ github.base_ref || github.event.merge_group.base_ref }} --name-only)
+          git fetch origin ${{ github.base_ref || github.event.merge_group.base_ref || github.ref }} --depth 1
+          CHANGED_FILES=$(git diff remotes/origin/${{ github.base_ref || github.event.merge_group.base_ref || github.ref }} --name-only)
           if echo "$CHANGED_FILES" | grep -q -E '^core/|^services/s3/|^services-custom/s3-transfer-manager/|^http-client-spi/|^http-clients/'; then
             echo "Detected changes in S3, HTTP client, or core modules"
             echo "has_s3_related_changes=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
use `github.event.merge_group.base_ref` for s3 regression test in merge queue