### PR TITLE
Stream based upload retry support

### DIFF
--- a/.changes/next-release/deprecation-AWSSDKforJavav2-6069419.json
+++ b/.changes/next-release/deprecation-AWSSDKforJavav2-6069419.json
@@ -1,0 +1,6 @@
+{
+    "type": "deprecation",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Deprecate `AsyncRequestBody#split` in favor of `AsyncRequestBody#splitCloseable` that takes the same input but returns `SdkPublisher<CloseableAsyncRequestBody>`"
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-500254f.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-500254f.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Add `AsyncRequestBody#splitCloseable` API that returns a Publisher of `ClosableAsyncRequestBody`"
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-72c5f55.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-72c5f55.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Introduce CloseableAsyncRequestBody interface that extends both AsyncRequestBody and SdkAutoClosable interfaces"
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-ed2c57a.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-ed2c57a.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Introduce BufferedSplittableAsyncRequestBody that enables splitting into retryable sub-request bodies."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BufferedSplittableAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BufferedSplittableAsyncRequestBody.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.internal.async.SplittingPublisher;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * An {@link AsyncRequestBody} decorator that enables splitting into retryable sub-request bodies.
+ *
+ * <p>This wrapper allows any {@link AsyncRequestBody} to be split into multiple parts where each part
+ * can be retried independently. When split, each sub-body buffers its portion of data, enabling
+ * resubscription if a retry is needed (e.g., due to network failures or service errors).</p>
+ *
+ * <p><b>Retry Requirements:</b></p>
+ * <p>Retry is only possible if all the data has been successfully buffered during the first subscription.
+ * If the first subscriber fails to consume all the data (e.g., due to early cancellation or errors),
+ * subsequent retry attempts will fail since the complete data set is not available for resubscription.</p>
+ *
+ * <p><b>Usage Example:</b></p>
+ * {@snippet :
+ * AsyncRequestBody originalBody = AsyncRequestBody.fromString("Hello World");
+ * BufferedSplittableAsyncRequestBody retryableBody =
+ *     BufferedSplittableAsyncRequestBody.create(originalBody);
+ * }
+ *
+ * <p><b>Performance Considerations:</b></p>
+ * <p>This implementation buffers data in memory to enable retries, but memory usage is controlled by
+ * the {@code bufferSizeInBytes} configuration. However, this buffering limits the ability to request
+ * more data from the original AsyncRequestBody until buffered data is consumed (i.e., when subscribers
+ * closes sub-body), which may increase latency compared to non-buffered implementations.
+ *
+ * @see AsyncRequestBody
+ * @see AsyncRequestBodySplitConfiguration
+ * @see CloseableAsyncRequestBody
+ */
+@SdkPublicApi
+public final class BufferedSplittableAsyncRequestBody implements AsyncRequestBody {
+    private final AsyncRequestBody delegate;
+
+    private BufferedSplittableAsyncRequestBody(AsyncRequestBody delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Creates a new {@link BufferedSplittableAsyncRequestBody} that wraps the provided {@link AsyncRequestBody}.
+     *
+     * @param delegate the {@link AsyncRequestBody} to wrap and make retryable. Must not be null.
+     * @return a new {@link BufferedSplittableAsyncRequestBody} instance
+     * @throws NullPointerException if delegate is null
+     */
+    public static BufferedSplittableAsyncRequestBody create(AsyncRequestBody delegate) {
+        Validate.paramNotNull(delegate, "delegate");
+        return new BufferedSplittableAsyncRequestBody(delegate);
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return delegate.contentLength();
+    }
+
+    /**
+     * Splits this request body into multiple retryable parts based on the provided configuration.
+     *
+     * <p>Each part returned by the publisher will be a {@link CloseableAsyncRequestBody} that buffers
+     * its portion of data, enabling resubscription for retry scenarios. This is the key difference from non-buffered splitting -
+     * each part can be safely retried without data loss.
+     *
+     * <p>The splitting process respects the chunk size and buffer size specified in the configuration
+     * to optimize memory usage.
+     *
+     * <p>The subscriber MUST close each {@link CloseableAsyncRequestBody} to ensure resource is released
+     *
+     * @param splitConfiguration configuration specifying how to split the request body
+     * @return a publisher that emits retryable closable request body parts
+     * @see AsyncRequestBodySplitConfiguration
+     */
+    @Override
+    public SdkPublisher<CloseableAsyncRequestBody> splitCloseable(AsyncRequestBodySplitConfiguration splitConfiguration) {
+        return SplittingPublisher.builder()
+                .asyncRequestBody(this)
+                .splitConfiguration(splitConfiguration)
+                .retryableSubAsyncRequestBodyEnabled(true)
+                .build();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        delegate.subscribe(s);
+    }
+
+    @Override
+    public String body() {
+        return delegate.body();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/CloseableAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/CloseableAsyncRequestBody.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
+/**
+ * An extension of {@link AsyncRequestBody} that is closable.
+ */
+@SdkPublicApi
+public interface CloseableAsyncRequestBody extends AsyncRequestBody, SdkAutoCloseable {
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/listener/AsyncRequestBodyListener.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/listener/AsyncRequestBodyListener.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -74,6 +75,17 @@ public interface AsyncRequestBodyListener extends PublisherListener<ByteBuffer> 
         @Override
         public SdkPublisher<AsyncRequestBody> split(Consumer<AsyncRequestBodySplitConfiguration.Builder> splitConfiguration) {
             return delegate.split(splitConfiguration);
+        }
+
+        @Override
+        public SdkPublisher<CloseableAsyncRequestBody> splitCloseable(AsyncRequestBodySplitConfiguration splitConfiguration) {
+            return delegate.splitCloseable(splitConfiguration);
+        }
+
+        @Override
+        public SdkPublisher<CloseableAsyncRequestBody> splitCloseable(
+            Consumer<AsyncRequestBodySplitConfiguration.Builder> splitConfiguration) {
+            return delegate.splitCloseable(splitConfiguration);
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBody.java
@@ -76,7 +76,9 @@ public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody, SdkA
     private final Object lock = new Object();
     private boolean closed;
 
-    private ByteBuffersAsyncRequestBody(String mimetype, Long length, List<ByteBuffer> buffers) {
+    private ByteBuffersAsyncRequestBody(String mimetype,
+                                        Long length,
+                                        List<ByteBuffer> buffers) {
         this.mimetype = mimetype;
         this.buffers = buffers;
         this.length = length;
@@ -121,6 +123,10 @@ public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody, SdkA
         return BodyType.BYTES.getName();
     }
 
+    public static ByteBuffersAsyncRequestBody of(List<ByteBuffer> buffers, long length) {
+        return new ByteBuffersAsyncRequestBody(Mimetype.MIMETYPE_OCTET_STREAM, length, buffers);
+    }
+
     public static ByteBuffersAsyncRequestBody of(List<ByteBuffer> buffers) {
         long length = buffers.stream()
                             .mapToLong(ByteBuffer::remaining)
@@ -129,7 +135,11 @@ public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody, SdkA
     }
 
     public static ByteBuffersAsyncRequestBody of(ByteBuffer... buffers) {
-        return of(Arrays.asList(buffers));
+        List<ByteBuffer> byteBuffers = Arrays.asList(buffers);
+        long length = byteBuffers.stream()
+                             .mapToLong(ByteBuffer::remaining)
+                             .sum();
+        return of(byteBuffers, length);
     }
 
     public static ByteBuffersAsyncRequestBody of(Long length, ByteBuffer... buffers) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBody.java
@@ -16,21 +16,47 @@
 package software.amazon.awssdk.core.internal.async;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.internal.util.Mimetype;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * An implementation of {@link AsyncRequestBody} for providing data from the supplied {@link ByteBuffer} array. This is created
  * using static methods on {@link AsyncRequestBody}
  *
+ * <h3>Subscription Behavior:</h3>
+ * <ul>
+ *   <li>Each subscriber receives a read-only view of the buffered data</li>
+ *   <li>Subscribers receive data independently based on their own demand signaling</li>
+ *   <li>If the body is closed, new subscribers will receive an error immediately</li>
+ * </ul>
+ *
+ * <h3>Resource Management:</h3>
+ * The body should be closed when no longer needed to free buffered data and notify active subscribers.
+ * Closing the body will:
+ * <ul>
+ *   <li>Clear all buffered data</li>
+ *   <li>Send error notifications to all active subscribers</li>
+ *   <li>Prevent new subscriptions</li>
+ * </ul>
  * @see AsyncRequestBody#fromBytes(byte[])
  * @see AsyncRequestBody#fromBytesUnsafe(byte[])
  * @see AsyncRequestBody#fromByteBuffer(ByteBuffer)
@@ -40,17 +66,21 @@ import software.amazon.awssdk.utils.Logger;
  * @see AsyncRequestBody#fromString(String)
  */
 @SdkInternalApi
-public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody {
+public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody, SdkAutoCloseable {
     private static final Logger log = Logger.loggerFor(ByteBuffersAsyncRequestBody.class);
 
     private final String mimetype;
     private final Long length;
-    private final ByteBuffer[] buffers;
+    private List<ByteBuffer> buffers;
+    private final Set<ReplayableByteBufferSubscription> subscriptions;
+    private final Object lock = new Object();
+    private boolean closed;
 
-    private ByteBuffersAsyncRequestBody(String mimetype, Long length, ByteBuffer... buffers) {
+    private ByteBuffersAsyncRequestBody(String mimetype, Long length, List<ByteBuffer> buffers) {
         this.mimetype = mimetype;
-        this.length = length;
         this.buffers = buffers;
+        this.length = length;
+        this.subscriptions = ConcurrentHashMap.newKeySet();
     }
 
     @Override
@@ -64,61 +94,25 @@ public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody {
     }
 
     @Override
-    public void subscribe(Subscriber<? super ByteBuffer> s) {
-        // As per rule 1.9 we must throw NullPointerException if the subscriber parameter is null
-        if (s == null) {
-            throw new NullPointerException("Subscription MUST NOT be null.");
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        Validate.paramNotNull(subscriber, "subscriber");
+        synchronized (lock) {
+            if (closed) {
+                subscriber.onSubscribe(new NoopSubscription(subscriber));
+                subscriber.onError(NonRetryableException.create(
+                    "AsyncRequestBody has been closed"));
+                return;
+            }
         }
 
-        // As per 2.13, this method must return normally (i.e. not throw).
         try {
-            s.onSubscribe(
-                new Subscription() {
-                    private final AtomicInteger index = new AtomicInteger(0);
-                    private final AtomicBoolean completed = new AtomicBoolean(false);
-
-                    @Override
-                    public void request(long n) {
-                        if (completed.get()) {
-                            return;
-                        }
-
-                        if (n > 0) {
-                            int i = index.getAndIncrement();
-
-                            if (buffers.length == 0 && completed.compareAndSet(false, true)) {
-                                s.onComplete();
-                            }
-
-                            if (i >= buffers.length) {
-                                return;
-                            }
-
-                            long remaining = n;
-
-                            do {
-                                ByteBuffer buffer = buffers[i];
-
-                                s.onNext(buffer.asReadOnlyBuffer());
-                                remaining--;
-                            } while (remaining > 0 && (i = index.getAndIncrement()) < buffers.length);
-
-                            if (i >= buffers.length - 1 && completed.compareAndSet(false, true)) {
-                                s.onComplete();
-                            }
-                        } else {
-                            s.onError(new IllegalArgumentException("§3.9: non-positive requests are not allowed!"));
-                        }
-                    }
-
-                    @Override
-                    public void cancel() {
-                        completed.set(true);
-                    }
-                }
-            );
+            ReplayableByteBufferSubscription replayableByteBufferSubscription =
+                new ReplayableByteBufferSubscription(subscriber);
+            subscriber.onSubscribe(replayableByteBufferSubscription);
+            subscriptions.add(replayableByteBufferSubscription);
         } catch (Throwable ex) {
-            log.error(() -> s + " violated the Reactive Streams rule 2.13 by throwing an exception from onSubscribe.", ex);
+            log.error(() -> subscriber + " violated the Reactive Streams rule 2.13 by throwing an exception from onSubscribe.",
+                      ex);
         }
     }
 
@@ -127,34 +121,167 @@ public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody {
         return BodyType.BYTES.getName();
     }
 
-    public static ByteBuffersAsyncRequestBody of(ByteBuffer... buffers) {
-        long length = Arrays.stream(buffers)
-                         .mapToLong(ByteBuffer::remaining)
-                         .sum();
+    public static ByteBuffersAsyncRequestBody of(List<ByteBuffer> buffers) {
+        long length = buffers.stream()
+                            .mapToLong(ByteBuffer::remaining)
+                            .sum();
         return new ByteBuffersAsyncRequestBody(Mimetype.MIMETYPE_OCTET_STREAM, length, buffers);
     }
 
+    public static ByteBuffersAsyncRequestBody of(ByteBuffer... buffers) {
+        return of(Arrays.asList(buffers));
+    }
+
     public static ByteBuffersAsyncRequestBody of(Long length, ByteBuffer... buffers) {
-        return new ByteBuffersAsyncRequestBody(Mimetype.MIMETYPE_OCTET_STREAM, length, buffers);
+        return new ByteBuffersAsyncRequestBody(Mimetype.MIMETYPE_OCTET_STREAM, length, Arrays.asList(buffers));
     }
 
     public static ByteBuffersAsyncRequestBody of(String mimetype, ByteBuffer... buffers) {
         long length = Arrays.stream(buffers)
                             .mapToLong(ByteBuffer::remaining)
                             .sum();
-        return new ByteBuffersAsyncRequestBody(mimetype, length, buffers);
+        return new ByteBuffersAsyncRequestBody(mimetype, length, Arrays.asList(buffers));
     }
 
     public static ByteBuffersAsyncRequestBody of(String mimetype, Long length, ByteBuffer... buffers) {
-        return new ByteBuffersAsyncRequestBody(mimetype, length, buffers);
+        return new ByteBuffersAsyncRequestBody(mimetype, length, Arrays.asList(buffers));
     }
 
     public static ByteBuffersAsyncRequestBody from(byte[] bytes) {
         return new ByteBuffersAsyncRequestBody(Mimetype.MIMETYPE_OCTET_STREAM, (long) bytes.length,
-                                               ByteBuffer.wrap(bytes));
+                                               Collections.singletonList(ByteBuffer.wrap(bytes)));
     }
 
     public static ByteBuffersAsyncRequestBody from(String mimetype, byte[] bytes) {
-        return new ByteBuffersAsyncRequestBody(mimetype, (long) bytes.length, ByteBuffer.wrap(bytes));
+        return new ByteBuffersAsyncRequestBody(mimetype, (long) bytes.length,
+                                               Collections.singletonList(ByteBuffer.wrap(bytes)));
+    }
+
+    @Override
+    public void close() {
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+
+            closed = true;
+            buffers = new ArrayList<>();
+            subscriptions.forEach(s -> s.notifyError(new IllegalStateException("The publisher has been closed")));
+            subscriptions.clear();
+        }
+    }
+
+    @SdkTestInternalApi
+    public List<ByteBuffer> bufferedData() {
+        return buffers;
+    }
+
+    private class ReplayableByteBufferSubscription implements Subscription {
+        private final AtomicInteger index = new AtomicInteger(0);
+        private volatile boolean done;
+        private final AtomicBoolean processingRequest = new AtomicBoolean(false);
+        private Subscriber<? super ByteBuffer> currentSubscriber;
+        private final AtomicLong outstandingDemand = new AtomicLong();
+
+        private ReplayableByteBufferSubscription(Subscriber<? super ByteBuffer> subscriber) {
+            this.currentSubscriber = subscriber;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                currentSubscriber.onError(new IllegalArgumentException("§3.9: non-positive requests are not allowed!"));
+                currentSubscriber = null;
+                return;
+            }
+
+            if (done) {
+                return;
+            }
+
+            if (buffers.size() == 0) {
+                currentSubscriber.onComplete();
+                done = true;
+                subscriptions.remove(this);
+                return;
+            }
+
+            outstandingDemand.updateAndGet(current -> {
+                if (Long.MAX_VALUE - current < n) {
+                    return Long.MAX_VALUE;
+                }
+
+                return current + n;
+            });
+            processRequest();
+        }
+
+        private void processRequest() {
+            do {
+                if (!processingRequest.compareAndSet(false, true)) {
+                    // Some other thread is processing the queue, so we don't need to.
+                    return;
+                }
+
+                try {
+                    doProcessRequest();
+                } catch (Throwable e) {
+                    notifyError(new IllegalStateException("Encountered fatal error in publisher", e));
+                    subscriptions.remove(this);
+                    break;
+                } finally {
+                    processingRequest.set(false);
+                }
+
+            } while (shouldProcessRequest());
+        }
+
+        private boolean shouldProcessRequest() {
+            return !done && outstandingDemand.get() > 0 && index.get() < buffers.size();
+        }
+
+        private void doProcessRequest() {
+            while (true) {
+                if (!shouldProcessRequest()) {
+                    return;
+                }
+
+                int currentIndex = this.index.getAndIncrement();
+
+                if (currentIndex >= buffers.size()) {
+                    // This should never happen because shouldProcessRequest() ensures that index.get() < buffers.size()
+                    // before incrementing. If this condition is true, it likely indicates a concurrency bug or that buffers
+                    // was modified unexpectedly. This defensive check is here to catch such rare, unexpected situations.
+                    notifyError(new IllegalStateException("Index out of bounds"));
+                    subscriptions.remove(this);
+                    return;
+                }
+
+                ByteBuffer buffer = buffers.get(currentIndex);
+                currentSubscriber.onNext(buffer.asReadOnlyBuffer());
+                outstandingDemand.decrementAndGet();
+
+                if (currentIndex == buffers.size() - 1) {
+                    done = true;
+                    currentSubscriber.onComplete();
+                    subscriptions.remove(this);
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            done = true;
+            subscriptions.remove(this);
+        }
+
+        public void notifyError(Exception exception) {
+            if (currentSubscriber != null) {
+                done = true;
+                currentSubscriber.onError(exception);
+                currentSubscriber = null;
+            }
+        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/NonRetryableSubAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/NonRetryableSubAsyncRequestBody.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.async.SimplePublisher;
+
+/**
+ * A {@link SubAsyncRequestBody} implementation that doesn't support resubscribe/retry
+ */
+@SdkInternalApi
+public final class NonRetryableSubAsyncRequestBody implements SubAsyncRequestBody {
+    private static final Logger log = Logger.loggerFor(NonRetryableSubAsyncRequestBody.class);
+    private final SubAsyncRequestBodyConfiguration configuration;
+    private final int partNumber;
+    private final boolean contentLengthKnown;
+    private final String sourceBodyName;
+    private final SimplePublisher<ByteBuffer> delegate = new SimplePublisher<>();
+    private final AtomicBoolean subscribeCalled = new AtomicBoolean(false);
+    private volatile long bufferedLength = 0;
+    private final Consumer<Long> onNumBytesReceived;
+    private final Consumer<Long> onNumBytesConsumed;
+
+    /**
+     * Creates a new NonRetryableSubAsyncRequestBody with the given configuration.
+     */
+    public NonRetryableSubAsyncRequestBody(SubAsyncRequestBodyConfiguration configuration) {
+        this.configuration = Validate.paramNotNull(configuration, "configuration");
+        this.partNumber = configuration.partNumber();
+        this.contentLengthKnown = configuration.contentLengthKnown();
+        this.sourceBodyName = configuration.sourceBodyName();
+        this.onNumBytesReceived = configuration.onNumBytesReceived();
+        this.onNumBytesConsumed = configuration.onNumBytesConsumed();
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return contentLengthKnown ? Optional.of(configuration.maxLength()) : Optional.of(bufferedLength);
+    }
+
+    public void send(ByteBuffer data) {
+        log.debug(() -> String.format("Sending bytebuffer %s to part %d", data, partNumber));
+        long length = data.remaining();
+        bufferedLength += length;
+        onNumBytesReceived.accept(length);
+        delegate.send(data).whenComplete((r, t) -> {
+            onNumBytesConsumed.accept(length);
+            if (t != null) {
+                error(t);
+            }
+        });
+    }
+
+    public void complete() {
+        log.debug(() -> "Received complete() for part number: " + partNumber);
+        delegate.complete().whenComplete((r, t) -> {
+            if (t != null) {
+                error(t);
+            }
+        });
+    }
+
+    @Override
+    public long maxLength() {
+        return configuration.maxLength();
+    }
+
+    @Override
+    public long receivedBytesLength() {
+        return bufferedLength;
+    }
+
+    @Override
+    public int partNumber() {
+        return partNumber;
+    }
+
+    public void error(Throwable error) {
+        delegate.error(error);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        if (subscribeCalled.compareAndSet(false, true)) {
+            delegate.subscribe(s);
+        } else {
+            s.onSubscribe(new NoopSubscription(s));
+            s.onError(NonRetryableException.create(
+                "Multiple subscribers detected. This could happen due to a retry attempt. The AsyncRequestBody implementation"
+                + " provided does not support splitting to retryable/resubscribable AsyncRequestBody. If you need retry "
+                + "capability or multiple subscriptions, consider using BufferedSplittableAsyncRequestBody to wrap your "
+                + "AsyncRequestBody."));
+        }
+    }
+
+    @Override
+    public String body() {
+        return sourceBodyName;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/RetryableSubAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/RetryableSubAsyncRequestBody.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.async.SimplePublisher;
+
+/**
+ * A {@link SubAsyncRequestBody} implementation that supports resubscribe/retry once all data has been published to the first
+ * subscriber
+ */
+@SdkInternalApi
+public final class RetryableSubAsyncRequestBody implements SubAsyncRequestBody {
+    private static final Logger log = Logger.loggerFor(RetryableSubAsyncRequestBody.class);
+    /**
+     * The maximum length of the content this AsyncRequestBody can hold. If the upstream content length is known, this is
+     * the same as totalLength
+     */
+    private final SubAsyncRequestBodyConfiguration configuration;
+    private final int partNumber;
+    private final boolean contentLengthKnown;
+    private final String sourceBodyName;
+
+    private volatile long bufferedLength = 0;
+    private volatile ByteBuffersAsyncRequestBody bufferedAsyncRequestBody;
+    private List<ByteBuffer> buffers = new ArrayList<>();
+    private final AtomicBoolean subscribeCalled = new AtomicBoolean(false);
+    private final SimplePublisher<ByteBuffer> delegate = new SimplePublisher<>();
+    private final Consumer<Long> onNumBytesReceived;
+    private final Consumer<Long> onNumBytesConsumed;
+    private final Object buffersLock = new Object();
+
+    /**
+     * Creates a new RetryableSubAsyncRequestBody with the given configuration.
+     */
+    public RetryableSubAsyncRequestBody(SubAsyncRequestBodyConfiguration configuration) {
+        this.configuration = Validate.paramNotNull(configuration, "configuration");
+        this.partNumber = configuration.partNumber();
+        this.contentLengthKnown = configuration.contentLengthKnown();
+        this.sourceBodyName = configuration.sourceBodyName();
+        this.onNumBytesReceived = configuration.onNumBytesReceived();
+        this.onNumBytesConsumed = configuration.onNumBytesConsumed();
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return contentLengthKnown ? Optional.of(configuration.maxLength()) : Optional.of(bufferedLength);
+    }
+
+    @Override
+    public void send(ByteBuffer data) {
+        log.trace(() -> String.format("Sending bytebuffer %s to part number %d", data, partNumber));
+        long length = data.remaining();
+        bufferedLength += length;
+
+        onNumBytesReceived.accept(length);
+        delegate.send(data.asReadOnlyBuffer()).whenComplete((r, t) -> {
+            if (t != null) {
+                delegate.error(t);
+            }
+        });
+        synchronized (buffersLock) {
+            buffers.add(data.asReadOnlyBuffer());
+        }
+    }
+
+    @Override
+    public void complete() {
+        log.debug(() -> "Received complete() for part number: " + partNumber);
+        // ByteBuffersAsyncRequestBody MUST be created before we complete the current
+        // request because retry may happen right after
+        synchronized (buffersLock) {
+            bufferedAsyncRequestBody = ByteBuffersAsyncRequestBody.of(buffers, bufferedLength);
+        }
+        delegate.complete().exceptionally(e -> {
+            delegate.error(e);
+            return null;
+        });
+    }
+
+    @Override
+    public long maxLength() {
+        return configuration.maxLength();
+    }
+
+    @Override
+    public long receivedBytesLength() {
+        return bufferedLength;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        log.debug(() -> "Subscribe for part number: " + partNumber);
+        if (subscribeCalled.compareAndSet(false, true)) {
+            delegate.subscribe(s);
+        } else {
+            log.debug(() -> "Resubscribe for part number " + partNumber);
+            if (bufferedAsyncRequestBody == null) {
+                s.onSubscribe(new NoopSubscription(s));
+                s.onError(NonRetryableException.create(
+                    "A retry was attempted, but data is not buffered successfully for retry for partNumber: " + partNumber));
+                return;
+            }
+            bufferedAsyncRequestBody.subscribe(s);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            log.debug(() -> "Closing current body " + partNumber);
+            onNumBytesConsumed.accept(bufferedLength);
+            if (bufferedAsyncRequestBody != null) {
+                synchronized (buffersLock) {
+                    buffers.clear();
+                    buffers = null;
+                }
+                bufferedAsyncRequestBody.close();
+                bufferedAsyncRequestBody = null;
+            }
+        } catch (Throwable e) {
+            log.warn(() -> String.format("Unexpected error thrown from cleaning up AsyncRequestBody for part number %d, "
+                                         + "resource may be leaked", partNumber));
+        }
+    }
+
+    @Override
+    public int partNumber() {
+        return partNumber;
+    }
+
+    @Override
+    public String body() {
+        return sourceBodyName;
+    }
+
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingPublisher.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingPublisher.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.core.internal.async;
 
 import java.nio.ByteBuffer;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -25,9 +24,8 @@ import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.async.SdkPublisher;
-import software.amazon.awssdk.core.exception.NonRetryableException;
-import software.amazon.awssdk.core.internal.util.NoopSubscription;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.async.SimplePublisher;
@@ -40,28 +38,33 @@ import software.amazon.awssdk.utils.async.SimplePublisher;
  * Otherwise, it is sent after the entire content for that chunk is buffered. This is required to get content length.
  */
 @SdkInternalApi
-public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
+public class SplittingPublisher implements SdkPublisher<CloseableAsyncRequestBody> {
     private static final Logger log = Logger.loggerFor(SplittingPublisher.class);
     private final AsyncRequestBody upstreamPublisher;
     private final SplittingSubscriber splittingSubscriber;
-    private final SimplePublisher<AsyncRequestBody> downstreamPublisher = new SimplePublisher<>();
+    private final SimplePublisher<CloseableAsyncRequestBody> downstreamPublisher = new SimplePublisher<>();
     private final long chunkSizeInBytes;
     private final long bufferSizeInBytes;
+    private final boolean retryableSubAsyncRequestBodyEnabled;
+    private final AtomicBoolean currentBodySent = new AtomicBoolean(false);
+    private final String sourceBodyName;
 
-    public SplittingPublisher(AsyncRequestBody asyncRequestBody,
-                              AsyncRequestBodySplitConfiguration splitConfiguration) {
-        this.upstreamPublisher = Validate.paramNotNull(asyncRequestBody, "asyncRequestBody");
-        Validate.notNull(splitConfiguration, "splitConfiguration");
-        this.chunkSizeInBytes = splitConfiguration.chunkSizeInBytes() == null ?
+    private SplittingPublisher(Builder builder) {
+        this.upstreamPublisher = Validate.paramNotNull(builder.asyncRequestBody, "asyncRequestBody");
+        Validate.notNull(builder.splitConfiguration, "splitConfiguration");
+        this.chunkSizeInBytes = builder.splitConfiguration.chunkSizeInBytes() == null ?
                                 AsyncRequestBodySplitConfiguration.defaultConfiguration().chunkSizeInBytes() :
-                                splitConfiguration.chunkSizeInBytes();
+                                builder.splitConfiguration.chunkSizeInBytes();
 
-        this.bufferSizeInBytes = splitConfiguration.bufferSizeInBytes() == null ?
+        this.bufferSizeInBytes = builder.splitConfiguration.bufferSizeInBytes() == null ?
                                  AsyncRequestBodySplitConfiguration.defaultConfiguration().bufferSizeInBytes() :
-                                 splitConfiguration.bufferSizeInBytes();
+                                 builder.splitConfiguration.bufferSizeInBytes();
 
         this.splittingSubscriber = new SplittingSubscriber(upstreamPublisher.contentLength().orElse(null));
 
+        this.retryableSubAsyncRequestBodyEnabled = Validate.paramNotNull(builder.retryableSubAsyncRequestBodyEnabled,
+                                                                         "retryableSubAsyncRequestBodyEnabled");
+        this.sourceBodyName = builder.asyncRequestBody.body();
         if (!upstreamPublisher.contentLength().isPresent()) {
             Validate.isTrue(bufferSizeInBytes >= chunkSizeInBytes,
                             "bufferSizeInBytes must be larger than or equal to " +
@@ -69,8 +72,15 @@ public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
         }
     }
 
+    /**
+     * Returns a newly initialized builder object for a {@link SplittingPublisher}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
     @Override
-    public void subscribe(Subscriber<? super AsyncRequestBody> downstreamSubscriber) {
+    public void subscribe(Subscriber<? super CloseableAsyncRequestBody> downstreamSubscriber) {
         downstreamPublisher.subscribe(downstreamSubscriber);
         upstreamPublisher.subscribe(splittingSubscriber);
     }
@@ -78,8 +88,11 @@ public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
     private class SplittingSubscriber implements Subscriber<ByteBuffer> {
         private Subscription upstreamSubscription;
         private final Long upstreamSize;
-        private final AtomicInteger chunkNumber = new AtomicInteger(0);
-        private volatile DownstreamBody currentBody;
+        /**
+         * 1 based index number for each part/chunk
+         */
+        private final AtomicInteger partNumber = new AtomicInteger(1);
+        private volatile SubAsyncRequestBody currentBody;
         private final AtomicBoolean hasOpenUpstreamDemand = new AtomicBoolean(false);
         private final AtomicLong dataBuffered = new AtomicLong(0);
 
@@ -98,13 +111,31 @@ public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
             this.upstreamSubscription = s;
             this.currentBody =
                 initializeNextDownstreamBody(upstreamSize != null, calculateChunkSize(upstreamSize),
-                                             chunkNumber.get());
+                                             partNumber.get());
             // We need to request subscription *after* we set currentBody because onNext could be invoked right away.
             upstreamSubscription.request(1);
         }
 
-        private DownstreamBody initializeNextDownstreamBody(boolean contentLengthKnown, long chunkSize, int chunkNumber) {
-            DownstreamBody body = new DownstreamBody(contentLengthKnown, chunkSize, chunkNumber);
+        private SubAsyncRequestBody initializeNextDownstreamBody(boolean contentLengthKnown, long chunkSize, int chunkNumber) {
+            SubAsyncRequestBody body;
+            log.debug(() -> "initializing next downstream body " + partNumber);
+
+            SubAsyncRequestBodyConfiguration config = SubAsyncRequestBodyConfiguration.builder()
+                    .contentLengthKnown(contentLengthKnown)
+                    .maxLength(chunkSize)
+                    .partNumber(chunkNumber)
+                    .onNumBytesReceived(data -> addDataBuffered(data))
+                    .onNumBytesConsumed(data -> addDataBuffered(-data))
+                    .sourceBodyName(sourceBodyName)
+                    .build();
+            
+            if (retryableSubAsyncRequestBodyEnabled) {
+                body = new RetryableSubAsyncRequestBody(config);
+            } else {
+                body = new NonRetryableSubAsyncRequestBody(config);
+            }
+
+            currentBodySent.set(false);
             if (contentLengthKnown) {
                 sendCurrentBody(body);
             }
@@ -158,7 +189,7 @@ public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
 
         private void completeCurrentBodyAndCreateNewIfNeeded(ByteBuffer byteBuffer) {
             completeCurrentBody();
-            int currentChunk = chunkNumber.incrementAndGet();
+            int nextChunk = partNumber.incrementAndGet();
             boolean shouldCreateNewDownstreamRequestBody;
             Long dataRemaining = totalDataRemaining();
 
@@ -170,18 +201,40 @@ public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
 
             if (shouldCreateNewDownstreamRequestBody) {
                 long chunkSize = calculateChunkSize(dataRemaining);
-                currentBody = initializeNextDownstreamBody(upstreamSize != null, chunkSize, currentChunk);
+                currentBody = initializeNextDownstreamBody(upstreamSize != null, chunkSize, nextChunk);
             }
         }
 
         private int amountRemainingInChunk() {
-            return Math.toIntExact(currentBody.maxLength - currentBody.transferredLength);
+            return Math.toIntExact(currentBody.maxLength() - currentBody.receivedBytesLength());
         }
 
+
         private void completeCurrentBody() {
-            log.debug(() -> "completeCurrentBody for chunk " + chunkNumber.get());
+            log.debug(() -> "completeCurrentBody for part " + currentBody.partNumber());
+            long bufferedLength = currentBody.receivedBytesLength();
+            // For unknown content length, we always create a new DownstreamBody once the current one is sent
+            // because we don't know if there is data
+            // left or not, so we need to check the length and only send the body if there is actually data
+            if (bufferedLength == 0) {
+                return;
+            }
+
+            Long totalLength = currentBody.maxLength();
+            if (upstreamSize != null && totalLength != bufferedLength) {
+                upstreamSubscription.cancel();
+                downstreamPublisher.error(new IllegalStateException(
+                    String.format("Content length of buffered data mismatches "
+                                  + "with the expected content length, buffered data content length: %d, "
+                                  + "expected length: %d", totalLength,
+                                  bufferedLength)));
+                return;
+            }
             currentBody.complete();
-            if (upstreamSize == null) {
+
+            // Current body could be completed in either onNext or onComplete, so we need to guard against sending the last body
+            // twice.
+            if (upstreamSize == null && currentBodySent.compareAndSet(false, true)) {
                 sendCurrentBody(currentBody);
             }
         }
@@ -189,18 +242,19 @@ public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
         @Override
         public void onComplete() {
             upstreamComplete = true;
-            log.trace(() -> "Received onComplete()");
+            log.debug(() -> "Received onComplete()");
             completeCurrentBody();
             downstreamPublisher.complete();
         }
 
         @Override
         public void onError(Throwable t) {
-            log.trace(() -> "Received onError()", t);
+            log.debug(() -> "Received onError()", t);
             downstreamPublisher.error(t);
         }
 
-        private void sendCurrentBody(AsyncRequestBody body) {
+        private void sendCurrentBody(SubAsyncRequestBody body) {
+            log.debug(() -> "sendCurrentBody for part " + body.partNumber());
             downstreamPublisher.send(body).exceptionally(t -> {
                 downstreamPublisher.error(t);
                 upstreamSubscription.cancel();
@@ -223,88 +277,68 @@ public class SplittingPublisher implements SdkPublisher<AsyncRequestBody> {
                 hasOpenUpstreamDemand.compareAndSet(false, true)) {
                 log.trace(() -> "Requesting more data, current data buffered: " + buffered);
                 upstreamSubscription.request(1);
+            } else {
+                log.trace(() -> "Should not request more data, current data buffered: " + buffered);
             }
         }
 
         private boolean shouldRequestMoreData(long buffered) {
-            return buffered == 0 || buffered + byteBufferSizeHint <= bufferSizeInBytes;
+            return buffered <= 0 || buffered + byteBufferSizeHint <= bufferSizeInBytes;
         }
 
         private Long totalDataRemaining() {
             if (upstreamSize == null) {
                 return null;
             }
-            return upstreamSize - (chunkNumber.get() * chunkSizeInBytes);
+            return upstreamSize - ((partNumber.get() - 1) * chunkSizeInBytes);
         }
 
-        private final class DownstreamBody implements AsyncRequestBody {
-
-            /**
-             * The maximum length of the content this AsyncRequestBody can hold. If the upstream content length is known, this is
-             * the same as totalLength
-             */
-            private final long maxLength;
-            private final Long totalLength;
-            private final SimplePublisher<ByteBuffer> delegate = new SimplePublisher<>();
-            private final int chunkNumber;
-            private final AtomicBoolean subscribeCalled = new AtomicBoolean(false);
-            private volatile long transferredLength = 0;
-
-            private DownstreamBody(boolean contentLengthKnown, long maxLength, int chunkNumber) {
-                this.totalLength = contentLengthKnown ? maxLength : null;
-                this.maxLength = maxLength;
-                this.chunkNumber = chunkNumber;
+        private void addDataBuffered(long length) {
+            log.trace(() -> "Adding data buffered " + length);
+            dataBuffered.addAndGet(length);
+            if (length < 0) {
+                maybeRequestMoreUpstreamData();
             }
+        }
+    }
 
-            @Override
-            public Optional<Long> contentLength() {
-                return totalLength != null ? Optional.of(totalLength) : Optional.of(transferredLength);
-            }
+    public static final class Builder {
+        private AsyncRequestBody asyncRequestBody;
+        private AsyncRequestBodySplitConfiguration splitConfiguration;
+        private Boolean retryableSubAsyncRequestBodyEnabled;
 
-            public void send(ByteBuffer data) {
-                log.trace(() -> String.format("Sending bytebuffer %s to chunk %d", data, chunkNumber));
-                int length = data.remaining();
-                transferredLength += length;
-                addDataBuffered(length);
-                delegate.send(data).whenComplete((r, t) -> {
-                    addDataBuffered(-length);
-                    if (t != null) {
-                        error(t);
-                    }
-                });
-            }
+        private Builder() {
+        }
 
-            public void complete() {
-                log.debug(() -> "Received complete() for chunk number: " + chunkNumber + " length " + transferredLength);
-                delegate.complete().whenComplete((r, t) -> {
-                    if (t != null) {
-                        error(t);
-                    }
-                });
-            }
+        /**
+         * Sets the AsyncRequestBody to be split.
+         */
+        public Builder asyncRequestBody(AsyncRequestBody asyncRequestBody) {
+            this.asyncRequestBody = asyncRequestBody;
+            return this;
+        }
 
-            public void error(Throwable error) {
-                delegate.error(error);
-            }
+        /**
+         * Sets the split configuration.
+         */
+        public Builder splitConfiguration(AsyncRequestBodySplitConfiguration splitConfiguration) {
+            this.splitConfiguration = splitConfiguration;
+            return this;
+        }
 
-            @Override
-            public void subscribe(Subscriber<? super ByteBuffer> s) {
-                if (subscribeCalled.compareAndSet(false, true)) {
-                    delegate.subscribe(s);
-                } else {
-                    s.onSubscribe(new NoopSubscription(s));
-                    s.onError(NonRetryableException.create(
-                        "A retry was attempted, but AsyncRequestBody.split does not "
-                        + "support retries."));
-                }
-            }
+        /**
+         * Sets whether to enable retryable sub async request bodies.
+         */
+        public Builder retryableSubAsyncRequestBodyEnabled(Boolean retryableSubAsyncRequestBodyEnabled) {
+            this.retryableSubAsyncRequestBodyEnabled = retryableSubAsyncRequestBodyEnabled;
+            return this;
+        }
 
-            private void addDataBuffered(int length) {
-                dataBuffered.addAndGet(length);
-                if (length < 0) {
-                    maybeRequestMoreUpstreamData();
-                }
-            }
+        /**
+         * Builds a {@link SplittingPublisher} object based on the values held by this builder.
+         */
+        public SplittingPublisher build() {
+            return new SplittingPublisher(this);
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SubAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SubAsyncRequestBody.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import java.nio.ByteBuffer;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
+
+/**
+ * Represent a sub {@link AsyncRequestBody} that publishes a portion of the source {@link AsyncRequestBody}
+ */
+@SdkInternalApi
+public interface SubAsyncRequestBody extends CloseableAsyncRequestBody {
+
+    /**
+     * Send a byte buffer.
+     * <p>
+     * This method must not be invoked concurrently.
+     */
+    void send(ByteBuffer byteBuffer);
+
+    /**
+     *  Indicate that no more {@link #send(ByteBuffer)} )} calls will be made,
+     *  and that stream of messages is completed successfully.
+     */
+    void complete();
+
+    /**
+     * The maximum length of the content this AsyncRequestBody can hold. If the upstream content length is known, this should be
+     * the same as receivedBytesLength
+     */
+    long maxLength();
+
+    /**
+     * The length of the bytes received
+     */
+    long receivedBytesLength();
+
+    @Override
+    default void close() {
+        // no op
+    }
+
+    /**
+     * The part number associated with this SubAsyncRequestBody
+     * @return
+     */
+    int partNumber();
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SubAsyncRequestBodyConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SubAsyncRequestBodyConfiguration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Configuration class containing shared properties for SubAsyncRequestBody implementations.
+ */
+@SdkInternalApi
+public final class SubAsyncRequestBodyConfiguration {
+    private final boolean contentLengthKnown;
+    private final long maxLength;
+    private final int partNumber;
+    private final Consumer<Long> onNumBytesReceived;
+    private final Consumer<Long> onNumBytesConsumed;
+    private final String sourceBodyName;
+
+    private SubAsyncRequestBodyConfiguration(Builder builder) {
+        this.contentLengthKnown = Validate.paramNotNull(builder.contentLengthKnown, "contentLengthKnown");
+        this.maxLength = Validate.paramNotNull(builder.maxLength, "maxLength");
+        this.partNumber = Validate.paramNotNull(builder.partNumber, "partNumber");
+        this.onNumBytesReceived = Validate.paramNotNull(builder.onNumBytesReceived, "onNumBytesReceived");
+        this.onNumBytesConsumed = Validate.paramNotNull(builder.onNumBytesConsumed, "onNumBytesConsumed");
+        this.sourceBodyName = Validate.paramNotNull(builder.sourceBodyName, "sourceBodyName");
+    }
+
+    /**
+     * Returns a newly initialized builder object for a {@link SubAsyncRequestBodyConfiguration}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public boolean contentLengthKnown() {
+        return contentLengthKnown;
+    }
+
+    public long maxLength() {
+        return maxLength;
+    }
+
+    public int partNumber() {
+        return partNumber;
+    }
+
+    public Consumer<Long> onNumBytesReceived() {
+        return onNumBytesReceived;
+    }
+
+    public Consumer<Long> onNumBytesConsumed() {
+        return onNumBytesConsumed;
+    }
+
+    public String sourceBodyName() {
+        return sourceBodyName;
+    }
+
+    public static final class Builder {
+        private Boolean contentLengthKnown;
+        private Long maxLength;
+        private Integer partNumber;
+        private Consumer<Long> onNumBytesReceived;
+        private Consumer<Long> onNumBytesConsumed;
+        private String sourceBodyName;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets whether the content length is known.
+         */
+        public Builder contentLengthKnown(Boolean contentLengthKnown) {
+            this.contentLengthKnown = contentLengthKnown;
+            return this;
+        }
+
+        /**
+         * Sets the maximum length of the content this AsyncRequestBody can hold.
+         */
+        public Builder maxLength(Long maxLength) {
+            this.maxLength = maxLength;
+            return this;
+        }
+
+        /**
+         * Sets the part number for this request body.
+         */
+        public Builder partNumber(Integer partNumber) {
+            this.partNumber = partNumber;
+            return this;
+        }
+
+        /**
+         * Sets the callback to be invoked when bytes are received.
+         */
+        public Builder onNumBytesReceived(Consumer<Long> onNumBytesReceived) {
+            this.onNumBytesReceived = onNumBytesReceived;
+            return this;
+        }
+
+        /**
+         * Sets the callback to be invoked when bytes are consumed.
+         */
+        public Builder onNumBytesConsumed(Consumer<Long> onNumBytesConsumed) {
+            this.onNumBytesConsumed = onNumBytesConsumed;
+            return this;
+        }
+
+        /**
+         * Sets the source body name for identification.
+         */
+        public Builder sourceBodyName(String sourceBodyName) {
+            this.sourceBodyName = sourceBodyName;
+            return this;
+        }
+
+        /**
+         * Builds a {@link SubAsyncRequestBodyConfiguration} object based on the values held by this builder.
+         */
+        public SubAsyncRequestBodyConfiguration build() {
+            return new SubAsyncRequestBodyConfiguration(this);
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodySplitConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodySplitConfigurationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class AsyncRequestBodyConfigurationTest {
+public class AsyncRequestBodySplitConfigurationTest {
 
     @Test
     void equalsHashCode() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteBufferAsyncRequestBodyTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteBufferAsyncRequestBodyTckTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.core.SdkBytes;
+
+public class ByteBufferAsyncRequestBodyTckTest extends org.reactivestreams.tck.PublisherVerification<ByteBuffer> {
+    public ByteBufferAsyncRequestBodyTckTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long elements) {
+        List<ByteBuffer> buffers = new ArrayList<>();
+        for (int i = 0; i < elements; i++) {
+            buffers.add(SdkBytes.fromUtf8String(RandomStringUtils.randomAscii(1024)).asByteBuffer());
+        }
+        return ByteBuffersAsyncRequestBody.of(buffers.toArray(new ByteBuffer[0]));
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        ByteBuffersAsyncRequestBody bufferingAsyncRequestBody = ByteBuffersAsyncRequestBody.of(ByteBuffer.wrap(RandomStringUtils.randomAscii(1024).getBytes()));
+        bufferingAsyncRequestBody.close();
+        return bufferingAsyncRequestBody;
+    }
+
+    public long maxElementsFromPublisher() {
+        return 100;
+    }
+
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodySplitHelperTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodySplitHelperTest.java
@@ -77,7 +77,9 @@ public class FileAsyncRequestBodySplitHelperTest {
         ScheduledFuture<?> scheduledFuture = executor.scheduleWithFixedDelay(verifyConcurrentRequests(helper, maxConcurrency),
                                                                              1, 50, TimeUnit.MICROSECONDS);
 
-        verifyIndividualAsyncRequestBody(helper.split(), testFile, chunkSize);
+        verifyIndividualAsyncRequestBody(helper.split(),
+                                         testFile,
+                                         chunkSize);
         scheduledFuture.cancel(true);
         int expectedMaxConcurrency = (int) (bufferSize / chunkSizeInBytes);
         assertThat(maxConcurrency.get()).isLessThanOrEqualTo(expectedMaxConcurrency);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/NonRetryableSubAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/NonRetryableSubAsyncRequestBodyTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+
+class NonRetryableSubAsyncRequestBodyTest {
+
+    private SubAsyncRequestBodyConfiguration configuration;
+    private Consumer<Long> onNumBytesReceived;
+    private Consumer<Long> onNumBytesConsumed;
+    private NonRetryableSubAsyncRequestBody requestBody;
+
+    @BeforeEach
+    void setUp() {
+        onNumBytesReceived = mock(Consumer.class);
+        onNumBytesConsumed = mock(Consumer.class);
+        
+        configuration = SubAsyncRequestBodyConfiguration.builder()
+                .contentLengthKnown(true)
+                .maxLength(1024L)
+                .partNumber(1)
+                .onNumBytesReceived(onNumBytesReceived)
+                .onNumBytesConsumed(onNumBytesConsumed)
+                .sourceBodyName("test-body")
+                .build();
+        
+        requestBody = new NonRetryableSubAsyncRequestBody(configuration);
+    }
+
+    @Test
+    void getters_shouldReturnConfigurationValues() {
+        assertThat(requestBody.maxLength()).isEqualTo(1024L);
+        assertThat(requestBody.partNumber()).isEqualTo(1);
+        assertThat(requestBody.body()).isEqualTo("test-body");
+        assertThat(requestBody.contentLength()).isEqualTo(Optional.of(1024L));
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(0L);
+    }
+
+    @Test
+    void constructor_withNullConfiguration_shouldThrowException() {
+        assertThatThrownBy(() -> new NonRetryableSubAsyncRequestBody(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void contentLength_whenContentLengthUnknown_shouldReturnBufferedLength() {
+        SubAsyncRequestBodyConfiguration unknownLengthConfig = SubAsyncRequestBodyConfiguration.builder()
+                .contentLengthKnown(false)
+                .maxLength(1024L)
+                .partNumber(1)
+                .onNumBytesReceived(onNumBytesReceived)
+                .onNumBytesConsumed(onNumBytesConsumed)
+                .sourceBodyName("test-body")
+                .build();
+        
+        NonRetryableSubAsyncRequestBody unknownLengthBody = new NonRetryableSubAsyncRequestBody(unknownLengthConfig);
+        
+        assertThat(unknownLengthBody.contentLength()).isEqualTo(Optional.of(0L));
+        
+        // Send some data
+        ByteBuffer data = ByteBuffer.wrap("test".getBytes());
+        unknownLengthBody.send(data);
+        
+        assertThat(unknownLengthBody.contentLength()).isEqualTo(Optional.of(4L));
+    }
+
+    @Test
+    void subscribe_shouldReceiveAllData() {
+        byte[] part1 = RandomStringUtils.randomAscii(1024).getBytes(StandardCharsets.UTF_8);
+        byte[] part2 = RandomStringUtils.randomAscii(512).getBytes(StandardCharsets.UTF_8);
+        requestBody.send(ByteBuffer.wrap(part1));
+        requestBody.send(ByteBuffer.wrap(part2));
+        requestBody.complete();
+        List<ByteBuffer> receivedBuffers = new ArrayList<>();
+        Flowable.fromPublisher(requestBody).forEach(buffer -> receivedBuffers.add(buffer));
+
+        verify(onNumBytesReceived).accept(1024L);
+        verify(onNumBytesConsumed).accept(1024L);
+        verify(onNumBytesReceived).accept(512L);
+        verify(onNumBytesConsumed).accept(512L);
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(1536L);
+        assertThat(receivedBuffers).containsExactly(ByteBuffer.wrap(part1), ByteBuffer.wrap(part2));
+    }
+
+    @Test
+    void subscribe_secondTime_shouldSendError() {
+        Subscriber<ByteBuffer> subscriber1 = mock(Subscriber.class);
+        Subscriber<ByteBuffer> subscriber2 = mock(Subscriber.class);
+        
+        // First subscription
+        requestBody.subscribe(subscriber1);
+        
+        // Second subscription should fail
+        requestBody.subscribe(subscriber2);
+        
+        ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+        verify(subscriber2).onSubscribe(subscriptionCaptor.capture());
+        
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(subscriber2).onError(errorCaptor.capture());
+        
+        Throwable error = errorCaptor.getValue();
+        assertThat(error).isInstanceOf(NonRetryableException.class);
+        assertThat(error.getMessage()).contains("This could happen due to a retry attempt");
+    }
+
+    @Test
+    void receivedBytesLength_shouldTrackSentData() {
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(0L);
+        
+        ByteBuffer data1 = ByteBuffer.wrap("hello".getBytes());
+        requestBody.send(data1);
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(5L);
+        
+        ByteBuffer data2 = ByteBuffer.wrap(" world".getBytes());
+        requestBody.send(data2);
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(11L);
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/RetryableSubAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/RetryableSubAsyncRequestBodyTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+
+class RetryableSubAsyncRequestBodyTest {
+
+    private SubAsyncRequestBodyConfiguration configuration;
+    private Consumer<Long> onNumBytesReceived;
+    private Consumer<Long> onNumBytesConsumed;
+    private RetryableSubAsyncRequestBody requestBody;
+
+    @BeforeEach
+    void setUp() {
+        onNumBytesReceived = mock(Consumer.class);
+        onNumBytesConsumed = mock(Consumer.class);
+        
+        configuration = SubAsyncRequestBodyConfiguration.builder()
+                .contentLengthKnown(true)
+                .maxLength(1024L)
+                .partNumber(1)
+                .onNumBytesReceived(onNumBytesReceived)
+                .onNumBytesConsumed(onNumBytesConsumed)
+                .sourceBodyName("test-body")
+                .build();
+        
+        requestBody = new RetryableSubAsyncRequestBody(configuration);
+    }
+
+    @Test
+    void getters_shouldReturnConfigurationValues() {
+        assertThat(requestBody.maxLength()).isEqualTo(1024L);
+        assertThat(requestBody.partNumber()).isEqualTo(1);
+        assertThat(requestBody.body()).isEqualTo("test-body");
+        assertThat(requestBody.contentLength()).isEqualTo(Optional.of(1024L));
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(0L);
+    }
+
+    @Test
+    void constructor_withNullConfiguration_shouldThrowException() {
+        assertThatThrownBy(() -> new RetryableSubAsyncRequestBody(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void contentLength_whenContentLengthUnknown_shouldReturnBufferedLength() {
+        SubAsyncRequestBodyConfiguration unknownLengthConfig = SubAsyncRequestBodyConfiguration.builder()
+                .contentLengthKnown(false)
+                .maxLength(1024L)
+                .partNumber(1)
+                .onNumBytesReceived(onNumBytesReceived)
+                .onNumBytesConsumed(onNumBytesConsumed)
+                .sourceBodyName("test-body")
+                .build();
+        
+        RetryableSubAsyncRequestBody unknownLengthBody = new RetryableSubAsyncRequestBody(unknownLengthConfig);
+        
+        assertThat(unknownLengthBody.contentLength()).isEqualTo(Optional.of(0L));
+        
+        // Send some data
+        ByteBuffer data = ByteBuffer.wrap("test".getBytes());
+        unknownLengthBody.send(data);
+        
+        assertThat(unknownLengthBody.contentLength()).isEqualTo(Optional.of(4L));
+    }
+
+    @Test
+    void subscribe_shouldReceiveAllData() {
+        byte[] part1 = RandomStringUtils.randomAscii(1024).getBytes(StandardCharsets.UTF_8);
+        byte[] part2 = RandomStringUtils.randomAscii(512).getBytes(StandardCharsets.UTF_8);
+        requestBody.send(ByteBuffer.wrap(part1));
+        requestBody.send(ByteBuffer.wrap(part2));
+        requestBody.complete();
+        List<ByteBuffer> receivedBuffers = new ArrayList<>();
+        Flowable.fromPublisher(requestBody).forEach(buffer -> receivedBuffers.add(buffer));
+
+        verify(onNumBytesReceived).accept(1024L);
+        verify(onNumBytesReceived).accept(512L);
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(1536L);
+        assertThat(receivedBuffers).containsExactly(ByteBuffer.wrap(part1), ByteBuffer.wrap(part2));
+    }
+
+    @Test
+    void subscribe_secondTime_shouldUseBufferedBody() {
+        byte[] part1 = RandomStringUtils.randomAscii(1024).getBytes(StandardCharsets.UTF_8);
+        byte[] part2 = RandomStringUtils.randomAscii(512).getBytes(StandardCharsets.UTF_8);
+        requestBody.send(ByteBuffer.wrap(part1));
+        requestBody.send(ByteBuffer.wrap(part2));
+        requestBody.complete();
+
+        List<ByteBuffer> buffer1 = new ArrayList<>();
+        Flowable.fromPublisher(requestBody).forEach(buffer -> buffer1.add(buffer));
+
+        List<ByteBuffer> buffer2 = new ArrayList<>();
+        Flowable.fromPublisher(requestBody).forEach(buffer -> buffer2.add(buffer));
+
+        assertThat(buffer1).containsExactly(ByteBuffer.wrap(part1), ByteBuffer.wrap(part2));
+        assertThat(buffer2).containsExactly(ByteBuffer.wrap(part1), ByteBuffer.wrap(part2));
+    }
+
+    @Test
+    void subscribe_retryWithoutFirstSubscriberDone_shouldSendError() {
+        Subscriber<ByteBuffer> subscriber1 = mock(Subscriber.class);
+        Subscriber<ByteBuffer> subscriber2 = mock(Subscriber.class);
+
+        // First subscription
+        requestBody.subscribe(subscriber1);
+        // Second subscription without completing first (no buffered data)
+        requestBody.subscribe(subscriber2);
+        
+        ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+        verify(subscriber2).onSubscribe(subscriptionCaptor.capture());
+        
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(subscriber2).onError(errorCaptor.capture());
+        
+        Throwable error = errorCaptor.getValue();
+        assertThat(error).isInstanceOf(NonRetryableException.class);
+        assertThat(error.getMessage()).contains("data is not buffered successfully for retry");
+    }
+
+    @Test
+    void subscribe_resubscribeAfterClose_shouldSendError() {
+        byte[] data = RandomStringUtils.randomAscii(1024).getBytes(StandardCharsets.UTF_8);
+        requestBody.send(ByteBuffer.wrap(data));
+        requestBody.complete();
+
+        Flowable.fromPublisher(requestBody).forEach(buffer -> {});
+
+        requestBody.close();
+        Subscriber<ByteBuffer> secondSubscriber = mock(Subscriber.class);
+        requestBody.subscribe(secondSubscriber);
+
+        ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+        verify(secondSubscriber).onSubscribe(subscriptionCaptor.capture());
+
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(secondSubscriber).onError(errorCaptor.capture());
+
+        Throwable error = errorCaptor.getValue();
+        assertThat(error).isInstanceOf(NonRetryableException.class);
+        assertThat(error.getMessage()).contains("data is not buffered successfully for retry");
+    }
+
+    @Test
+    void close_shouldInvokeOnNumBytesConsumed() {
+        ByteBuffer data = ByteBuffer.wrap("test data".getBytes());
+        requestBody.send(data);
+        
+        requestBody.close();
+        
+        verify(onNumBytesConsumed).accept(9L);
+    }
+
+    @Test
+    void receivedBytesLength_shouldTrackSentData() {
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(0L);
+        
+        ByteBuffer data1 = ByteBuffer.wrap("hello".getBytes());
+        requestBody.send(data1);
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(5L);
+        
+        ByteBuffer data2 = ByteBuffer.wrap(" world".getBytes());
+        requestBody.send(data2);
+        assertThat(requestBody.receivedBytesLength()).isEqualTo(11L);
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/SplittingPublisherTestUtils.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/SplittingPublisherTestUtils.java
@@ -15,23 +15,16 @@
 
 package software.amazon.awssdk.core.internal.async;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
-import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.assertj.core.api.Assertions;
-import org.reactivestreams.Publisher;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.async.SdkPublisher;
-import software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer;
-import software.amazon.awssdk.core.internal.async.SplittingPublisherTest;
 
 public final class SplittingPublisherTestUtils {
 
@@ -45,6 +38,11 @@ public final class SplittingPublisherTestUtils {
             ByteArrayAsyncResponseTransformer.BaosSubscriber subscriber =
                 new ByteArrayAsyncResponseTransformer.BaosSubscriber(baosFuture);
             requestBody.subscribe(subscriber);
+            baosFuture.whenComplete((baos, throwable) -> {
+                if (requestBody instanceof CloseableAsyncRequestBody) {
+                    ((CloseableAsyncRequestBody) requestBody).close();
+                }
+            });
             futures.add(baosFuture);
         }).get(5, TimeUnit.SECONDS);
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
@@ -34,6 +34,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.async.listener.PublisherListener;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -47,7 +48,7 @@ import software.amazon.awssdk.utils.NumericUtils;
 import software.amazon.awssdk.utils.Pair;
 
 @SdkInternalApi
-public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<AsyncRequestBody>  {
+public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<CloseableAsyncRequestBody>  {
 
     private static final Logger log = Logger.loggerFor(KnownContentLengthAsyncRequestBodySubscriber.class);
 
@@ -144,16 +145,21 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     }
 
     @Override
-    public void onNext(AsyncRequestBody asyncRequestBody) {
+    public void onNext(CloseableAsyncRequestBody asyncRequestBody) {
         if (isPaused || isDone) {
             return;
         }
 
         int currentPartNum = partNumber.getAndIncrement();
+
+        log.debug(() -> String.format("Received asyncRequestBody for part number %d with length %s", currentPartNum,
+                                      asyncRequestBody.contentLength()));
+
         if (existingParts.containsKey(currentPartNum)) {
             asyncRequestBody.subscribe(new CancelledSubscriber<>());
-            subscription.request(1);
             asyncRequestBody.contentLength().ifPresent(progressListener::subscriberOnNext);
+            asyncRequestBody.close();
+            subscription.request(1);
             return;
         }
 
@@ -178,10 +184,12 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
         multipartUploadHelper.sendIndividualUploadPartRequest(uploadId, completedPartConsumer, futures,
                                                               Pair.of(uploadRequest, asyncRequestBody), progressListener)
                              .whenComplete((r, t) -> {
+                                 asyncRequestBody.close();
                                  if (t != null) {
                                      if (shouldFailRequest()) {
                                          multipartUploadHelper.failRequestsElegantly(futures, t, uploadId, returnFuture,
                                                                                      putObjectRequest);
+                                         subscription.cancel();
                                      }
                                  } else {
                                      completeMultipartUploadIfFinished(asyncRequestBodyInFlight.decrementAndGet());
@@ -206,7 +214,7 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
         }
 
         if (currentPartSize != partSize) {
-            return Optional.of(contentLengthMismatchForPart(partSize, currentPartSize));
+            return Optional.of(contentLengthMismatchForPart(partSize, currentPartSize, currentPartNum));
         }
         return Optional.empty();
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartUploadHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartUploadHelper.java
@@ -162,11 +162,12 @@ public final class MultipartUploadHelper {
         return SdkClientException.create("Content length is missing on the AsyncRequestBody for part number " + currentPartNum);
     }
 
-    static SdkClientException contentLengthMismatchForPart(long expected, long actual) {
+    static SdkClientException contentLengthMismatchForPart(long expected, long actual, int partNum) {
         return SdkClientException.create(String.format("Content length must not be greater than "
-                                                       + "part size. Expected: %d, Actual: %d",
+                                                       + "part size. Expected: %d, Actual: %d, partNum: %d",
                                                        expected,
-                                                       actual));
+                                                       actual,
+                                                       partNum));
     }
 
     static SdkClientException partNumMismatch(int expectedNumParts, int actualNumParts) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithKnownContentLengthHelper.java
@@ -186,8 +186,8 @@ public final class UploadWithKnownContentLengthHelper {
         attachSubscriberToObservable(subscriber, mpuRequestContext.request().left());
 
         mpuRequestContext.request().right()
-            .split(b -> b.chunkSizeInBytes(mpuRequestContext.partSize())
-                         .bufferSizeInBytes(maxMemoryUsageInBytes))
+            .splitCloseable(b -> b.chunkSizeInBytes(mpuRequestContext.partSize())
+                                  .bufferSizeInBytes(maxMemoryUsageInBytes))
             .subscribe(subscriber);
     }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -25,11 +24,9 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -39,9 +36,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -60,7 +57,7 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     private static final int TOTAL_NUM_PARTS = 4;
     private static final String UPLOAD_ID = "1234";
     private static RandomTempFile testFile;
-    
+
     private AsyncRequestBody asyncRequestBody;
     private PutObjectRequest putObjectRequest;
     private S3AsyncClient s3AsyncClient;
@@ -114,7 +111,7 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     void validateLastPartSize_withIncorrectSize_shouldFailRequest() {
         long expectedLastPartSize = MPU_CONTENT_SIZE % PART_SIZE;
         long incorrectLastPartSize = expectedLastPartSize + 1;
-        
+
         KnownContentLengthAsyncRequestBodySubscriber lastPartSubscriber = createSubscriber(createDefaultMpuRequestContext());
         lastPartSubscriber.onSubscribe(subscription);
 
@@ -130,12 +127,12 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     @Test
     void validateTotalPartNum_receivedMoreParts_shouldFail() {
         long expectedLastPartSize = MPU_CONTENT_SIZE % PART_SIZE;
-        
+
         KnownContentLengthAsyncRequestBodySubscriber lastPartSubscriber = createSubscriber(createDefaultMpuRequestContext());
         lastPartSubscriber.onSubscribe(subscription);
 
         for (int i = 0; i < TOTAL_NUM_PARTS - 1; i++) {
-            AsyncRequestBody regularPart = createMockAsyncRequestBody(PART_SIZE);
+            CloseableAsyncRequestBody regularPart = createMockAsyncRequestBody(PART_SIZE);
             when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(null));
             lastPartSubscriber.onNext(regularPart);
@@ -157,7 +154,7 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         subscriber.onSubscribe(subscription);
 
         for (int i = 0; i < TOTAL_NUM_PARTS - 1; i++) {
-            AsyncRequestBody regularPart = createMockAsyncRequestBody(PART_SIZE);
+            CloseableAsyncRequestBody regularPart = createMockAsyncRequestBody(PART_SIZE);
             when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(null));
             subscriber.onNext(regularPart);
@@ -175,7 +172,7 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     void pause_withOngoingCompleteMpuFuture_shouldReturnTokenAndCancelFuture() {
         CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture = new CompletableFuture<>();
         int numExistingParts = 2;
-        
+
         S3ResumeToken resumeToken = testPauseScenario(numExistingParts, completeMpuFuture);
 
         verifyResumeToken(resumeToken, numExistingParts);
@@ -187,7 +184,7 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture =
             CompletableFuture.completedFuture(CompleteMultipartUploadResponse.builder().build());
         int numExistingParts = 2;
-        
+
         S3ResumeToken resumeToken = testPauseScenario(numExistingParts, completeMpuFuture);
 
         assertThat(resumeToken).isNull();
@@ -196,15 +193,15 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
     @Test
     void pause_withUninitiatedCompleteMpuFuture_shouldReturnToken() {
         int numExistingParts = 2;
-        
+
         S3ResumeToken resumeToken = testPauseScenario(numExistingParts, null);
 
         verifyResumeToken(resumeToken, numExistingParts);
     }
-    
-    private S3ResumeToken testPauseScenario(int numExistingParts, 
+
+    private S3ResumeToken testPauseScenario(int numExistingParts,
                                            CompletableFuture<CompleteMultipartUploadResponse> completeMpuFuture) {
-        KnownContentLengthAsyncRequestBodySubscriber subscriber = 
+        KnownContentLengthAsyncRequestBodySubscriber subscriber =
             createSubscriber(createMpuRequestContextWithExistingParts(numExistingParts));
 
         when(multipartUploadHelper.completeMultipartUpload(any(CompletableFuture.class), any(String.class),
@@ -246,14 +243,14 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         return new KnownContentLengthAsyncRequestBodySubscriber(mpuRequestContext, returnFuture, multipartUploadHelper);
     }
 
-    private AsyncRequestBody createMockAsyncRequestBody(long contentLength) {
-        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+    private CloseableAsyncRequestBody createMockAsyncRequestBody(long contentLength) {
+        CloseableAsyncRequestBody mockBody = mock(CloseableAsyncRequestBody.class);
         when(mockBody.contentLength()).thenReturn(Optional.of(contentLength));
         return mockBody;
     }
 
-    private AsyncRequestBody createMockAsyncRequestBodyWithEmptyContentLength() {
-        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+    private CloseableAsyncRequestBody createMockAsyncRequestBodyWithEmptyContentLength() {
+        CloseableAsyncRequestBody mockBody = mock(CloseableAsyncRequestBody.class);
         when(mockBody.contentLength()).thenReturn(Optional.empty());
         return mockBody;
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
@@ -26,11 +26,9 @@ import static software.amazon.awssdk.services.s3.internal.multipart.MpuTestUtils
 import static software.amazon.awssdk.services.s3.internal.multipart.MpuTestUtils.stubSuccessfulCreateMultipartCall;
 import static software.amazon.awssdk.services.s3.internal.multipart.MpuTestUtils.stubSuccessfulUploadPartCalls;
 
-import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -46,18 +44,17 @@ import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.testutils.RandomTempFile;
-import software.amazon.awssdk.utils.StringInputStream;
 
 public class UploadWithUnknownContentLengthHelperTest {
     private static final String BUCKET = "bucket";
@@ -114,14 +111,14 @@ public class UploadWithUnknownContentLengthHelperTest {
 
     @Test
     void uploadObject_withMissingContentLength_shouldFailRequest() {
-        AsyncRequestBody asyncRequestBody = createMockAsyncRequestBodyWithEmptyContentLength();
+        CloseableAsyncRequestBody asyncRequestBody = createMockAsyncRequestBodyWithEmptyContentLength();
         CompletableFuture<PutObjectResponse> future = setupAndTriggerUploadFailure(asyncRequestBody);
         verifyFailureWithMessage(future, "Content length is missing on the AsyncRequestBody for part number");
     }
 
     @Test
     void uploadObject_withPartSizeExceedingLimit_shouldFailRequest() {
-        AsyncRequestBody asyncRequestBody = createMockAsyncRequestBody(PART_SIZE + 1);
+        CloseableAsyncRequestBody asyncRequestBody = createMockAsyncRequestBody(PART_SIZE + 1);
         CompletableFuture<PutObjectResponse> future = setupAndTriggerUploadFailure(asyncRequestBody);
         verifyFailureWithMessage(future, "Content length must not be greater than part size");
     }
@@ -139,27 +136,27 @@ public class UploadWithUnknownContentLengthHelperTest {
                 .collect(Collectors.toList());
     }
 
-    private AsyncRequestBody createMockAsyncRequestBody(long contentLength) {
-        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+    private CloseableAsyncRequestBody createMockAsyncRequestBody(long contentLength) {
+        CloseableAsyncRequestBody mockBody = mock(CloseableAsyncRequestBody.class);
         when(mockBody.contentLength()).thenReturn(Optional.of(contentLength));
         return mockBody;
     }
 
-    private AsyncRequestBody createMockAsyncRequestBodyWithEmptyContentLength() {
-        AsyncRequestBody mockBody = mock(AsyncRequestBody.class);
+    private CloseableAsyncRequestBody createMockAsyncRequestBodyWithEmptyContentLength() {
+        CloseableAsyncRequestBody mockBody = mock(CloseableAsyncRequestBody.class);
         when(mockBody.contentLength()).thenReturn(Optional.empty());
         return mockBody;
     }
 
-    private CompletableFuture<PutObjectResponse> setupAndTriggerUploadFailure(AsyncRequestBody asyncRequestBody) {
-        SdkPublisher<AsyncRequestBody> mockPublisher = mock(SdkPublisher.class);
-        when(asyncRequestBody.split(any(Consumer.class))).thenReturn(mockPublisher);
+    private CompletableFuture<PutObjectResponse> setupAndTriggerUploadFailure(CloseableAsyncRequestBody asyncRequestBody) {
+        SdkPublisher<CloseableAsyncRequestBody> mockPublisher = mock(SdkPublisher.class);
+        when(asyncRequestBody.splitCloseable(any(Consumer.class))).thenReturn(mockPublisher);
 
-        ArgumentCaptor<Subscriber<AsyncRequestBody>> subscriberCaptor = ArgumentCaptor.forClass(Subscriber.class);
+        ArgumentCaptor<Subscriber<CloseableAsyncRequestBody>> subscriberCaptor = ArgumentCaptor.forClass(Subscriber.class);
         CompletableFuture<PutObjectResponse> future = helper.uploadObject(createPutObjectRequest(), asyncRequestBody);
 
         verify(mockPublisher).subscribe(subscriberCaptor.capture());
-        Subscriber<AsyncRequestBody> subscriber = subscriberCaptor.getValue();
+        Subscriber<CloseableAsyncRequestBody> subscriber = subscriberCaptor.getValue();
 
         Subscription subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);

--- a/services/s3/src/test/resources/log4j2.properties
+++ b/services/s3/src/test/resources/log4j2.properties
@@ -36,3 +36,6 @@ rootLogger.appenderRef.stdout.ref = ConsoleAppender
 #
 #logger.netty.name = io.netty.handler.logging
 #logger.netty.level = debug
+
+#logger.multipart.name = software.amazon.awssdk.services.s3.internal.multipart
+#logger.multipart.level = debug

--- a/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/CodingConventionWithSuppressionTest.java
+++ b/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/CodingConventionWithSuppressionTest.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.internal.async.RetryableSubAsyncRequestBody;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.metrics.publishers.emf.EmfMetricLoggingPublisher;
@@ -52,7 +53,8 @@ public class CodingConventionWithSuppressionTest {
                       ArchUtils.classNameToPattern(MakeHttpRequestStage.class),
                       ArchUtils.classNameToPattern("software.amazon.awssdk.services.s3.internal.crt.S3CrtResponseHandlerAdapter"),
                       ArchUtils.classNameToPattern(
-                          "software.amazon.awssdk.services.s3.internal.crt.CrtResponseFileResponseTransformer")));
+                          "software.amazon.awssdk.services.s3.internal.crt.CrtResponseFileResponseTransformer"),
+                      ArchUtils.classNameToPattern(RetryableSubAsyncRequestBody.class)));
 
     private static final Set<Pattern> ALLOWED_ERROR_LOG_SUPPRESSION = new HashSet<>(
         Arrays.asList(


### PR DESCRIPTION
## Motivation and Context

Currently retry is not supported for putObject operation in S3 multipart client if a non-file based AsyncRequestBody is configured. When a retry is attempted, the following error will be thrown. See 
https://github.com/aws/aws-sdk-java-v2/issues/6198  
```
 A retry was attempted, but AsyncRequestBody.split does not support retries.
```
This pull request adds support retries for individual parts of a multipart upload in S3 multipart client through a new API: `BufferedSplittableAsyncRequestBody`

Code Example:

```java
AsyncRequestBody originalBody = AsyncRequestBody.fromString("Hello World");

BufferedSplittableAsyncRequestBody retryableBody =
    BufferedSplittableAsyncRequestBody.create(originalBody);

s3Client.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), retryableBody).join();
```

## Modifications
The changes have been reviewed previously in #6313 and #6346