### PR TITLE
Remove unnecessary `String.join()` call.

### DIFF
--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/GetAttr.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/GetAttr.java.resource
@@ -122,7 +122,7 @@ public class GetAttr extends Fn {
                 .argv(
                         Arrays.asList(
                                 builder.target,
-                                Literal.fromStr(String.join(".", builder.path))))
+                                Literal.fromStr(builder.path)))
                 .build());
     }
 


### PR DESCRIPTION
## Motivation and Context
This fixes a bug flagged by https://errorprone.info/bugpattern/StringJoin

## Modifications
Removes an unnecessary/misleading `String.join()` call.

## Testing
n/a

## Screenshots (if appropriate)
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
