### PR TITLE
Add ConsistentRead client config to DDB Enhanced Client

### DIFF
--- a/.changes/next-release/feature-DynamoDBEnhancedClient-078c185.json
+++ b/.changes/next-release/feature-DynamoDBEnhancedClient-078c185.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Adds consistent read client configuration to DDB Enhanced Client"
+}

--- a/services-custom/dynamodb-enhanced/pom.xml
+++ b/services-custom/dynamodb-enhanced/pom.xml
@@ -233,5 +233,10 @@
             <type>so</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedAsyncClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedAsyncClient.java
@@ -560,6 +560,9 @@ public interface DynamoDbEnhancedAsyncClient extends DynamoDbEnhancedResource {
         @Override
         Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions);
 
+        @Override
+        Builder consistentRead(Boolean consistentRead);
+
         /**
          * Builds an enhanced client based on the settings supplied to this builder
          *

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
@@ -569,6 +569,9 @@ public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
         @Override
         Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions);
 
+        @Override
+        Builder consistentRead(Boolean consistentRead);
+
         /**
          * Builds an enhanced client based on the settings supplied to this builder
          *

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedResource.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedResource.java
@@ -54,5 +54,28 @@ public interface DynamoDbEnhancedResource {
          * @param dynamoDbEnhancedClientExtensions a list of extensions to load with the enhanced client
          */
         Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions);
+
+        /**
+         * Sets the default read consistency model for single read operations (GetItem, Query, Scan). When set to true, these
+         * operations will use strongly consistent reads. By default, this is set to null/false, i.e., eventually consistent
+         * reads.
+         * <p>
+         * If set at the request level, e.g., {@code QueryEnhancedRequest}, the request level value will take precedence.
+         * <p>
+         * Note: This setting applies to single read operations only:
+         * <ul>
+         * <li>BatchGetItem: Eventually consistent by default, consistent read setting must be configured at the individual
+         * request level, i.e. {@code GetItemEnhancedRequest}s passed to {@code ReachBatch} on the {@code
+         * BatchGetItemEnhancedRequest}, when performing batch GET.
+         * </li>
+         * <li>TransactGetItems: Always uses strongly consistent reads by design, so this setting is not applicable.</li>
+         * </ul>
+         *
+         * @param consistentRead true for strongly consistent reads, null/false (default value) for eventually consistent reads
+         * @return this builder for method chaining
+         */
+        default Builder consistentRead(Boolean consistentRead) {
+            throw  new UnsupportedOperationException();
+        }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/MappedTableResource.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/MappedTableResource.java
@@ -54,4 +54,25 @@ public interface MappedTableResource<T> {
      * @return A key that has been initialized with the index values extracted from the modelled object.
      */
     Key keyFrom(T item);
+
+    /**
+     * The default read consistency model for single read operations (GetItem, Query, Scan). When set to true, these
+     * operations will use strongly consistent reads. By default, this is set to null/false, i.e., eventually consistent reads.
+     * <p>
+     * If set at the request level, e.g., {@code QueryEnhancedRequest}, the request level value will take precedence.
+     * <p>
+     * Note: This setting applies to single read operations only:
+     * <ul>
+     * <li>BatchGetItem: Eventually consistent by default, consistent read setting must be configured at the individual
+     * request level, i.e. {@code GetItemEnhancedRequest}s passed to {@code ReachBatch} on the {@code
+     * BatchGetItemEnhancedRequest}, when performing batch GET.
+     * </li>
+     * <li>TransactGetItems: Always uses strongly consistent reads by design, so this setting is not applicable.</li>
+     * </ul>
+     *
+     * @return The default consistent read setting on the table.
+     */
+    default Boolean consistentRead() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtils.java
@@ -30,11 +30,15 @@ import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.OperationContext;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.ReadModification;
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.DefaultDynamoDbExtensionContext;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity;
 
@@ -203,5 +207,32 @@ public final class EnhancedClientUtils {
      */
     public static boolean isNullAttributeValue(AttributeValue attributeValue) {
         return attributeValue.nul() != null && attributeValue.nul();
+    }
+
+    public static GetItemEnhancedRequest applyClientDefaultsIfAbsentOnRequest(GetItemEnhancedRequest request,
+                                                                              MappedTableResource<?> table) {
+        if (request.consistentRead() == null) {
+            request = request.toBuilder().consistentRead(table.consistentRead()).build();
+        }
+
+        return request;
+    }
+
+    public static QueryEnhancedRequest applyClientDefaultsIfAbsentOnRequest(QueryEnhancedRequest request,
+                                                                            MappedTableResource<?> table) {
+        if (request.consistentRead() == null) {
+            request = request.toBuilder().consistentRead(table.consistentRead()).build();
+        }
+
+        return request;
+    }
+
+    public static ScanEnhancedRequest applyClientDefaultsIfAbsentOnRequest(ScanEnhancedRequest request,
+                                                                           MappedTableResource<?> table) {
+        if (request.consistentRead() == null) {
+            request = request.toBuilder().consistentRead(table.consistentRead()).build();
+        }
+
+        return request;
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClient.java
@@ -43,10 +43,12 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhancedAsyncClient {
     private final DynamoDbAsyncClient dynamoDbClient;
     private final DynamoDbEnhancedClientExtension extension;
+    private final Boolean consistentRead;
 
     private DefaultDynamoDbEnhancedAsyncClient(Builder builder) {
         this.dynamoDbClient = builder.dynamoDbClient == null ? DynamoDbAsyncClient.create() : builder.dynamoDbClient;
         this.extension = ExtensionResolver.resolveExtensions(builder.dynamoDbEnhancedClientExtensions);
+        this.consistentRead = builder.consistentRead;
     }
 
     public static Builder builder() {
@@ -55,7 +57,7 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
 
     @Override
     public <T> DefaultDynamoDbAsyncTable<T> table(String tableName, TableSchema<T> tableSchema) {
-        return new DefaultDynamoDbAsyncTable<>(dynamoDbClient, extension, tableSchema, tableName);
+        return new DefaultDynamoDbAsyncTable<>(dynamoDbClient, extension, tableSchema, tableName, consistentRead);
     }
 
     @Override
@@ -140,8 +142,14 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
         return extension;
     }
 
+    public Boolean consistentRead() {
+        return consistentRead;
+    }
+
     public Builder toBuilder() {
-        return builder().dynamoDbClient(this.dynamoDbClient).extensions(this.extension);
+        return builder().dynamoDbClient(this.dynamoDbClient)
+                        .extensions(this.extension)
+                        .consistentRead(this.consistentRead);
     }
 
     @Override
@@ -160,6 +168,9 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
 
             return false;
         }
+        if (consistentRead != null ? !consistentRead.equals(that.consistentRead) : that.consistentRead != null) {
+            return false;
+        }
         return extension != null ? extension.equals(that.extension) : that.extension == null;
     }
 
@@ -167,6 +178,7 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
     public int hashCode() {
         int result = dynamoDbClient != null ? dynamoDbClient.hashCode() : 0;
         result = 31 * result + (extension != null ? extension.hashCode() : 0);
+        result = 31 * result + (consistentRead != null ? consistentRead.hashCode() : 0);
         return result;
     }
 
@@ -175,6 +187,7 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
         private DynamoDbAsyncClient dynamoDbClient;
         private List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions =
             new ArrayList<>(ExtensionResolver.defaultExtensions());
+        private Boolean consistentRead;
 
         @Override
         public DefaultDynamoDbEnhancedAsyncClient build() {
@@ -196,6 +209,12 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
         @Override
         public Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions) {
             this.dynamoDbEnhancedClientExtensions = new ArrayList<>(dynamoDbEnhancedClientExtensions);
+            return this;
+        }
+
+        @Override
+        public Builder consistentRead(Boolean consistentRead) {
+            this.consistentRead = consistentRead;
             return this;
         }
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClient.java
@@ -42,10 +42,12 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClient {
     private final DynamoDbClient dynamoDbClient;
     private final DynamoDbEnhancedClientExtension extension;
+    private final Boolean consistentRead;
 
     private DefaultDynamoDbEnhancedClient(Builder builder) {
         this.dynamoDbClient = builder.dynamoDbClient == null ? DynamoDbClient.create() : builder.dynamoDbClient;
         this.extension = ExtensionResolver.resolveExtensions(builder.dynamoDbEnhancedClientExtensions);
+        this.consistentRead = builder.consistentRead;
     }
 
     public static Builder builder() {
@@ -54,7 +56,7 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
 
     @Override
     public <T> DefaultDynamoDbTable<T> table(String tableName, TableSchema<T> tableSchema) {
-        return new DefaultDynamoDbTable<>(dynamoDbClient, extension, tableSchema, tableName);
+        return new DefaultDynamoDbTable<>(dynamoDbClient, extension, tableSchema, tableName, consistentRead);
     }
 
     @Override
@@ -134,8 +136,14 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
         return extension;
     }
 
+    public Boolean consistentRead() {
+        return consistentRead;
+    }
+
     public Builder toBuilder() {
-        return builder().dynamoDbClient(this.dynamoDbClient).extensions(this.extension);
+        return builder().dynamoDbClient(this.dynamoDbClient)
+                        .extensions(this.extension)
+                        .consistentRead(this.consistentRead);
     }
 
     @Override
@@ -152,6 +160,9 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
         if (dynamoDbClient != null ? !dynamoDbClient.equals(that.dynamoDbClient) : that.dynamoDbClient != null) {
             return false;
         }
+        if (consistentRead != null ? !consistentRead.equals(that.consistentRead) : that.consistentRead != null) {
+            return false;
+        }
         return extension != null ?
                extension.equals(that.extension) :
                that.extension == null;
@@ -160,8 +171,8 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
     @Override
     public int hashCode() {
         int result = dynamoDbClient != null ? dynamoDbClient.hashCode() : 0;
-        result = 31 * result + (extension != null ?
-                                extension.hashCode() : 0);
+        result = 31 * result + (extension != null ? extension.hashCode() : 0);
+        result = 31 * result + (consistentRead != null ? consistentRead.hashCode() : 0);
         return result;
     }
 
@@ -170,6 +181,7 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
         private DynamoDbClient dynamoDbClient;
         private List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions =
             new ArrayList<>(ExtensionResolver.defaultExtensions());
+        private Boolean consistentRead;
 
         @Override
         public DefaultDynamoDbEnhancedClient build() {
@@ -191,6 +203,12 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
         @Override
         public Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions) {
             this.dynamoDbEnhancedClientExtensions = new ArrayList<>(dynamoDbEnhancedClientExtensions);
+            return this;
+        }
+
+        @Override
+        public Builder consistentRead(Boolean consistentRead) {
+            this.consistentRead = consistentRead;
             return this;
         }
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbIndex.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbIndex.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 
+import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.applyClientDefaultsIfAbsentOnRequest;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.createKeyFromItem;
 
 import java.util.function.Consumer;
@@ -40,22 +41,21 @@ public class DefaultDynamoDbIndex<T> implements DynamoDbIndex<T> {
     private final TableSchema<T> tableSchema;
     private final String tableName;
     private final String indexName;
+    private final DefaultDynamoDbTable<T> table;
 
-    DefaultDynamoDbIndex(DynamoDbClient dynamoDbClient,
-                         DynamoDbEnhancedClientExtension extension,
-                         TableSchema<T> tableSchema,
-                         String tableName,
-                         String indexName) {
-        this.dynamoDbClient = dynamoDbClient;
-        this.extension = extension;
-        this.tableSchema = tableSchema;
-        this.tableName = tableName;
+    DefaultDynamoDbIndex(DefaultDynamoDbTable<T> table, String indexName) {
+        this.dynamoDbClient = table.dynamoDbClient();
+        this.extension = table.mapperExtension();
+        this.tableSchema = table.tableSchema();
+        this.tableName = table.tableName();
         this.indexName = indexName;
+        this.table = table;
     }
 
     @Override
     public SdkIterable<Page<T>> query(QueryEnhancedRequest request) {
-        PaginatedIndexOperation<T, ?, ?> operation = QueryOperation.create(request);
+        QueryEnhancedRequest requestWithDefaults = applyClientDefaultsIfAbsentOnRequest(request, this.table);
+        PaginatedIndexOperation<T, ?, ?> operation = QueryOperation.create(requestWithDefaults);
         return operation.executeOnSecondaryIndex(tableSchema, tableName, indexName, extension, dynamoDbClient);
     }
 
@@ -73,7 +73,8 @@ public class DefaultDynamoDbIndex<T> implements DynamoDbIndex<T> {
 
     @Override
     public SdkIterable<Page<T>> scan(ScanEnhancedRequest request) {
-        PaginatedIndexOperation<T, ?, ?> operation = ScanOperation.create(request);
+        ScanEnhancedRequest requestWithDefaults = applyClientDefaultsIfAbsentOnRequest(request, this.table);
+        PaginatedIndexOperation<T, ?, ?> operation = ScanOperation.create(requestWithDefaults);
         return operation.executeOnSecondaryIndex(tableSchema, tableName, indexName, extension, dynamoDbClient);
     }
 
@@ -141,6 +142,9 @@ public class DefaultDynamoDbIndex<T> implements DynamoDbIndex<T> {
         if (tableName != null ? ! tableName.equals(that.tableName) : that.tableName != null) {
             return false;
         }
+        if (table != null ? ! table.equals(that.table) : that.table != null) {
+            return false;
+        }
         return indexName != null ? indexName.equals(that.indexName) : that.indexName == null;
     }
 
@@ -151,6 +155,7 @@ public class DefaultDynamoDbIndex<T> implements DynamoDbIndex<T> {
         result = 31 * result + (tableSchema != null ? tableSchema.hashCode() : 0);
         result = 31 * result + (tableName != null ? tableName.hashCode() : 0);
         result = 31 * result + (indexName != null ? indexName.hashCode() : 0);
+        result = 31 * result + (table != null ? table.hashCode() : 0);
         return result;
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncIndexTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncIndexTest.java
@@ -39,13 +39,11 @@ public class DefaultDynamoDbAsyncIndexTest {
 
     @Test
     public void keyFrom_secondaryIndex_partitionAndSort() {
+        DefaultDynamoDbAsyncTable<FakeItemWithIndices> table = createTable();
+
         FakeItemWithIndices item = FakeItemWithIndices.createUniqueFakeItemWithIndices();
         DefaultDynamoDbAsyncIndex<FakeItemWithIndices> dynamoDbMappedIndex =
-            new DefaultDynamoDbAsyncIndex<>(mockDynamoDbAsyncClient,
-                                            mockDynamoDbEnhancedClientExtension,
-                                            FakeItemWithIndices.getTableSchema(),
-                                            "test_table",
-                                            "gsi_1");
+            new DefaultDynamoDbAsyncIndex<>(table, "gsi_1");
 
         Key key = dynamoDbMappedIndex.keyFrom(item);
 
@@ -55,17 +53,21 @@ public class DefaultDynamoDbAsyncIndexTest {
 
     @Test
     public void keyFrom_secondaryIndex_partitionOnly() {
+        DefaultDynamoDbAsyncTable<FakeItemWithIndices> table = createTable();
+
         FakeItemWithIndices item = FakeItemWithIndices.createUniqueFakeItemWithIndices();
         DefaultDynamoDbAsyncIndex<FakeItemWithIndices> dynamoDbMappedIndex =
-            new DefaultDynamoDbAsyncIndex<>(mockDynamoDbAsyncClient,
-                                            mockDynamoDbEnhancedClientExtension,
-                                            FakeItemWithIndices.getTableSchema(),
-                                            "test_table",
-                                            "gsi_2");
+            new DefaultDynamoDbAsyncIndex<>(table,"gsi_2");
 
         Key key = dynamoDbMappedIndex.keyFrom(item);
 
         assertThat(key.partitionKeyValue(), is(stringValue(item.getGsiId())));
         assertThat(key.sortKeyValue(), is(Optional.empty()));
+    }
+
+    private DefaultDynamoDbAsyncTable<FakeItemWithIndices> createTable() {
+        return new DefaultDynamoDbAsyncTable<>(mockDynamoDbAsyncClient,
+                                               mockDynamoDbEnhancedClientExtension,
+                                               FakeItemWithIndices.getTableSchema(), "test_table");
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClientTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClientTest.java
@@ -18,7 +18,7 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Arrays;
 import org.junit.Before;
@@ -28,7 +28,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
-import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension;
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.ChainExtension;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
@@ -51,6 +50,7 @@ public class DefaultDynamoDbEnhancedAsyncClientTest {
             DefaultDynamoDbEnhancedAsyncClient.builder()
                                               .dynamoDbClient(mockDynamoDbAsyncClient)
                                               .extensions(mockDynamoDbEnhancedClientExtension)
+                                              .consistentRead(true)
                                               .build();
     }
 
@@ -62,6 +62,7 @@ public class DefaultDynamoDbEnhancedAsyncClientTest {
         assertThat(mappedTable.mapperExtension(), is(mockDynamoDbEnhancedClientExtension));
         assertThat(mappedTable.tableSchema(), is(mockTableSchema));
         assertThat(mappedTable.tableName(), is("table-name"));
+        assertThat(mappedTable.consistentRead(), is(true));
     }
 
     @Test
@@ -73,6 +74,7 @@ public class DefaultDynamoDbEnhancedAsyncClientTest {
 
         assertThat(builtObject.dynamoDbAsyncClient(), is(mockDynamoDbAsyncClient));
         assertThat(builtObject.mapperExtension(), instanceOf(ChainExtension.class));
+        assertThat(builtObject.consistentRead(), is(nullValue()));
     }
 
     @Test
@@ -81,10 +83,12 @@ public class DefaultDynamoDbEnhancedAsyncClientTest {
             DefaultDynamoDbEnhancedAsyncClient.builder()
                                               .dynamoDbClient(mockDynamoDbAsyncClient)
                                               .extensions(mockDynamoDbEnhancedClientExtension)
+                                              .consistentRead(true)
                                               .build();
 
         assertThat(builtObject.dynamoDbAsyncClient(), is(mockDynamoDbAsyncClient));
         assertThat(builtObject.mapperExtension(), is(mockDynamoDbEnhancedClientExtension));
+        assertThat(builtObject.consistentRead(), is(true));
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClientTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClientTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Arrays;
 import org.junit.Before;
@@ -27,7 +28,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
-import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension;
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.ChainExtension;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
@@ -52,6 +52,7 @@ public class DefaultDynamoDbEnhancedClientTest {
         this.dynamoDbEnhancedClient = DefaultDynamoDbEnhancedClient.builder()
                                                                    .dynamoDbClient(mockDynamoDbClient)
                                                                    .extensions(mockDynamoDbEnhancedClientExtension)
+                                                                   .consistentRead(true)
                                                                    .build();
     }
 
@@ -63,6 +64,7 @@ public class DefaultDynamoDbEnhancedClientTest {
         assertThat(mappedTable.mapperExtension(), is(mockDynamoDbEnhancedClientExtension));
         assertThat(mappedTable.tableSchema(), is(mockTableSchema));
         assertThat(mappedTable.tableName(), is("table-name"));
+        assertThat(mappedTable.consistentRead(), is(true));
     }
 
     @Test
@@ -73,6 +75,7 @@ public class DefaultDynamoDbEnhancedClientTest {
 
         assertThat(builtObject.dynamoDbClient(), is(mockDynamoDbClient));
         assertThat(builtObject.mapperExtension(), instanceOf(ChainExtension.class));
+        assertThat(builtObject.consistentRead(), is(nullValue()));
     }
 
     @Test
@@ -80,10 +83,12 @@ public class DefaultDynamoDbEnhancedClientTest {
         DefaultDynamoDbEnhancedClient builtObject = DefaultDynamoDbEnhancedClient.builder()
                                                                                  .dynamoDbClient(mockDynamoDbClient)
                                                                                  .extensions(mockDynamoDbEnhancedClientExtension)
+                                                                                 .consistentRead(true)
                                                                                  .build();
 
         assertThat(builtObject.dynamoDbClient(), is(mockDynamoDbClient));
         assertThat(builtObject.mapperExtension(), is(mockDynamoDbEnhancedClientExtension));
+        assertThat(builtObject.consistentRead(), is(true));
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbIndexTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbIndexTest.java
@@ -17,17 +17,23 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.verify;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
 
 import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithIndices;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultDynamoDbIndexTest {
@@ -39,13 +45,11 @@ public class DefaultDynamoDbIndexTest {
 
     @Test
     public void keyFrom_secondaryIndex_partitionAndSort() {
+        DefaultDynamoDbTable<FakeItemWithIndices> table = createTable();
+
         FakeItemWithIndices item = FakeItemWithIndices.createUniqueFakeItemWithIndices();
         DefaultDynamoDbIndex<FakeItemWithIndices> dynamoDbMappedIndex =
-            new DefaultDynamoDbIndex<>(mockDynamoDbClient,
-                                       mockDynamoDbEnhancedClientExtension,
-                                       FakeItemWithIndices.getTableSchema(),
-                                       "test_table",
-                                       "gsi_1");
+            new DefaultDynamoDbIndex<>(table, "gsi_1");
 
         Key key = dynamoDbMappedIndex.keyFrom(item);
 
@@ -55,17 +59,68 @@ public class DefaultDynamoDbIndexTest {
 
     @Test
     public void keyFrom_secondaryIndex_partitionOnly() {
+        DefaultDynamoDbTable<FakeItemWithIndices> table = createTable();
+
         FakeItemWithIndices item = FakeItemWithIndices.createUniqueFakeItemWithIndices();
         DefaultDynamoDbIndex<FakeItemWithIndices> dynamoDbMappedIndex =
-            new DefaultDynamoDbIndex<>(mockDynamoDbClient,
-                                       mockDynamoDbEnhancedClientExtension,
-                                       FakeItemWithIndices.getTableSchema(),
-                                       "test_table",
-                                       "gsi_2");
+            new DefaultDynamoDbIndex<>(table, "gsi_2");
 
         Key key = dynamoDbMappedIndex.keyFrom(item);
 
         assertThat(key.partitionKeyValue(), is(stringValue(item.getGsiId())));
         assertThat(key.sortKeyValue(), is(Optional.empty()));
+    }
+
+    @Test
+    public void query_consistentReadNotSetOnTableOrRequest_shouldDefaultToNull() {
+        DefaultDynamoDbTable<FakeItemWithIndices> table = createTable();
+        DefaultDynamoDbIndex<FakeItemWithIndices> dynamoDbMappedIndex = new DefaultDynamoDbIndex<>(table, "gsi_2");
+        dynamoDbMappedIndex.query(q -> q.queryConditional(QueryConditional.keyEqualTo(Key.builder().partitionValue("val").build())));
+
+        ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(mockDynamoDbClient).queryPaginator(captor.capture());
+
+        QueryRequest actualRequest = captor.getValue();
+        assertThat(actualRequest.consistentRead(), is(nullValue()));
+    }
+
+    @Test
+    public void scan_consistentReadSetOnTableNotSetOnRequest_shouldUseTableValue() {
+        DefaultDynamoDbTable<FakeItemWithIndices> table =  new DefaultDynamoDbTable<>(mockDynamoDbClient,
+                                                                                      mockDynamoDbEnhancedClientExtension,
+                                                                                      FakeItemWithIndices.getTableSchema(),
+                                                                                      "test-table",
+                                                                                      true);
+        DefaultDynamoDbIndex<FakeItemWithIndices> dynamoDbMappedIndex = new DefaultDynamoDbIndex<>(table, "gsi_2");
+        dynamoDbMappedIndex.scan();
+
+        ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
+        verify(mockDynamoDbClient).scanPaginator(captor.capture());
+
+        ScanRequest actualRequest = captor.getValue();
+        assertThat(actualRequest.consistentRead(), is(true));
+    }
+
+    @Test
+    public void scan_consistentReadSetOnTableAndRequest_shouldUseRequestValue() {
+        DefaultDynamoDbTable<FakeItemWithIndices> table =  new DefaultDynamoDbTable<>(mockDynamoDbClient,
+                                                                                      mockDynamoDbEnhancedClientExtension,
+                                                                                      FakeItemWithIndices.getTableSchema(),
+                                                                                      "test-table",
+                                                                                      true);
+        DefaultDynamoDbIndex<FakeItemWithIndices> dynamoDbMappedIndex = new DefaultDynamoDbIndex<>(table, "gsi_2");
+        dynamoDbMappedIndex.scan(s -> s.consistentRead(false));
+
+        ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
+        verify(mockDynamoDbClient).scanPaginator(captor.capture());
+
+        ScanRequest actualRequest = captor.getValue();
+        assertThat(actualRequest.consistentRead(), is(false));
+    }
+
+    private DefaultDynamoDbTable<FakeItemWithIndices> createTable() {
+        return new DefaultDynamoDbTable<>(mockDynamoDbClient,
+                                          mockDynamoDbEnhancedClientExtension,
+                                          FakeItemWithIndices.getTableSchema(), "test-table");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently, consistent read can be configured at the request level, i.e., GetItemEnhancedRequest, QueryEnhancedRequest, and ScanEnhancedRequest, but not on the client level.

https://github.com/aws/aws-sdk-java-v2/issues/2363

## Modifications
<!--- Describe your changes in detail -->
Add consistentRead() setter on DynamoDbEnhancedClient / DynamoDbEnhancedAsyncClient

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit and integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
