### PR TITLE
Add ThreadStorage utility class and support for 

### DIFF
--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptorTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptorTest.java
@@ -113,11 +113,11 @@ public class TraceIdExecutionInterceptorTest {
     }
 
     @Test
-    public void modifyHttpRequest_whenMultiConcurrencyModeWithMdc_shouldAddTraceIdHeader() {
+    public void modifyHttpRequest_whenMultiConcurrencyModeWithThreadStorage_shouldAddTraceIdHeader() {
         EnvironmentVariableHelper.run(env -> {
             resetRelevantEnvVars(env);
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
-            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "ThreadStorage-trace-123");
 
             try {
                 TraceIdExecutionInterceptor interceptor = new TraceIdExecutionInterceptor();
@@ -127,7 +127,7 @@ public class TraceIdExecutionInterceptorTest {
                 Context.ModifyHttpRequest context = context();
 
                 SdkHttpRequest request = interceptor.modifyHttpRequest(context, executionAttributes);
-                assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
             } finally {
                 ThreadStorage.remove("AWS_LAMBDA_X_TRACE_ID");
             }
@@ -135,12 +135,12 @@ public class TraceIdExecutionInterceptorTest {
     }
 
     @Test
-    public void modifyHttpRequest_whenMultiConcurrencyModeWithBothMdcAndSystemProperty_shouldUseMdcValue() {
+    public void modifyHttpRequest_whenMultiConcurrencyModeWithBothThreadStorageAndSystemProperty_shouldUseThreadStorageValue() {
         EnvironmentVariableHelper.run(env -> {
             resetRelevantEnvVars(env);
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
 
-            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "ThreadStorage-trace-123");
             Properties props = System.getProperties();
             props.setProperty("com.amazonaws.xray.traceHeader", "sys-prop-345");
 
@@ -153,7 +153,7 @@ public class TraceIdExecutionInterceptorTest {
                 Context.ModifyHttpRequest context = context();
                 SdkHttpRequest request = interceptor.modifyHttpRequest(context, executionAttributes);
 
-                assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
             } finally {
                 ThreadStorage.remove("AWS_LAMBDA_X_TRACE_ID");
                 props.remove("com.amazonaws.xray.traceHeader");
@@ -162,7 +162,7 @@ public class TraceIdExecutionInterceptorTest {
     }
 
     @Test
-    public void modifyHttpRequest_whenNotInLambdaEnvironmentWithMdc_shouldNotAddHeader() {
+    public void modifyHttpRequest_whenNotInLambdaEnvironmentWithThreadStorage_shouldNotAddHeader() {
         EnvironmentVariableHelper.run(env -> {
             resetRelevantEnvVars(env);
 

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptorTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/TraceIdExecutionInterceptorTest.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.core.interceptor.InterceptorContext;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.ThreadStorage;
 
 public class TraceIdExecutionInterceptorTest {
     @Test
@@ -108,6 +109,78 @@ public class TraceIdExecutionInterceptorTest {
             env.set("_X_AMZN_TRACE_ID", "bar");
             Context.ModifyHttpRequest context = context();
             assertThat(modifyHttpRequest(context)).isSameAs(context.httpRequest());
+        });
+    }
+
+    @Test
+    public void modifyHttpRequest_whenMultiConcurrencyModeWithMdc_shouldAddTraceIdHeader() {
+        EnvironmentVariableHelper.run(env -> {
+            resetRelevantEnvVars(env);
+            env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+
+            try {
+                TraceIdExecutionInterceptor interceptor = new TraceIdExecutionInterceptor();
+                ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+                interceptor.beforeExecution(null, executionAttributes);
+                Context.ModifyHttpRequest context = context();
+
+                SdkHttpRequest request = interceptor.modifyHttpRequest(context, executionAttributes);
+                assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+            } finally {
+                ThreadStorage.remove("AWS_LAMBDA_X_TRACE_ID");
+            }
+        });
+    }
+
+    @Test
+    public void modifyHttpRequest_whenMultiConcurrencyModeWithBothMdcAndSystemProperty_shouldUseMdcValue() {
+        EnvironmentVariableHelper.run(env -> {
+            resetRelevantEnvVars(env);
+            env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
+
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+            Properties props = System.getProperties();
+            props.setProperty("com.amazonaws.xray.traceHeader", "sys-prop-345");
+
+            try {
+                TraceIdExecutionInterceptor interceptor = new TraceIdExecutionInterceptor();
+                ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+                interceptor.beforeExecution(null, executionAttributes);
+
+                Context.ModifyHttpRequest context = context();
+                SdkHttpRequest request = interceptor.modifyHttpRequest(context, executionAttributes);
+
+                assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+            } finally {
+                ThreadStorage.remove("AWS_LAMBDA_X_TRACE_ID");
+                props.remove("com.amazonaws.xray.traceHeader");
+            }
+        });
+    }
+
+    @Test
+    public void modifyHttpRequest_whenNotInLambdaEnvironmentWithMdc_shouldNotAddHeader() {
+        EnvironmentVariableHelper.run(env -> {
+            resetRelevantEnvVars(env);
+
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "should-be-ignored");
+
+            try {
+                TraceIdExecutionInterceptor interceptor = new TraceIdExecutionInterceptor();
+                ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+                interceptor.beforeExecution(null, executionAttributes);
+
+                Context.ModifyHttpRequest context = context();
+                SdkHttpRequest request = interceptor.modifyHttpRequest(context, executionAttributes);
+
+                assertThat(request.firstMatchingHeader("X-Amzn-Trace-Id")).isEmpty();
+            } finally {
+                ThreadStorage.remove("AWS_LAMBDA_X_TRACE_ID");
+            }
         });
     }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/TraceIdTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/TraceIdTest.java
@@ -17,17 +17,25 @@ package software.amazon.awssdk.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.awscore.interceptor.TraceIdExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
 import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
 import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.ThreadStorage;
 
 /**
  * Verifies that the {@link TraceIdExecutionInterceptor} is actually wired up for AWS services.
@@ -56,4 +64,182 @@ public class TraceIdTest {
             }
         });
     }
+
+    @Test
+    public void traceIdInterceptorPreservesTraceIdAcrossRetries() {
+        EnvironmentVariableHelper.run(env -> {
+            env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+
+            try (MockAsyncHttpClient mockHttpClient = new MockAsyncHttpClient();
+                 ProtocolRestJsonAsyncClient client = ProtocolRestJsonAsyncClient.builder()
+                                                                                 .region(Region.US_WEST_2)
+                                                                                 .credentialsProvider(AnonymousCredentialsProvider.create())
+                                                                                 .httpClient(mockHttpClient)
+                                                                                 .build()) {
+
+                mockHttpClient.stubResponses(
+                    HttpExecuteResponse.builder()
+                                       .response(SdkHttpResponse.builder().statusCode(500).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build(),
+                    HttpExecuteResponse.builder()
+                                       .response(SdkHttpResponse.builder().statusCode(500).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build(),
+                    HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(200).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build());
+
+                client.allTypes().join();
+
+                List<SdkHttpRequest> requests = mockHttpClient.getRequests();
+                assertThat(requests).hasSize(3);
+
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(2).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+
+            } finally {
+                ThreadStorage.clear();
+            }
+        });
+    }
+
+    @Test
+    public void traceIdInterceptorPreservesTraceIdAcrossChainedFutures() {
+        EnvironmentVariableHelper.run(env -> {
+            env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+
+            try (MockAsyncHttpClient mockHttpClient = new MockAsyncHttpClient();
+                 ProtocolRestJsonAsyncClient client = ProtocolRestJsonAsyncClient.builder()
+                                                                                 .region(Region.US_WEST_2)
+                                                                                 .credentialsProvider(AnonymousCredentialsProvider.create())
+                                                                                 .httpClient(mockHttpClient)
+                                                                                 .build()) {
+
+                mockHttpClient.stubResponses(
+                    HttpExecuteResponse.builder()
+                                       .response(SdkHttpResponse.builder().statusCode(200).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build(),
+                    HttpExecuteResponse.builder()
+                                       .response(SdkHttpResponse.builder().statusCode(200).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build()
+                );
+
+                client.allTypes()
+                      .thenRun(() -> {
+                          client.allTypes().join();
+                      })
+                      .join();
+
+                List<SdkHttpRequest> requests = mockHttpClient.getRequests();
+
+                assertThat(requests).hasSize(2);
+
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+
+            } finally {
+                ThreadStorage.clear();
+            }
+        });
+    }
+
+    @Test
+    public void traceIdInterceptorPreservesTraceIdAcrossExceptionallyCompletedFutures() {
+        EnvironmentVariableHelper.run(env -> {
+            env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+
+            try (MockAsyncHttpClient mockHttpClient = new MockAsyncHttpClient();
+                 ProtocolRestJsonAsyncClient client = ProtocolRestJsonAsyncClient.builder()
+                                                                                 .region(Region.US_WEST_2)
+                                                                                 .credentialsProvider(AnonymousCredentialsProvider.create())
+                                                                                 .httpClient(mockHttpClient)
+                                                                                 .build()) {
+
+                mockHttpClient.stubResponses(
+                    HttpExecuteResponse.builder()
+                                       .response(SdkHttpResponse.builder().statusCode(400).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build(),
+                    HttpExecuteResponse.builder()
+                                       .response(SdkHttpResponse.builder().statusCode(200).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build()
+                );
+
+                client.allTypes()
+                      .exceptionally(throwable -> {
+                          client.allTypes().join();
+                          return null;
+                      }).join();
+
+                List<SdkHttpRequest> requests = mockHttpClient.getRequests();
+
+                assertThat(requests).hasSize(2);
+
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+
+            } finally {
+                ThreadStorage.clear();
+            }
+        });
+    }
+
+    @Test
+    public void traceIdInterceptorPreservesTraceIdAcrossExceptionallyCompletedFuturesThrownInPreExecution() {
+        EnvironmentVariableHelper.run(env -> {
+            env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+
+            ExecutionInterceptor throwingInterceptor = new ExecutionInterceptor() {
+                private boolean hasThrown = false;
+
+                @Override
+                public void beforeMarshalling(Context.BeforeMarshalling context, ExecutionAttributes executionAttributes) {
+                    if (!hasThrown) {
+                        hasThrown = true;
+                        throw new RuntimeException("failing in pre execution");
+                    }
+                }
+            };
+
+            try (MockAsyncHttpClient mockHttpClient = new MockAsyncHttpClient();
+                 ProtocolRestJsonAsyncClient client = ProtocolRestJsonAsyncClient.builder()
+                                                                                 .region(Region.US_WEST_2)
+                                                                                 .credentialsProvider(AnonymousCredentialsProvider.create())
+                                                                                 .overrideConfiguration(o -> o.addExecutionInterceptor(throwingInterceptor))
+                                                                                 .httpClient(mockHttpClient)
+                                                                                 .build()) {
+
+                mockHttpClient.stubResponses(
+                    HttpExecuteResponse.builder()
+                                       .response(SdkHttpResponse.builder().statusCode(200).build())
+                                       .responseBody(AbortableInputStream.create(new StringInputStream("{}")))
+                                       .build()
+                );
+
+                client.allTypes()
+                      .exceptionally(throwable -> {
+                          client.allTypes().join();
+                          return null;
+                      }).join();
+
+                List<SdkHttpRequest> requests = mockHttpClient.getRequests();
+
+                assertThat(requests).hasSize(1);
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+
+            } finally {
+                ThreadStorage.clear();
+            }
+        });
+    }
 }
+

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/TraceIdTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/TraceIdTest.java
@@ -69,7 +69,7 @@ public class TraceIdTest {
     public void traceIdInterceptorPreservesTraceIdAcrossRetries() {
         EnvironmentVariableHelper.run(env -> {
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
-            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "ThreadStorage-trace-123");
 
             try (MockAsyncHttpClient mockHttpClient = new MockAsyncHttpClient();
                  ProtocolRestJsonAsyncClient client = ProtocolRestJsonAsyncClient.builder()
@@ -96,9 +96,9 @@ public class TraceIdTest {
                 List<SdkHttpRequest> requests = mockHttpClient.getRequests();
                 assertThat(requests).hasSize(3);
 
-                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
-                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
-                assertThat(requests.get(2).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
+                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
+                assertThat(requests.get(2).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
 
             } finally {
                 ThreadStorage.clear();
@@ -110,7 +110,7 @@ public class TraceIdTest {
     public void traceIdInterceptorPreservesTraceIdAcrossChainedFutures() {
         EnvironmentVariableHelper.run(env -> {
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
-            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "ThreadStorage-trace-123");
 
             try (MockAsyncHttpClient mockHttpClient = new MockAsyncHttpClient();
                  ProtocolRestJsonAsyncClient client = ProtocolRestJsonAsyncClient.builder()
@@ -140,8 +140,8 @@ public class TraceIdTest {
 
                 assertThat(requests).hasSize(2);
 
-                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
-                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
+                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
 
             } finally {
                 ThreadStorage.clear();
@@ -153,7 +153,7 @@ public class TraceIdTest {
     public void traceIdInterceptorPreservesTraceIdAcrossExceptionallyCompletedFutures() {
         EnvironmentVariableHelper.run(env -> {
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
-            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "ThreadStorage-trace-123");
 
             try (MockAsyncHttpClient mockHttpClient = new MockAsyncHttpClient();
                  ProtocolRestJsonAsyncClient client = ProtocolRestJsonAsyncClient.builder()
@@ -183,8 +183,8 @@ public class TraceIdTest {
 
                 assertThat(requests).hasSize(2);
 
-                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
-                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
+                assertThat(requests.get(1).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
 
             } finally {
                 ThreadStorage.clear();
@@ -196,7 +196,7 @@ public class TraceIdTest {
     public void traceIdInterceptorPreservesTraceIdAcrossExceptionallyCompletedFuturesThrownInPreExecution() {
         EnvironmentVariableHelper.run(env -> {
             env.set("AWS_LAMBDA_FUNCTION_NAME", "foo");
-            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "mdc-trace-123");
+            ThreadStorage.put("AWS_LAMBDA_X_TRACE_ID", "ThreadStorage-trace-123");
 
             ExecutionInterceptor throwingInterceptor = new ExecutionInterceptor() {
                 private boolean hasThrown = false;
@@ -234,7 +234,7 @@ public class TraceIdTest {
                 List<SdkHttpRequest> requests = mockHttpClient.getRequests();
 
                 assertThat(requests).hasSize(1);
-                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("mdc-trace-123");
+                assertThat(requests.get(0).firstMatchingHeader("X-Amzn-Trace-Id")).hasValue("ThreadStorage-trace-123");
 
             } finally {
                 ThreadStorage.clear();

--- a/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
@@ -18,11 +18,12 @@ package software.amazon.awssdk.utils;
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
  * Utility for thread-local context storage.
  */
-@SdkInternalApi
+@SdkProtectedApi
 public final class ThreadStorage {
     private static final ThreadLocal<Map<String, String>> STORAGE = ThreadLocal.withInitial(HashMap::new);
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
@@ -24,27 +24,28 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
  */
 @SdkInternalApi
 public final class ThreadStorage {
-    private static final ThreadLocal<Map<String, String>> storage = ThreadLocal.withInitial(HashMap::new);
+    private static final ThreadLocal<Map<String, String>> STORAGE = ThreadLocal.withInitial(HashMap::new);
 
-    private ThreadStorage() {}
+    private ThreadStorage() {
+    }
 
     public static void put(String key, String value) {
-        storage.get().put(key, value);
+        STORAGE.get().put(key, value);
     }
 
     public static String get(String key) {
-        return storage.get().get(key);
+        return STORAGE.get().get(key);
     }
 
     public static String remove(String key) {
-        return storage.get().remove(key);
+        return STORAGE.get().remove(key);
     }
 
     public static void clear() {
-        storage.get().clear();
+        STORAGE.get().clear();
     }
 
     public static boolean containsKey(String key) {
-        return storage.get().containsKey(key);
+        return STORAGE.get().containsKey(key);
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Utility for thread-local context storage.
+ */
+@SdkInternalApi
+public final class ThreadStorage {
+    private static final ThreadLocal<Map<String, String>> storage = ThreadLocal.withInitial(HashMap::new);
+
+    private ThreadStorage() {}
+
+    public static void put(String key, String value) {
+        storage.get().put(key, value);
+    }
+
+    public static String get(String key) {
+        return storage.get().get(key);
+    }
+
+    public static String remove(String key) {
+        return storage.get().remove(key);
+    }
+
+    public static void clear() {
+        storage.get().clear();
+    }
+
+    public static boolean containsKey(String key) {
+        return storage.get().containsKey(key);
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ThreadStorage.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.utils;
 
 import java.util.HashMap;
 import java.util.Map;
-import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**

--- a/utils/src/test/java/software/amazon/awssdk/utils/ThreadStorageTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/ThreadStorageTest.java
@@ -79,24 +79,4 @@ class ThreadStorageTest {
     void containsKey_withNonExistentKey_shouldReturnFalse() {
         assertThat(ThreadStorage.containsKey("non-existent")).isFalse();
     }
-
-    @Test
-    void get_fromDifferentThread_shouldNotShareData() throws InterruptedException {
-        ThreadStorage.put("shared-key", "main-thread-value");
-        
-        Thread otherThread = new Thread(() -> {
-            // Should not see main thread's value
-            assertThat(ThreadStorage.get("shared-key")).isNull();
-            
-            // Set own value
-            ThreadStorage.put("shared-key", "other-thread-value");
-            assertThat(ThreadStorage.get("shared-key")).isEqualTo("other-thread-value");
-        });
-        
-        otherThread.start();
-        otherThread.join();
-        
-        // Main thread should still have its own value
-        assertThat(ThreadStorage.get("shared-key")).isEqualTo("main-thread-value");
-    }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/ThreadStorageTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/ThreadStorageTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThreadStorageTest {
+
+    @AfterEach
+    void cleanup() {
+        ThreadStorage.clear();
+    }
+
+    @Test
+    void put_withValidKeyValue_shouldStoreValue() {
+        ThreadStorage.put("test-key", "test-value");
+        
+        assertThat(ThreadStorage.get("test-key")).isEqualTo("test-value");
+    }
+
+    @Test
+    void get_withNonExistentKey_shouldReturnNull() {
+        assertThat(ThreadStorage.get("non-existent")).isNull();
+    }
+
+    @Test
+    void remove_withExistingKey_shouldRemoveAndReturnValue() {
+        ThreadStorage.put("test-key", "test-value");
+        
+        String removed = ThreadStorage.remove("test-key");
+        
+        assertThat(removed).isEqualTo("test-value");
+        assertThat(ThreadStorage.get("test-key")).isNull();
+    }
+
+    @Test
+    void put_withNullValue_shouldRemoveKey() {
+        ThreadStorage.put("test-key", "test-value");
+        ThreadStorage.put("test-key", null);
+        
+        assertThat(ThreadStorage.get("test-key")).isNull();
+    }
+
+    @Test
+    void clear_withMultipleValues_shouldRemoveAllValues() {
+        ThreadStorage.put("key1", "value1");
+        ThreadStorage.put("key2", "value2");
+        
+        ThreadStorage.clear();
+        
+        assertThat(ThreadStorage.get("key1")).isNull();
+        assertThat(ThreadStorage.get("key2")).isNull();
+    }
+
+    @Test
+    void containsKey_withExistingKey_shouldReturnTrue() {
+        ThreadStorage.put("test-key", "test-value");
+        
+        assertThat(ThreadStorage.containsKey("test-key")).isTrue();
+    }
+
+    @Test
+    void containsKey_withNonExistentKey_shouldReturnFalse() {
+        assertThat(ThreadStorage.containsKey("non-existent")).isFalse();
+    }
+
+    @Test
+    void get_fromDifferentThread_shouldNotShareData() throws InterruptedException {
+        ThreadStorage.put("shared-key", "main-thread-value");
+        
+        Thread otherThread = new Thread(() -> {
+            // Should not see main thread's value
+            assertThat(ThreadStorage.get("shared-key")).isNull();
+            
+            // Set own value
+            ThreadStorage.put("shared-key", "other-thread-value");
+            assertThat(ThreadStorage.get("shared-key")).isEqualTo("other-thread-value");
+        });
+        
+        otherThread.start();
+        otherThread.join();
+        
+        // Main thread should still have its own value
+        assertThat(ThreadStorage.get("shared-key")).isEqualTo("main-thread-value");
+    }
+}


### PR DESCRIPTION
This implementation introduces a new ThreadStorage utility class (which is a wrapper for ThreadLocal), specifically this is used to manage the trace ID `AWS_LAMBDA_X_TraceId` in the traceID execution interceptor. This would be set by the Lambda runtime interface client,  and later used by Xray SDK.