### PR TITLE
Maven Central Migration

### DIFF
--- a/archetypes/archetype-tools/pom.xml
+++ b/archetypes/archetype-tools/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>archetype-tools</artifactId>
-
+    <name>AWS Java SDK :: Archetype Tools</name>
     <dependencies>
         <!-- Depends on the artifacts of all services to generate serviceMapping.vm -->
         <dependency>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>bom-internal</artifactId>
-
+    <name>AWS Java SDK :: Bill of Materials Internal</name>
     <dependencyManagement>
         <dependencies>
             <!-- Non-Test Dependencies -->

--- a/buildspecs/release-to-maven-central.yml
+++ b/buildspecs/release-to-maven-central.yml
@@ -21,9 +21,9 @@ phases:
   build:
     commands:
       - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
-      - SONATYPE_URL="https://repo1.maven.org/maven2/software/amazon/awssdk/aws-sdk-java/$RELEASE_VERSION/"
+      - ARTIFACT_URL="https://repo1.maven.org/maven2/software/amazon/awssdk/aws-sdk-java/$RELEASE_VERSION/"
       - |
-        if ! curl -f --head $SONATYPE_URL; then
+        if ! curl -f --head $ARTIFACT_URL; then
           SONATYPE_USERNAME=`aws secretsmanager get-secret-value --secret-id $SONATYPE_USERNAME_ARN --query SecretString --output text`
           SONATYPE_PASSWORD=`aws secretsmanager get-secret-value --secret-id $SONATYPE_PASSWORD_ARN --query SecretString --output text`
           SDK_SIGNING_GPG_KEYNAME=`aws secretsmanager get-secret-value --secret-id $SDK_SIGNING_GPG_KEYNAME_ARN --query SecretString --output text`

--- a/buildspecs/release-to-maven-central.yml
+++ b/buildspecs/release-to-maven-central.yml
@@ -48,7 +48,7 @@ phases:
             STAGING_SIZE_MB=$(du -sm target/central-staging | cut -f1)
             aws cloudwatch put-metric-data \
               --namespace "AwsJavaSdkRelease" \
-              --metric-data MetricName=StagingFolderSize,Value=$STAGING_SIZE_MB,Unit=Megabytes,Dimensions=Name=ReleaseVersion,Value=$RELEASE_VERSION
+              --metric-data "MetricName=StagingFolderSize,Value=$STAGING_SIZE_MB,Unit=Megabytes,Dimensions=[{Name=ReleaseVersion,Value=$RELEASE_VERSION}]"
           else
             echo "Staging folder target/central-staging not found"
           fi

--- a/buildspecs/release-to-maven-central.yml
+++ b/buildspecs/release-to-maven-central.yml
@@ -2,6 +2,8 @@ version: 0.2
 
 phases:
   install:
+    runtime-versions:
+      java: corretto8
     commands:
       - pip install awscli --upgrade --user
 

--- a/buildspecs/release-to-maven-central.yml
+++ b/buildspecs/release-to-maven-central.yml
@@ -48,7 +48,7 @@ phases:
             STAGING_SIZE_MB=$(du -sm target/central-staging | cut -f1)
             aws cloudwatch put-metric-data \
               --namespace "AwsJavaSdkRelease" \
-              --metric-data "MetricName=StagingFolderSize,Value=$STAGING_SIZE_MB,Unit=Megabytes,Dimensions=[{Name=ReleaseVersion,Value=$RELEASE_VERSION}]"
+              --metric-data "MetricName=StagingFolderSize,Value=$STAGING_SIZE_MB,Unit=Megabytes"
           else
             echo "Staging folder target/central-staging not found"
           fi

--- a/buildspecs/release-to-maven-central.yml
+++ b/buildspecs/release-to-maven-central.yml
@@ -1,0 +1,57 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - pip install awscli --upgrade --user
+
+  pre_build:
+    commands:
+      - ROOT=`pwd`
+      - SETTINGS_XML_TEMPLATE=buildspecs/resources/maven-central-release-settings.xml
+      - SETTINGS_XML=release-settings-final.xml
+      - SDK_SIGNING_GPG_SECRING=secring.gpg
+      - SDK_SIGNING_GPG_SECRING_ARN="arn:aws:secretsmanager:us-east-1:103431983078:secret:sdk-signing-gpg-secret-ring-9d0YXc"
+      - SDK_SIGNING_GPG_KEYNAME_ARN="arn:aws:secretsmanager:us-east-1:103431983078:secret:sdk-signing-gpg-keyname-wFsOOg"
+      - SDK_SIGNING_GPG_PASSPHRASE_ARN="arn:aws:secretsmanager:us-east-1:103431983078:secret:sdk-signing-gpg-passphrase-A0H1Kq"
+      - SONATYPE_PASSWORD_ARN="arn:aws:secretsmanager:us-east-1:103431983078:secret:maven-central-publishing-password-yktnUc"
+      - SONATYPE_USERNAME_ARN="arn:aws:secretsmanager:us-east-1:103431983078:secret:maven-central-publishing-username-RDvOnW"
+      - MODULES_TO_SKIP="protocol-tests,protocol-tests-core,codegen-generated-classes-test,sdk-benchmarks,module-path-tests,tests-coverage-reporting,stability-tests,sdk-native-image-test,auth-tests,s3-benchmarks,http-client-benchmarks,region-testing,old-client-version-compatibility-test,crt-unavailable-tests,bundle-shading-tests,v2-migration-tests,architecture-tests,s3-tests"
+
+  build:
+    commands:
+      - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
+      - SONATYPE_URL="https://repo1.maven.org/maven2/software/amazon/awssdk/aws-sdk-java/$RELEASE_VERSION/"
+      - |
+        if ! curl -f --head $SONATYPE_URL; then
+          SONATYPE_USERNAME=`aws secretsmanager get-secret-value --secret-id $SONATYPE_USERNAME_ARN --query SecretString --output text`
+          SONATYPE_PASSWORD=`aws secretsmanager get-secret-value --secret-id $SONATYPE_PASSWORD_ARN --query SecretString --output text`
+          SDK_SIGNING_GPG_KEYNAME=`aws secretsmanager get-secret-value --secret-id $SDK_SIGNING_GPG_KEYNAME_ARN --query SecretString --output text`
+          SDK_SIGNING_GPG_PASSPHRASE=`aws secretsmanager get-secret-value --secret-id $SDK_SIGNING_GPG_PASSPHRASE_ARN --query SecretString --output text`
+          aws secretsmanager get-secret-value --secret-id  $SDK_SIGNING_GPG_SECRING_ARN --query SecretBinary --output text | base64 -d > $SDK_SIGNING_GPG_SECRING
+          gpg --passphrase $SDK_SIGNING_GPG_PASSPHRASE --batch --import $SDK_SIGNING_GPG_SECRING
+
+          cat $SETTINGS_XML_TEMPLATE | \
+            awk 'BEGIN { var=ENVIRON["SONATYPE_USERNAME"] } { gsub("\\$SONATYPE_USERNAME", var, $0); print }' | \
+            awk 'BEGIN { var=ENVIRON["SONATYPE_PASSWORD"] } { gsub("\\$SONATYPE_PASSWORD", var, $0); print }' | \
+            awk 'BEGIN { var=ENVIRON["SDK_SIGNING_GPG_PASSPHRASE"] } { gsub("\\$SDK_SIGNING_GPG_PASSPHRASE", var, $0); print }' | \
+            awk 'BEGIN { var=ENVIRON["SDK_SIGNING_GPG_KEYNAME"] } { gsub("\\$SDK_SIGNING_GPG_KEYNAME", var, $0); print }' > \
+            $SETTINGS_XML
+
+          # Convert comma-separated list to space-separated list with !: prefix for each module
+          MODULES_TO_SKIP_FORMATTED=$(echo $MODULES_TO_SKIP | sed 's/,/,!:/g' | sed 's/^/!:/')
+          
+          mvn clean deploy -B -s $SETTINGS_XML -Pcentral-portal-publishing -DperformRelease -DautoPublish=true -DdeploymentName="software.amazon.awssdk-$RELEASE_VERSION" -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -DstagingProgressTimeoutMinutes=30 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -pl $MODULES_TO_SKIP_FORMATTED
+
+          # Report staging folder size to CloudWatch
+          if [ -d "/target/central-staging" ]; then
+            STAGING_SIZE_MB=$(du -sm target/central-staging | cut -f1)
+            aws cloudwatch put-metric-data \
+              --namespace "AwsJavaSdkRelease" \
+              --metric-data MetricName=StagingFolderSize,Value=$STAGING_SIZE_KB,Unit=Kilobytes,Dimensions=Name=ReleaseVersion,Value=$RELEASE_VERSION
+          else
+            echo "Staging folder /target/central-staging not found"
+          fi
+        else
+          echo "This version was already released."
+        fi

--- a/buildspecs/release-to-maven-central.yml
+++ b/buildspecs/release-to-maven-central.yml
@@ -2,8 +2,6 @@ version: 0.2
 
 phases:
   install:
-    runtime-versions:
-      java: corretto8
     commands:
       - pip install awscli --upgrade --user
 
@@ -46,13 +44,13 @@ phases:
           mvn clean deploy -B -s $SETTINGS_XML -Pcentral-portal-publishing -DperformRelease -DautoPublish=true -DdeploymentName="software.amazon.awssdk-$RELEASE_VERSION" -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -DstagingProgressTimeoutMinutes=30 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -pl $MODULES_TO_SKIP_FORMATTED
 
           # Report staging folder size to CloudWatch
-          if [ -d "/target/central-staging" ]; then
+          if [ -d "target/central-staging" ]; then
             STAGING_SIZE_MB=$(du -sm target/central-staging | cut -f1)
             aws cloudwatch put-metric-data \
               --namespace "AwsJavaSdkRelease" \
-              --metric-data MetricName=StagingFolderSize,Value=$STAGING_SIZE_KB,Unit=Kilobytes,Dimensions=Name=ReleaseVersion,Value=$RELEASE_VERSION
+              --metric-data MetricName=StagingFolderSize,Value=$STAGING_SIZE_MB,Unit=Megabytes,Dimensions=Name=ReleaseVersion,Value=$RELEASE_VERSION
           else
-            echo "Staging folder /target/central-staging not found"
+            echo "Staging folder target/central-staging not found"
           fi
         else
           echo "This version was already released."

--- a/buildspecs/resources/maven-central-release-settings.xml
+++ b/buildspecs/resources/maven-central-release-settings.xml
@@ -1,0 +1,21 @@
+<settings>
+    <servers>
+        <server>
+            <id>central</id>
+            <username>$SONATYPE_USERNAME</username>
+            <password>$SONATYPE_PASSWORD</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>central-portal-publishing</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.keyname>$SDK_SIGNING_GPG_KEYNAME</gpg.keyname>
+                <gpg.passphrase>$SDK_SIGNING_GPG_PASSPHRASE</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+</settings>

--- a/bundle-sdk/pom.xml
+++ b/bundle-sdk/pom.xml
@@ -238,8 +238,38 @@
     </build>
     
     <profiles>
-        <profile>
+            <profile>
             <id>publishing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <sourcepath>${basedir}/../core/profiles/src/main/java/software/amazon/awssdk/profiles;${basedir}/../core/sdk-core/src/main/java/software/amazon/awssdk/core</sourcepath>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>central-portal-publishing</id>
             <build>
                 <plugins>
                     <plugin>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -90,8 +90,47 @@
            </plugin>
 	</plugins>
     </build>
-
     <profiles>
+        <profile>
+            <id>central-portal-publishing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <sourcepath>${basedir}/../core/profiles/src/main/java/software/amazon/awssdk/profiles;${basedir}/../core/sdk-core/src/main/java/software/amazon/awssdk/core</sourcepath>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <configuration>
+                            <ignoredUnusedDeclaredDependencies>
+                                <ignoredUnusedDeclaredDependency>software.amazon.awssdk:bundle-sdk</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>software.amazon.awssdk:bundle-logging-bridge</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>publishing</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <checkstyle.version>8.42</checkstyle.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
@@ -222,6 +223,16 @@
         </resources>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${central-publishing-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>central</publishingServerId>
+                        <autoPublish>false</autoPublish>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -746,7 +757,74 @@
                 <javadoc.skip>true</javadoc.skip>
             </properties>
         </profile>
-
+        <profile>
+            <id>central-portal-publishing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>generate-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <detectJavaApiLink>false</detectJavaApiLink>
+                                    <source>8</source>
+                                    <notree>true</notree>
+                                    <includeDependencySources>false</includeDependencySources>
+                                    <doclint>none</doclint>
+                                    <excludePackageNames>software.amazon.awssdk.services.*:*.codegen</excludePackageNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--batch</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>publishing</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -775,27 +775,6 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven-javadoc-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>generate-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <configuration>
-                                    <detectJavaApiLink>false</detectJavaApiLink>
-                                    <source>8</source>
-                                    <notree>true</notree>
-                                    <includeDependencySources>false</includeDependencySources>
-                                    <doclint>none</doclint>
-                                    <excludePackageNames>software.amazon.awssdk.services.*:*.codegen</excludePackageNames>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>${maven-gpg-plugin.version}</version>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,8 @@
                         <configuration>
                             <gpgArguments>
                                 <arg>--batch</arg>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
                             </gpgArguments>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,9 @@
             </properties>
         </profile>
         <profile>
+            <!-- This is the new maven publishing profile. It's similar to the "publishing" profile except
+            for the fact that it uses the maven central publishing plugin instead of the nexus publishing plugin. 
+            Once OSSRH is disabled we can rename this "publishing", and remove the existing publishing profile -->
             <id>central-portal-publishing</id>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -224,16 +224,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.sonatype.central</groupId>
-                    <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>${central-publishing-maven-plugin.version}</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <publishingServerId>central</publishingServerId>
-                        <autoPublish>false</autoPublish>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
@@ -761,18 +751,6 @@
             <id>central-portal-publishing</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
This PR adds the needed configuration, profile, and buildspec needed to release to maven central.

1. new buildspec file
- Pretty much follows the existing script
- Uses new secrets
- mvn deploy command targerts the new `central-portal-publishing` profile
- Reports deployment size to cloudwatch

2. new settings file used by the buildspec
3. Adding `<name>` tags for the bom internal and archetype tools packages (required by maven central)
4. Added the new profile to the `bundle` and `bundle-sdk` poms to be shaded.
