### PR TITLE
Avoid extra byte array copying when downloading to memory with AsyncResponseTransformer

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-dd9f8bf.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-dd9f8bf.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Avoid extra byte array copying when downloading to memory with AsyncResponseTransformer"
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/ResponseBytesTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/ResponseBytesTest.java
@@ -17,13 +17,14 @@ package software.amazon.awssdk.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 
 public class ResponseBytesTest {
     private static final Object OBJECT = new Object();
     @Test
     public void fromByteArrayCreatesCopy() {
-        byte[] input = new byte[] { 'a' };
+        byte[] input = {'a'};
         byte[] output = ResponseBytes.fromByteArray(OBJECT, input).asByteArrayUnsafe();
 
         input[0] = 'b';
@@ -32,7 +33,7 @@ public class ResponseBytesTest {
 
     @Test
     public void asByteArrayCreatesCopy() {
-        byte[] input = new byte[] { 'a' };
+        byte[] input = {'a'};
         byte[] output = ResponseBytes.fromByteArrayUnsafe(OBJECT, input).asByteArray();
 
         input[0] = 'b';
@@ -41,9 +42,27 @@ public class ResponseBytesTest {
 
     @Test
     public void fromByteArrayUnsafeAndAsByteArrayUnsafeDoNotCopy() {
-        byte[] input = new byte[] { 'a' };
+        byte[] input = {'a'};
         byte[] output = ResponseBytes.fromByteArrayUnsafe(OBJECT, input).asByteArrayUnsafe();
 
         assertThat(output).isSameAs(input);
+    }
+
+    @Test
+    public void fromByteBufferUnsafe_doNotCopy() {
+        byte[] inputBytes = {'a'};
+        ByteBuffer inputBuffer = ByteBuffer.wrap(inputBytes);
+
+        ResponseBytes<Object> responseBytes = ResponseBytes.fromByteBufferUnsafe(OBJECT, inputBuffer);
+
+        ByteBuffer outputBuffer = responseBytes.asByteBuffer();
+        byte[] outputBytes = responseBytes.asByteArrayUnsafe();
+
+        assertThat(outputBuffer).isEqualTo(inputBuffer);
+        assertThat(outputBytes).isSameAs(inputBytes);
+
+        inputBytes[0] = 'b';
+        assertThat(outputBuffer).isEqualTo(inputBuffer);
+        assertThat(outputBytes).isEqualTo(inputBytes);
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodyTest.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.core.internal.async;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static software.amazon.awssdk.core.internal.async.SplittingPublisherTestUtils.verifyIndividualAsyncRequestBody;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.io.ByteArrayOutputStream;
@@ -38,12 +37,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
-import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.utils.BinaryUtils;
 
@@ -236,7 +232,7 @@ public class FileAsyncRequestBodyTest {
 
     @Test
     public void positionNotZero_shouldReadFromPosition() throws Exception {
-        CompletableFuture<byte[]> future = new CompletableFuture<>();
+        CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
         long position = 20L;
         AsyncRequestBody asyncRequestBody = FileAsyncRequestBody.builder()
                                                                 .path(smallFile)
@@ -249,7 +245,9 @@ public class FileAsyncRequestBodyTest {
         asyncRequestBody.subscribe(baosSubscriber);
         assertThat(asyncRequestBody.contentLength()).contains(80L);
 
-        byte[] bytes = future.get(1, TimeUnit.SECONDS);
+        ByteBuffer buffer = future.get(1, TimeUnit.SECONDS);
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
 
         byte[] expected = new byte[80];
         try(FileInputStream inputStream = new FileInputStream(smallFile.toFile())) {
@@ -262,7 +260,7 @@ public class FileAsyncRequestBodyTest {
 
     @Test
     public void bothPositionAndNumBytesToReadConfigured_shouldHonor() throws Exception {
-        CompletableFuture<byte[]> future = new CompletableFuture<>();
+        CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
         long position = 20L;
         long numBytesToRead = 5L;
         AsyncRequestBody asyncRequestBody = FileAsyncRequestBody.builder()
@@ -277,7 +275,9 @@ public class FileAsyncRequestBodyTest {
         asyncRequestBody.subscribe(baosSubscriber);
         assertThat(asyncRequestBody.contentLength()).contains(numBytesToRead);
 
-        byte[] bytes = future.get(1, TimeUnit.SECONDS);
+        ByteBuffer buffer = future.get(1, TimeUnit.SECONDS);
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
 
         byte[] expected = new byte[5];
         try (FileInputStream inputStream = new FileInputStream(smallFile.toFile())) {
@@ -290,7 +290,7 @@ public class FileAsyncRequestBodyTest {
 
     @Test
     public void numBytesToReadConfigured_shouldHonor() throws Exception {
-        CompletableFuture<byte[]> future = new CompletableFuture<>();
+        CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
         AsyncRequestBody asyncRequestBody = FileAsyncRequestBody.builder()
                                                                 .path(smallFile)
                                                                 .numBytesToRead(5L)
@@ -302,7 +302,9 @@ public class FileAsyncRequestBodyTest {
         asyncRequestBody.subscribe(baosSubscriber);
         assertThat(asyncRequestBody.contentLength()).contains(5L);
 
-        byte[] bytes = future.get(1, TimeUnit.SECONDS);
+        ByteBuffer buffer = future.get(1, TimeUnit.SECONDS);
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
 
         byte[] expected = new byte[5];
         try (FileInputStream inputStream = new FileInputStream(smallFile.toFile())) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/PublisherAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/PublisherAsyncResponseTransformerTest.java
@@ -83,9 +83,13 @@ class PublisherAsyncResponseTransformerTest {
     }
 
     private static String drainPublisherToStr(SdkPublisher<ByteBuffer> publisher) throws Exception {
-        CompletableFuture<byte[]> bodyFuture = new CompletableFuture<>();
+        CompletableFuture<ByteBuffer> bodyFuture = new CompletableFuture<>();
         publisher.subscribe(new BaosSubscriber(bodyFuture));
-        byte[] body = bodyFuture.get();
-        return new String(body);
+
+        ByteBuffer buffer = bodyFuture.get();
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
+
+        return new String(bytes);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Follow up to https://github.com/aws/aws-sdk-java-v2/pull/6348

More optimizations in `ByteArrayAsyncResponseTransformer` to avoid unnecessary copying of data

## Modifications
<!--- Describe your changes in detail -->
- Replace future return type of `byte[]` to `ByteBuffer` in `ByteArrayAsyncResponseTransformer`
- New subclass `DirectAccessByteArrayOutputStream` that extends `ByteArrayOutputStream`, with method `toByteBuffer()` to access the internal buffer directly without copying
- New method `ResponseBytes.fromByteBufferUnsafe()` to create `ResponseBytes` from `ByteBuffer` without copying

`ByteArrayAsyncResponseTransformer.BaosSubscriber`
- in `onNext()`, if `byteBuffer.hasArray()` is true, then we can safely invoke `byteBuffer.array()` and directly write the content to `ByteArrayOutputStream` instead of copying the bytes with `BinaryUtils.copyBytesFrom()`
- in `onComplete()`, get the internal buffer from `DirectAccessByteArrayOutputStream` without copying, using `toByteBuffer()` instead of `toByteArray()`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests
Existing tests passing
Performance tests showed increased throughput and decrease in latency

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
