### PR TITLE
Avoid extra byte array copying when downloading to memory with AsyncResponseTransformer

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-d4e19d2.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d4e19d2.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Avoid extra byte array copying when downloading to memory with AsyncResponseTransformer"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
@@ -47,6 +47,8 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
     @Override
     public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
         cf = new CompletableFuture<>();
+        // Using fromByteArrayUnsafe() to avoid unnecessary extra copying of byte array. The data writing has completed and the
+        // byte array will not be further modified so this is safe
         return cf.thenApply(arr -> ResponseBytes.fromByteArrayUnsafe(response, arr));
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
@@ -47,7 +47,7 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
     @Override
     public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
         cf = new CompletableFuture<>();
-        return cf.thenApply(arr -> ResponseBytes.fromByteArray(response, arr));
+        return cf.thenApply(arr -> ResponseBytes.fromByteArrayUnsafe(response, arr));
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently `ByteArrayAsyncResponseTransformer` invokes `ResponseBytes.fromByteArray()` once all the data is downloaded, which copies the contents of the byte array when creating `ResponseBytes`

## Modifications
<!--- Describe your changes in detail -->
replace `ResponseBytes.fromByteArray()` with `ResponseBytes.fromByteArrayUnsafe()`, which creates `ResponseBytes` without copying the contents of the byte array

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Performance tests showed increased throughput and decrease in latency

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)