### PR TITLE
Handle null when serializing enum to string 

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MemberCopierSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MemberCopierSpec.java
@@ -224,7 +224,9 @@ class MemberCopierSpec implements ClassSpec {
                 case NONE:
                     return inputVariableName;
                 case ENUM_TO_STRING:
-                    code.add("$T $N = $N.toString();", String.class, outputVariableName, inputVariableName);
+                    code.add(
+                        "$T $N = $N == null ? null : $N.toString();",
+                        String.class, outputVariableName, inputVariableName, inputVariableName);
                     return outputVariableName;
                 case STRING_TO_ENUM:
                     code.add("$1T $2N = $1T.fromValue($3N);", enumType, outputVariableName, inputVariableName);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
@@ -33,7 +33,7 @@ final class ListOfEnumsCopier {
         } else {
             List<String> modifiableList = new ArrayList<>(listOfEnumsParam.size());
             listOfEnumsParam.forEach(entry -> {
-                String result = entry.toString();
+                String result = entry == null ? null : entry.toString();
                 modifiableList.add(result);
             });
             list = Collections.unmodifiableList(modifiableList);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofenumtostringcopier.java
@@ -53,7 +53,7 @@ final class ListOfMapOfEnumToStringCopier {
                 } else {
                     Map<String, String> modifiableMap = new LinkedHashMap<>(entry.size());
                     entry.forEach((key, value) -> {
-                        String result = key.toString();
+                        String result = key == null ? null : key.toString();
                         modifiableMap.put(result, value);
                     });
                     map = Collections.unmodifiableMap(modifiableMap);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
@@ -32,8 +32,8 @@ final class MapOfEnumToEnumCopier {
         } else {
             Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfEnumToEnumParam.size());
             mapOfEnumToEnumParam.forEach((key, value) -> {
-                String result = key.toString();
-                String result1 = value.toString();
+                String result = key == null ? null : key.toString();
+                String result1 = value == null ? null : value.toString();
                 modifiableMap.put(result, result1);
             });
             map = Collections.unmodifiableMap(modifiableMap);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtolistofenumscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtolistofenumscopier.java
@@ -47,14 +47,14 @@ final class MapOfEnumToListOfEnumsCopier {
         } else {
             Map<String, List<String>> modifiableMap = new LinkedHashMap<>(mapOfEnumToListOfEnumsParam.size());
             mapOfEnumToListOfEnumsParam.forEach((key, value) -> {
-                String result = key.toString();
+                String result = key == null ? null : key.toString();
                 List<String> list;
                 if (value == null || value instanceof SdkAutoConstructList) {
                     list = DefaultSdkAutoConstructList.getInstance();
                 } else {
                     List<String> modifiableList = new ArrayList<>(value.size());
                     value.forEach(entry -> {
-                        String result1 = entry.toString();
+                        String result1 = entry == null ? null : entry.toString();
                         modifiableList.add(result1);
                     });
                     list = Collections.unmodifiableList(modifiableList);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtomapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtomapofstringtoenumcopier.java
@@ -43,14 +43,14 @@ final class MapOfEnumToMapOfStringToEnumCopier {
         } else {
             Map<String, Map<String, String>> modifiableMap = new LinkedHashMap<>(mapOfEnumToMapOfStringToEnumParam.size());
             mapOfEnumToMapOfStringToEnumParam.forEach((key, value) -> {
-                String result = key.toString();
+                String result = key == null ? null : key.toString();
                 Map<String, String> map1;
                 if (value == null || value instanceof SdkAutoConstructMap) {
                     map1 = DefaultSdkAutoConstructMap.getInstance();
                 } else {
                     Map<String, String> modifiableMap1 = new LinkedHashMap<>(value.size());
                     value.forEach((key1, value1) -> {
-                        String result1 = value1.toString();
+                        String result1 = value1 == null ? null : value1.toString();
                         modifiableMap1.put(key1, result1);
                     });
                     map1 = Collections.unmodifiableMap(modifiableMap1);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
@@ -62,7 +62,7 @@ final class MapOfEnumToSimpleStructCopier {
         } else {
             Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>(mapOfEnumToSimpleStructParam.size());
             mapOfEnumToSimpleStructParam.forEach((key, value) -> {
-                String result = key.toString();
+                String result = key == null ? null : key.toString();
                 modifiableMap.put(result, value);
             });
             map = Collections.unmodifiableMap(modifiableMap);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
@@ -32,7 +32,7 @@ final class MapOfEnumToStringCopier {
         } else {
             Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfEnumToStringParam.size());
             mapOfEnumToStringParam.forEach((key, value) -> {
-                String result = key.toString();
+                String result = key == null ? null : key.toString();
                 modifiableMap.put(result, value);
             });
             map = Collections.unmodifiableMap(modifiableMap);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
@@ -32,7 +32,7 @@ final class MapOfStringToEnumCopier {
         } else {
             Map<String, String> modifiableMap = new LinkedHashMap<>(mapOfStringToEnumParam.size());
             mapOfStringToEnumParam.forEach((key, value) -> {
-                String result = value.toString();
+                String result = value == null ? null : value.toString();
                 modifiableMap.put(key, result);
             });
             map = Collections.unmodifiableMap(modifiableMap);

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/model/MemberCopierTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/model/MemberCopierTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.protocolrestjson.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+
+public class MemberCopierTest {
+    private MockSyncHttpClient mockHttpClient;
+    private ProtocolRestJsonClient client;
+
+    @BeforeEach
+    public void setupClient() {
+        mockHttpClient = new MockSyncHttpClient();
+        mockHttpClient.stubNextResponse200();
+
+        client = ProtocolRestJsonClient.builder()
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                                                        "skid")))
+                                       .region(Region.US_EAST_1)
+                                       .httpClient(mockHttpClient)
+                                       .build();
+    }
+
+    @Test
+    public void enumListWithNulls_serializesWithoutNPE() {
+        AllTypesRequest request = AllTypesRequest.builder()
+                                                 .listOfEnums(Arrays.asList(EnumType.ENUM_VALUE1, null, EnumType.ENUM_VALUE2))
+                                                 .build();
+
+        assertDoesNotThrow(() -> client.allTypes(request));
+    }
+}


### PR DESCRIPTION
## Motivation and Context
https://github.com/aws/aws-sdk-java-v2/issues/3861

## Modifications
Updated `MemberCopierSpec.java` to generate a null check before calling `entry.toString() when serializing enums to strings.

## Testing
- Updated codegen fixture files with the expected code generated content
- Added a unit test to verify that null enum doesn't throw NPE.