### PR TITLE
Remove unused fast unmarshaller configuration for Dynamodb and DynamodbStreams

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDB-7af8955.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-7af8955.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB",
+    "contributor": "",
+    "description": "Enable fast unmarshaller for DynamoDB and DynamoDBStreams"
+}

--- a/.changes/next-release/bugfix-AmazonDynamoDB-7af8955.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-7af8955.json
@@ -1,6 +1,0 @@
-{
-    "type": "bugfix",
-    "category": "Amazon DynamoDB",
-    "contributor": "",
-    "description": "Enable fast unmarshaller for DynamoDB and DynamoDBStreams"
-}

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
@@ -36,6 +36,5 @@
   "customRetryStrategy" : "software.amazon.awssdk.services.dynamodb.DynamoDbRetryPolicy",
   "enableEndpointDiscoveryMethodRequired": true,
   "enableGenerateCompiledEndpointRules": true,
-  "enableFastUnmarshaller": false,
   "enableEndpointProviderUriCaching": true
 }

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
@@ -20,6 +20,5 @@
     "verifiedSimpleMethods" : [
         "listStreams"
     ],
-    "enableGenerateCompiledEndpointRules": true,
-    "enableFastUnmarshaller": false
+    "enableGenerateCompiledEndpointRules": true
 }


### PR DESCRIPTION
Removes the unused `enableFastUnmarshaller` configuration.

## Motivation and Context
#6089 made the fast marshaller the default (and ignores configuration).  The enableFastUnmarshaller was mostly removed from services, but was missed in ddb and ddb streams.  

There should be no behavior changes from the PR, it just removes vestigial configuration.

## Modifications
Removes the `enableFastUnmarshaller` false configuration - the default is true.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
