### PR TITLE
Add utils-lite package

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -32,6 +32,7 @@
         "s3-transfer-manager": { "packageName": "AwsJavaSdk-S3-TransferManager" },
         "s3-event-notifications": { "packageName": "AwsJavaSdk-S3-EventNotifications" },
         "sdk-core": { "packageName": "AwsJavaSdk-Core" },
+        "utils-lite": { "packageName": "AwsJavaSdk-UtilsLite" },
         "url-connection-client": { "packageName": "AwsJavaSdk-HttpClient-UrlConnectionClient" },
         "utils": { "packageName": "AwsJavaSdk-Core-Utils" },
         "imds": { "packageName": "AwsJavaSdk-Imds" },

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -214,6 +214,11 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
+                <artifactId>utils-lite</artifactId>
+                <version>${awsjavasdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
                 <artifactId>cloudwatch-metric-publisher</artifactId>
                 <version>${awsjavasdk.version}</version>
             </dependency>

--- a/core/aws-core/pom.xml
+++ b/core/aws-core/pom.xml
@@ -101,11 +101,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>utils-lite</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>retries-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/core/aws-core/pom.xml
+++ b/core/aws-core/pom.xml
@@ -101,6 +101,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils-lite</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>retries-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <module>metric-publishers</module>
         <module>release-scripts</module>
         <module>utils</module>
+        <module>utils-lite</module>
         <module>codegen-lite</module>
         <module>codegen-lite-maven-plugin</module>
         <module>archetypes</module>
@@ -665,6 +666,7 @@
                             <includeModule>cloudwatch-metric-publisher</includeModule>
                             <includeModule>emf-metric-logging-publisher</includeModule>
                             <includeModule>utils</includeModule>
+                            <includeModule>utils-lite</includeModule>
                             <includeModule>imds</includeModule>
                             <includeModule>retries</includeModule>
                             <includeModule>retries-spi</includeModule>

--- a/test/architecture-tests/pom.xml
+++ b/test/architecture-tests/pom.xml
@@ -62,6 +62,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <artifactId>utils-lite</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>s3</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>

--- a/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/UtilsLitePackageTest.java
+++ b/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/UtilsLitePackageTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.archtests;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture tests for the utils-lite package to ensure it only contains allowed classes.
+ */
+public class UtilsLitePackageTest {
+
+    private static final JavaClasses CLASSES = new ClassFileImporter()
+        .importPackages("software.amazon.awssdk.utilslite");
+
+    @Test
+    public void utilsLitePackage_shouldOnlyContainAllowedClasses() {
+        ArchRule rule = classes()
+            .that().resideInAPackage("software.amazon.awssdk.utilslite")
+            .should().haveNameMatching(".*\\.(SdkInternalThreadLocal|SdkInternalThreadLocalTest)")
+            .allowEmptyShould(true)
+            .because("utils-lite package should only contain SdkInternalThreadLocal and its test");
+
+        rule.check(CLASSES);
+    }
+}

--- a/test/http-client-benchmarks/pom.xml
+++ b/test/http-client-benchmarks/pom.xml
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -340,7 +340,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/test/tests-coverage-reporting/pom.xml
+++ b/test/tests-coverage-reporting/pom.xml
@@ -326,6 +326,11 @@
             <artifactId>http-client-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils-lite</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/utils-lite/pom.xml
+++ b/utils-lite/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>aws-sdk-java-pom</artifactId>
+        <version>2.33.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>utils-lite</artifactId>
+    <name>AWS Java SDK :: Utils Lite</name>
+    <description>
+        A package providing minimal external utils.
+    </description>
+    <url>https://aws.amazon.com/sdkforjava</url>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom-internal</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.utilslite</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/utils-lite/src/main/java/software/amazon/awssdk/utilslite/SdkInternalThreadLocal.java
+++ b/utils-lite/src/main/java/software/amazon/awssdk/utilslite/SdkInternalThreadLocal.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utilslite;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * Utility for thread-local context storage.
+ */
+@SdkProtectedApi
+public final class SdkInternalThreadLocal {
+    private static final ThreadLocal<Map<String, String>> STORAGE = ThreadLocal.withInitial(HashMap::new);
+
+    private SdkInternalThreadLocal() {
+    }
+
+    public static void put(String key, String value) {
+        if (value == null) {
+            STORAGE.get().remove(key);
+        } else {
+            STORAGE.get().put(key, value);
+        }
+    }
+
+    public static String get(String key) {
+        return STORAGE.get().get(key);
+    }
+
+    public static String remove(String key) {
+        return STORAGE.get().remove(key);
+    }
+
+    public static void clear() {
+        STORAGE.get().clear();
+    }
+
+    public static boolean containsKey(String key) {
+        return STORAGE.get().containsKey(key);
+    }
+}

--- a/utils-lite/src/test/java/software/amazon/awssdk/utilslite/ThreadStorageTest.java
+++ b/utils-lite/src/test/java/software/amazon/awssdk/utilslite/ThreadStorageTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utilslite;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SdkInternalThreadLocalTest {
+
+    @AfterEach
+    void cleanup() {
+        SdkInternalThreadLocal.clear();
+    }
+
+    @Test
+    void putAndGet_shouldStoreAndRetrieveValue() {
+        SdkInternalThreadLocal.put("test-key", "test-value");
+
+        assertThat(SdkInternalThreadLocal.get("test-key")).isEqualTo("test-value");
+    }
+
+    @Test
+    void get_withNonExistentKey_shouldReturnNull() {
+        assertThat(SdkInternalThreadLocal.get("non-existent")).isNull();
+    }
+
+    @Test
+    void put_withValidKeyValue_shouldStoreValue() {
+        SdkInternalThreadLocal.put("test-key", "test-value");
+
+        String removed = SdkInternalThreadLocal.remove("test-key");
+
+        assertThat(removed).isEqualTo("test-value");
+        assertThat(SdkInternalThreadLocal.get("test-key")).isNull();
+    }
+
+    @Test
+    void remove_withExistingKey_shouldRemoveAndReturnValue() {
+        SdkInternalThreadLocal.put("test-key", "test-value");
+        SdkInternalThreadLocal.put("test-key", null);
+
+        assertThat(SdkInternalThreadLocal.get("test-key")).isNull();
+    }
+
+    @Test
+    void clear_withMultipleValues_shouldRemoveAllValues() {
+        SdkInternalThreadLocal.put("key1", "value1");
+        SdkInternalThreadLocal.put("key2", "value2");
+
+        SdkInternalThreadLocal.clear();
+
+        assertThat(SdkInternalThreadLocal.get("key1")).isNull();
+        assertThat(SdkInternalThreadLocal.get("key2")).isNull();
+    }
+}


### PR DESCRIPTION
This PR adds a new utils-lite code package that provides thread local storage wrapper for sharing data across components, specifically to support lambda trace ID propagation.

### Background

Previously, we implemented trace ID propagation using SLF4J's MDC in [PR #6363](https://github.com/aws/aws-sdk-java-v2/pull/6363), but this was 
reverted because the MDC interface exists but the implementation is not provided by the SDK, Lambda runtime, or X-Ray SDK.

### Solution

Added a small `SdkInternalThreadLocal` utility class that provides thread local key value storage using `ThreadLocal<Map<String, String>>`. For this case, it allows the Lambda Runtime Interface Client, AWS SDK, and X-Ray SDK to share trace context via this one package, but can extended to other use cases.

### Example:

```java
SdkInternalThreadLocal.put("some-value", foo);
String SdkInternalThreadLocal = ThreadStorage.get("some-value");
SdkInternalThreadLocal.remove("some-value");
SdkInternalThreadLocal.clear();
```