### PR TITLE
Rename SdkLengthAwareInputStream to LengthAwareInputStream

### DIFF
--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkInputStream.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkInputStream.java
@@ -18,13 +18,13 @@ package software.amazon.awssdk.http.auth.aws.internal.signer.chunkedencoding;
 import java.io.IOException;
 import java.io.InputStream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.utils.io.SdkLengthAwareInputStream;
+import software.amazon.awssdk.utils.io.LengthAwareInputStream;
 
 /**
  * A wrapped stream to represent a "chunk" of data
  */
 @SdkInternalApi
-public final class ChunkInputStream extends SdkLengthAwareInputStream {
+public final class ChunkInputStream extends LengthAwareInputStream {
 
     public ChunkInputStream(InputStream inputStream, long length) {
         super(inputStream, length);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.core.internal.util.NoopSubscription;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.async.InputStreamConsumingPublisher;
-import software.amazon.awssdk.utils.io.SdkLengthAwareInputStream;
+import software.amazon.awssdk.utils.io.LengthAwareInputStream;
 
 /**
  * An implementation of {@link AsyncRequestBody} that allows performing a blocking write of an input stream to a downstream
@@ -89,7 +89,7 @@ public final class BlockingInputStreamAsyncRequestBody implements AsyncRequestBo
         try {
             waitForSubscriptionIfNeeded();
             if (contentLength != null) {
-                return delegate.doBlockingWrite(new SdkLengthAwareInputStream(inputStream, contentLength));
+                return delegate.doBlockingWrite(new LengthAwareInputStream(inputStream, contentLength));
             }
 
             return delegate.doBlockingWrite(inputStream);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -48,7 +48,7 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.utils.Pair;
 import software.amazon.awssdk.utils.StringUtils;
-import software.amazon.awssdk.utils.io.SdkLengthAwareInputStream;
+import software.amazon.awssdk.utils.io.LengthAwareInputStream;
 
 @SdkInternalApi
 public abstract class BaseClientHandler {
@@ -136,7 +136,7 @@ public abstract class BaseClientHandler {
             ContentStreamProvider streamProvider = contentStreamProviderOptional.get();
             if (contentLengthOptional.isPresent()) {
                 ContentStreamProvider toWrap = contentStreamProviderOptional.get();
-                streamProvider = () -> new SdkLengthAwareInputStream(toWrap.newStream(), contentLength);
+                streamProvider = () -> new LengthAwareInputStream(toWrap.newStream(), contentLength);
             }
 
             return new SdkInternalOnlyRequestBody(streamProvider,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeHttpRequestStage.java
@@ -38,7 +38,7 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Pair;
-import software.amazon.awssdk.utils.io.SdkLengthAwareInputStream;
+import software.amazon.awssdk.utils.io.LengthAwareInputStream;
 
 /**
  * Delegate to the HTTP implementation to make an HTTP request and receive the response.
@@ -119,8 +119,8 @@ public class MakeHttpRequestStage
         }
 
         ContentStreamProvider requestContentProvider = requestContentStreamProviderOptional.get();
-        ContentStreamProvider lengthVerifyingProvider = () -> new SdkLengthAwareInputStream(requestContentProvider.newStream(),
-                                                                                            contentLength.get());
+        ContentStreamProvider lengthVerifyingProvider = () -> new LengthAwareInputStream(requestContentProvider.newStream(),
+                                                                                         contentLength.get());
         return request.toBuilder()
                       .contentStreamProvider(lengthVerifyingProvider)
                       .build();

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeHttpRequestStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeHttpRequestStageTest.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.timers.TimeoutTracker;
-import software.amazon.awssdk.utils.io.SdkLengthAwareInputStream;
+import software.amazon.awssdk.utils.io.LengthAwareInputStream;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -135,9 +135,9 @@ public class MakeHttpRequestStageTest {
             InputStream requestContentStream = capturedRequest.contentStreamProvider().get().newStream();
 
             if (expectLengthAware) {
-                assertThat(requestContentStream).isInstanceOf(SdkLengthAwareInputStream.class);
+                assertThat(requestContentStream).isInstanceOf(LengthAwareInputStream.class);
             } else {
-                assertThat(requestContentStream).isNotInstanceOf(SdkLengthAwareInputStream.class);
+                assertThat(requestContentStream).isNotInstanceOf(LengthAwareInputStream.class);
             }
         } else {
             assertThat(capturedRequest.contentStreamProvider()).isEmpty();

--- a/utils/src/main/java/software/amazon/awssdk/utils/io/LengthAwareInputStream.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/io/LengthAwareInputStream.java
@@ -30,13 +30,13 @@ import software.amazon.awssdk.utils.Validate;
  * has less bytes (i.e. reaches EOF) before the expected length is reached, it will throw {@code IOException}.
  */
 @SdkProtectedApi
-public class SdkLengthAwareInputStream extends FilterInputStream {
-    private static final Logger LOG = Logger.loggerFor(SdkLengthAwareInputStream.class);
+public class LengthAwareInputStream extends FilterInputStream {
+    private static final Logger LOG = Logger.loggerFor(LengthAwareInputStream.class);
     private final long length;
     private long remaining;
     private long markedRemaining;
 
-    public SdkLengthAwareInputStream(InputStream in, long length) {
+    public LengthAwareInputStream(InputStream in, long length) {
         super(in);
         this.length = Validate.isNotNegative(length, "length");
         this.remaining = this.length;
@@ -44,7 +44,7 @@ public class SdkLengthAwareInputStream extends FilterInputStream {
     }
 
     @Override
-    public int read() throws IOException {
+    public final int read() throws IOException {
         if (!hasMoreBytes()) {
             LOG.debug(() -> String.format("Specified InputStream length of %d has been reached. Returning EOF.", length));
             return -1;
@@ -66,7 +66,7 @@ public class SdkLengthAwareInputStream extends FilterInputStream {
     }
 
     @Override
-    public int read(byte[] b, int off, int len) throws IOException {
+    public final int read(byte[] b, int off, int len) throws IOException {
         if (!hasMoreBytes()) {
             LOG.debug(() -> String.format("Specified InputStream length of %d has been reached. Returning EOF.", length));
             return -1;
@@ -90,7 +90,7 @@ public class SdkLengthAwareInputStream extends FilterInputStream {
     }
 
     @Override
-    public long skip(long requestedBytesToSkip) throws IOException {
+    public final long skip(long requestedBytesToSkip) throws IOException {
         requestedBytesToSkip = Math.min(requestedBytesToSkip, remaining);
         long skippedActual = super.skip(requestedBytesToSkip);
         remaining -= skippedActual;
@@ -98,25 +98,25 @@ public class SdkLengthAwareInputStream extends FilterInputStream {
     }
 
     @Override
-    public int available() throws IOException {
+    public final int available() throws IOException {
         int streamAvailable = super.available();
         return Math.min(streamAvailable, saturatedCast(remaining));
     }
 
     @Override
-    public void mark(int readlimit) {
+    public final void mark(int readlimit) {
         super.mark(readlimit);
         // Store the current remaining bytes to restore on reset()
         markedRemaining = remaining;
     }
 
     @Override
-    public void reset() throws IOException {
+    public final void reset() throws IOException {
         super.reset();
         remaining = markedRemaining;
     }
 
-    public long remaining() {
+    public final long remaining() {
         return remaining;
     }
 

--- a/utils/src/test/java/software/amazon/awssdk/utils/io/LengthAwareInputStreamTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/io/LengthAwareInputStreamTest.java
@@ -28,7 +28,7 @@ import java.io.InputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class SdkLengthAwareInputStreamTest {
+class LengthAwareInputStreamTest {
     private InputStream delegateStream;
 
     @BeforeEach
@@ -40,7 +40,7 @@ class SdkLengthAwareInputStreamTest {
     void read_lengthIs0_returnsEof() throws IOException {
         when(delegateStream.available()).thenReturn(Integer.MAX_VALUE);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 0);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 0);
 
         assertThat(is.read()).isEqualTo(-1);
         assertThat(is.read(new byte[16], 0, 16)).isEqualTo(-1);
@@ -51,7 +51,7 @@ class SdkLengthAwareInputStreamTest {
         when(delegateStream.read()).thenReturn(-1);
         when(delegateStream.read(any(byte[].class), any(int.class), any(int.class))).thenReturn(-1);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 0);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 0);
 
         assertThat(is.read()).isEqualTo(-1);
         assertThat(is.read(new byte[16], 0, 16)).isEqualTo(-1);
@@ -61,7 +61,7 @@ class SdkLengthAwareInputStreamTest {
     void readByte_lengthNonZero_delegateHasAvailable_returnsDelegateData() throws IOException {
         when(delegateStream.read()).thenReturn(42);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 16);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 16);
 
         assertThat(is.read()).isEqualTo(42);
     }
@@ -70,7 +70,7 @@ class SdkLengthAwareInputStreamTest {
     void readArray_lengthNonZero_delegateHasAvailable_returnsDelegateData() throws IOException {
         when(delegateStream.read(any(byte[].class), any(int.class), any(int.class))).thenReturn(8);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 16);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 16);
 
         assertThat(is.read(new byte[16], 0, 16)).isEqualTo(8);
     }
@@ -79,7 +79,7 @@ class SdkLengthAwareInputStreamTest {
     void readArray_lengthNonZero_propagatesCallToDelegate() throws IOException {
         when(delegateStream.read(any(byte[].class), any(int.class), any(int.class))).thenReturn(8);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 16);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 16);
         byte[] buff = new byte[16];
         is.read(buff, 0, 16);
 
@@ -90,7 +90,7 @@ class SdkLengthAwareInputStreamTest {
     void read_markAndReset_availableReflectsNewLength() throws IOException {
         delegateStream = new ByteArrayInputStream(new byte[32]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 16);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 16);
 
         for (int i = 0; i < 4; ++i) {
             is.read();
@@ -113,7 +113,7 @@ class SdkLengthAwareInputStreamTest {
     void skip_markAndReset_availableReflectsNewLength() throws IOException {
         delegateStream = new ByteArrayInputStream(new byte[32]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 16);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 16);
 
         is.skip(4);
 
@@ -141,7 +141,7 @@ class SdkLengthAwareInputStreamTest {
 
         when(delegateStream.read(any(byte[].class), any(int.class), any(int.class))).thenReturn(1);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 16);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 16);
 
         long skipped = is.skip(4);
 
@@ -156,7 +156,7 @@ class SdkLengthAwareInputStreamTest {
             return n / 2;
         });
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegateStream, 16);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegateStream, 16);
 
         long read = is.read(new byte[16], 0, 8);
 
@@ -169,7 +169,7 @@ class SdkLengthAwareInputStreamTest {
         int delegateLength = 16;
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, delegateLength + 1);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, delegateLength + 1);
 
         assertThatThrownBy(() -> {
             int read;
@@ -186,7 +186,7 @@ class SdkLengthAwareInputStreamTest {
         int delegateLength = 16;
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, delegateLength);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, delegateLength);
 
         int total = 0;
         int read;
@@ -204,7 +204,7 @@ class SdkLengthAwareInputStreamTest {
         int length = 16;
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, length);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, length);
 
         int total = 0;
         int read;
@@ -221,7 +221,7 @@ class SdkLengthAwareInputStreamTest {
         int delegateLength = 16;
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, delegateLength + 1);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, delegateLength + 1);
 
         assertThatThrownBy(() -> {
             int read;
@@ -237,7 +237,7 @@ class SdkLengthAwareInputStreamTest {
         int delegateLength = 16;
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, delegateLength);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, delegateLength);
 
         int total = 0;
         while (total != delegateLength && is.read() != -1) {
@@ -253,7 +253,7 @@ class SdkLengthAwareInputStreamTest {
         int expectedContentLength = delegateLength + 1;
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, expectedContentLength);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, expectedContentLength);
         is.read(); // read one byte
         is.mark(1024);
         // read another byte and reset, the length should not be reset based on the byte that was already read
@@ -274,7 +274,7 @@ class SdkLengthAwareInputStreamTest {
         int length = 16;
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, length);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, length);
 
         int total = 0;
         while (total != delegateLength && is.read() != -1) {
@@ -290,7 +290,7 @@ class SdkLengthAwareInputStreamTest {
 
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, delegateLength);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, delegateLength);
 
         int bytesToSkip = 8;
         int skippedBytes = 0;
@@ -315,7 +315,7 @@ class SdkLengthAwareInputStreamTest {
 
         ByteArrayInputStream delegate = new ByteArrayInputStream(new byte[delegateLength]);
 
-        SdkLengthAwareInputStream is = new SdkLengthAwareInputStream(delegate, delegateLength);
+        LengthAwareInputStream is = new LengthAwareInputStream(delegate, delegateLength);
 
         int bytesToSkip = 8;
         int skippedBytes = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Rename `SdkLengthAwareInputStream` to `LengthAwareInputStream`
- Mark methods as `final` in `LengthAwareInputStream`. The class itself is not final because it's extended by existing implementations 