### PR TITLE
Use actual member name for NULL

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDB-474adb8.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-474adb8.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB",
+    "contributor": "",
+    "description": "Add a `setNull(Boolean)` setter for the serializable builder class returned by `AttributeValue.serializableBuilderClass()`. This allows successfully converting from a JSON blob such as `{\"NULL\": true}`."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
@@ -204,6 +204,14 @@ abstract class AddShapes {
         memberModel.setRequired(isRequiredMember(c2jMemberName, parentShape));
         memberModel.setSynthetic(shape.isSynthetic());
 
+        if (c2jMemberDefinition.getAlternateBeanPropertyName() != null) {
+            String alternatePropertyName = c2jMemberDefinition.getAlternateBeanPropertyName();
+
+            String setter = String.format("set%s", alternatePropertyName);
+
+            memberModel.setAdditionalBeanStyleSetterName(setter);
+        }
+
 
         // Pass the xmlNameSpace from the member reference
         if (c2jMemberDefinition.getXmlNamespace() != null) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ShapeModifiersProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ShapeModifiersProcessor.java
@@ -224,6 +224,11 @@ final class ShapeModifiersProcessor implements CodegenCustomizationProcessor {
                 member.setDeprecatedMessage(modifyModel.getDeprecatedMessage());
             }
         }
+
+        if (modifyModel.getAlternateBeanPropertyName() != null) {
+            shape.getMembers().get(memberToModify).setAlternateBeanPropertyName(modifyModel.getAlternateBeanPropertyName());
+        }
+
         // Currently only supports emitPropertyName which is to rename the member
         if (modifyModel.getEmitPropertyName() != null) {
             Member member = shape.getMembers().remove(memberToModify);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ModifyModelShapeModifier.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ModifyModelShapeModifier.java
@@ -50,6 +50,12 @@ public class ModifyModelShapeModifier {
     private String emitEnumValue;
 
     /**
+     * An additional, alternate name for this member that should additionally be used when generating bean style
+     * setters/getters for the enclosing shape.
+     */
+    private String alternateBeanPropertyName;
+
+    /**
      * Emit as a different primitive type. Used by AWS Budget Service to change string
      * to BigDecimal (see API-433).
      */
@@ -142,5 +148,13 @@ public class ModifyModelShapeModifier {
 
     public boolean isIgnoreDataTypeConversionFailures() {
         return ignoreDataTypeConversionFailures;
+    }
+
+    public String getAlternateBeanPropertyName() {
+        return alternateBeanPropertyName;
+    }
+
+    public void setAlternateBeanPropertyName(String alternateBeanPropertyName) {
+        this.alternateBeanPropertyName = alternateBeanPropertyName;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
@@ -90,6 +90,8 @@ public class MemberModel extends DocumentationModel {
 
     private String beanStyleSetterName;
 
+    private String additionalBeanStyleSetterName;
+
     private String unionEnumTypeName;
 
     private boolean isJsonValue;
@@ -787,6 +789,19 @@ public class MemberModel extends DocumentationModel {
         return ignoreDataTypeConversionFailures;
     }
 
+    public String getAdditionalBeanStyleSetterName() {
+        return additionalBeanStyleSetterName;
+    }
+
+    public void setAdditionalBeanStyleSetterName(String additionalBeanStyleSetterName) {
+        this.additionalBeanStyleSetterName = additionalBeanStyleSetterName;
+    }
+
+    public MemberModel withAdditionalBeanStyleSetterName(String additionalBeanStyleSetterName) {
+        setAdditionalBeanStyleSetterName(additionalBeanStyleSetterName);
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {
@@ -834,6 +849,7 @@ public class MemberModel extends DocumentationModel {
                && Objects.equals(fluentDeprecatedGetterMethodName, that.fluentDeprecatedGetterMethodName)
                && Objects.equals(fluentDeprecatedSetterMethodName, that.fluentDeprecatedSetterMethodName)
                && Objects.equals(deprecatedBeanStyleSetterMethodName, that.deprecatedBeanStyleSetterMethodName)
+               && Objects.equals(additionalBeanStyleSetterName, that.additionalBeanStyleSetterName)
                && Objects.equals(contextParam, that.contextParam);
     }
 
@@ -878,6 +894,8 @@ public class MemberModel extends DocumentationModel {
         result = 31 * result + Objects.hashCode(deprecatedBeanStyleSetterMethodName);
         result = 31 * result + Objects.hashCode(contextParam);
         result = 31 * result + Boolean.hashCode(ignoreDataTypeConversionFailures);
+        result = 31 * result + Objects.hashCode(additionalBeanStyleSetterName);
+
         return result;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Member.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Member.java
@@ -59,6 +59,12 @@ public class Member {
 
     private String deprecatedName;
 
+    /**
+     * An additional, alternate name for this member that should additionally be used when generating bean style
+     * setters/getters for the enclosing shape.
+     */
+    private String alternateBeanPropertyName;
+
     private ContextParam contextParam;
 
     public String getShape() {
@@ -235,5 +241,13 @@ public class Member {
 
     public void setContextParam(ContextParam contextParam) {
         this.contextParam = contextParam;
+    }
+
+    public String getAlternateBeanPropertyName() {
+        return alternateBeanPropertyName;
+    }
+
+    public void setAlternateBeanPropertyName(String alternateBeanPropertyName) {
+        this.alternateBeanPropertyName = alternateBeanPropertyName;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/NonCollectionSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/NonCollectionSetters.java
@@ -128,6 +128,14 @@ class NonCollectionSetters extends AbstractMemberSetters {
                             .build());
         }
 
+        String additionalSetter = memberModel().getAdditionalBeanStyleSetterName();
+        if (StringUtils.isNotBlank(additionalSetter)) {
+            MethodSpec.Builder methodBuilder = beanStyleSetterBuilder();
+            methodBuilder.setName(additionalSetter);
+            methods.add(methodBuilder.addCode(beanCopySetterBody())
+                                     .build());
+        }
+
         return methods;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/containsreservedkeyword.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/containsreservedkeyword.java
@@ -1,0 +1,193 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class ContainsReservedKeyword implements SdkPojo, Serializable,
+                                                      ToCopyableBuilder<ContainsReservedKeyword.Builder, ContainsReservedKeyword> {
+    private static final SdkField<String> NUL_FIELD = SdkField.<String> builder(MarshallingType.STRING).memberName("NUL")
+                                                              .getter(getter(ContainsReservedKeyword::nul)).setter(setter(Builder::nul))
+                                                              .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("NULL").build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(NUL_FIELD));
+
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+
+    private static final long serialVersionUID = 1L;
+
+    private final String nul;
+
+    private ContainsReservedKeyword(BuilderImpl builder) {
+        this.nul = builder.nul;
+    }
+
+    /**
+     * Returns the value of the NUL property for this object.
+     *
+     * @return The value of the NUL property for this object.
+     */
+    public final String nul() {
+        return nul;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public final int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + Objects.hashCode(nul());
+        return hashCode;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return equalsBySdkFields(obj);
+    }
+
+    @Override
+    public final boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ContainsReservedKeyword)) {
+            return false;
+        }
+        ContainsReservedKeyword other = (ContainsReservedKeyword) obj;
+        return Objects.equals(nul(), other.nul());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public final String toString() {
+        return ToString.builder("ContainsReservedKeyword").add("NUL", nul()).build();
+    }
+
+    public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "NUL":
+                return Optional.ofNullable(clazz.cast(nul()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public final List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    @Override
+    public final Map<String, SdkField<?>> sdkFieldNameToField() {
+        return SDK_NAME_TO_FIELD;
+    }
+
+    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
+        Map<String, SdkField<?>> map = new HashMap<>();
+        map.put("NULL", NUL_FIELD);
+        return Collections.unmodifiableMap(map);
+    }
+
+    private static <T> Function<Object, T> getter(Function<ContainsReservedKeyword, T> g) {
+        return obj -> g.apply((ContainsReservedKeyword) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    @Mutable
+    @NotThreadSafe
+    public interface Builder extends SdkPojo, CopyableBuilder<Builder, ContainsReservedKeyword> {
+        /**
+         * Sets the value of the NUL property for this object.
+         *
+         * @param nul
+         *        The new value for the NUL property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder nul(String nul);
+    }
+
+    static final class BuilderImpl implements Builder {
+        private String nul;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(ContainsReservedKeyword model) {
+            nul(model.nul);
+        }
+
+        public final String getNul() {
+            return nul;
+        }
+
+        public final void setNul(String nul) {
+            this.nul = nul;
+        }
+
+        public final void setNull(String nul) {
+            this.nul = nul;
+        }
+
+        @Override
+        public final Builder nul(String nul) {
+            this.nul = nul;
+            return this;
+        }
+
+        @Override
+        public ContainsReservedKeyword build() {
+            return new ContainsReservedKeyword(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return SDK_NAME_TO_FIELD;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/customization.config
@@ -6,6 +6,16 @@
         "eventStreamOperation"
     ],
     "shapeModifiers": {
+        "ContainsReservedKeyword": {
+            "modify": [
+                {
+                    "NULL": {
+                        "emitPropertyName": "NUL",
+                        "alternateBeanPropertyName": "Null"
+                    }
+                }
+            ]
+        },
         "DeprecatedRenameRequest": {
             "modify": [
                 {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithreservedkeywordmemberrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithreservedkeywordmemberrequest.java
@@ -1,0 +1,234 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class OperationWithReservedKeywordMemberRequest extends JsonProtocolTestsRequest implements
+                                                                                              ToCopyableBuilder<OperationWithReservedKeywordMemberRequest.Builder, OperationWithReservedKeywordMemberRequest> {
+    private static final SdkField<ContainsReservedKeyword> RESERVED_KEYWORD_MEMBER_FIELD = SdkField
+        .<ContainsReservedKeyword> builder(MarshallingType.SDK_POJO).memberName("ReservedKeywordMember")
+        .getter(getter(OperationWithReservedKeywordMemberRequest::reservedKeywordMember))
+        .setter(setter(Builder::reservedKeywordMember)).constructor(ContainsReservedKeyword::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ReservedKeywordMember").build())
+        .build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections
+        .unmodifiableList(Arrays.asList(RESERVED_KEYWORD_MEMBER_FIELD));
+
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+
+    private final ContainsReservedKeyword reservedKeywordMember;
+
+    private OperationWithReservedKeywordMemberRequest(BuilderImpl builder) {
+        super(builder);
+        this.reservedKeywordMember = builder.reservedKeywordMember;
+    }
+
+    /**
+     * Returns the value of the ReservedKeywordMember property for this object.
+     *
+     * @return The value of the ReservedKeywordMember property for this object.
+     */
+    public final ContainsReservedKeyword reservedKeywordMember() {
+        return reservedKeywordMember;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public final int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        hashCode = 31 * hashCode + Objects.hashCode(reservedKeywordMember());
+        return hashCode;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public final boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof OperationWithReservedKeywordMemberRequest)) {
+            return false;
+        }
+        OperationWithReservedKeywordMemberRequest other = (OperationWithReservedKeywordMemberRequest) obj;
+        return Objects.equals(reservedKeywordMember(), other.reservedKeywordMember());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public final String toString() {
+        return ToString.builder("OperationWithReservedKeywordMemberRequest")
+                       .add("ReservedKeywordMember", reservedKeywordMember()).build();
+    }
+
+    public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "ReservedKeywordMember":
+                return Optional.ofNullable(clazz.cast(reservedKeywordMember()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public final List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    @Override
+    public final Map<String, SdkField<?>> sdkFieldNameToField() {
+        return SDK_NAME_TO_FIELD;
+    }
+
+    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
+        Map<String, SdkField<?>> map = new HashMap<>();
+        map.put("ReservedKeywordMember", RESERVED_KEYWORD_MEMBER_FIELD);
+        return Collections.unmodifiableMap(map);
+    }
+
+    private static <T> Function<Object, T> getter(Function<OperationWithReservedKeywordMemberRequest, T> g) {
+        return obj -> g.apply((OperationWithReservedKeywordMemberRequest) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    @Mutable
+    @NotThreadSafe
+    public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, OperationWithReservedKeywordMemberRequest> {
+        /**
+         * Sets the value of the ReservedKeywordMember property for this object.
+         *
+         * @param reservedKeywordMember
+         *        The new value for the ReservedKeywordMember property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder reservedKeywordMember(ContainsReservedKeyword reservedKeywordMember);
+
+        /**
+         * Sets the value of the ReservedKeywordMember property for this object.
+         *
+         * This is a convenience method that creates an instance of the {@link ContainsReservedKeyword.Builder} avoiding
+         * the need to create one manually via {@link ContainsReservedKeyword#builder()}.
+         *
+         * <p>
+         * When the {@link Consumer} completes, {@link ContainsReservedKeyword.Builder#build()} is called immediately
+         * and its result is passed to {@link #reservedKeywordMember(ContainsReservedKeyword)}.
+         *
+         * @param reservedKeywordMember
+         *        a consumer that will call methods on {@link ContainsReservedKeyword.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #reservedKeywordMember(ContainsReservedKeyword)
+         */
+        default Builder reservedKeywordMember(Consumer<ContainsReservedKeyword.Builder> reservedKeywordMember) {
+            return reservedKeywordMember(ContainsReservedKeyword.builder().applyMutation(reservedKeywordMember).build());
+        }
+
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends JsonProtocolTestsRequest.BuilderImpl implements Builder {
+        private ContainsReservedKeyword reservedKeywordMember;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(OperationWithReservedKeywordMemberRequest model) {
+            super(model);
+            reservedKeywordMember(model.reservedKeywordMember);
+        }
+
+        public final ContainsReservedKeyword.Builder getReservedKeywordMember() {
+            return reservedKeywordMember != null ? reservedKeywordMember.toBuilder() : null;
+        }
+
+        public final void setReservedKeywordMember(ContainsReservedKeyword.BuilderImpl reservedKeywordMember) {
+            this.reservedKeywordMember = reservedKeywordMember != null ? reservedKeywordMember.build() : null;
+        }
+
+        @Override
+        public final Builder reservedKeywordMember(ContainsReservedKeyword reservedKeywordMember) {
+            this.reservedKeywordMember = reservedKeywordMember;
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public OperationWithReservedKeywordMemberRequest build() {
+            return new OperationWithReservedKeywordMemberRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return SDK_NAME_TO_FIELD;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithreservedkeywordmemberresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithreservedkeywordmemberresponse.java
@@ -1,0 +1,122 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.Mutable;
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+@Generated("software.amazon.awssdk:codegen")
+public final class OperationWithReservedKeywordMemberResponse extends JsonProtocolTestsResponse implements
+                                                                                                ToCopyableBuilder<OperationWithReservedKeywordMemberResponse.Builder, OperationWithReservedKeywordMemberResponse> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.emptyList();
+
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+
+    private OperationWithReservedKeywordMemberResponse(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public final int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public final boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof OperationWithReservedKeywordMemberResponse)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public final String toString() {
+        return ToString.builder("OperationWithReservedKeywordMemberResponse").build();
+    }
+
+    public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public final List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    @Override
+    public final Map<String, SdkField<?>> sdkFieldNameToField() {
+        return SDK_NAME_TO_FIELD;
+    }
+
+    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
+        return Collections.emptyMap();
+    }
+
+    @Mutable
+    @NotThreadSafe
+    public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, OperationWithReservedKeywordMemberResponse> {
+    }
+
+    static final class BuilderImpl extends JsonProtocolTestsResponse.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(OperationWithReservedKeywordMemberResponse model) {
+            super(model);
+        }
+
+        @Override
+        public OperationWithReservedKeywordMemberResponse build() {
+            return new OperationWithReservedKeywordMemberResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return SDK_NAME_TO_FIELD;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/service-2.json
@@ -128,6 +128,14 @@
         "requestUri":"/2016-03-11/queryParameterOperation/{PathParam}"
       },
       "input":{"shape":"QueryParameterOperationRequest"}
+    },
+    "OperationWithReservedKeywordMember": {
+      "name": "DeprecatedRename",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {"shape": "OperationWithReservedKeywordMemberRequest"}
     }
   },
   "shapes":{
@@ -263,6 +271,14 @@
         },
         "MemberModifiedAsDeprecated":{"shape": "String"},
         "UndeprecatedMember": {"shape": "String"}
+      }
+    },
+    "OperationWithReservedKeywordMemberRequest": {
+      "type": "structure",
+      "members": {
+        "ReservedKeywordMember": {
+          "shape": "ContainsReservedKeyword"
+        }
       }
     },
     "Double":{"type":"double"},
@@ -656,6 +672,14 @@
         }
       },
       "payload":"NestedQueryParameterOperation"
+    },
+    "ContainsReservedKeyword": {
+      "type": "structure",
+      "members": {
+        "NULL": {
+          "shape": "String"
+        }
+      }
     }
   }
 }

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
@@ -5,7 +5,8 @@
         "modify": [
             {
                 "NULL": {
-                    "emitPropertyName": "NUL"
+                    "emitPropertyName": "NUL",
+                    "alternateBeanPropertyName": "Null"
                 }
             }
         ],

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
@@ -5,7 +5,8 @@
           "modify": [
               {
                   "NULL": {
-                      "emitPropertyName": "NUL"
+                    "emitPropertyName": "NUL",
+                    "alternateBeanPropertyName": "Null"
                   }
               }
           ],

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/AttributeValueTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/AttributeValueTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class AttributeValueTest {
+    private static ObjectMapper mapper;
+
+    @BeforeAll
+    public static void setup() {
+        mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+    }
+
+    @Test
+    void serializableBuilderClass_jsonIsNullAttributeValue_deserializesCorrectly() throws JsonProcessingException {
+        String nullAttributeValueJson = "{\"NULL\":true}";
+
+        AttributeValue.Builder builder = mapper.readValue(nullAttributeValueJson, AttributeValue.serializableBuilderClass());
+        AttributeValue attr = builder.build();
+
+        assertThat(attr.nul()).isTrue();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In DynamoDB, the "NULL" member of AttributeValue is customized to "NUL" because "null" is a reserved keyword. This has the effect of generating nul() and getNul() as getters, and nul(Boolean), and setNul(Boolean) as setters for the serializable builder class.

If using the serializable builder class to map from a JSON string with the correct property name "NULL", it will not be recognized.

To fix this, generate an additional setter with the correct name setNull().

To make this work, `ModifyModelShapeModifier` has been updated with a new option called `alternateBeanPropertyName`. When set, for the modified member, we will generate an additional bean style setter on the model builder using the given property name.

Diff of generated code. Adds a `setNull` that behaves exactly like `setNul`.

```diff
--- attributevalue-old.java     2025-08-20 15:03:41
+++ attributevalue-new.java     2025-08-20 15:01:46
@@ -1340,6 +1340,12 @@
         }

         public final void setNul(Boolean nul) {
+            Object oldValue = this.nul;
+            this.nul = nul;
+            handleUnionValueChange(Type.NUL, oldValue, this.nul);
+        }
+
+        public final void setNull(Boolean nul) {
             Object oldValue = this.nul;
             this.nul = nul;
             handleUnionValueChange(Type.NUL, oldValue, this.nul);
```

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
