### PR TITLE
Remove flaky integ test that has been tested in setUp method

### DIFF
--- a/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
+++ b/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
@@ -156,24 +156,6 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
         iam.deleteRole(req -> req.roleName(ROLE_NAME));
     }
 
-
-    /** Tests that we can call assumeRole successfully. */
-    @Test
-    public void testAssumeRole() throws InterruptedException {
-        AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
-                                                               .durationSeconds(SESSION_DURATION)
-                                                               .roleArn(ROLE_ARN)
-                                                               .roleSessionName("Name")
-                                                               .build();
-
-        StsClient sts = StsClient.builder().credentialsProvider(StaticCredentialsProvider.create(userCredentials)).build();
-        AssumeRoleResponse assumeRoleResult = sts.assumeRole(assumeRoleRequest);
-        assertNotNull(assumeRoleResult.assumedRoleUser());
-        assertNotNull(assumeRoleResult.assumedRoleUser().arn());
-        assertNotNull(assumeRoleResult.assumedRoleUser().assumedRoleId());
-        assertNotNull(assumeRoleResult.credentials());
-    }
-
     @Test
     public void profileCredentialsProviderCanAssumeRoles() throws InterruptedException {
         String ASSUME_ROLE_PROFILE =


### PR DESCRIPTION
Remove flaky integ test that has been tested in `setUp`

https://github.com/aws/aws-sdk-java-v2/blob/0e604d371cffb0ce3f76d9a83668a3cede45f35f/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java#L128-L142