### PR TITLE
Add thread context package for Lambda runtime interface client support

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -32,6 +32,7 @@
         "s3-transfer-manager": { "packageName": "AwsJavaSdk-S3-TransferManager" },
         "s3-event-notifications": { "packageName": "AwsJavaSdk-S3-EventNotifications" },
         "sdk-core": { "packageName": "AwsJavaSdk-Core" },
+        "thread-context": { "packageName": "AwsJavaSdk-ThreadContext" },
         "url-connection-client": { "packageName": "AwsJavaSdk-HttpClient-UrlConnectionClient" },
         "utils": { "packageName": "AwsJavaSdk-Core-Utils" },
         "imds": { "packageName": "AwsJavaSdk-Imds" },

--- a/.changes/next-release/feature-AWSSDKforJavav2-2e7c0a3.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-2e7c0a3.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Adding a small utility class to store data on thread local that can be used across components."
+}

--- a/aws-sdk-java/pom.xml
+++ b/aws-sdk-java/pom.xml
@@ -815,6 +815,11 @@ Amazon AutoScaling, etc).</description>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>thread-context</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>textract</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -252,6 +252,11 @@
                 <artifactId>endpoints-spi</artifactId>
                 <version>${awsjavasdk.version}</version>
             </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>thread-context</artifactId>
+                <version>${awsjavasdk.version}</version>
+            </dependency>
             <!-- Services -->
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <module>test/crt-unavailable-tests</module>
         <module>test/architecture-tests</module>
         <module>test/s3-tests</module>
+        <module>thread-context</module>
     </modules>
     <scm>
         <url>${scm.github.url}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <module>archetypes</module>
         <module>third-party</module>
         <module>v2-migration</module>
+        <module>thread-context</module>
         <module>test/http-client-tests</module>
         <module>test/protocol-tests</module>
         <module>test/protocol-tests-core</module>
@@ -95,7 +96,6 @@
         <module>test/crt-unavailable-tests</module>
         <module>test/architecture-tests</module>
         <module>test/s3-tests</module>
-        <module>thread-context</module>
     </modules>
     <scm>
         <url>${scm.github.url}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,7 @@
                             <includeModule>protocols</includeModule>
                             <includeModule>regions</includeModule>
                             <includeModule>sdk-core</includeModule>
+                            <includeModule>thread-context</includeModule>
                             <includeModule>http-client-spi</includeModule>
                             <includeModule>apache-client</includeModule>
                             <includeModule>netty-nio-client</includeModule>

--- a/test/architecture-tests/pom.xml
+++ b/test/architecture-tests/pom.xml
@@ -62,6 +62,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <artifactId>thread-context</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>s3</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>

--- a/test/tests-coverage-reporting/pom.xml
+++ b/test/tests-coverage-reporting/pom.xml
@@ -242,6 +242,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <artifactId>thread-context</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
 
         <!-- Need to explicitly add service modules to aggregate the tests coverage
         and a few services that we know with more tests should be sufficient

--- a/thread-context/pom.xml
+++ b/thread-context/pom.xml
@@ -30,4 +30,45 @@
     </description>
     <url>https://aws.amazon.com/sdkforjava</url>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom-internal</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.threadcontext</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/thread-context/pom.xml
+++ b/thread-context/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>aws-sdk-java-pom</artifactId>
+        <version>2.33.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>thread-context</artifactId>
+    <name>AWS Java SDK :: Thread Context</name>
+    <description>
+        Provides thread-local context storage utilities for sharing data across components.
+    </description>
+    <url>https://aws.amazon.com/sdkforjava</url>
+
+</project>

--- a/thread-context/src/main/java/software/amazon/awssdk/threadcontext/ThreadStorage.java
+++ b/thread-context/src/main/java/software/amazon/awssdk/threadcontext/ThreadStorage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.threadcontext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ThreadStorage {
+    private static final ThreadLocal<Map<String, String>> storage = ThreadLocal.withInitial(HashMap::new);
+
+    private ThreadStorage() {}
+
+    public static void put(String key, String value) {
+        storage.get().put(key, value);
+    }
+
+    public static String get(String key) {
+        return storage.get().get(key);
+    }
+
+    public static String remove(String key) {
+        return storage.get().remove(key);
+    }
+
+    public static void clear() {
+        storage.get().clear();
+    }
+
+    public static boolean containsKey(String key) {
+        return storage.get().containsKey(key);
+    }
+}

--- a/thread-context/src/test/java/software/amazon/awssdk/threadcontext/ThreadStorageTest.java
+++ b/thread-context/src/test/java/software/amazon/awssdk/threadcontext/ThreadStorageTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.threadcontext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThreadStorageTest {
+
+    @AfterEach
+    void cleanup() {
+        ThreadStorage.clear();
+    }
+
+    @Test
+    void putAndGet_shouldStoreAndRetrieveValue() {
+        ThreadStorage.put("test-key", "test-value");
+        
+        assertThat(ThreadStorage.get("test-key")).isEqualTo("test-value");
+    }
+
+    @Test
+    void get_withNonExistentKey_shouldReturnNull() {
+        assertThat(ThreadStorage.get("non-existent")).isNull();
+    }
+
+    @Test
+    void put_withValidKeyValue_shouldStoreValue() {
+        ThreadStorage.put("test-key", "test-value");
+        
+        String removed = ThreadStorage.remove("test-key");
+        
+        assertThat(removed).isEqualTo("test-value");
+        assertThat(ThreadStorage.get("test-key")).isNull();
+    }
+
+    @Test
+    void remove_withExistingKey_shouldRemoveAndReturnValue() {
+        ThreadStorage.put("test-key", "test-value");
+        ThreadStorage.put("test-key", null);
+        
+        assertThat(ThreadStorage.get("test-key")).isNull();
+    }
+
+    @Test
+    void clear_withMultipleValues_shouldRemoveAllValues() {
+        ThreadStorage.put("key1", "value1");
+        ThreadStorage.put("key2", "value2");
+        
+        ThreadStorage.clear();
+        
+        assertThat(ThreadStorage.get("key1")).isNull();
+        assertThat(ThreadStorage.get("key2")).isNull();
+    }
+}


### PR DESCRIPTION
This PR adds a new thread-context module that provides thread-local storage utilities for sharing data across components, specifically to support trace ID propagation.

### Background

Previously, we implemented trace ID propagation using SLF4J's MDC in [PR #6363](https://github.com/aws/aws-sdk-java-v2/pull/6363), but this was 
reverted because the MDC interface exists but the implementation is not provided by the SDK, Lambda runtime, or X-Ray SDK.

### Solution

Added a small `ThreadStorage` utility class that provides thread local key value storage using `ThreadLocal<Map<String, String>>`. For this case, it allows the Lambda Runtime Interface Client, AWS SDK, and X-Ray SDK to share trace context via this one package, but can extended to other use cases.

### Example:

```java
ThreadStorage.put("some-value", foo);
String traceId = ThreadStorage.get("some-value");
ThreadStorage.remove("some-value");
ThreadStorage.clear();
```