### PR TITLE
Auto add changelog moves

### DIFF
--- a/scripts/minor-version-bump
+++ b/scripts/minor-version-bump
@@ -7,9 +7,15 @@ NEXT_VERSION_SNAPSHOT=$NEXT_MINOR_VERSION.0-SNAPSHOT
 
 mvn versions:set -DnewVersion=$NEXT_VERSION_SNAPSHOT -DgenerateBackupPoms=false -DprocessAllModules=true
 
-mkdir -p .changes/$PREVIOUS_MINOR_VERSION.x
-mv .changes/*.json .changes/$PREVIOUS_MINOR_VERSION.x/
-mv CHANGELOG.md changelogs/$PREVIOUS_MINOR_VERSION.x-CHANGELOG.md
+PREVIOUS_VERSION_CHANGELOGS_DIR=.changes/$PREVIOUS_MINOR_VERSION.x
+mkdir -p $PREVIOUS_VERSION_CHANGELOGS_DIR
+mv .changes/*.json $PREVIOUS_VERSION_CHANGELOGS_DIR
+git add $PREVIOUS_VERSION_CHANGELOGS_DIR
+
+PREVIOUS_CHANGELOG=$PREVIOUS_MINOR_VERSION.x-CHANGELOG.md
+mv CHANGELOG.md changelogs/$PREVIOUS_CHANGELOG
+git add changelogs/$PREVIOUS_CHANGELOG
+
 echo " #### 👋 _Looking for changelogs for older versions? You can find them in the [changelogs](./changelogs) directory._" > CHANGELOG.md
 
 echo "Version bumped to $NEXT_VERSION_SNAPSHOT"


### PR DESCRIPTION
The changelogs added to `.changes/<previous minor version>` and `changelogs/<previous minor version>-CHANGELOG.md` are new files that are not tracked by Git and it's easy to miss doing a 'git add' for them when running scripts/minor-version-bump. Add them automatically so it's ensured that they're part of the version bump commit.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
Tested manually by running the script against c2fb40cd69b9b0becf3c95a004fce950d82f6a7e and manually inspecting the output of `git status` to check the files that were added:

```
        new file:   .changes/2.35.x/2.35.0.json
        new file:   .changes/2.35.x/2.35.1.json
        new file:   .changes/2.35.x/2.35.2.json
        new file:   .changes/2.35.x/2.35.3.json
        new file:   .changes/2.35.x/2.35.4.json
        new file:   .changes/2.35.x/2.35.5.json
        new file:   .changes/2.35.x/2.35.6.json
        new file:   .changes/2.35.x/2.35.7.json
        new file:   .changes/2.35.x/2.35.8.json
        new file:   changelogs/2.35.x-CHANGELOG.md
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
