### PR TITLE
Reuse computed checksums across retries

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSigner.java
@@ -33,6 +33,7 @@ import static software.amazon.awssdk.http.auth.aws.internal.signer.util.Credenti
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.CredentialUtils.sanitizeCredentials;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.PRESIGN_URL_MAX_EXPIRATION_DURATION;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_TRAILER;
+import static software.amazon.awssdk.http.auth.spi.signer.SdkInternalHttpSignerProperty.CHECKSUM_CACHE;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -47,11 +48,13 @@ import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.internal.signer.Checksummer;
 import software.amazon.awssdk.http.auth.aws.internal.signer.CredentialScope;
+import software.amazon.awssdk.http.auth.aws.internal.signer.NoOpPayloadChecksumStore;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
 import software.amazon.awssdk.http.auth.spi.signer.BaseSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
@@ -70,7 +73,7 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
 
     @Override
     public SignedRequest sign(SignRequest<? extends AwsCredentialsIdentity> request) {
-        Checksummer checksummer = checksummer(request, null);
+        Checksummer checksummer = checksummer(request, null, checksumCache(request));
         V4aProperties v4aProperties = v4aProperties(request);
         AwsSigningConfig signingConfig = signingConfig(request, v4aProperties);
         V4aPayloadSigner payloadSigner = v4aPayloadSigner(request, v4aProperties);
@@ -104,7 +107,7 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
     }
 
     private static V4aPayloadSigner v4aPayloadSigner(
-        BaseSignRequest<?, ? extends AwsCredentialsIdentity> request,
+        SignRequest<? extends AwsCredentialsIdentity> request,
         V4aProperties v4aProperties) {
 
         boolean isPayloadSigning = isPayloadSigning(request);
@@ -117,6 +120,7 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
                                              .credentialScope(v4aProperties.getCredentialScope())
                                              .chunkSize(DEFAULT_CHUNK_SIZE_IN_BYTES)
                                              .checksumAlgorithm(request.property(CHECKSUM_ALGORITHM))
+                                             .checksumCache(checksumCache(request))
                                              .build();
         }
 
@@ -251,5 +255,13 @@ public final class DefaultAwsCrtV4aHttpSigner implements AwsV4aHttpSigner {
             toRequest(request, signingResult.getSignedRequest()).toBuilder(),
             signingResult.getSignature(),
             signingConfig);
+    }
+
+    private static PayloadChecksumStore checksumCache(SignRequest<? extends AwsCredentialsIdentity> request) {
+        PayloadChecksumStore cache = request.property(CHECKSUM_CACHE);
+        if (cache == null) {
+            return NoOpPayloadChecksumStore.create();
+        }
+        return cache;
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/AwsChunkedV4PayloadSigner.java
@@ -45,7 +45,9 @@ import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.SigV
 import software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding.TrailerProvider;
 import software.amazon.awssdk.http.auth.aws.internal.signer.io.ChecksumInputStream;
 import software.amazon.awssdk.http.auth.aws.internal.signer.io.ResettableContentStreamProvider;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Pair;
 import software.amazon.awssdk.utils.Validate;
 
@@ -55,16 +57,20 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkInternalApi
 public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
+    private static final Logger LOG = Logger.loggerFor(AwsChunkedV4PayloadSigner.class);
 
     private final CredentialScope credentialScope;
     private final int chunkSize;
     private final ChecksumAlgorithm checksumAlgorithm;
+    private final PayloadChecksumStore payloadChecksumStore;
     private final List<Pair<String, List<String>>> preExistingTrailers = new ArrayList<>();
 
     private AwsChunkedV4PayloadSigner(Builder builder) {
         this.credentialScope = Validate.paramNotNull(builder.credentialScope, "CredentialScope");
         this.chunkSize = Validate.isPositive(builder.chunkSize, "ChunkSize");
         this.checksumAlgorithm = builder.checksumAlgorithm;
+        this.payloadChecksumStore = builder.payloadChecksumStore == null ? NoOpPayloadChecksumStore.create() :
+                                    builder.payloadChecksumStore;
     }
 
     public static Builder builder() {
@@ -259,22 +265,43 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
         if (checksumAlgorithm == null) {
             return;
         }
+
         String checksumHeaderName = checksumHeaderName(checksumAlgorithm);
+
+        String cachedChecksum = getCachedChecksum();
+
+        if (cachedChecksum != null) {
+            LOG.debug(() -> String.format("Cached payload checksum available for algorithm %s: %s. Using cached value",
+                                          checksumAlgorithm.algorithmId(), checksumHeaderName));
+            builder.addTrailer(() -> Pair.of(checksumHeaderName, Collections.singletonList(cachedChecksum)));
+            return;
+        }
+
         SdkChecksum sdkChecksum = fromChecksumAlgorithm(checksumAlgorithm);
         ChecksumInputStream checksumInputStream = new ChecksumInputStream(
             builder.inputStream(),
             Collections.singleton(sdkChecksum)
         );
 
-        TrailerProvider checksumTrailer = new ChecksumTrailerProvider(sdkChecksum, checksumHeaderName);
+        TrailerProvider checksumTrailer =
+            new ChecksumTrailerProvider(sdkChecksum, checksumHeaderName, checksumAlgorithm, payloadChecksumStore);
 
         builder.inputStream(checksumInputStream).addTrailer(checksumTrailer);
+    }
+
+    private String getCachedChecksum() {
+        byte[] checksumBytes = payloadChecksumStore.getChecksumValue(checksumAlgorithm);
+        if (checksumBytes != null) {
+            return BinaryUtils.toBase64(checksumBytes);
+        }
+        return null;
     }
 
     static class Builder {
         private CredentialScope credentialScope;
         private Integer chunkSize;
         private ChecksumAlgorithm checksumAlgorithm;
+        private PayloadChecksumStore payloadChecksumStore;
 
         public Builder credentialScope(CredentialScope credentialScope) {
             this.credentialScope = credentialScope;
@@ -288,6 +315,11 @@ public final class AwsChunkedV4PayloadSigner implements V4PayloadSigner {
 
         public Builder checksumAlgorithm(ChecksumAlgorithm checksumAlgorithm) {
             this.checksumAlgorithm = checksumAlgorithm;
+            return this;
+        }
+
+        public Builder checksumCache(PayloadChecksumStore payloadChecksumStore) {
+            this.payloadChecksumStore = payloadChecksumStore;
             return this;
         }
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/Checksummer.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/Checksummer.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.utils.BinaryUtils;
 
 /**
@@ -47,8 +48,9 @@ public interface Checksummer {
      * Get a default implementation of a checksummer, which calculates the SHA-256 checksum and places it in the
      * x-amz-content-sha256 header.
      */
-    static Checksummer create() {
+    static Checksummer create(PayloadChecksumStore cache) {
         return new FlexibleChecksummer(
+            cache,
             option().headerName(X_AMZ_CONTENT_SHA256).algorithm(SHA256).formatter(BinaryUtils::toHex).build()
         );
     }
@@ -57,9 +59,10 @@ public interface Checksummer {
      * Get a flexible checksummer that performs two checksums: the given checksum-algorithm and the SHA-256 checksum. It places
      * the SHA-256 checksum in x-amz-content-sha256 header, and the given checksum-algorithm in the x-amz-checksum-[name] header.
      */
-    static Checksummer forFlexibleChecksum(ChecksumAlgorithm checksumAlgorithm) {
+    static Checksummer forFlexibleChecksum(ChecksumAlgorithm checksumAlgorithm, PayloadChecksumStore cache) {
         if (checksumAlgorithm != null) {
             return new FlexibleChecksummer(
+                cache,
                 option().headerName(X_AMZ_CONTENT_SHA256).algorithm(SHA256).formatter(BinaryUtils::toHex)
                         .build(),
                 option().headerName(checksumHeaderName(checksumAlgorithm)).algorithm(checksumAlgorithm)
@@ -82,9 +85,12 @@ public interface Checksummer {
      * given checksum string. It places the precomputed checksum in x-amz-content-sha256 header, and the given checksum-algorithm
      * in the x-amz-checksum-[name] header.
      */
-    static Checksummer forFlexibleChecksum(String precomputedSha256, ChecksumAlgorithm checksumAlgorithm) {
+    static Checksummer forFlexibleChecksum(String precomputedSha256,
+                                           ChecksumAlgorithm checksumAlgorithm,
+                                           PayloadChecksumStore cache) {
         if (checksumAlgorithm != null) {
             return new FlexibleChecksummer(
+                cache,
                 option().headerName(X_AMZ_CONTENT_SHA256).algorithm(new ConstantChecksumAlgorithm(precomputedSha256))
                         .formatter(b -> new String(b, StandardCharsets.UTF_8)).build(),
                 option().headerName(checksumHeaderName(checksumAlgorithm)).algorithm(checksumAlgorithm)
@@ -96,7 +102,7 @@ public interface Checksummer {
     }
 
     static Checksummer forNoOp() {
-        return new FlexibleChecksummer();
+        return new FlexibleChecksummer(NoOpPayloadChecksumStore.create());
     }
 
     /**

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSigner.java
@@ -24,6 +24,7 @@ import static software.amazon.awssdk.http.auth.aws.internal.signer.util.Credenti
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.OptionalDependencyLoaderUtil.getEventStreamV4PayloadSigner;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.PRESIGN_URL_MAX_EXPIRATION_DURATION;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_TRAILER;
+import static software.amazon.awssdk.http.auth.spi.signer.SdkInternalHttpSignerProperty.CHECKSUM_CACHE;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -38,6 +39,7 @@ import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
 import software.amazon.awssdk.http.auth.spi.signer.BaseSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
@@ -55,7 +57,7 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
 
     @Override
     public SignedRequest sign(SignRequest<? extends AwsCredentialsIdentity> request) {
-        Checksummer checksummer = checksummer(request, null);
+        Checksummer checksummer = checksummer(request, null, checksumCache(request));
         V4Properties v4Properties = v4Properties(request);
         V4RequestSigner v4RequestSigner = v4RequestSigner(request, v4Properties);
         V4PayloadSigner payloadSigner = v4PayloadSigner(request, v4Properties);
@@ -140,7 +142,7 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
         // check for payload signing is done.
         Boolean overridePayloadSigning = shouldTreatAsUnsigned ? false : null;
 
-        return checksummer(request, overridePayloadSigning);
+        return checksummer(request, overridePayloadSigning, PayloadChecksumStore.create());
     }
 
     private static V4PayloadSigner v4PayloadSigner(
@@ -168,6 +170,7 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
             return AwsChunkedV4PayloadSigner.builder()
                                             .credentialScope(properties.getCredentialScope())
                                             .chunkSize(DEFAULT_CHUNK_SIZE_IN_BYTES)
+                                            .checksumCache(checksumCache(request))
                                             .checksumAlgorithm(request.property(CHECKSUM_ALGORITHM))
                                             .build();
         }
@@ -260,5 +263,13 @@ public final class DefaultAwsV4HttpSigner implements AwsV4HttpSigner {
 
     private static boolean isBetweenInclusive(Duration start, Duration x, Duration end) {
         return start.compareTo(x) <= 0 && x.compareTo(end) <= 0;
+    }
+
+    private static PayloadChecksumStore checksumCache(SignRequest<? extends AwsCredentialsIdentity> request) {
+        PayloadChecksumStore cache = request.property(CHECKSUM_CACHE);
+        if (cache == null) {
+            return NoOpPayloadChecksumStore.create();
+        }
+        return cache;
     }
 }

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/FlexibleChecksummer.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/FlexibleChecksummer.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.internal.signer.io.ChecksumInputStream;
 import software.amazon.awssdk.http.auth.aws.internal.signer.io.ChecksumSubscriber;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -44,10 +45,12 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkInternalApi
 public final class FlexibleChecksummer implements Checksummer {
+    private final PayloadChecksumStore cache;
     private final Collection<Option> options;
     private final Map<Option, SdkChecksum> optionToSdkChecksum;
 
-    public FlexibleChecksummer(Option... options) {
+    public FlexibleChecksummer(PayloadChecksumStore cache, Option... options) {
+        this.cache = cache;
         this.options = Arrays.asList(options);
         this.optionToSdkChecksum = this.options.stream().collect(
             Collectors.toMap(Function.identity(), o -> fromChecksumAlgorithm(o.algorithm))
@@ -85,9 +88,14 @@ public final class FlexibleChecksummer implements Checksummer {
 
     private void addChecksums(SdkHttpRequest.Builder request) {
         optionToSdkChecksum.forEach(
-            (option, sdkChecksum) -> request.putHeader(
-                option.headerName,
-                option.formatter.apply(sdkChecksum.getChecksumBytes()))
+            (option, sdkChecksum) -> {
+                byte[] checksumValue = cache.getChecksumValue(option.algorithm);
+                if (checksumValue == null) {
+                    checksumValue = sdkChecksum.getChecksumBytes();
+                    cache.putChecksumValue(option.algorithm, checksumValue);
+                }
+                request.putHeader(option.headerName, option.formatter.apply(checksumValue));
+            }
         );
     }
 

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/NoOpPayloadChecksumStore.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/NoOpPayloadChecksumStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.signer;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
+
+@SdkInternalApi
+public final class NoOpPayloadChecksumStore implements PayloadChecksumStore {
+    private NoOpPayloadChecksumStore() {
+    }
+
+    @Override
+    public byte[] putChecksumValue(ChecksumAlgorithm algorithm, byte[] checksum) {
+        return null;
+    }
+
+    @Override
+    public byte[] getChecksumValue(ChecksumAlgorithm algorithm) {
+        return null;
+    }
+
+    @Override
+    public boolean containsChecksumValue(ChecksumAlgorithm algorithm) {
+        return false;
+    }
+
+    public static NoOpPayloadChecksumStore create() {
+        return new NoOpPayloadChecksumStore();
+    }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/ChecksumUtil.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/ChecksumUtil.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.internal.signer.Checksummer;
 import software.amazon.awssdk.http.auth.aws.internal.signer.checksums.ConstantChecksum;
 import software.amazon.awssdk.http.auth.spi.signer.BaseSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.utils.FunctionalUtils;
 import software.amazon.awssdk.utils.Logger;
@@ -157,7 +158,7 @@ public final class ChecksumUtil {
     }
 
     public static Checksummer checksummer(BaseSignRequest<?, ? extends AwsCredentialsIdentity> request,
-                                          Boolean isPayloadSigningOverride) {
+                                          Boolean isPayloadSigningOverride, PayloadChecksumStore payloadChecksumStore) {
         boolean isPayloadSigning = isPayloadSigningOverride != null ? isPayloadSigningOverride : isPayloadSigning(request);
         boolean isEventStreaming = isEventStreaming(request.request());
         boolean hasChecksumHeader = hasChecksumHeader(request);
@@ -179,9 +180,9 @@ public final class ChecksumUtil {
             }
 
             if (isFlexible) {
-                return Checksummer.forFlexibleChecksum(request.property(CHECKSUM_ALGORITHM));
+                return Checksummer.forFlexibleChecksum(request.property(CHECKSUM_ALGORITHM), payloadChecksumStore);
             }
-            return Checksummer.create();
+            return Checksummer.create(payloadChecksumStore);
         }
 
         if (isFlexible || isTrailing) {
@@ -191,7 +192,7 @@ public final class ChecksumUtil {
         }
 
         if (isFlexible) {
-            return Checksummer.forFlexibleChecksum(UNSIGNED_PAYLOAD, request.property(CHECKSUM_ALGORITHM));
+            return Checksummer.forFlexibleChecksum(UNSIGNED_PAYLOAD, request.property(CHECKSUM_ALGORITHM), payloadChecksumStore);
         }
 
         if (isAnonymous) {

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/TestUtils.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/TestUtils.java
@@ -25,6 +25,10 @@ public final class TestUtils {
     private TestUtils() {
     }
 
+    public static byte[] testPayload() {
+        return "{\"TableName\": \"foo\"}".getBytes();
+    }
+
     // Helpers for generating test requests
     public static <T extends AwsCredentialsIdentity> SignRequest<T> generateBasicRequest(
         T credentials,
@@ -40,7 +44,7 @@ public final class TestUtils {
                                                      .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
                                                      .build()
                                                      .copy(requestOverrides))
-                          .payload(() -> new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
+                          .payload(() -> new ByteArrayInputStream(testPayload()))
                           .putProperty(REGION_NAME, "us-east-1")
                           .putProperty(SERVICE_SIGNING_NAME, "demo")
                           .putProperty(SIGNING_CLOCK,
@@ -56,7 +60,7 @@ public final class TestUtils {
     ) {
         SimplePublisher<ByteBuffer> publisher = new SimplePublisher<>();
 
-        publisher.send(ByteBuffer.wrap("{\"TableName\": \"foo\"}".getBytes()));
+        publisher.send(ByteBuffer.wrap(testPayload()));
         publisher.complete();
 
         return AsyncSignRequest.builder(credentials)

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/TestUtils.java
@@ -25,6 +25,7 @@ import static software.amazon.awssdk.http.auth.spi.signer.HttpSigner.SIGNING_CLO
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.function.Consumer;
 import software.amazon.awssdk.crt.auth.signing.AwsSigningConfig;
@@ -45,6 +46,10 @@ public final class TestUtils {
     private TestUtils() {
     }
 
+    public static byte[] testPayload() {
+        return "Hello world".getBytes(StandardCharsets.UTF_8);
+    }
+
     // Helpers for generating test requests
     public static <T extends AwsCredentialsIdentity> SignRequest<T> generateBasicRequest(
         T credentials,
@@ -60,7 +65,7 @@ public final class TestUtils {
                                                      .uri(URI.create("https://demo.us-east-1.amazonaws.com"))
                                                      .build()
                                                      .copy(requestOverrides))
-                          .payload(() -> new ByteArrayInputStream("Hello world".getBytes()))
+                          .payload(() -> new ByteArrayInputStream(testPayload()))
                           .putProperty(REGION_SET, RegionSet.create("aws-global"))
                           .putProperty(SERVICE_SIGNING_NAME, "demo")
                           .putProperty(SIGNING_CLOCK, new TickingClock(Instant.ofEpochMilli(1596476903000L)))

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -446,8 +446,9 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
     @Test
     @Disabled("Broken - We don't pass x-amz-content-sha256 to CRT signer")
-    // This is currently broken because we don't preserve the 'x-amz-content-sha256' header when sending to CRT to sign:
+    // TODO: This is currently broken because we don't preserve the 'x-amz-content-sha256' header when sending to CRT to sign:
     // https://github.com/aws/aws-sdk-java-v2/blob/59e3a000503e1299675698e5c4c7af51f2525669/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/util/CrtUtils.java#L45
+    // Refer to JAVA-8531
     void sign_WithPayloadSigningTrue_chunkEncodingFalse_cacheContainsChecksum_usesCachedValue() {
         PayloadChecksumStore cache = PayloadChecksumStore.create();
 
@@ -545,9 +546,6 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         byte[] crc32Value = "my-crc32-checksum".getBytes(StandardCharsets.UTF_8);
         cache.putChecksumValue(CRC32, crc32Value);
 
-        // byte[] sha256Value = "my-sha256-checksum".getBytes(StandardCharsets.UTF_8);
-        // cache.putChecksumValue(SHA256, sha256Value);
-
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -562,7 +560,6 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
         SdkHttpRequest httpRequest = signedRequest.request();
 
-        // assertThat(httpRequest.firstMatchingHeader("x-amz-content-sha256")).hasValue(BinaryUtils.toHex(sha256Value));
         assertThat(httpRequest.firstMatchingHeader("x-amz-checksum-crc32")).hasValue(BinaryUtils.toBase64(crc32Value));
     }
 

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -32,6 +32,7 @@ import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSigned
 import static software.amazon.awssdk.crt.auth.signing.AwsSigningConfig.AwsSigningAlgorithm.SIGV4_ASYMMETRIC;
 import static software.amazon.awssdk.http.auth.aws.TestUtils.AnonymousCredentialsIdentity;
 import static software.amazon.awssdk.http.auth.aws.crt.TestUtils.generateBasicRequest;
+import static software.amazon.awssdk.http.auth.aws.crt.TestUtils.testPayload;
 import static software.amazon.awssdk.http.auth.aws.crt.internal.util.CrtUtils.toCredentials;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil.readAll;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner.CHECKSUM_ALGORITHM;
@@ -43,20 +44,25 @@ import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.EXPIR
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.PAYLOAD_SIGNING_ENABLED;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4aHttpSigner.REGION_SET;
 import static software.amazon.awssdk.http.auth.spi.signer.HttpSigner.SIGNING_CLOCK;
+import static software.amazon.awssdk.http.auth.spi.signer.SdkInternalHttpSignerProperty.CHECKSUM_CACHE;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.checksums.SdkChecksum;
 import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.crt.auth.signing.AwsSigningConfig;
 import software.amazon.awssdk.http.Header;
@@ -65,10 +71,13 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.TestUtils;
 import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.awssdk.utils.IoUtils;
 
 
 /**
@@ -92,7 +101,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_withBasicRequest_shouldSignWithHeaders() {
+    void sign_withBasicRequest_shouldSignWithHeaders() {
         AwsCredentialsIdentity credentials =
             AwsCredentialsIdentity.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
         SignRequest<AwsCredentialsIdentity> request = generateBasicRequest(
@@ -122,7 +131,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_withQuery_shouldSignWithQueryParams() {
+    void sign_withQuery_shouldSignWithQueryParams() {
         AwsCredentialsIdentity credentials =
             AwsCredentialsIdentity.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
         SignRequest<AwsCredentialsIdentity> request = generateBasicRequest(
@@ -208,7 +217,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_withQueryAndExpiration_shouldSignWithQueryParamsAndExpire() {
+    void sign_withQueryAndExpiration_shouldSignWithQueryParamsAndExpire() {
         AwsCredentialsIdentity credentials =
             AwsCredentialsIdentity.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
         SignRequest<AwsCredentialsIdentity> request = generateBasicRequest(
@@ -245,7 +254,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_withUnsignedPayload_shouldNotSignPayload() {
+    void sign_withUnsignedPayload_shouldNotSignPayload() {
         AwsCredentialsIdentity credentials =
             AwsCredentialsIdentity.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
         SignRequest<AwsCredentialsIdentity> request = generateBasicRequest(
@@ -276,7 +285,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_withAnonymousCredentials_shouldNotSign() {
+    void sign_withAnonymousCredentials_shouldNotSign() {
         AwsCredentialsIdentity credentials = new AnonymousCredentialsIdentity();
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             credentials,
@@ -292,14 +301,14 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void signAsync_throwsUnsupportedOperationException() {
+    void signAsync_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class,
                      () -> signer.signAsync((AsyncSignRequest<? extends AwsCredentialsIdentity>) null)
         );
     }
 
     @Test
-    public void sign_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner() {
+    void sign_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -320,7 +329,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner() {
+    void sign_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -343,7 +352,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndTrailer_DelegatesToAwsChunkedPayloadSigner() {
+    void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndTrailer_DelegatesToAwsChunkedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -367,7 +376,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndChunkEncodingTrueWithoutTrailer_DelegatesToUnsignedPayload() {
+    void sign_WithPayloadSigningFalseAndChunkEncodingTrueWithoutTrailer_DelegatesToUnsignedPayload() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -384,7 +393,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
 
     @ParameterizedTest
     @MethodSource("checksumAlgorithmToValueParams")
-    public void sign_checksumAlgorithmPresent_shouldAddChecksumHeader(Map.Entry<ChecksumAlgorithm, String> checksumToValue) {
+    void sign_checksumAlgorithmPresent_shouldAddChecksumHeader(Map.Entry<ChecksumAlgorithm, String> checksumToValue) {
         ChecksumAlgorithm checksumAlgorithm = checksumToValue.getKey();
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
@@ -400,7 +409,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_checksumValueProvided_shouldNotOverrideChecksumHeader() {
+    void sign_checksumValueProvided_shouldNotOverrideChecksumHeader() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
                 httpRequest -> httpRequest
@@ -414,7 +423,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
     }
 
     @Test
-    public void sign_withProvidedHostHeader_shouldRespectUserHostHeader() {
+    void sign_withProvidedHostHeader_shouldRespectUserHostHeader() {
         AwsCredentialsIdentity credentials =
             AwsCredentialsIdentity.create("access", "secret");
 
@@ -433,5 +442,156 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Date")).hasValue("20200803T174823Z");
         assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Region-Set")).hasValue("aws-global");
         assertThat(signedRequest.request().firstMatchingHeader("Authorization")).isPresent();
+    }
+
+    @Test
+    @Disabled("Broken - We don't pass x-amz-content-sha256 to CRT signer")
+    // This is currently broken because we don't preserve the 'x-amz-content-sha256' header when sending to CRT to sign:
+    // https://github.com/aws/aws-sdk-java-v2/blob/59e3a000503e1299675698e5c4c7af51f2525669/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/crt/internal/util/CrtUtils.java#L45
+    void sign_WithPayloadSigningTrue_chunkEncodingFalse_cacheContainsChecksum_usesCachedValue() {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        byte[] checksumValue = "my-checksum".getBytes(StandardCharsets.UTF_8);
+        cache.putChecksumValue(SHA256, checksumValue);
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        Optional<String> sha256Header = signedRequest.request().firstMatchingHeader("x-amz-content-sha256");
+        assertThat(sha256Header).hasValue(BinaryUtils.toHex(checksumValue));
+    }
+
+    @Test
+    void sign_WithPayloadSigningTrue_chunkEncodingFalse_cacheEmpty_storesComputedChecksum() throws IOException {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        byte[] requestBytes = IoUtils.toByteArray(signedRequest.payload().get().newStream());
+        byte[] sha256Checksum = computeChecksum(SHA256, requestBytes);
+
+        assertThat(cache.getChecksumValue(SHA256)).isEqualTo(sha256Checksum);
+    }
+
+    @Test
+    void sign_WithPayloadSigningFalse_chunkEncodingTrue_cacheEmpty_storesComputedChecksum() throws IOException {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
+                .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        String requestPayload = IoUtils.toUtf8String(signedRequest.payload().get().newStream());
+
+        byte[] payloadChecksum = computeChecksum(CRC32, testPayload());
+
+        assertThat(cache.getChecksumValue(CRC32)).isEqualTo(payloadChecksum);
+        assertThat(requestPayload).contains("x-amz-checksum-crc32:" + BinaryUtils.toBase64(payloadChecksum) + "\r\n");
+    }
+
+    @Test
+    void sign_WithPayloadSigningFalse_chunkEncodingTrue_cacheContainsChecksum_usesCachedValue() throws IOException {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        byte[] checksumValue = "my-checksum".getBytes(StandardCharsets.UTF_8);
+        cache.putChecksumValue(CRC32, checksumValue);
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
+                .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        String requestPayload = IoUtils.toUtf8String(signedRequest.payload().get().newStream());
+
+        assertThat(requestPayload).contains("x-amz-checksum-crc32:" + BinaryUtils.toBase64(checksumValue) + "\r\n");
+    }
+
+    @Test
+    void sign_withPayloadSigningTrue_chunkEncodingFalse_withChecksum_cacheContainsCrc32AndSha256_usesCachedValues() {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        byte[] crc32Value = "my-crc32-checksum".getBytes(StandardCharsets.UTF_8);
+        cache.putChecksumValue(CRC32, crc32Value);
+
+        // byte[] sha256Value = "my-sha256-checksum".getBytes(StandardCharsets.UTF_8);
+        // cache.putChecksumValue(SHA256, sha256Value);
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        SdkHttpRequest httpRequest = signedRequest.request();
+
+        // assertThat(httpRequest.firstMatchingHeader("x-amz-content-sha256")).hasValue(BinaryUtils.toHex(sha256Value));
+        assertThat(httpRequest.firstMatchingHeader("x-amz-checksum-crc32")).hasValue(BinaryUtils.toBase64(crc32Value));
+    }
+
+    @Test
+    void sign_withPayloadSigningTrue_chunkEncodingFalse_withChecksum_cacheEmpty_storesComputeChecksums() {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        signer.sign(request);
+
+        byte[] crc32Value = computeChecksum(CRC32, testPayload());
+        byte[] sha256Value = computeChecksum(SHA256, testPayload());
+
+        AssertionsForClassTypes.assertThat(cache.getChecksumValue(SHA256)).isEqualTo(sha256Value);
+        AssertionsForClassTypes.assertThat(cache.getChecksumValue(CRC32)).isEqualTo(crc32Value);
+    }
+
+    private static byte[] computeChecksum(ChecksumAlgorithm algorithm, byte[] data) {
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(algorithm);
+        checksum.update(data, 0, data.length);
+        return checksum.getChecksumBytes();
     }
 }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -18,33 +18,45 @@ package software.amazon.awssdk.http.auth.aws.internal.signer;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.CRC32;
+import static software.amazon.awssdk.checksums.DefaultChecksumAlgorithm.SHA256;
 import static software.amazon.awssdk.http.auth.aws.TestUtils.generateBasicAsyncRequest;
 import static software.amazon.awssdk.http.auth.aws.TestUtils.generateBasicRequest;
+import static software.amazon.awssdk.http.auth.aws.TestUtils.testPayload;
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.CONTENT_ENCODING;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner.AUTH_LOCATION;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner.CHECKSUM_ALGORITHM;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner.CHUNK_ENCODING_ENABLED;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner.EXPIRATION_DURATION;
 import static software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner.PAYLOAD_SIGNING_ENABLED;
+import static software.amazon.awssdk.http.auth.spi.signer.SdkInternalHttpSignerProperty.CHECKSUM_CACHE;
 
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import software.amazon.awssdk.checksums.SdkChecksum;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.http.Header;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.aws.TestUtils;
 import software.amazon.awssdk.http.auth.aws.eventstream.internal.io.SigV4DataFramePublisher;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner.AuthLocation;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.ClassLoaderHelper;
+import software.amazon.awssdk.utils.IoUtils;
 
 /**
  * Test the delegation of signing to the correct implementations.
@@ -54,7 +66,7 @@ public class DefaultAwsV4HttpSignerTest {
     DefaultAwsV4HttpSigner signer = new DefaultAwsV4HttpSigner();
 
     @Test
-    public void sign_WithNoAdditonalProperties_DelegatesToHeaderSigner() {
+    void sign_WithNoAdditonalProperties_DelegatesToHeaderSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -69,7 +81,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithNoAdditonalProperties_DelegatesToHeaderSigner() {
+    void signAsync_WithNoAdditonalProperties_DelegatesToHeaderSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -84,7 +96,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithQueryAuthLocation_DelegatesToQuerySigner() {
+    void sign_WithQueryAuthLocation_DelegatesToQuerySigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -98,7 +110,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithQueryAuthLocation_DelegatesToQuerySigner() {
+    void signAsync_WithQueryAuthLocation_DelegatesToQuerySigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -113,7 +125,7 @@ public class DefaultAwsV4HttpSignerTest {
 
     @ParameterizedTest
     @ValueSource(longs = {-1, 0, 604801})
-    public void sign_WithQueryAuthLocationAndInvalidExpiration_Throws(long seconds) {
+    void sign_WithQueryAuthLocationAndInvalidExpiration_Throws(long seconds) {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -128,7 +140,7 @@ public class DefaultAwsV4HttpSignerTest {
 
     @ParameterizedTest
     @ValueSource(longs = {-1, 0, 604801})
-    public void signAsync_WithQueryAuthLocationAndInvalidExpiration_Throws(long seconds) {
+    void signAsync_WithQueryAuthLocationAndInvalidExpiration_Throws(long seconds) {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -142,7 +154,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithQueryAuthLocationAndExpiration_DelegatesToPresignedSigner() {
+    void sign_WithQueryAuthLocationAndExpiration_DelegatesToPresignedSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -158,7 +170,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithQueryAuthLocationAndExpiration_DelegatesToPresignedSigner() {
+    void signAsync_WithQueryAuthLocationAndExpiration_DelegatesToPresignedSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -174,7 +186,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithHeaderAuthLocationAndExpirationDuration_Throws() {
+    void sign_WithHeaderAuthLocationAndExpirationDuration_Throws() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -188,7 +200,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithHeaderAuthLocationAndExpirationDuration_Throws() {
+    void signAsync_WithHeaderAuthLocationAndExpirationDuration_Throws() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -202,7 +214,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_withAnonymousCreds_shouldNotSign() {
+    void sign_withAnonymousCreds_shouldNotSign() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             new TestUtils.AnonymousCredentialsIdentity(),
             httpRequest -> {
@@ -218,7 +230,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_withAnonymousCreds_shouldNotSign() {
+    void signAsync_withAnonymousCreds_shouldNotSign() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             new TestUtils.AnonymousCredentialsIdentity(),
             httpRequest -> {
@@ -234,7 +246,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalse_DelegatesToUnsignedPayloadSigner() {
+    void sign_WithPayloadSigningFalse_DelegatesToUnsignedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -249,7 +261,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithPayloadSigningFalse_DelegatesToUnsignedPayloadSigner() {
+    void signAsync_WithPayloadSigningFalse_DelegatesToUnsignedPayloadSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -264,7 +276,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndHttpAndNoPayload_DelegatesToUnsignedPayloadSigner() {
+    void sign_WithPayloadSigningFalseAndHttpAndNoPayload_DelegatesToUnsignedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest ->
@@ -280,7 +292,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithPayloadSigningFalseAndHttpAndNoPayload_DelegatesToUnsignedPayloadSigner() {
+    void signAsync_WithPayloadSigningFalseAndHttpAndNoPayload_DelegatesToUnsignedPayloadSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest ->
@@ -296,7 +308,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithEventStreamContentTypeWithoutHttpAuthAwsEventStreamModule_throws() {
+    void sign_WithEventStreamContentTypeWithoutHttpAuthAwsEventStreamModule_throws() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -316,7 +328,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithEventStreamContentTypeWithoutHttpAuthAwsEventStreamModule_throws() {
+    void signAsync_WithEventStreamContentTypeWithoutHttpAuthAwsEventStreamModule_throws() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -336,7 +348,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithEventStreamContentType_Throws() {
+    void sign_WithEventStreamContentType_Throws() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -349,7 +361,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithEventStreamContentType_DelegatesToEventStreamPayloadSigner() {
+    void signAsync_WithEventStreamContentType_DelegatesToEventStreamPayloadSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -364,7 +376,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithEventStreamContentTypeAndUnsignedPayload_Throws() {
+    void sign_WithEventStreamContentTypeAndUnsignedPayload_Throws() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -377,7 +389,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithEventStreamContentTypeAndUnsignedPayload_Throws() {
+    void signAsync_WithEventStreamContentTypeAndUnsignedPayload_Throws() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -390,7 +402,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner() {
+    void sign_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -410,7 +422,7 @@ public class DefaultAwsV4HttpSignerTest {
     // TODO(sra-identity-and-auth): Once chunk-encoding support in async is added, we can enable these tests.
     @Disabled("Chunk-encoding is not currently supported in the Async signing path - it is handled in HttpChecksumStage for now.")
     @Test
-    public void signAsync_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner_futureBehavior() {
+    void signAsync_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner_futureBehavior() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -430,7 +442,7 @@ public class DefaultAwsV4HttpSignerTest {
 
     // TODO(sra-identity-and-auth): Replace this test with the above test once chunk-encoding support is added
     @Test
-    public void signAsync_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner() {
+    void signAsync_WithChunkEncodingTrue_DelegatesToAwsChunkedPayloadSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -448,7 +460,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner() {
+    void sign_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -470,7 +482,7 @@ public class DefaultAwsV4HttpSignerTest {
     // TODO(sra-identity-and-auth): Once chunk-encoding support in async is added, we can enable these tests.
     @Disabled("Chunk-encoding is not currently supported in the Async signing path - it is handled in HttpChecksumStage for now.")
     @Test
-    public void signAsync_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner_futureBehavior() {
+    void signAsync_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner_futureBehavior() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -492,7 +504,7 @@ public class DefaultAwsV4HttpSignerTest {
 
     // TODO(sra-identity-and-auth): Replace this test with the above test once chunk-encoding support is added
     @Test
-    public void signAsync_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner() {
+    void signAsync_WithChunkEncodingTrueAndChecksumAlgorithm_DelegatesToAwsChunkedPayloadSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -512,7 +524,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndFlexibleChecksum_DelegatesToAwsChunkedPayloadSigner() {
+    void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndFlexibleChecksum_DelegatesToAwsChunkedPayloadSigner() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -535,7 +547,7 @@ public class DefaultAwsV4HttpSignerTest {
     // TODO(sra-identity-and-auth): Once chunk-encoding support in async is added, we can enable these tests.
     @Disabled("Chunk-encoding is not currently supported in the Async signing path - it is handled in HttpChecksumStage for now.")
     @Test
-    public void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndTrailer_DelegatesToAwsChunkedPayloadSigner_futureBehavior() {
+    void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndTrailer_DelegatesToAwsChunkedPayloadSigner_futureBehavior() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -558,7 +570,7 @@ public class DefaultAwsV4HttpSignerTest {
 
     // TODO(sra-identity-and-auth): Replace this test with the above test once chunk-encoding support is added
     @Test
-    public void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndTrailer_DelegatesToAwsChunkedPayloadSigner() {
+    void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndTrailer_DelegatesToAwsChunkedPayloadSigner() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest
@@ -579,7 +591,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndChunkEncodingTrue_DelegatesToUnsignedPayload() {
+    void sign_WithPayloadSigningFalseAndChunkEncodingTrue_DelegatesToUnsignedPayload() {
         // Currently, there is no use-case for unsigned chunk-encoding without trailers, so we should assert it falls back to
         // unsigned-payload (not chunk-encoded)
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
@@ -597,7 +609,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueWithoutTrailer_DelegatesToUnsignedPayload() {
+    void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueWithoutTrailer_DelegatesToUnsignedPayload() {
         // Currently, there is no use-case for unsigned chunk-encoding without trailers, so we should assert it falls back to
         // unsigned-payload (not chunk-encoded)
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
@@ -615,7 +627,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndChunkEncodingTrueWithChecksumHeader_DelegatesToUnsignedPayload() {
+    void sign_WithPayloadSigningFalseAndChunkEncodingTrueWithChecksumHeader_DelegatesToUnsignedPayload() {
         // If a checksum is given explicitly, we shouldn't treat it as a flexible-checksum-enabled request
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
@@ -634,7 +646,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueWithChecksumHeader_DelegatesToUnsignedPayload() {
+    void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueWithChecksumHeader_DelegatesToUnsignedPayload() {
         // If a checksum is given explicitly, we shouldn't treat it as a flexible-checksum-enabled request
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
@@ -653,7 +665,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_withChecksumAlgorithm_DelegatesToChecksummerWithThatChecksumAlgorithm() {
+    void sign_withChecksumAlgorithm_DelegatesToChecksummerWithThatChecksumAlgorithm() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -668,7 +680,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_withChecksumAlgorithm_DelegatesToChecksummerWithThatChecksumAlgorithm() {
+    void signAsync_withChecksumAlgorithm_DelegatesToChecksummerWithThatChecksumAlgorithm() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -683,7 +695,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_withChecksumAlgorithmAndPayloadSigningFalse_DelegatesToChecksummerWithThatChecksumAlgorithm() {
+    void sign_withChecksumAlgorithmAndPayloadSigningFalse_DelegatesToChecksummerWithThatChecksumAlgorithm() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -700,7 +712,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_withChecksumAlgorithmAndPayloadSigningFalse_DelegatesToChecksummerWithThatChecksumAlgorithm() {
+    void signAsync_withChecksumAlgorithmAndPayloadSigningFalse_DelegatesToChecksummerWithThatChecksumAlgorithm() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {
@@ -717,7 +729,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndHttp_FallsBackToPayloadSigning() {
+    void sign_WithPayloadSigningFalseAndHttp_FallsBackToPayloadSigning() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -732,7 +744,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void signAsync_WithPayloadSigningFalseAndHttp_FallsBackToPayloadSigning() {
+    void signAsync_WithPayloadSigningFalseAndHttp_FallsBackToPayloadSigning() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -747,7 +759,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningTrueAndChunkEncodingTrueAndHttp_SignsPayload() {
+    void sign_WithPayloadSigningTrueAndChunkEncodingTrueAndHttp_SignsPayload() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -767,7 +779,7 @@ public class DefaultAwsV4HttpSignerTest {
     // TODO(sra-identity-and-auth): Once chunk-encoding is implemented in the async path, the assertions this test makes should
     //  be different - the assertions should mirror the above case.
     @Test
-    public void signAsync_WithPayloadSigningTrueAndChunkEncodingTrueAndHttp_IgnoresPayloadSigning() {
+    void signAsync_WithPayloadSigningTrueAndChunkEncodingTrueAndHttp_IgnoresPayloadSigning() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -783,7 +795,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndHttp_SignsPayload() {
+    void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndHttp_SignsPayload() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -803,7 +815,7 @@ public class DefaultAwsV4HttpSignerTest {
     // TODO(sra-identity-and-auth): Once chunk-encoding is implemented in the async path, the assertions this test makes should
     //  be different - the assertions should mirror the above case.
     @Test
-    public void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndHttp_DoesNotFallBackToPayloadSigning() {
+    void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndHttp_DoesNotFallBackToPayloadSigning() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -819,7 +831,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    public void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndFlexibleChecksumAndHttp_SignsPayload() {
+    void sign_WithPayloadSigningFalseAndChunkEncodingTrueAndFlexibleChecksumAndHttp_SignsPayload() {
         SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -841,7 +853,7 @@ public class DefaultAwsV4HttpSignerTest {
     // TODO(sra-identity-and-auth): Once chunk-encoding is implemented in the async path, the assertions this test makes should
     //  be different - the assertions should mirror the above case.
     @Test
-    public void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndFlexibleChecksumAndHttp_DoesNotFallBackToPayloadSigning() {
+    void signAsync_WithPayloadSigningFalseAndChunkEncodingTrueAndFlexibleChecksumAndHttp_DoesNotFallBackToPayloadSigning() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
@@ -855,5 +867,152 @@ public class DefaultAwsV4HttpSignerTest {
 
         assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256"))
             .hasValue("STREAMING-UNSIGNED-PAYLOAD-TRAILER");
+    }
+
+    @Test
+    void sign_WithPayloadSigningTrue_chunkEncodingFalse_cacheContainsChecksum_usesCachedValue() {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        byte[] checksumValue = "my-checksum".getBytes(StandardCharsets.UTF_8);
+        cache.putChecksumValue(SHA256, checksumValue);
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        Optional<String> sha256Header = signedRequest.request().firstMatchingHeader("x-amz-content-sha256");
+        assertThat(sha256Header).hasValue(BinaryUtils.toHex(checksumValue));
+    }
+
+    @Test
+    void sign_WithPayloadSigningTrue_chunkEncodingFalse_cacheEmpty_storesComputedChecksum() throws IOException {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        byte[] requestBytes = IoUtils.toByteArray(signedRequest.payload().get().newStream());
+        byte[] sha256Checksum = computeChecksum(SHA256, requestBytes);
+
+        assertThat(cache.getChecksumValue(SHA256)).isEqualTo(sha256Checksum);
+    }
+
+    @Test
+    void sign_WithPayloadSigningFalse_chunkEncodingTrue_cacheEmpty_storesComputedChecksum() throws IOException {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
+                .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        String requestPayload = IoUtils.toUtf8String(signedRequest.payload().get().newStream());
+
+        byte[] payloadChecksum = computeChecksum(CRC32, testPayload());
+
+        assertThat(cache.getChecksumValue(CRC32)).isEqualTo(payloadChecksum);
+        assertThat(requestPayload).contains("x-amz-checksum-crc32:" + BinaryUtils.toBase64(payloadChecksum) + "\r\n");
+    }
+
+    @Test
+    void sign_WithPayloadSigningFalse_chunkEncodingTrue_cacheContainsChecksum_usesCachedValue() throws IOException {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        byte[] checksumValue = "my-checksum".getBytes(StandardCharsets.UTF_8);
+        cache.putChecksumValue(CRC32, checksumValue);
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, false)
+                .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        String requestPayload = IoUtils.toUtf8String(signedRequest.payload().get().newStream());
+
+        assertThat(requestPayload).contains("x-amz-checksum-crc32:" + BinaryUtils.toBase64(checksumValue) + "\r\n");
+    }
+
+    @Test
+    void sign_withPayloadSigningTrue_chunkEncodingFalse_withChecksum_cacheContainsCrc32AndSha256_usesCachedValues() {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        byte[] crc32Value = "my-crc32-checksum".getBytes(StandardCharsets.UTF_8);
+        cache.putChecksumValue(CRC32, crc32Value);
+
+        byte[] sha256Value = "my-sha256-checksum".getBytes(StandardCharsets.UTF_8);
+        cache.putChecksumValue(SHA256, sha256Value);
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        SdkHttpRequest httpRequest = signedRequest.request();
+        assertThat(httpRequest.firstMatchingHeader("x-amz-content-sha256")).hasValue(BinaryUtils.toHex(sha256Value));
+        assertThat(httpRequest.firstMatchingHeader("x-amz-checksum-crc32")).hasValue(BinaryUtils.toBase64(crc32Value));
+    }
+
+    @Test
+    void sign_withPayloadSigningTrue_chunkEncodingFalse_withChecksum_cacheEmpty_storesComputeChecksums() {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com")),
+            signRequest -> signRequest
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
+                .putProperty(CHUNK_ENCODING_ENABLED, false)
+                .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(CHECKSUM_CACHE, cache)
+        );
+
+        signer.sign(request);
+
+        byte[] crc32Value = computeChecksum(CRC32, testPayload());
+        byte[] sha256Value = computeChecksum(SHA256, testPayload());
+
+        assertThat(cache.getChecksumValue(SHA256)).isEqualTo(sha256Value);
+        assertThat(cache.getChecksumValue(CRC32)).isEqualTo(crc32Value);
+    }
+
+    private static byte[] computeChecksum(ChecksumAlgorithm algorithm, byte[] data) {
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(algorithm);
+        checksum.update(data, 0, data.length);
+        return checksum.getChecksumBytes();
     }
 }

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProviderTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChecksumTrailerProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
+import software.amazon.awssdk.checksums.SdkChecksum;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Pair;
+
+public class ChecksumTrailerProviderTest {
+
+    @Test
+    void reset_resetsChecksum() {
+        SdkChecksum mockCrc32 = mock(SdkChecksum.class);
+
+        ChecksumTrailerProvider provider = new ChecksumTrailerProvider(mockCrc32,
+                                                                       "my-checksum",
+                                                                       DefaultChecksumAlgorithm.CRC32,
+                                                                       PayloadChecksumStore.create());
+
+        provider.reset();
+
+        verify(mockCrc32).reset();
+    }
+
+    @Test
+    void get_cacheContainsChecksumValue_usesCachedValued() {
+        SdkChecksum mockCrc32 = mock(SdkChecksum.class);
+        byte[] checksumValue = "Hello".getBytes(StandardCharsets.UTF_8);
+        when(mockCrc32.getChecksumBytes()).thenReturn(checksumValue);
+
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+        cache.putChecksumValue(DefaultChecksumAlgorithm.CRC32, checksumValue);
+
+        ChecksumTrailerProvider provider = new ChecksumTrailerProvider(mockCrc32,
+                                                                       "my-checksum-crc32",
+                                                                       DefaultChecksumAlgorithm.CRC32,
+                                                                       cache);
+
+        Pair<String, List<String>> result = provider.get();
+
+        assertThat(result.right().get(0)).isEqualTo(BinaryUtils.toBase64(checksumValue));
+        verifyNoInteractions(mockCrc32);
+    }
+
+    @Test
+    public void get_cacheEmpty_storesSdkChecksumValue() {
+        SdkChecksum mockCrc32 = mock(SdkChecksum.class);
+        byte[] checksumValue = "Hello".getBytes(StandardCharsets.UTF_8);
+        when(mockCrc32.getChecksumBytes()).thenReturn(checksumValue);
+
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        ChecksumTrailerProvider provider = new ChecksumTrailerProvider(mockCrc32,
+                                                                       "my-checksum-crc32",
+                                                                       DefaultChecksumAlgorithm.CRC32,
+                                                                       cache);
+
+        Pair<String, List<String>> result = provider.get();
+
+        assertThat(result.right().get(0)).isEqualTo(BinaryUtils.toBase64(checksumValue));
+        assertThat(cache.getChecksumValue(DefaultChecksumAlgorithm.CRC32)).isEqualTo(checksumValue);
+    }
+}

--- a/core/http-auth-spi/pom.xml
+++ b/core/http-auth-spi/pom.xml
@@ -50,6 +50,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>checksums-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
             <version>${reactive-streams.version}</version>

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/signer/DefaultPayloadChecksumStore.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/internal/signer/DefaultPayloadChecksumStore.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.spi.internal.signer;
+
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
+
+/**
+ * Default implementation of {@link PayloadChecksumStore}.
+ */
+@SdkInternalApi
+@ThreadSafe
+public class DefaultPayloadChecksumStore implements PayloadChecksumStore {
+    private final ConcurrentHashMap<String, byte[]> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public byte[] putChecksumValue(ChecksumAlgorithm algorithm, byte[] value) {
+        return cache.put(algorithm.algorithmId(), value);
+    }
+
+    @Override
+    public byte[] getChecksumValue(ChecksumAlgorithm algorithm) {
+        return cache.get(algorithm.algorithmId());
+    }
+
+    @Override
+    public boolean containsChecksumValue(ChecksumAlgorithm algorithm) {
+        return cache.containsKey(algorithm.algorithmId());
+    }
+}

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/PayloadChecksumStore.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/PayloadChecksumStore.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.spi.signer;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
+import software.amazon.awssdk.http.auth.spi.internal.signer.DefaultPayloadChecksumStore;
+
+/**
+ * Storage object for storing computed checksums for a request payload.
+ */
+@SdkProtectedApi
+public interface PayloadChecksumStore {
+    /**
+     * Store the checksum value computed using the given algorithm.
+     *
+     * @return The previous value stored for this algorithm or {@code null} if not present.
+     */
+    byte[] putChecksumValue(ChecksumAlgorithm algorithm, byte[] checksum);
+
+    /**
+     * Retrieve the stored checksum value for the given algorithm.
+     *
+     * @return The checksum value for the given algorithm or {@code null} if not present.
+     */
+    byte[] getChecksumValue(ChecksumAlgorithm algorithm);
+
+    /**
+     * Returns {@code true} if the store contains a checksum value for the given algorithm, {@code false} otherwise.
+     */
+    boolean containsChecksumValue(ChecksumAlgorithm algorithm);
+
+    /**
+     * Returns the default implementation of this interface.
+     */
+    static PayloadChecksumStore create() {
+        return new DefaultPayloadChecksumStore();
+    }
+}

--- a/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/SdkInternalHttpSignerProperty.java
+++ b/core/http-auth-spi/src/main/java/software/amazon/awssdk/http/auth/spi/signer/SdkInternalHttpSignerProperty.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.spi.signer;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * {@code HttpSigner} properties intended for use only by internal components of the SDK and SDK-provided implementations of
+ * this SPI.
+ */
+@SdkProtectedApi
+public final class SdkInternalHttpSignerProperty {
+
+    /**
+     * A cache for storing checksums calculated for a payload.
+     *
+     * <p>Note, checksums may not be relevant to some signers.
+     */
+    public static final SignerProperty<PayloadChecksumStore> CHECKSUM_CACHE =
+        SignerProperty.create(SdkInternalHttpSignerProperty.class, "ChecksumCache");
+
+    private SdkInternalHttpSignerProperty() {
+    }
+}

--- a/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/PayloadChecksumStoreTest.java
+++ b/core/http-auth-spi/src/test/java/software/amazon/awssdk/http/auth/spi/signer/PayloadChecksumStoreTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.auth.spi.signer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
+import software.amazon.awssdk.http.auth.spi.internal.signer.DefaultPayloadChecksumStore;
+
+public class PayloadChecksumStoreTest {
+    private static final ChecksumAlgorithm ALGORITHM  = () -> "crc32";
+
+    @Test
+    void putChecksumValue_noPreviousEntry_returnsNull() {
+        DefaultPayloadChecksumStore cache = new DefaultPayloadChecksumStore();
+
+        byte[] previous = cache.putChecksumValue(ALGORITHM, new byte[] {1, 2, 3});
+
+        assertThat(previous).isNull();
+    }
+
+    @Test
+    public void putChecksumValue_previousEntry_returnsValue() {
+        DefaultPayloadChecksumStore cache = new DefaultPayloadChecksumStore();
+
+        byte[] previous = {1, 2, 3};
+        cache.putChecksumValue(ALGORITHM, previous);
+
+        byte[] cached = cache.putChecksumValue(ALGORITHM, new byte[] {4, 5, 6});
+
+        assertThat(cached).isEqualTo(previous);
+    }
+
+    @Test
+    public void getChecksumValue_noEntry_returnsNull() {
+        DefaultPayloadChecksumStore cache = new DefaultPayloadChecksumStore();
+
+        assertThat(cache.getChecksumValue(ALGORITHM)).isNull();
+    }
+
+    @Test
+    public void getChecksumValue_hasEntry_returnsValue() {
+        DefaultPayloadChecksumStore cache = new DefaultPayloadChecksumStore();
+
+        byte[] value = {1, 2, 3};
+        cache.putChecksumValue(ALGORITHM, value);
+
+        assertThat(cache.getChecksumValue(ALGORITHM)).isEqualTo(value);
+    }
+
+    @Test
+    void containsChecksumValue_noEntry_returnsFalse() {
+        DefaultPayloadChecksumStore cache = new DefaultPayloadChecksumStore();
+        assertThat(cache.containsChecksumValue(ALGORITHM)).isFalse();
+    }
+
+    @Test
+    void containsChecksumValue_hasEntry_returnsValue() {
+        DefaultPayloadChecksumStore cache = new DefaultPayloadChecksumStore();
+        byte[] value = {1, 2, 3};
+        cache.putChecksumValue(ALGORITHM, value);
+        assertThat(cache.containsChecksumValue(ALGORITHM)).isTrue();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -36,6 +36,8 @@ import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeProvider;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -203,6 +205,12 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<String> TOKEN_CONFIGURED_FROM_ENV = new ExecutionAttribute<>(
         "TokenConfiguredFromEnv");
+
+    /**
+     * The cache used by {@link HttpSigner} implementations to store payload checksums.
+     */
+    public static final ExecutionAttribute<PayloadChecksumStore> CHECKSUM_CACHE =
+        new ExecutionAttribute<>("ChecksumCache");
 
     /**
      * The backing attribute for RESOLVED_CHECKSUM_SPECS.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/checksums/LegacyPayloadChecksumCache.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/checksums/LegacyPayloadChecksumCache.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.checksums;
+
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.checksums.Algorithm;
+
+/**
+ * Cache for storing computed payload checksums. Only to be used in the legacy signing paths.
+ */
+@SdkInternalApi
+@SuppressWarnings("deprecation")
+public class LegacyPayloadChecksumCache {
+    private final ConcurrentHashMap<Algorithm, byte[]> cache = new ConcurrentHashMap<>();
+
+    public byte[] putChecksumValue(Algorithm algorithm, byte[] checksumValue) {
+        return cache.put(algorithm, checksumValue);
+    }
+
+    public byte[] getChecksumValue(Algorithm algorithm) {
+        return cache.get(algorithm);
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -91,8 +91,7 @@ public class SigningStage implements RequestToRequestPipeline {
         CompletableFuture<? extends T> identityFuture = selectedAuthScheme.identity();
         T identity = CompletableFutureUtils.joinLikeSync(identityFuture);
 
-        // Should not be null, added bye HttpChecksumStage for SRA signed requests. But even if it's null, this is not a
-        // required property.
+        // Should not be null, added by HttpChecksumStage for SRA signed requests
         PayloadChecksumStore payloadChecksumStore =
             context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.CHECKSUM_CACHE);
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStage.java
@@ -35,6 +35,8 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
+import software.amazon.awssdk.http.auth.spi.signer.SdkInternalHttpSignerProperty;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.Identity;
@@ -89,8 +91,13 @@ public class SigningStage implements RequestToRequestPipeline {
         CompletableFuture<? extends T> identityFuture = selectedAuthScheme.identity();
         T identity = CompletableFutureUtils.joinLikeSync(identityFuture);
 
+        // Should not be null, added bye HttpChecksumStage for SRA signed requests. But even if it's null, this is not a
+        // required property.
+        PayloadChecksumStore payloadChecksumStore =
+            context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.CHECKSUM_CACHE);
+
         Pair<SdkHttpFullRequest, Duration> measuredSign = MetricUtils.measureDuration(
-            () -> doSraSign(request, selectedAuthScheme, identity));
+            () -> doSraSign(request, selectedAuthScheme, identity, payloadChecksumStore));
         context.attemptMetricCollector().reportMetric(CoreMetric.SIGNING_DURATION, measuredSign.right());
 
         SdkHttpFullRequest signedRequest = measuredSign.left();
@@ -100,10 +107,12 @@ public class SigningStage implements RequestToRequestPipeline {
 
     private <T extends Identity> SdkHttpFullRequest doSraSign(SdkHttpFullRequest request,
                                                               SelectedAuthScheme<T> selectedAuthScheme,
-                                                              T identity) {
+                                                              T identity,
+                                                              PayloadChecksumStore payloadChecksumStore) {
         SignRequest.Builder<T> signRequestBuilder = SignRequest
             .builder(identity)
             .putProperty(HttpSigner.SIGNING_CLOCK, signingClock())
+            .putProperty(SdkInternalHttpSignerProperty.CHECKSUM_CACHE, payloadChecksumStore)
             .request(request)
             .payload(request.contentStreamProvider().orElse(null));
         AuthSchemeOption authSchemeOption = selectedAuthScheme.authSchemeOption();

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HttpChecksumStageSraTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HttpChecksumStageSraTest.java
@@ -20,6 +20,7 @@ import static software.amazon.awssdk.core.HttpChecksumConstant.HEADER_FOR_TRAILE
 import static software.amazon.awssdk.core.HttpChecksumConstant.SIGNING_METHOD;
 import static software.amazon.awssdk.core.interceptor.SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS;
 import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.AUTH_SCHEMES;
+import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.CHECKSUM_CACHE;
 import static software.amazon.awssdk.core.internal.signer.SigningMethod.UNSIGNED_PAYLOAD;
 import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
 import static software.amazon.awssdk.http.Header.CONTENT_MD5;
@@ -44,6 +45,7 @@ import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.auth.aws.internal.signer.util.ChecksumUtil;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
 import utils.ValidSdkObjects;
 
 public class HttpChecksumStageSraTest {
@@ -141,6 +143,31 @@ public class HttpChecksumStageSraTest {
 
         assertThat(requestBuilder.firstMatchingHeader(CONTENT_MD5)).isEmpty();
         assertThat(requestBuilder.firstMatchingHeader(CHECKSUM_SPECS_HEADER)).isEmpty();
+    }
+
+    @Test
+    public void execute_checksumCacheAttributeNotPresent_shouldCreate() throws Exception {
+        SdkHttpFullRequest.Builder requestBuilder = createHttpRequestBuilder();
+        RequestExecutionContext ctx =
+            flexibleChecksumRequestContext(ClientType.SYNC, ChecksumSpecs.builder().isRequestChecksumRequired(true), false);
+
+        new HttpChecksumStage(ClientType.SYNC).execute(requestBuilder, ctx);
+
+        assertThat(ctx.executionAttributes().getAttribute(CHECKSUM_CACHE)).isNotNull();
+    }
+
+    @Test
+    public void execute_checksumCacheAttributePresent_shouldNotOverwrite() throws Exception {
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+
+        SdkHttpFullRequest.Builder requestBuilder = createHttpRequestBuilder();
+        RequestExecutionContext ctx =
+            flexibleChecksumRequestContext(ClientType.SYNC, ChecksumSpecs.builder().isRequestChecksumRequired(true), false);
+        ctx.executionAttributes().putAttribute(CHECKSUM_CACHE, cache);
+
+        new HttpChecksumStage(ClientType.SYNC).execute(requestBuilder, ctx);
+
+        assertThat(ctx.executionAttributes().getAttribute(CHECKSUM_CACHE)).isSameAs(cache);
     }
 
     private SdkHttpFullRequest.Builder createHttpRequestBuilder() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/SigningStageTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.core.interceptor.SdkExecutionAttribute.TIME_OFFSET;
+import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.CHECKSUM_CACHE;
 import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME;
 import static software.amazon.awssdk.core.metrics.CoreMetric.SIGNING_DURATION;
 
@@ -54,6 +55,8 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
+import software.amazon.awssdk.http.auth.spi.signer.SdkInternalHttpSignerProperty;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.http.auth.spi.signer.SignerProperty;
@@ -370,6 +373,35 @@ public class SigningStageTest {
         verify(metricCollector).reportMetric(eq(SIGNING_DURATION), any());
 
         verifyNoInteractions(httpSigner);
+    }
+
+    @Test
+    public void execute_checksumCacheAttributePresent_propagatesChecksumCacheToSigner() throws Exception {
+        SelectedAuthScheme<Identity> selectedAuthScheme = new SelectedAuthScheme<>(
+            CompletableFuture.completedFuture(identity),
+            httpSigner,
+            AuthSchemeOption.builder()
+                            .schemeId("my.auth#myAuth")
+                            .putSignerProperty(SIGNER_PROPERTY, "value")
+                            .build());
+        RequestExecutionContext context = createContext(selectedAuthScheme, null);
+
+        PayloadChecksumStore cache = PayloadChecksumStore.create();
+        context.executionAttributes().putAttribute(CHECKSUM_CACHE, cache);
+
+        SdkHttpRequest signedRequest = ValidSdkObjects.sdkHttpFullRequest().build();
+        when(httpSigner.sign(ArgumentMatchers.<SignRequest<? extends Identity>>any()))
+            .thenReturn(SignedRequest.builder()
+                                     .request(signedRequest)
+                                     .build());
+
+        SdkHttpFullRequest request = ValidSdkObjects.sdkHttpFullRequest().build();
+        stage.execute(request, context);
+
+        ArgumentCaptor<SignRequest<? extends Identity>> signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
+        verify(httpSigner).sign(signRequestCaptor.capture());
+
+        assertThat(signRequestCaptor.getValue().property(SdkInternalHttpSignerProperty.CHECKSUM_CACHE)).isSameAs(cache);
     }
 
     private RequestExecutionContext createContext(SelectedAuthScheme<Identity> selectedAuthScheme, Signer oldSigner) {

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -159,6 +159,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <artifactId>retries</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumReuseTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumReuseTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.checksums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Tests to ensure that checksum values are not recomputed between retries.
+ */
+public class ChecksumReuseTest {
+    private static final String BUCKET = "test-bucket";
+    private static final String KEY = "test-key";
+    private static final AwsCredentialsProvider CREDENTIALS_PROVIDER = StaticCredentialsProvider.create(
+        AwsBasicCredentials.create("akid", "skid"));
+
+    @Test
+    public void putObject_serverResponds500_usesSameChecksumOnRetries() {
+        MockHttpClient httpClient = new MockHttpClient();
+
+        S3Client s3 = S3Client.builder()
+                              .region(Region.US_WEST_2)
+                              .credentialsProvider(CREDENTIALS_PROVIDER)
+                              .requestChecksumCalculation(RequestChecksumCalculation.WHEN_SUPPORTED)
+                              .httpClient(httpClient)
+                              .overrideConfiguration(o -> o.retryStrategy(StandardRetryStrategy.builder()
+                                                                                               .maxAttempts(4)
+                                                                                               .backoffStrategy(BackoffStrategy.retryImmediately())
+                                                                                               .build()))
+                              .build();
+
+        RequestBody requestBody = RequestBody.fromInputStream(new RandomInputStream(), 4096);
+
+        assertThatThrownBy(() -> s3.putObject(r -> r.bucket(BUCKET).key(KEY).checksumAlgorithm(ChecksumAlgorithm.CRC32),
+                                              requestBody))
+            .isInstanceOf(S3Exception.class)
+            // Ensure we actually retried
+            .matches(e -> ((SdkException) e).numAttempts() == 4);
+
+        List<String> trailingChecksumHeaders = new ArrayList<>();
+        for (byte[] requestPayload : httpClient.requestPayloads) {
+            String payloadAsString = new String(requestPayload, StandardCharsets.UTF_8);
+            for (String part : payloadAsString.split("\r\n")) {
+                if (part.startsWith("x-amz-checksum-crc32")) {
+                    trailingChecksumHeaders.add(part);
+                    break;
+                }
+            }
+        }
+
+        // sanity check, ensure each request has a trailing checksum header
+        assertThat(trailingChecksumHeaders).hasSize(4);
+        // All checksum trailers should be the same
+        assertThat(trailingChecksumHeaders.stream().distinct().count()).isEqualTo(1);
+    }
+
+    private static class MockHttpClient implements SdkHttpClient {
+        private List<byte[]> requestPayloads = new ArrayList<>();
+
+        @Override
+        public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+            return new MockExecutableHttpRequest(request.contentStreamProvider().get().newStream(), requestPayloads);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class MockExecutableHttpRequest implements ExecutableHttpRequest {
+        private final InputStream content;
+        private final List<byte[]> requestPayloads;
+
+        private MockExecutableHttpRequest(InputStream content, List<byte[]> requestPayloads) {
+            this.content = content;
+            this.requestPayloads = requestPayloads;
+        }
+
+        @Override
+        public HttpExecuteResponse call() throws IOException {
+            requestPayloads.add(IoUtils.toByteArray(content));
+
+            return HttpExecuteResponse.builder()
+                                      .response(SdkHttpFullResponse.builder().statusCode(503)
+                                                                   .build())
+                                      .responseBody(AbortableInputStream.create(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8))))
+                                      .build();
+        }
+
+        @Override
+        public void abort() {
+        }
+    }
+
+    /**
+     * A stream that randomly returns other 'a' or 'b' from each read() invocation.
+     */
+    private static class RandomInputStream extends InputStream {
+        private final Random rng = new Random();
+
+        @Override
+        public int read() throws IOException {
+            if (rng.nextBoolean()) {
+                return 'a';
+            }
+            return 'b';
+        }
+
+        @Override
+        public boolean markSupported() {
+            return true;
+        }
+
+        @Override
+        public synchronized void mark(int readlimit) {
+        }
+
+        @Override
+        public synchronized void reset() throws IOException {
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumReuseTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumReuseTest.java
@@ -134,7 +134,7 @@ public class ChecksumReuseTest {
     }
 
     /**
-     * A stream that randomly returns other 'a' or 'b' from each read() invocation.
+     * A stream that randomly returns either 'a' or 'b' from each read() invocation.
      */
     private static class RandomInputStream extends InputStream {
         private final Random rng = new Random();


### PR DESCRIPTION
## Motivation and Context
This commit adds the ability to reuse previously computed checksums for a request across retries.

This ensures that if a request data stream is modified between attempts that the server will reject the request.

As part of this change, the `http-auth-spi` package has been updated to expose a new interface: `PayloadChecksumStore`. This is a simple storage interface that allows signers to store and retrieve computed checksums. Additionally, a new `SignerProperty` is introduced, `SdkInternalHttpSignerProperty.CHECKSUM_CACHE` so that signers and their callers can access this cache.

Note that both the interface and associated signer property are `@SdkProtectedApi` and not intended to be used by non-SDK consumers of `http-auth-spi`.

Finally, this adds a dependency on `checksums-spi` for `http-auth-spi`.

**Note: this PR only adds support in the sync codepath. Will follow up with async (merging to a feature branch).**

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
