### PR TITLE
[POC] Optimistic Locking for Delete Operations

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
@@ -247,6 +247,10 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
         throw new UnsupportedOperationException();
     }
 
+    default CompletableFuture<T> deleteItem(T keyItem, boolean useOptimisticLocking) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Deletes a single item from the mapped table using a supplied primary {@link Key}.
      * <p>

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
@@ -245,6 +245,10 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
         throw new UnsupportedOperationException();
     }
 
+    default T deleteItem(T keyItem, boolean useOptimisticLocking) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Deletes a single item from the mapped table using a supplied primary {@link Key}.
      * <p>

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.enhanced.dynamodb.internal.client;
 
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.createKeyFromItem;
+import static software.amazon.awssdk.enhanced.dynamodb.model.OptimisticLockingHelper.conditionallyApplyOptimisticLocking;
 
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
@@ -124,6 +125,9 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
                                                      .build());
     }
 
+    /**
+     * Supports optimistic locking via {@link software.amazon.awssdk.enhanced.dynamodb.model.OptimisticLockingHelper}.
+     */
     @Override
     public CompletableFuture<T> deleteItem(DeleteItemEnhancedRequest request) {
         TableOperation<T, ?, ?, DeleteItemEnhancedResponse<T>> operation = DeleteItemOperation.create(request);
@@ -131,6 +135,9 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
                         .thenApply(DeleteItemEnhancedResponse::attributes);
     }
 
+    /**
+     * Supports optimistic locking via {@link software.amazon.awssdk.enhanced.dynamodb.model.OptimisticLockingHelper}.
+     */
     @Override
     public CompletableFuture<T> deleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
         DeleteItemEnhancedRequest.Builder builder = DeleteItemEnhancedRequest.builder();
@@ -138,14 +145,35 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
         return deleteItem(builder.build());
     }
 
+    /**
+     * Does not support optimistic locking. Use {@link #deleteItem(Object, boolean)} for optimistic locking support.
+     */
     @Override
     public CompletableFuture<T> deleteItem(Key key) {
         return deleteItem(r -> r.key(key));
     }
 
+    /**
+     * @deprecated Use {@link #deleteItem(Object, boolean)} instead to explicitly control optimistic locking behavior.
+     */
     @Override
+    @Deprecated
     public CompletableFuture<T> deleteItem(T keyItem) {
-        return deleteItem(keyFrom(keyItem));
+        return deleteItem(keyItem, false);
+    }
+
+    /**
+     * Deletes an item from the table with optional optimistic locking.
+     *
+     * @param keyItem the item containing the key to delete
+     * @param useOptimisticLocking if true, applies optimistic locking if the item has version information
+     * @return a CompletableFuture containing the deleted item, or null if the item was not found
+     */
+    @Override
+    public CompletableFuture<T> deleteItem(T keyItem, boolean useOptimisticLocking) {
+        DeleteItemEnhancedRequest request = DeleteItemEnhancedRequest.builder().key(keyFrom(keyItem)).build();
+        request = conditionallyApplyOptimisticLocking(request, keyItem, tableSchema, useOptimisticLocking);
+        return deleteItem(request);
     }
 
     @Override
@@ -311,7 +339,7 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
     public Key keyFrom(T item) {
         return createKeyFromItem(item, tableSchema, TableMetadata.primaryIndexName());
     }
-
+    
 
     @Override
     public CompletableFuture<Void> deleteTable() {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/DeleteItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/DeleteItemEnhancedRequest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
+import static software.amazon.awssdk.enhanced.dynamodb.model.OptimisticLockingHelper.createVersionCondition;
+
 import java.util.Objects;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
@@ -24,6 +26,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity;
@@ -287,6 +290,22 @@ public final class DeleteItemEnhancedRequest {
         public Builder returnValuesOnConditionCheckFailure(String returnValuesOnConditionCheckFailure) {
             this.returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure;
             return this;
+        }
+
+        /**
+         * Adds optimistic locking to this delete request.
+         * <p>
+         * This method applies a condition expression that ensures the delete operation only succeeds
+         * if the version attribute of the item matches the provided expected value.
+         *
+         * @param versionValue the expected version value that must match for the deletion to succeed
+         * @param versionAttributeName the name of the version attribute in the DynamoDB table
+         * @return a builder of this type with optimistic locking condition applied
+         * @throws IllegalArgumentException if any parameter is null
+         */
+        public Builder withOptimisticLocking(AttributeValue versionValue, String versionAttributeName) {
+            Expression optimisticLockingCondition = createVersionCondition(versionValue, versionAttributeName);
+            return conditionExpression(optimisticLockingCondition);
         }
 
         public DeleteItemEnhancedRequest build() {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/OptimisticLockingHelper.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/OptimisticLockingHelper.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.model;
+
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Utility class for adding optimistic locking to DynamoDB delete operations.
+ * <p>
+ * Optimistic locking prevents concurrent modifications by checking that an item's version hasn't changed since it was last read.
+ * If the version has changed, the delete operation fails with a {@code ConditionalCheckFailedException}.
+ */
+@SdkPublicApi
+public final class OptimisticLockingHelper {
+
+    private OptimisticLockingHelper() {
+    }
+
+    /**
+     * Adds optimistic locking to a delete request.
+     *
+     * @param request              the original delete request
+     * @param versionValue         the expected version value
+     * @param versionAttributeName the version attribute name
+     * @return delete request with optimistic locking condition
+     */
+    public static DeleteItemEnhancedRequest withOptimisticLocking(
+        DeleteItemEnhancedRequest request, AttributeValue versionValue, String versionAttributeName) {
+
+        Expression conditionExpression = createVersionCondition(versionValue, versionAttributeName);
+        return request.toBuilder()
+                      .conditionExpression(conditionExpression)
+                      .build();
+    }
+
+    /**
+     * Adds optimistic locking to a transactional delete request.
+     *
+     * @param request              the original transactional delete request
+     * @param versionValue         the expected version value
+     * @param versionAttributeName the version attribute name
+     * @return transactional delete request with optimistic locking condition
+     */
+    public static TransactDeleteItemEnhancedRequest withOptimisticLocking(
+        TransactDeleteItemEnhancedRequest request, AttributeValue versionValue, String versionAttributeName) {
+
+        Expression conditionExpression = createVersionCondition(versionValue, versionAttributeName);
+        return request.toBuilder()
+                      .conditionExpression(conditionExpression)
+                      .build();
+    }
+
+    /**
+     * Conditionally applies optimistic locking if enabled and version information exists.
+     *
+     * @param <T>                  the type of the item
+     * @param request              the original delete request
+     * @param keyItem              the item containing version information
+     * @param tableSchema          the table schema
+     * @param useOptimisticLocking if true, applies optimistic locking
+     * @return delete request with optimistic locking if enabled and version exists, otherwise original request
+     */
+    public static <T> DeleteItemEnhancedRequest conditionallyApplyOptimisticLocking(
+        DeleteItemEnhancedRequest request, T keyItem, TableSchema<T> tableSchema, boolean useOptimisticLocking) {
+
+        if (!useOptimisticLocking) {
+            return request;
+        }
+
+        return getVersionAttributeName(tableSchema)
+            .map(versionAttributeName -> {
+                AttributeValue version = tableSchema.attributeValue(keyItem, versionAttributeName);
+                return version != null ? withOptimisticLocking(request, version, versionAttributeName) : request;
+            })
+            .orElse(request);
+    }
+
+    /**
+     * Conditionally applies optimistic locking if enabled and version information exists.
+     *
+     * @param <T>                  the type of the item
+     * @param request              the original transactional delete request
+     * @param keyItem              the item containing version information
+     * @param tableSchema          the table schema
+     * @param useOptimisticLocking if true, applies optimistic locking
+     * @return delete request with optimistic locking if enabled and version exists, otherwise original request
+     */
+    public static <T> TransactDeleteItemEnhancedRequest conditionallyApplyOptimisticLocking(
+        TransactDeleteItemEnhancedRequest request, T keyItem, TableSchema<T> tableSchema, boolean useOptimisticLocking) {
+
+        if (!useOptimisticLocking) {
+            return request;
+        }
+
+        return getVersionAttributeName(tableSchema)
+            .map(versionAttributeName -> {
+                AttributeValue version = tableSchema.attributeValue(keyItem, versionAttributeName);
+                return version != null ? withOptimisticLocking(request, version, versionAttributeName) : request;
+            })
+            .orElse(request);
+    }
+
+
+    /**
+     * Creates a version condition expression.
+     *
+     * @param versionValue         the expected version value
+     * @param versionAttributeName the version attribute name
+     * @return version check condition expression
+     */
+    public static Expression createVersionCondition(AttributeValue versionValue, String versionAttributeName) {
+        return Expression.builder()
+                         .expression(versionAttributeName + " = :version_value")
+                         .putExpressionValue(":version_value", versionValue)
+                         .build();
+    }
+
+    /**
+     * Gets the version attribute name from table schema.
+     *
+     * @param <T>         the type of the item
+     * @param tableSchema the table schema
+     * @return version attribute name if present, empty otherwise
+     */
+    public static <T> Optional<String> getVersionAttributeName(TableSchema<T> tableSchema) {
+        return tableSchema.tableMetadata().customMetadataObject("VersionedRecordExtension:VersionAttribute", String.class);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactDeleteItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactDeleteItemEnhancedRequest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
+import static software.amazon.awssdk.enhanced.dynamodb.model.OptimisticLockingHelper.createVersionCondition;
+
 import java.util.Objects;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
@@ -24,6 +26,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure;
 
 /**
@@ -215,6 +218,21 @@ public final class TransactDeleteItemEnhancedRequest {
             return this;
         }
 
+        /**
+         * Adds optimistic locking to this transactional delete request.
+         * <p>
+         * This method applies a condition expression that ensures the delete operation only succeeds if the version attribute of
+         * the item matches the provided expected value. If the condition fails, the entire transaction will be cancelled.
+         *
+         * @param versionValue the expected version value that must match for the deletion to succeed
+         * @param versionAttributeName the name of the version attribute in the DynamoDB table
+         * @return a builder of this type with optimistic locking condition applied
+         * @throws IllegalArgumentException if any parameter is null
+         */
+        public Builder withOptimisticLocking(AttributeValue versionValue, String versionAttributeName) {
+            Expression optimisticLockingCondition = createVersionCondition(versionValue, versionAttributeName);
+            return conditionExpression(optimisticLockingCondition);
+        }
 
         public TransactDeleteItemEnhancedRequest build() {
             return new TransactDeleteItemEnhancedRequest(this);

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequest.java
@@ -246,6 +246,11 @@ public final class TransactWriteItemsEnhancedRequest {
          * the delete action, see the low-level operation description in for instance
          * {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)} and how to construct the low-level request in
          * {@link TransactDeleteItemEnhancedRequest}.
+         * <p>
+         * For optimistic locking support, use
+         * {@link TransactDeleteItemEnhancedRequest.Builder#withOptimisticLocking(
+         * software.amazon.awssdk.services.dynamodb.model.AttributeValue, String)}
+         * to create a request with version checking conditions before adding it to the transaction.
          *
          * @param mappedTableResource the table where the key is located
          * @param request             A {@link TransactDeleteItemEnhancedRequest}
@@ -272,13 +277,19 @@ public final class TransactWriteItemsEnhancedRequest {
         }
 
         /**
-         * Adds a primary lookup key for the item to delete, and it's associated table, to the transaction. For more information
-         * on the delete action, see the low-level operation description in for instance
+         * Adds the supplied item and its associated table to the transaction for deletion.
+         * <p>
+         * Unlike {@link #addDeleteItem(MappedTableResource, Key)}, this variant allows you to provide the full modeled item
+         * instead of only its primary key.
+         *
+         * <strong>Does not support Optimistic Locking.</strong>
+         * <p>
+         * For more information on the delete action, see the low-level operation description in for instance
          * {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)}.
          *
-         * @param mappedTableResource the table where the key is located
-         * @param keyItem             an item that will have its key fields used to match a record to retrieve from the database
-         * @param <T>                 the type of modelled objects in the table
+         * @param mappedTableResource the table where the item is located
+         * @param keyItem             the modeled item to be deleted as part of the transaction
+         * @param <T>                 the type of modeled objects in the table
          * @return a builder of this type
          */
         public <T> Builder addDeleteItem(MappedTableResource<T> mappedTableResource, T keyItem) {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/OptimisticLockingAsyncCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/OptimisticLockingAsyncCrudTest.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension.AttributeTags.versionAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primarySortKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondarySortKey;
+
+import java.util.concurrent.CompletionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.VersionedRecord;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.Record;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactDeleteItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
+
+public class OptimisticLockingAsyncCrudTest extends LocalDynamoDbAsyncTestBase {
+
+    private static final TableSchema<Record> TABLE_SCHEMA =
+        StaticTableSchema.builder(Record.class)
+                         .newItemSupplier(Record::new)
+                         .addAttribute(String.class,
+                                       a -> a.name("id")
+                                             .getter(Record::getId)
+                                             .setter(Record::setId)
+                                             .tags(primaryPartitionKey(), secondaryPartitionKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("sort")
+                                             .getter(Record::getSort)
+                                             .setter(Record::setSort)
+                                             .tags(primarySortKey(), secondarySortKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("value")
+                                             .getter(Record::getValue)
+                                             .setter(Record::setValue))
+                         .addAttribute(String.class,
+                                       a -> a.name("gsi_id")
+                                             .getter(Record::getGsiId)
+                                             .setter(Record::setGsiId)
+                                             .tags(secondaryPartitionKey("gsi_keys_only")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("gsi_sort")
+                                             .getter(Record::getGsiSort)
+                                             .setter(Record::setGsiSort)
+                                             .tags(secondarySortKey("gsi_keys_only")))
+                         .addAttribute(String.class,
+                                       a -> a.name("stringAttribute")
+                                             .getter(Record::getStringAttribute)
+                                             .setter(Record::setStringAttribute))
+                         .build();
+
+    private static final TableSchema<VersionedRecord> VERSIONED_RECORD_TABLE_SCHEMA =
+        StaticTableSchema.builder(VersionedRecord.class)
+                         .newItemSupplier(VersionedRecord::new)
+                         .addAttribute(String.class,
+                                       a -> a.name("id")
+                                             .getter(VersionedRecord::getId)
+                                             .setter(VersionedRecord::setId)
+                                             .tags(primaryPartitionKey(), secondaryPartitionKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("sort")
+                                             .getter(VersionedRecord::getSort)
+                                             .setter(VersionedRecord::setSort)
+                                             .tags(primarySortKey(), secondarySortKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("value")
+                                             .getter(VersionedRecord::getValue)
+                                             .setter(VersionedRecord::setValue))
+                         .addAttribute(String.class,
+                                       a -> a.name("gsi_id")
+                                             .getter(VersionedRecord::getGsiId)
+                                             .setter(VersionedRecord::setGsiId)
+                                             .tags(secondaryPartitionKey("gsi_keys_only")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("gsi_sort")
+                                             .getter(VersionedRecord::getGsiSort)
+                                             .setter(VersionedRecord::setGsiSort)
+                                             .tags(secondarySortKey("gsi_keys_only")))
+                         .addAttribute(String.class,
+                                       a -> a.name("stringAttribute")
+                                             .getter(VersionedRecord::getStringAttribute)
+                                             .setter(VersionedRecord::setStringAttribute))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("version")
+                                             .getter(VersionedRecord::getVersion)
+                                             .setter(VersionedRecord::setVersion)
+                                             .tags(versionAttribute()))
+                         .build();
+
+
+    private final DynamoDbEnhancedAsyncClient enhancedClient =
+        DynamoDbEnhancedAsyncClient.builder()
+                                   .dynamoDbClient(getDynamoDbAsyncClient())
+                                   .build();
+
+    private final DynamoDbAsyncTable<Record> mappedTable =
+        enhancedClient.table(getConcreteTableName("table-name"), TABLE_SCHEMA);
+    private final DynamoDbAsyncTable<VersionedRecord> versionedRecordTable =
+        enhancedClient.table(getConcreteTableName("versioned-table-name"), VERSIONED_RECORD_TABLE_SCHEMA);
+
+    @Before
+    public void createTable() {
+        mappedTable.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput())).join();
+        versionedRecordTable.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput())).join();
+    }
+
+    @After
+    public void deleteTable() {
+        getDynamoDbAsyncClient().deleteTable(
+            DeleteTableRequest.builder()
+                              .tableName(getConcreteTableName("table-name"))
+                              .build()).join();
+
+        getDynamoDbAsyncClient().deleteTable(
+            DeleteTableRequest.builder()
+                              .tableName(getConcreteTableName("versioned-table-name"))
+                              .build()).join();
+    }
+
+    // 1. deleteItem(T item) on Non-versioned record
+    // -> Optimistic Locking NOT applied -> deletes the record
+    @Test
+    public void deleteItem_onNonVersionedRecord_doesNotApplyOptimisticLockingAndDeletesTheRecord() {
+        Record item = new Record().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        mappedTable.putItem(item).join();
+        mappedTable.deleteItem(item).join();
+
+        Record deletedItem = mappedTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 2. deleteItem(T item) on Versioned record and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void deleteItem_onVersionedRecord_whenVersionsMatch_appliesOptimisticLockingAndDeletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        versionedRecordTable.deleteItem(savedItem).join();
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 3. deleteItem(T item, false) on Versioned record
+    // -> Optimistic Locking false -> Optimistic Locking is NOT applied -> deletes the record
+    @Test
+    public void deleteItem_onVersionedRecord_noOptimisticLocking_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+
+        // Update the item to change its version (new version = 2)
+        savedItem.setStringAttribute("Updated Item");
+        versionedRecordTable.updateItem(savedItem).join();
+
+        // Delete with old version (version = 1) but flag = false - should succeed (no optimistic locking)
+        VersionedRecord oldVersionItem = new VersionedRecord().setId("123").setSort(10).setVersion(1);
+        versionedRecordTable.deleteItem(oldVersionItem, false).join();
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 4. deleteItem(T item, true) on Versioned record with Optimistic Locking true and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void deleteItem_onVersionedRecord_optimisticLockingAndVersionsMatch_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        versionedRecordTable.deleteItem(savedItem, true).join();
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 5. deleteItem(T item, true) on Versioned record with Optimistic Locking true and versions DO NOT match
+    // -> Optimistic Locking applied -> does NOT delete the record
+    @Test
+    public void deleteItem_onVersionedRecord_optimisticLockingAndVersionsMismatch_doesNotDeleteTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+
+        // Update the item to change its version (new version = 2)
+        savedItem.setStringAttribute("Updated Item");
+        versionedRecordTable.updateItem(savedItem).join();
+
+        // Try to delete with old version (version = 1) and flag=true - should fail
+        VersionedRecord oldVersionItem = new VersionedRecord().setId("123").setSort(10).setVersion(1);
+
+        assertThatThrownBy(() -> versionedRecordTable.deleteItem(oldVersionItem, true).join())
+            .isInstanceOf(CompletionException.class)
+            .satisfies(e -> assertThat(e.getCause()).isInstanceOf(ConditionalCheckFailedException.class))
+            .satisfies(e -> assertThat(e.getMessage()).contains("The conditional request failed"));
+    }
+
+    // 6. deleteItem(DeleteItemEnhancedRequest) on VersionedRecord with Optimistic Locking true and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void deleteItemWithBuilder_onVersionedRecord_whenVersionsMatch_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+
+        AttributeValue matchVersion = AttributeValue.builder().n(savedItem.getVersion().toString()).build();
+        DeleteItemEnhancedRequest requestWithLocking =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(recordKey)
+                                     .withOptimisticLocking(matchVersion, "version")
+                                     .build();
+
+        versionedRecordTable.deleteItem(requestWithLocking).join();
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 7. deleteItem(DeleteItemEnhancedRequest) on VersionedRecord with Optimistic Locking true and versions DO NOT match
+    // -> Optimistic Locking is applied -> does NOT delete the record
+    @Test
+    public void deleteItemWithBuilder_onVersionedRecord_whenVersionsMismatch_doesNotDeleteTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+
+        AttributeValue mismatchVersion = AttributeValue.builder().n("2").build();
+        DeleteItemEnhancedRequest requestWithLocking =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(recordKey)
+                                     .withOptimisticLocking(mismatchVersion, "version")
+                                     .build();
+
+        assertThatThrownBy(() -> versionedRecordTable.deleteItem(requestWithLocking).join())
+            .isInstanceOf(CompletionException.class)
+            .satisfies(e -> assertThat(e.getMessage()).contains("The conditional request failed"));
+    }
+
+
+    // 8. TransactWriteItems.addDeleteItem(T item) on Non-versioned record
+    // -> Optimistic Locking NOT applied -> deletes the record
+    @Test
+    public void transactDeleteItem_onNonVersionedRecord_deletesTheRecord() {
+        Record item = new Record().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        mappedTable.putItem(item).join();
+
+        enhancedClient.transactWriteItems(
+            TransactWriteItemsEnhancedRequest.builder()
+                                             .addDeleteItem(mappedTable, item)
+                                             .build()).join();
+
+        Record deletedItem = mappedTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 9. TransactWriteItems.addDeleteItem(T item) on Versioned record and versions match
+    // -> Optimistic Locking is NOT applied (old deprecated method -> does NOT support Optimistic Locking) -> deletes the record
+    @Test
+    public void transactDeleteItem_versionedRecord_versionsMatch_shouldSucceed() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+
+        enhancedClient.transactWriteItems(
+                          TransactWriteItemsEnhancedRequest.builder()
+                                                           .addDeleteItem(versionedRecordTable, savedItem)
+                                                           .build())
+                      .join();
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 10. TransactWriteItems.addDeleteItem(T item) on Versioned record and versions do NOT match
+    // -> Optimistic Locking is NOT applied (old deprecated method -> does NOT support Optimistic Locking) -> deletes the record
+    @Test
+    public void transactDeleteItem_onVersionedRecord_whenVersionsMismatch_doesNotApplyOptimisticLockingAndDeletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        Integer mismatchedVersion = 2;
+        savedItem.setVersion(mismatchedVersion);
+
+        enhancedClient.transactWriteItems(
+                          TransactWriteItemsEnhancedRequest.builder()
+                                                           .addDeleteItem(versionedRecordTable, savedItem)
+                                                           .build())
+                      .join();
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 11. TransactWriteItems with builder method on Versioned record and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void transactDeleteItemWithBuilder_onVersionedRecord_whenVersionsMatch_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+
+        AttributeValue matchVersion = AttributeValue.builder().n(savedItem.getVersion().toString()).build();
+        TransactDeleteItemEnhancedRequest requestWithLocking =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(recordKey)
+                                             .withOptimisticLocking(matchVersion, "version")
+                                             .build();
+
+        enhancedClient.transactWriteItems(
+                          TransactWriteItemsEnhancedRequest.builder()
+                                                           .addDeleteItem(versionedRecordTable, requestWithLocking)
+                                                           .build())
+                      .join();
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey)).join();
+        assertThat(deletedItem).isNull();
+    }
+
+    // 12. TransactWriteItems with builder method on Versioned record and versions do NOT match
+    // -> Optimistic Locking applied -> does NOT delete the record
+    @Test
+    public void transactDeleteItemWithBuilder_onVersionedRecord_whenVersionsMismatch_doesNotDeleteTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item).join();
+
+        AttributeValue mismatchVersion = AttributeValue.builder().n("2").build();
+        TransactDeleteItemEnhancedRequest requestWithLocking =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(recordKey)
+                                             .withOptimisticLocking(mismatchVersion, "version")
+                                             .build();
+
+        assertThatThrownBy(() -> enhancedClient.transactWriteItems(
+                                                   TransactWriteItemsEnhancedRequest.builder()
+                                                                                    .addDeleteItem(versionedRecordTable,
+                                                                                                   requestWithLocking)
+                                                                                    .build())
+                                               .join())
+            .isInstanceOf(CompletionException.class)
+            .satisfies(e -> assertThat(((TransactionCanceledException) e.getCause())
+                                           .cancellationReasons()
+                                           .stream()
+                                           .anyMatch(reason -> "ConditionalCheckFailed".equals(reason.code())))
+                .isTrue());
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/OptimisticLockingCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/OptimisticLockingCrudTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension.AttributeTags.versionAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primarySortKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondarySortKey;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.VersionedRecord;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.Record;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactDeleteItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
+
+public class OptimisticLockingCrudTest extends LocalDynamoDbSyncTestBase {
+
+    private static final TableSchema<Record> TABLE_SCHEMA =
+        StaticTableSchema.builder(Record.class)
+                         .newItemSupplier(Record::new)
+                         .addAttribute(String.class,
+                                       a -> a.name("id")
+                                             .getter(Record::getId)
+                                             .setter(Record::setId)
+                                             .tags(primaryPartitionKey(), secondaryPartitionKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("sort")
+                                             .getter(Record::getSort)
+                                             .setter(Record::setSort)
+                                             .tags(primarySortKey(), secondarySortKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("value")
+                                             .getter(Record::getValue)
+                                             .setter(Record::setValue))
+                         .addAttribute(String.class,
+                                       a -> a.name("gsi_id")
+                                             .getter(Record::getGsiId)
+                                             .setter(Record::setGsiId)
+                                             .tags(secondaryPartitionKey("gsi_keys_only")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("gsi_sort")
+                                             .getter(Record::getGsiSort)
+                                             .setter(Record::setGsiSort)
+                                             .tags(secondarySortKey("gsi_keys_only")))
+                         .addAttribute(String.class,
+                                       a -> a.name("stringAttribute")
+                                             .getter(Record::getStringAttribute)
+                                             .setter(Record::setStringAttribute))
+                         .build();
+
+    private static final TableSchema<VersionedRecord> VERSIONED_RECORD_TABLE_SCHEMA =
+        StaticTableSchema.builder(VersionedRecord.class)
+                         .newItemSupplier(VersionedRecord::new)
+                         .addAttribute(String.class,
+                                       a -> a.name("id")
+                                             .getter(VersionedRecord::getId)
+                                             .setter(VersionedRecord::setId)
+                                             .tags(primaryPartitionKey(), secondaryPartitionKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("sort")
+                                             .getter(VersionedRecord::getSort)
+                                             .setter(VersionedRecord::setSort)
+                                             .tags(primarySortKey(), secondarySortKey("index1")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("value")
+                                             .getter(VersionedRecord::getValue)
+                                             .setter(VersionedRecord::setValue))
+                         .addAttribute(String.class,
+                                       a -> a.name("gsi_id")
+                                             .getter(VersionedRecord::getGsiId)
+                                             .setter(VersionedRecord::setGsiId)
+                                             .tags(secondaryPartitionKey("gsi_keys_only")))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("gsi_sort")
+                                             .getter(VersionedRecord::getGsiSort)
+                                             .setter(VersionedRecord::setGsiSort)
+                                             .tags(secondarySortKey("gsi_keys_only")))
+                         .addAttribute(String.class,
+                                       a -> a.name("stringAttribute")
+                                             .getter(VersionedRecord::getStringAttribute)
+                                             .setter(VersionedRecord::setStringAttribute))
+                         .addAttribute(Integer.class,
+                                       a -> a.name("version")
+                                             .getter(VersionedRecord::getVersion)
+                                             .setter(VersionedRecord::setVersion)
+                                             .tags(versionAttribute()))
+                         .build();
+
+
+    private final DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
+                                                                                .dynamoDbClient(getDynamoDbClient())
+                                                                                .build();
+
+    private final DynamoDbTable<Record> mappedTable =
+        enhancedClient.table(getConcreteTableName("table-name"), TABLE_SCHEMA);
+    private final DynamoDbTable<VersionedRecord> versionedRecordTable =
+        enhancedClient.table(getConcreteTableName("versioned-table-name"), VERSIONED_RECORD_TABLE_SCHEMA);
+
+    @Before
+    public void createTable() {
+        mappedTable.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+        versionedRecordTable.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+    }
+
+    @After
+    public void deleteTable() {
+        getDynamoDbClient().deleteTable(
+            DeleteTableRequest.builder()
+                              .tableName(getConcreteTableName("table-name"))
+                              .build());
+
+        getDynamoDbClient().deleteTable(
+            DeleteTableRequest.builder()
+                              .tableName(getConcreteTableName("versioned-table-name"))
+                              .build());
+    }
+
+    // 1. deleteItem(T item) on Non-versioned record
+    // -> Optimistic Locking NOT applied -> deletes the record
+    @Test
+    public void deleteItem_onNonVersionedRecord_doesNotApplyOptimisticLockingAndDeletesTheRecord() {
+        Record item = new Record().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        mappedTable.putItem(item);
+        mappedTable.deleteItem(item);
+
+        Record deletedItem = mappedTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 2. deleteItem(T item) on Versioned record and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void deleteItem_onVersionedRecord_whenVersionsMatch_appliesOptimisticLockingAndDeletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        versionedRecordTable.deleteItem(savedItem);
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 3. deleteItem(T item, false) on Versioned record
+    // -> Optimistic Locking false -> Optimistic Locking is NOT applied -> deletes the record
+    @Test
+    public void deleteItem_onVersionedRecord_noOptimisticLocking_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+
+        // Update the item to change its version (new version = 2)
+        savedItem.setStringAttribute("Updated Item");
+        versionedRecordTable.updateItem(savedItem);
+
+        // Delete with old version (version = 1) but flag = false - should succeed (no optimistic locking)
+        VersionedRecord oldVersionItem = new VersionedRecord().setId("123").setSort(10).setVersion(1);
+        versionedRecordTable.deleteItem(oldVersionItem, false);
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 4. deleteItem(T item, true) on Versioned record with Optimistic Locking true and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void deleteItem_onVersionedRecord_optimisticLockingAndVersionsMatch_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        versionedRecordTable.deleteItem(savedItem, true);
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 5. deleteItem(T item, true) on Versioned record with Optimistic Locking true and versions DO NOT match
+    // -> Optimistic Locking applied -> does NOT delete the record
+    @Test
+    public void deleteItem_onVersionedRecord_optimisticLockingAndVersionsMismatch_doesNotDeleteTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+
+        // Update the item to change its version (new version = 2)
+        savedItem.setStringAttribute("Updated Item");
+        versionedRecordTable.updateItem(savedItem);
+
+        // Try to delete with old version (version = 1) and flag = true - should fail
+        VersionedRecord oldVersionItem = new VersionedRecord().setId("123").setSort(10).setVersion(1);
+
+        assertThatThrownBy(() -> versionedRecordTable.deleteItem(oldVersionItem, true))
+            .isInstanceOf(ConditionalCheckFailedException.class)
+            .satisfies(e -> assertThat(e.getMessage()).contains("The conditional request failed"));
+    }
+
+    // 6. deleteItem(DeleteItemEnhancedRequest) on VersionedRecord with Optimistic Locking true and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void deleteItemWithBuilder_onVersionedRecord_whenVersionsMatch_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+
+        AttributeValue matchVersion = AttributeValue.builder().n(savedItem.getVersion().toString()).build();
+        DeleteItemEnhancedRequest requestWithLocking =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(recordKey)
+                                     .withOptimisticLocking(matchVersion, "version")
+                                     .build();
+
+        versionedRecordTable.deleteItem(requestWithLocking);
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 7. deleteItem(DeleteItemEnhancedRequest) on VersionedRecord with Optimistic Locking true and versions DO NOT match
+    // -> Optimistic Locking is applied -> does NOT delete the record
+    @Test
+    public void deleteItemWithBuilder_onVersionedRecord_whenVersionsMismatch_doesNotDeleteTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+
+        AttributeValue mismatchVersion = AttributeValue.builder().n("2").build();
+        DeleteItemEnhancedRequest requestWithLocking =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(recordKey)
+                                     .withOptimisticLocking(mismatchVersion, "version")
+                                     .build();
+
+        assertThatThrownBy(() -> versionedRecordTable.deleteItem(requestWithLocking))
+            .isInstanceOf(ConditionalCheckFailedException.class)
+            .satisfies(e -> assertThat(e.getMessage()).contains("The conditional request failed"));
+    }
+
+
+    // 8. TransactWriteItems.addDeleteItem(T item) on Non-versioned record
+    // -> Optimistic Locking NOT applied -> deletes the record
+    @Test
+    public void transactDeleteItem_onNonVersionedRecord_deletesTheRecord() {
+        Record item = new Record().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        mappedTable.putItem(item);
+
+        enhancedClient.transactWriteItems(
+            TransactWriteItemsEnhancedRequest.builder()
+                                             .addDeleteItem(mappedTable, item)
+                                             .build());
+
+        Record deletedItem = mappedTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 9. TransactWriteItems.addDeleteItem(T item) on Versioned record and versions match
+    // -> Optimistic Locking is NOT applied (old deprecated method -> does NOT support Optimistic Locking) -> deletes the record
+    @Test
+    public void transactDeleteItem_onVersionedRecord_whenVersionsMatch_doesNotApplyOptimisticLockingAndDeletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+
+        enhancedClient.transactWriteItems(
+            TransactWriteItemsEnhancedRequest.builder()
+                                             .addDeleteItem(versionedRecordTable, savedItem)
+                                             .build());
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 10. TransactWriteItems.addDeleteItem(T item) on Versioned record and versions do NOT match
+    // -> Optimistic Locking is NOT applied (old deprecated method -> does NOT support Optimistic Locking) -> deletes the record
+    @Test
+    public void transactDeleteItem_onVersionedRecord_whenVersionsMismatch_doesNotApplyOptimisticLockingAndDeletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        Integer mismatchedVersion = 2;
+        savedItem.setVersion(mismatchedVersion);
+
+        enhancedClient.transactWriteItems(
+            TransactWriteItemsEnhancedRequest.builder()
+                                             .addDeleteItem(versionedRecordTable, savedItem)
+                                             .build());
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 11. TransactWriteItems with builder method on Versioned record and versions match
+    // -> Optimistic Locking is applied -> deletes the record
+    @Test
+    public void transactDeleteItemWithBuilder_onVersionedRecord_whenVersionsMatch_deletesTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+        VersionedRecord savedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+
+        AttributeValue matchVersion = AttributeValue.builder().n(savedItem.getVersion().toString()).build();
+        TransactDeleteItemEnhancedRequest requestWithLocking =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(recordKey)
+                                             .withOptimisticLocking(matchVersion, "version")
+                                             .build();
+
+        enhancedClient.transactWriteItems(
+            TransactWriteItemsEnhancedRequest.builder()
+                                             .addDeleteItem(versionedRecordTable, requestWithLocking)
+                                             .build());
+
+        VersionedRecord deletedItem = versionedRecordTable.getItem(r -> r.key(recordKey));
+        assertThat(deletedItem).isNull();
+    }
+
+    // 12. TransactWriteItems with builder method on Versioned record and versions do NOT match
+    // -> Optimistic Locking applied -> does NOT delete the record
+    @Test
+    public void transactDeleteItemWithBuilder_onVersionedRecord_whenVersionsMismatch_doesNotDeleteTheRecord() {
+        VersionedRecord item = new VersionedRecord().setId("123").setSort(10).setStringAttribute("Test Item");
+        Key recordKey = Key.builder().partitionValue(item.getId()).sortValue(item.getSort()).build();
+
+        versionedRecordTable.putItem(item);
+
+        AttributeValue mismatchVersion = AttributeValue.builder().n("2").build();
+        TransactDeleteItemEnhancedRequest requestWithLocking =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(recordKey)
+                                             .withOptimisticLocking(mismatchVersion, "version")
+                                             .build();
+
+        TransactionCanceledException ex =
+            assertThrows(TransactionCanceledException.class,
+                         () -> enhancedClient.transactWriteItems(
+                             TransactWriteItemsEnhancedRequest.builder()
+                                                              .addDeleteItem(versionedRecordTable, requestWithLocking)
+                                                              .build()));
+
+        assertTrue(ex.hasCancellationReasons());
+        assertEquals(1, ex.cancellationReasons().size());
+        assertEquals("ConditionalCheckFailed", ex.cancellationReasons().get(0).code());
+        assertEquals("The conditional request failed", ex.cancellationReasons().get(0).message());
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/VersionedRecord.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/VersionedRecord.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+import java.util.Objects;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.annotations.DynamoDbVersionAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class VersionedRecord {
+
+    private String id;
+    private Integer sort;
+    private Integer value;
+    private String gsiId;
+    private Integer gsiSort;
+
+    private String stringAttribute;
+    private Integer version;
+
+    @DynamoDbPartitionKey
+    public String getId() {
+        return id;
+    }
+
+    public VersionedRecord setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public Integer getSort() {
+        return sort;
+    }
+
+    public VersionedRecord setSort(Integer sort) {
+        this.sort = sort;
+        return this;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public VersionedRecord setValue(Integer value) {
+        this.value = value;
+        return this;
+    }
+
+    public String getGsiId() {
+        return gsiId;
+    }
+
+    public VersionedRecord setGsiId(String gsiId) {
+        this.gsiId = gsiId;
+        return this;
+    }
+
+    public Integer getGsiSort() {
+        return gsiSort;
+    }
+
+    public VersionedRecord setGsiSort(Integer gsiSort) {
+        this.gsiSort = gsiSort;
+        return this;
+    }
+
+    public String getStringAttribute() {
+        return stringAttribute;
+    }
+
+    public VersionedRecord setStringAttribute(String stringAttribute) {
+        this.stringAttribute = stringAttribute;
+        return this;
+    }
+
+    @DynamoDbVersionAttribute
+    public Integer getVersion() {
+        return version;
+    }
+
+    public VersionedRecord setVersion(Integer version) {
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VersionedRecord versionedRecord = (VersionedRecord) o;
+        return Objects.equals(id, versionedRecord.id) &&
+               Objects.equals(sort, versionedRecord.sort) &&
+               Objects.equals(value, versionedRecord.value) &&
+               Objects.equals(gsiId, versionedRecord.gsiId) &&
+               Objects.equals(stringAttribute, versionedRecord.stringAttribute) &&
+               Objects.equals(gsiSort, versionedRecord.gsiSort) &&
+               Objects.equals(version, versionedRecord.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, sort, value, gsiId, gsiSort, stringAttribute, version);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/DeleteItemEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/DeleteItemEnhancedRequestTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -27,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity;
 import software.amazon.awssdk.services.dynamodb.model.ReturnItemCollectionMetrics;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure;
@@ -268,5 +270,20 @@ public class DeleteItemEnhancedRequestTest {
                                                                          .build();
 
         assertThat(containsKey.hashCode(), not(equalTo(emptyRequest.hashCode())));
+    }
+
+    @Test
+    public void withOptimisticLockingBuilder_addsVersinConditionExpression() {
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+
+        DeleteItemEnhancedRequest request =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(Key.builder().partitionValue("id").build())
+                                     .withOptimisticLocking(versionValue, "version")
+                                     .build();
+
+        assertThat(request.conditionExpression(), notNullValue());
+        assertThat(request.conditionExpression().expression(), is("version = :version_value"));
+        assertThat(request.conditionExpression().expressionValues().get(":version_value"), equalTo(versionValue));
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/OptimisticLockingHelperTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/OptimisticLockingHelperTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.RecordForUpdateExpressions;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.RecordWithUpdateBehaviors;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class OptimisticLockingHelperTest {
+
+    @Test
+    public void withOptimisticLocking_onDelete_addsConditionExpression() {
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        DeleteItemEnhancedRequest originalRequest =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(key)
+                                     .withOptimisticLocking(versionValue, versionAttributeName)
+                                     .build();
+
+        DeleteItemEnhancedRequest result =
+            OptimisticLockingHelper.withOptimisticLocking(originalRequest, versionValue, versionAttributeName);
+
+        assertThat(result).isNotNull();
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("version = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void withOptimisticLocking_onTransactDelete_addsConditionExpression() {
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        TransactDeleteItemEnhancedRequest originalRequest =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(key)
+                                             .withOptimisticLocking(versionValue, versionAttributeName)
+                                             .build();
+
+        TransactDeleteItemEnhancedRequest result =
+            OptimisticLockingHelper.withOptimisticLocking(originalRequest, versionValue, versionAttributeName);
+
+        assertThat(result).isNotNull();
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("version = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onDelete_whenFlagFalse_returnsOriginalRequest() {
+        boolean optimisticLockingEnabled = false;
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        // versioned record
+        RecordWithUpdateBehaviors keyItem = new RecordWithUpdateBehaviors();
+        TableSchema<RecordWithUpdateBehaviors> tableSchema = TableSchema.fromClass(RecordWithUpdateBehaviors.class);
+
+        DeleteItemEnhancedRequest originalRequest =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(key)
+                                     .withOptimisticLocking(versionValue, versionAttributeName)
+                                     .build();
+
+        DeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertEquals(originalRequest, result);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onDelete_whenFlagTrueAndVersionedRecord_returnsOriginalRequest() {
+        boolean optimisticLockingEnabled = true;
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        // non-versioned record
+        RecordForUpdateExpressions keyItem = new RecordForUpdateExpressions();
+        TableSchema<RecordForUpdateExpressions> tableSchema = TableSchema.fromClass(RecordForUpdateExpressions.class);
+
+        DeleteItemEnhancedRequest originalRequest =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(key)
+                                     .withOptimisticLocking(versionValue, versionAttributeName)
+                                     .build();
+
+        DeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("version = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onDelete_whenFlagTrueAndVersionedRecordWithoutVersion_returnsOriginalRequest() {
+        boolean optimisticLockingEnabled = true;
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = null;
+        String versionAttributeName = "version";
+
+        // versioned record
+        RecordWithUpdateBehaviors keyItem = new RecordWithUpdateBehaviors();
+        TableSchema<RecordWithUpdateBehaviors> tableSchema = TableSchema.fromClass(RecordWithUpdateBehaviors.class);
+
+        DeleteItemEnhancedRequest originalRequest =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(key)
+                                     .withOptimisticLocking(versionValue, versionAttributeName)
+                                     .build();
+
+        DeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertEquals(originalRequest, result);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onDelete_whenFlagTrueAndVersionedRecordWithVersion_addsConditionExpression() {
+        boolean optimisticLockingEnabled = true;
+        Key key = Key.builder().partitionValue("id").build();
+        Long version = 1L;
+        AttributeValue versionValue = AttributeValue.builder().n(String.valueOf(version)).build();
+        String versionAttributeName = "version";
+
+        // versioned record
+        RecordWithUpdateBehaviors keyItem = new RecordWithUpdateBehaviors();
+        keyItem.setVersion(version);
+        TableSchema<RecordWithUpdateBehaviors> tableSchema = TableSchema.fromClass(RecordWithUpdateBehaviors.class);
+
+        DeleteItemEnhancedRequest originalRequest =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(key)
+                                     .withOptimisticLocking(versionValue, versionAttributeName)
+                                     .build();
+
+        DeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("version = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onTransactDelete_whenFlagFalse_returnsOriginalRequest() {
+        boolean optimisticLockingEnabled = false;
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        // versioned record
+        RecordWithUpdateBehaviors keyItem = new RecordWithUpdateBehaviors();
+        TableSchema<RecordWithUpdateBehaviors> tableSchema = TableSchema.fromClass(RecordWithUpdateBehaviors.class);
+
+        TransactDeleteItemEnhancedRequest originalRequest =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(key)
+                                             .withOptimisticLocking(versionValue, versionAttributeName)
+                                             .build();
+
+        TransactDeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertEquals(originalRequest, result);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onTransactDelete_whenFlagTrueAndNonVersionedRecord_returnsOriginalRequest() {
+        boolean optimisticLockingEnabled = true;
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        // non-versioned record
+        RecordForUpdateExpressions keyItem = new RecordForUpdateExpressions();
+        TableSchema<RecordForUpdateExpressions> tableSchema = TableSchema.fromClass(RecordForUpdateExpressions.class);
+
+        TransactDeleteItemEnhancedRequest originalRequest =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(key)
+                                             .withOptimisticLocking(versionValue, versionAttributeName)
+                                             .build();
+
+        TransactDeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("version = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onTransactDelete_whenFlagTrueAndVersionedRecord_addsConditionExpression() {
+        boolean optimisticLockingEnabled = true;
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        // versioned record
+        RecordWithUpdateBehaviors keyItem = new RecordWithUpdateBehaviors();
+        TableSchema<RecordWithUpdateBehaviors> tableSchema = TableSchema.fromClass(RecordWithUpdateBehaviors.class);
+
+        TransactDeleteItemEnhancedRequest originalRequest =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(key)
+                                             .withOptimisticLocking(versionValue, versionAttributeName)
+                                             .build();
+
+        TransactDeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertEquals(originalRequest, result);
+    }
+
+    @Test
+    public void conditionallyApplyOptimistic_onTransactDelete_whenFlagTrueAndVersionedRecordWithVersion_addsConditionExpression() {
+        boolean optimisticLockingEnabled = true;
+        Key key = Key.builder().partitionValue("id").build();
+        Long version = 1L;
+        AttributeValue versionValue = AttributeValue.builder().n(String.valueOf(version)).build();
+        String versionAttributeName = "version";
+
+        // versioned record
+        RecordWithUpdateBehaviors keyItem = new RecordWithUpdateBehaviors();
+        keyItem.setVersion(version);
+        TableSchema<RecordWithUpdateBehaviors> tableSchema = TableSchema.fromClass(RecordWithUpdateBehaviors.class);
+
+        TransactDeleteItemEnhancedRequest originalRequest =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(key)
+                                             .withOptimisticLocking(versionValue, versionAttributeName)
+                                             .build();
+
+        TransactDeleteItemEnhancedRequest result = OptimisticLockingHelper.conditionallyApplyOptimisticLocking(
+            originalRequest, keyItem, tableSchema, optimisticLockingEnabled);
+
+        assertThat(result).isNotNull();
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("version = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void createVersionCondition_shouldCreateCorrectExpression() {
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        Expression result = OptimisticLockingHelper.createVersionCondition(versionValue, versionAttributeName);
+
+        assertThat(result.expression()).isEqualTo("version = :version_value");
+        assertThat(result.expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void getVersionAttributeName_forVersionedRecord_returnsTheCorrectVersionValueFromTheTableSchema() {
+        // versioned record
+        TableSchema<RecordWithUpdateBehaviors> tableSchema = TableSchema.fromClass(RecordWithUpdateBehaviors.class);
+        Optional<String> versionAttributeNameOpt = OptimisticLockingHelper.getVersionAttributeName(tableSchema);
+
+        assertNotNull(versionAttributeNameOpt);
+        assertTrue(versionAttributeNameOpt.isPresent());
+        assertThat(versionAttributeNameOpt.get()).isEqualTo("version");
+    }
+
+    @Test
+    public void getVersionAttributeName_forNonVersionedRecord_shouldNotReturnAVersionValue() {
+        // non-versioned record
+        TableSchema<RecordForUpdateExpressions> tableSchema = TableSchema.fromClass(RecordForUpdateExpressions.class);
+        Optional<String> versionAttributeNameOpt = OptimisticLockingHelper.getVersionAttributeName(tableSchema);
+
+        assertNotNull(versionAttributeNameOpt);
+        assertFalse(versionAttributeNameOpt.isPresent());
+    }
+
+    @Test
+    public void buildDeleteItemEnhancedRequest_addsCorrectExpressionOnRequest() {
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "version";
+
+        DeleteItemEnhancedRequest result =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(key)
+                                     .withOptimisticLocking(versionValue, versionAttributeName)
+                                     .build();
+
+        assertThat(result.key()).isEqualTo(key);
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("version = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+
+    @Test
+    public void buildDeleteItemEnhancedRequest_differentVersionAttributeNames_addsCorrectExpressionOnRequest() {
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+
+        // Test with different attribute names
+        String[] attributeNames = {"version", "recordVersion", "itemVersion", "v"};
+
+        for (String attributeName : attributeNames) {
+            DeleteItemEnhancedRequest result =
+                DeleteItemEnhancedRequest.builder()
+                                         .key(key)
+                                         .withOptimisticLocking(versionValue, attributeName)
+                                         .build();
+
+            assertThat(result.conditionExpression().expression()).isEqualTo(attributeName + " = :version_value");
+            assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+        }
+    }
+
+    @Test
+    public void buildDeleteItemEnhancedRequest_differentVersionValues_addsCorrectExpressionOnRequest() {
+        Key key = Key.builder().partitionValue("test-id").build();
+
+        // Test with different version values
+        AttributeValue[] versionValues = {
+            AttributeValue.builder().n("0").build(),
+            AttributeValue.builder().n("1").build(),
+            AttributeValue.builder().n("999").build(),
+            AttributeValue.builder().n("123456789").build()
+        };
+
+        for (AttributeValue versionValue : versionValues) {
+            DeleteItemEnhancedRequest result =
+                DeleteItemEnhancedRequest.builder()
+                                         .key(key)
+                                         .withOptimisticLocking(versionValue, "version")
+                                         .build();
+
+            assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+        }
+    }
+
+    @Test
+    public void buildDeleteItemEnhancedRequest_preservesExistingRequestProperties() {
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+
+        DeleteItemEnhancedRequest result =
+            DeleteItemEnhancedRequest.builder()
+                                     .key(key)
+                                     .returnConsumedCapacity("TOTAL")
+                                     .withOptimisticLocking(versionValue, "version")
+                                     .build();
+
+        assertThat(result.key()).isEqualTo(key);
+        assertThat(result.returnConsumedCapacityAsString()).isEqualTo("TOTAL");
+        assertThat(result.conditionExpression()).isNotNull();
+    }
+
+    @Test
+    public void buildTransactDeleteItemEnhancedRequest_addsCorrectExpressionOnRequest() {
+        Key key = Key.builder().partitionValue("id").build();
+        AttributeValue versionValue = AttributeValue.builder().n("1").build();
+        String versionAttributeName = "recordVersion";
+
+        TransactDeleteItemEnhancedRequest result =
+            TransactDeleteItemEnhancedRequest.builder()
+                                             .key(key)
+                                             .withOptimisticLocking(versionValue, versionAttributeName)
+                                             .build();
+
+        assertThat(result.key()).isEqualTo(key);
+        assertThat(result.conditionExpression()).isNotNull();
+        assertThat(result.conditionExpression().expression()).isEqualTo("recordVersion = :version_value");
+        assertThat(result.conditionExpression().expressionValues()).containsEntry(":version_value", versionValue);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactDeleteItemEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactDeleteItemEnhancedRequestTest.java
@@ -112,6 +112,16 @@ public class TransactDeleteItemEnhancedRequestTest {
     }
 
     @Test
+    public void equals_NullObject() {
+        Key key1 = Key.builder().partitionValue("key1").build();
+
+        TransactDeleteItemEnhancedRequest builtObject1 = TransactDeleteItemEnhancedRequest.builder().key(key1).build();
+        TransactDeleteItemEnhancedRequest builtObject2 = null;
+
+        assertThat(builtObject1, not(equalTo(builtObject2)));
+    }
+
+    @Test
     public void equals_keyNotEqual() {
         Key key1 = Key.builder().partitionValue("key1").build();
         Key key2 = Key.builder().partitionValue("key2").build();


### PR DESCRIPTION
## Description

Adds **explicit optimistic locking support for delete operations** in the DynamoDB Enhanced Client, while preserving full backward compatibility.

Until now, `deleteItem` operations did not automatically apply version-based conditional checks, even when a record was annotated with `@DynamoDbVersionAttribute`. This created an inconsistency with `putItem` and `updateItem`, which already integrate optimistic locking via `VersionedRecordExtension`.

>  Default behavior remains unchanged.
> Deletes are still unconditional unless optimistic locking is explicitly enabled.

------------------------------------------------------------------------

## Motivation and Context

This PR addresses community request #2358, where users expected delete operations to respect optimistic locking semantics similar to put/update operations.

An earlier attempt (PR #6043) proposed implicitly enabling version checks on deletes. However, this risked breaking existing applications that relied on unconditional deletes even when using `@DynamoDbVersionAttribute`.

To preserve backward compatibility, this PR introduces **explicit opt-in optimistic locking**.

------------------------------------------------------------------------

## What This PR Introduces

### 1. Boolean Overloads (Sync & Async)

New overloads allow explicit control of optimistic locking behavior:

-   `T deleteItem(T keyItem, boolean useOptimisticLocking);`
-   `CompletableFuture<T> deleteItem(T keyItem, boolean useOptimisticLocking);`

Usage:

``` java
// Unconditional delete (default behavior)
table.deleteItem(item, false);

// Optimistic locking enabled
table.deleteItem(item, true);
```

The existing `deleteItem(T keyItem)` method is now deprecated and delegates to `deleteItem(keyItem, false)`.

------------------------------------------------------------------------

### 2. Fluent Builder API

Added discoverable builder methods:

-   `DeleteItemEnhancedRequest.Builder#withOptimisticLocking(...)`
-   `TransactDeleteItemEnhancedRequest.Builder#withOptimisticLocking(...)`

Example:

``` java
DeleteItemEnhancedRequest request = DeleteItemEnhancedRequest.builder()
    .key(itemKey)
    .withOptimisticLocking(versionValue, "version")
    .build();

table.deleteItem(request);
```

------------------------------------------------------------------------

### 3. Centralized Helper: OptimisticLockingHelper

A new `@SdkPublicApi` class that:

-   Builds the version condition expression:
    `<versionAttributeName> = :version_value`
-   Merges version conditions with existing conditions using `AND`
-   Applies locking only when:
    -   `useOptimisticLocking == true`
    -   The table schema contains a version attribute
    -   The provided item has a non-null version value

If any of these conditions are not met, the delete proceeds unconditionally.

------------------------------------------------------------------------

## Modifications

-   Added new overload `deleteItem(T keyItem, boolean useOptimisticLocking)` (Sync & Async)
-   Deprecated implicit `deleteItem(T keyItem)` methods
-   Added `.withOptimisticLocking(...)` to request builders
-   Introduced `OptimisticLockingHelper`
-   Implemented safe condition merging logic
-   Added unit and integration tests
-   Ensured compatibility with `VersionedRecordExtension`
-   Preserved existing API contracts

------------------------------------------------------------------------

## Testing

Includes:

-   Unit tests for condition generation and merging
-   Integration tests for sync and async tables
-   Transactional delete validation
-   Version match success scenarios
-   Version mismatch failure scenarios
-   Backward compatibility verification

All new and existing tests pass successfully.

#### Test Coverage on modified classes:
<img width="819" height="421" alt="image" src="https://github.com/user-attachments/assets/e8db6e62-9fe1-41df-8914-b87c4c59abf1" />


## Test Coverage Checklist  

| Scenario | Done | Comments if Not Done |
|---------|:----:|---------------------|
| **1. Different TableSchema Creation Methods** | | |
| a. TableSchema.fromBean(Customer.class) | [x] | |
| b. TableSchema.fromImmutableClass(Customer.class) for immutable classes | [x] | |
| c. TableSchema.documentSchemaBuilder().build() | [ ] | |
| d. StaticTableSchema.builder(Customer.class) | [x] | |
| **2. Nesting of Different TableSchema Types** | | |
| a. @DynamoDbBean with annotated auto-generated key | [] | |
| b. @DynamoDbImmutable with annotated auto-generated key | [] | |
| c. Auto-generated key combined with partition/sort key | [] | |
| **3. CRUD Operations** | | |
| a. scan() | [ ] | |
| b. query() | [x] | |
| c. updateItem() preserves existing value or generates when absent | [x] | |
| d. putItem() with no key set (auto-generation occurs) | [x] | |
| e. putItem() with key set manually | [x] | |
| f. getItem() retrieves auto-generated key | [x] | |
| g. deleteItem() | [x] | |
| h. batchGetItem() | [ ] | |
| i. batchWriteItem() | [x] | |
| j. transactGetItems() | [ ] | |
| k. transactWriteItems()  | [x] | |
| **4. Data Types and Null Handling** | |  |
| a. Annotated attribute is null → key auto-generated | [] | |
| b. Annotated attribute non-null → value preserved | [] | |
| c. Validation rejects non-String annotated attribute | [] | |
| **5. AsyncTable and SyncTable** | | |
| a. DynamoDbAsyncTable Testing | [x] | |
| b. DynamoDbTable Testing | [x] | |
| **6. New/Modification in Extensions** | | |
| a. Works with other extensions like VersionedRecordExtension | [x] | |
| b. Test with Default Values in Annotations | [ ] | |
| c. Combination of Annotation and Builder passes extension | [ ] | |
| **7. New/Modification in Converters** | | |
| a. Tables with Scenario in ScenarioSl No.1 (All table schemas are Must) | [ ] | |
| b. Test with Default Values in Annotations | [ ] | |
| c. Test All Scenarios from 1 to 5 | [ ] | |

## Types of changes  
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  

## Checklist  
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document  
- [x] Local run of `mvn install` succeeds  
- [x] My code follows the code style of this project  
- [ ] My change requires a change to the Javadoc documentation  
- [ ] I have updated the Javadoc documentation accordingly  
- [x] I have added tests to cover my changes  
- [x] All new and existing tests passed  
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.  
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)  

## License  
- [x] I confirm that this pull request can be released under the Apache 2 license  
