### PR TITLE
Event stream response handler builder onError documentation improvement

### DIFF
--- a/.changes/next-release/documentation-AWSSDKforJavav2-6b16da2.json
+++ b/.changes/next-release/documentation-AWSSDKforJavav2-6b16da2.json
@@ -1,0 +1,6 @@
+{
+    "type": "documentation",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Improve EventStreamResponseHandler.Builder.onError method to mention the callback may be called multiple time, similarly to the exceptionOccurred method"
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamResponseHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamResponseHandler.java
@@ -94,7 +94,8 @@ public interface EventStreamResponseHandler<ResponseT, EventT> {
         SubBuilderT onResponse(Consumer<ResponseT> responseConsumer);
 
         /**
-         * Callback to invoke in the event on an error.
+         * Callback to invoke in the event on an error. The {@link Consumer#accept(Object)} method may be called multiple times
+         * during the lifecycle of a request if automatic retries are enabled.
          *
          * @param consumer Callback that will process any error that occurs.
          * @return This builder for method chaining.


### PR DESCRIPTION
Improve `EventStreamResponseHandler.Builder.onError` javadoc to mention that the callback may be called multiple time, similarly to the exceptionOccurred method.

The default implementation of the `exceptionOccurred` simply calls the consumer passed to the `onError(Consumer)` method of the builder. The `exceptionOccurred` already mentions that it can be called multiple time, but the `onError` method of the builder was not.