### PR TITLE
fix multi line xml tag, and add maven central validation

### DIFF
--- a/.github/workflows/new-module-verification.yml
+++ b/.github/workflows/new-module-verification.yml
@@ -129,7 +129,7 @@ jobs:
               fi
               
               # 2. Check if added to tests-coverage-reporting pom.xml
-              if ! grep -q "<dependency>.*$MODULE_NAME</dependency>" test/tests-coverage-reporting/pom.xml 2>/dev/null; then
+              if ! grep -q "<artifactId>$MODULE_NAME</artifactId>" test/tests-coverage-reporting/pom.xml 2>/dev/null; then
                 echo "::error::Module $MODULE_NAME is not added to tests-coverage-reporting pom.xml"
                 HAS_ERRORS=1
               else
@@ -137,7 +137,7 @@ jobs:
               fi
               
               # 3. Check if added to aws-sdk-java pom.xml
-              if ! grep -q "<dependency>.*$MODULE_NAME</dependency>" aws-sdk-java/pom.xml 2>/dev/null; then
+              if ! grep -q "<artifactId>$MODULE_NAME</artifactId>" aws-sdk-java/pom.xml 2>/dev/null; then
                 echo "::error::Module $MODULE_NAME is not added to aws-sdk-java pom.xml"
                 HAS_ERRORS=1
               else
@@ -145,7 +145,7 @@ jobs:
               fi
               
               # 4. Check if added to architecture-tests pom.xml
-              if ! grep -q "<dependency>.*$MODULE_NAME</dependency>" test/architecture-tests/pom.xml 2>/dev/null; then
+              if ! grep -q "<artifactId>$MODULE_NAME</artifactId>" test/architecture-tests/pom.xml 2>/dev/null; then
                 echo "::error::Module $MODULE_NAME is not added to architecture-tests pom.xml"
                 HAS_ERRORS=1
               else
@@ -176,6 +176,31 @@ jobs:
               else
                 echo "✅ Package name mapping is added in .brazil.json"
               fi
+              
+              # 8. Maven Central validation - Check for required tags
+              echo "Verifying Maven Central requirements..."
+              
+              if ! grep -q "<name>" "$POM_FILE" 2>/dev/null; then
+                echo "::error::Maven Central validation: <name> tag is missing in $POM_FILE"
+                HAS_ERRORS=1
+              else
+                echo "✅ Maven Central validation: <name> tag is present"
+              fi
+              
+              if ! grep -q "<description>" "$POM_FILE" 2>/dev/null; then
+                echo "::error::Maven Central validation: <description> tag is missing in $POM_FILE"
+                HAS_ERRORS=1
+              else
+                echo "✅ Maven Central validation: <description> tag is present"
+              fi
+              
+              if ! grep -q "<url>" "$POM_FILE" 2>/dev/null; then
+                echo "::error::Maven Central validation: <url> tag is missing in $POM_FILE"
+                HAS_ERRORS=1
+              else
+                echo "✅ Maven Central validation: <url> tag is present"
+              fi
+          
               echo "::endgroup::"
             fi
           done


### PR DESCRIPTION
1. fixes `grep -q "<dependency>.*$MODULE_NAME</dependency>"` since it doesnt account for mult-line xml code blocks like:

```
<dependency>
    <groupId>software.amazon.awssdk</groupId>
    <artifactId>utils-lite</artifactId>
    <version>${awsjavasdk.version}</version>
</dependency>
```
Changed to `grep -q "<artifactId>$MODULE_NAME</artifactId>"` , the same validation we have for the bom file.

2. Adds new validations needed for maven central (meta xml tags like name,description and url). This is is super important because it will fail to publish otherwise. We ideally want to catch this stuff in our CI.