### PR TITLE
Mixed version compatibility detection

### DIFF
--- a/.github/workflows/mixed-version-compatibility-review.yml
+++ b/.github/workflows/mixed-version-compatibility-review.yml
@@ -44,7 +44,12 @@ jobs:
           echo "$CHANGED_BASE_FILES"
           
           # Look for new public methods in the changed base class files
-          NEW_METHODS=$(git diff remotes/origin/${{ github.base_ref }} -- $BASE_CLASS_FILES | grep '^+.*public.*(' || true)
+          # Filter out obvious false positives: comments, string literals, javadoc
+          NEW_METHODS=$(git diff remotes/origin/${{ github.base_ref }} -- $BASE_CLASS_FILES | \
+            grep '^+.*public.*(' | \
+            grep -v '^+[[:space:]]*//.*public.*(' | \
+            grep -v '^+.*".*public.*(' | \
+            grep -v '^+[[:space:]]*\*.*public.*(' || true)
           
           if [ -n "$NEW_METHODS" ]; then
             echo "::warning::New public methods detected in base classes:"

--- a/.github/workflows/mixed-version-compatibility-review.yml
+++ b/.github/workflows/mixed-version-compatibility-review.yml
@@ -1,0 +1,87 @@
+name: Mixed Version Compatibility Review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  merge_group:
+  pull_request:
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    branches:
+      - master
+
+jobs:
+  mixed-version-compatibility-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Check for mixed version compatibility risks
+        id: compatibility-check
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1
+          
+          # Define the specific base class files that are risky for mixed versions
+          BASE_CLASS_FILES="core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsRequest.java
+          core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsResponse.java
+          core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsResponseMetadata.java
+          core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+          core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkPojo.java"
+          
+          # Check if any of the base class files were modified
+          CHANGED_BASE_FILES=$(git diff --name-only remotes/origin/${{ github.base_ref }} -- $BASE_CLASS_FILES || true)
+          
+          if [ -z "$CHANGED_BASE_FILES" ]; then
+            echo "No base class changes detected."
+            echo "has_risk=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Base class changes detected in:"
+          echo "$CHANGED_BASE_FILES"
+          
+          # Look for new public methods in the changed base class files
+          NEW_METHODS=$(git diff remotes/origin/${{ github.base_ref }} -- $BASE_CLASS_FILES | grep '^+.*public.*(' || true)
+          
+          if [ -n "$NEW_METHODS" ]; then
+            echo "::warning::New public methods detected in base classes:"
+            echo "$NEW_METHODS" | while read line; do
+              echo "::warning::$line"
+            done
+            echo "has_risk=true" >> $GITHUB_OUTPUT
+            echo "risk_type=new_methods" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Base class files modified but no new public methods detected"
+            echo "has_risk=true" >> $GITHUB_OUTPUT  
+            echo "risk_type=other_changes" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Fail if compatibility risks found without approval
+        if: ${{ steps.compatibility-check.outputs.has_risk == 'true' && !contains(github.event.pull_request.labels.*.name, 'mixed-version-compatibility-reviewed') }}
+        run: |
+          echo "::error::Mixed version compatibility risk detected!"
+          echo "::error::Changes were made to base classes that generated service code implements:"
+          echo "::error::- AwsRequest, AwsResponse, AwsResponseMetadata, AwsServiceException, SdkPojo"
+          echo "::error::"
+          echo "::error::This may break customers using mixed SDK versions if:"
+          echo "::error::- New methods are added with UnsupportedOperationException defaults"
+          echo "::error::- Core behavior changes invoke existing methods in new ways"
+          echo "::error::- Interface contracts change in subtle ways"
+          echo "::error::"
+          echo "::error::Please review with the team for mixed version impact and add"
+          echo "::error::'mixed-version-compatibility-reviewed' label after approval."
+          echo "::error::"
+          echo "::error::If this introduces compatibility issues, consider:"
+          echo "::error::- Bumping minor version"
+          echo "::error::- Documenting compatibility impact in release notes"
+          echo "::error::- Ensuring older service modules can handle the changes"
+          exit 1
+      
+      - name: Success message when approved
+        if: ${{ steps.compatibility-check.outputs.has_risk == 'true' && contains(github.event.pull_request.labels.*.name, 'mixed-version-compatibility-reviewed') }}
+        run: |
+          echo "✅ Mixed version compatibility risk detected but approved for merge"
+          echo "Base class changes have been reviewed and approved by the team"

--- a/.github/workflows/mixed-version-compatibility-review.yml
+++ b/.github/workflows/mixed-version-compatibility-review.yml
@@ -49,7 +49,8 @@ jobs:
             grep '^+.*public.*(' | \
             grep -v '^+[[:space:]]*//.*public.*(' | \
             grep -v '^+.*".*public.*(' | \
-            grep -v '^+[[:space:]]*\*.*public.*(' || true)
+            grep -v '^+[[:space:]]*\*.*public.*(' | \
+            grep -v '^+[[:space:]]*/\*.*public.*(' || true)
           
           if [ -n "$NEW_METHODS" ]; then
             echo "::warning::New public methods detected in base classes:"

--- a/.github/workflows/mixed-version-compatibility-review.yml
+++ b/.github/workflows/mixed-version-compatibility-review.yml
@@ -46,11 +46,11 @@ jobs:
           # Look for new public methods in the changed base class files
           # Filter out obvious false positives: comments, string literals, javadoc
           NEW_METHODS=$(git diff remotes/origin/${{ github.base_ref }} -- $BASE_CLASS_FILES | \
-            grep '^+.*public.*(' | \
-            grep -v '^+[[:space:]]*//.*public.*(' | \
-            grep -v '^+.*".*public.*(' | \
-            grep -v '^+[[:space:]]*\*.*public.*(' | \
-            grep -v '^+[[:space:]]*/\*.*public.*(' || true)
+          
+          grep '^+.*public.*(' | \                # Find lines with new public methods
+          grep -v '^+[[:space:]]*//.*' | \        # Line comments  
+          grep -v '^+[[:space:]]*\*.*' | \        # Javadoc lines
+          grep -v '^+[[:space:]]*/\*.*' || true   # Block comments
           
           if [ -n "$NEW_METHODS" ]; then
             echo "::warning::New public methods detected in base classes:"

--- a/.github/workflows/mixed-version-compatibility-review.yml
+++ b/.github/workflows/mixed-version-compatibility-review.yml
@@ -68,9 +68,20 @@ jobs:
       - name: Fail if compatibility risks found without approval
         if: ${{ steps.compatibility-check.outputs.has_risk == 'true' && !contains(github.event.pull_request.labels.*.name, 'mixed-version-compatibility-reviewed') }}
         run: |
+          # Define the base class files
+          BASE_CLASS_FILES="core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsRequest.java
+          core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsResponse.java
+          core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsResponseMetadata.java
+          core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+          core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkPojo.java"
+          
+          # Extract class names from the actually changed files
+          CHANGED_BASE_FILES=$(git diff --name-only remotes/origin/${{ github.base_ref }} -- $BASE_CLASS_FILES || true)
+          CHANGED_CLASS_NAMES=$(echo "$CHANGED_BASE_FILES" | sed 's|.*/||' | sed 's|\.java||' | paste -sd ',' - | sed 's/,/, /g')
+          
           echo "::error::Mixed version compatibility risk detected!"
           echo "::error::Changes were made to base classes that generated service code implements:"
-          echo "::error::- AwsRequest, AwsResponse, AwsResponseMetadata, AwsServiceException, SdkPojo"
+          echo "::error::- $CHANGED_CLASS_NAMES"
           echo "::error::"
           echo "::error::This may break customers using mixed SDK versions if:"
           echo "::error::- New methods are added with UnsupportedOperationException defaults"


### PR DESCRIPTION
Following the release of a breaking change where a newer version of a service client was trying to hit a non-existent code path on an older version of core, we have identified a number of core classes that are considered "risky" to change.

When changed / added to, a "risky" core class can have a codepath that breaks customers using mixed SDK versions. For example, when newer service clients expect methods or functionality that older core versions don't provide, it causes runtime failures for customers who haven't upgraded all their SDK modules together.

This workflow detects changes to the following base classes that generated service code implements:
• `AwsRequest`
• `AwsResponse`
• `AwsResponseMetadata`
• `AwsServiceException`
• `SdkPojo`

The workflow uses git diff to detect any modifications to these specific base class files. If changes are found, it searches for new public method additions using pattern matching, and (attempts to) filter out obvious false positives like comments, string literals, and javadoc examples. When "risky" changes are detected, the workflow blocks the PR from merging until the team adds a `mixed-version-compatibility-reviewed label`.



Testing:
[tested on personal fork](https://github.com/RanVaknin/aws-sdk-java-v2/actions/runs/18512371544/job/52755900802?pr=2)

Considerations: 
This is not supposed to be the "end all be all" tool for catching these potential runtime violations between mixed versions. It's supposed to be a first line of defense for flagging changes with potentially risky elements. Essentially is a very blunt instrument that will require us to do some manual validation after it flags potential violations. 

We can always disable this if its more annoying than helpful.