### PR TITLE
Set the RESOLVED_ACCOUNT_ID metric only when accountID is resolved

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-fa66812.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-fa66812.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Set the RESOLVED_ACCOUNT_ID (T) user-agent metric only when accountID is actually resolved from credentials."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointParamsKnowledgeIndex.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointParamsKnowledgeIndex.java
@@ -204,8 +204,11 @@ public final class EndpointParamsKnowledgeIndex {
         builder.addStatement("$T accountId = accountIdFromIdentity(executionAttributes.getAttribute($T.SELECTED_AUTH_SCHEME))",
                              String.class, SdkInternalExecutionAttribute.class);
 
-        builder.addStatement("executionAttributes.getAttribute($T.BUSINESS_METRICS).addMetric($T.RESOLVED_ACCOUNT_ID.value())",
-                             SdkInternalExecutionAttribute.class, BusinessMetricFeatureId.class);
+        builder
+            .beginControlFlow("if (accountId != null)")
+            .addStatement("executionAttributes.getAttribute($T.BUSINESS_METRICS).addMetric($T.RESOLVED_ACCOUNT_ID.value())",
+                             SdkInternalExecutionAttribute.class, BusinessMetricFeatureId.class)
+            .endControlFlow();
 
         builder.addStatement("return accountId");
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
@@ -266,8 +266,10 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     private static String resolveAndRecordAccountIdFromIdentity(ExecutionAttributes executionAttributes) {
         String accountId = accountIdFromIdentity(executionAttributes
                                                      .getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME));
-        executionAttributes.getAttribute(SdkInternalExecutionAttribute.BUSINESS_METRICS).addMetric(
-            BusinessMetricFeatureId.RESOLVED_ACCOUNT_ID.value());
+        if (accountId != null) {
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.BUSINESS_METRICS).addMetric(
+                BusinessMetricFeatureId.RESOLVED_ACCOUNT_ID.value());
+        }
         return accountId;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
@@ -242,8 +242,10 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     private static String resolveAndRecordAccountIdFromIdentity(ExecutionAttributes executionAttributes) {
         String accountId = accountIdFromIdentity(executionAttributes
                                                      .getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME));
-        executionAttributes.getAttribute(SdkInternalExecutionAttribute.BUSINESS_METRICS).addMetric(
-            BusinessMetricFeatureId.RESOLVED_ACCOUNT_ID.value());
+        if (accountId != null) {
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.BUSINESS_METRICS).addMetric(
+                BusinessMetricFeatureId.RESOLVED_ACCOUNT_ID.value());
+        }
         return accountId;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -240,8 +240,10 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     private static String resolveAndRecordAccountIdFromIdentity(ExecutionAttributes executionAttributes) {
         String accountId = accountIdFromIdentity(executionAttributes
                                                      .getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME));
-        executionAttributes.getAttribute(SdkInternalExecutionAttribute.BUSINESS_METRICS).addMetric(
-            BusinessMetricFeatureId.RESOLVED_ACCOUNT_ID.value());
+        if (accountId != null) {
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.BUSINESS_METRICS).addMetric(
+                BusinessMetricFeatureId.RESOLVED_ACCOUNT_ID.value());
+        }
         return accountId;
     }
 


### PR DESCRIPTION
Set the `RESOLVED_ACCOUNT_ID` (`T`) metric only when accountID is actually resolved.

## Motivation and Context
The current generated code will always set the `T` metric on user-agent regardless of whether an accountID is actually available or not.

## Modifications
Add a check that accountID is set after resolving it before setting the business metric.

## Testing
Added new unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
