### PR TITLE
Add version compatibility readme entry

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -22,6 +22,21 @@ following in the AWS SDKs and Tools Shared Configuration and Credentials Referen
 
 The SDK versions all service clients (e.g. `S3`, `EC2`, `DynamoDb`, etc) and the runtime (e.g. `aws-config`) together under a single version. This allows customers to easily upgrade multiple SDK clients at once and keep dependencies, such as the core runtime, compatible. The SDK may in the future consider versioning service clients separately from one another.
 
+## Component Version Compatibility
+
+**Best Practice: Use matching versions across all SDK modules.**
+
+The SDK supports limited mixed version combinations within the same minor version boundary only. Cross minor version mixing is not supported and may cause runtime exceptions when newer core components call methods that older service modules only implement as default stubs.
+
+### Supported Version Combinations
+
+- ✅ **Recommended**: All modules at the same version (e.g., `2.34.5`)
+- ✅ **Limited Support**: New core + old service within the same minor version (e.g., `sdk-core 2.34.5` with `s3 2.34.2`)
+
+
+- ❌ **Not Supported**: Cross minor-version mixing (e.g., `sdk-core 2.34.x` with `s3 2.32.y`)
+- ❌ **Not Supported**: Old core + new service (causes compile-time failures)
+
 ## Internal APIs
 
 Any API marked with either `@SdkInternalApi` or `@SdkTestInternalApi` is not subject to any backwards compatibility guarantee. These are meant to be consumed only by the SDK and may be changed or removed without notice. The SDK MAY bump the `MINOR` version when making such a change.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -23,23 +23,10 @@ following in the AWS SDKs and Tools Shared Configuration and Credentials Referen
 The SDK versions all service clients (e.g. `S3`, `EC2`, `DynamoDb`, etc) and the runtime (e.g. `aws-config`) together under a single version. This allows customers to easily upgrade multiple SDK clients at once and keep dependencies, such as the core runtime, compatible. The SDK may in the future consider versioning service clients separately from one another.
 
 ## Component Version Compatibility
+**Always use the same version across all AWS SDK dependencies**. Mixed versions can cause runtime exceptions or compile time errors depending on which components are mismatched
 
-**Best Practice: Use matching versions across all SDK modules.**
+The easiest way to ensure version consistency is to use the [AWS SDK BOM](https://github.com/aws/aws-sdk-java-v2/?tab=readme-ov-file#importing-the-bom), which automatically manages all SDK dependency versions for you.
 
-The SDK supports mixed version combinations only within the same minor version boundary. Mixed version combinations create untested scenarios that are difficult to reproduce and debug. The SDK team cannot guarantee compatibility testing coverage for all possible version combinations, and issues may require upgrading to matching versions to resolve. 
-
-Cross minor version mixing is not supported and may cause runtime exceptions when newer core components call methods that older service modules only implement as default stubs.
-
-### Supported Version Combinations
-
-- ✅ **Recommended**: All modules at the same version (e.g., `2.34.5`)
-- ✅ **Limited Support**: New core + old service within the same minor version (e.g., `sdk-core 2.34.5` with `s3 2.34.2`)
-
-
-- ❌ **Not Supported**: Cross minor-version mixing (e.g., `sdk-core 2.34.x` with `s3 2.32.y`)
-- ❌ **Not Supported**: Old core + new service (causes compile-time failures)
-
-Use the [SDK BOM (Bill of Materials)](https://github.com/aws/aws-sdk-java-v2/?tab=readme-ov-file#importing-the-bom) to automatically manage compatible versions across all SDK modules and prevent version mismatches.
 
 ## Internal APIs
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -26,7 +26,9 @@ The SDK versions all service clients (e.g. `S3`, `EC2`, `DynamoDb`, etc) and the
 
 **Best Practice: Use matching versions across all SDK modules.**
 
-The SDK supports limited mixed version combinations within the same minor version boundary only. Cross minor version mixing is not supported and may cause runtime exceptions when newer core components call methods that older service modules only implement as default stubs.
+The SDK supports mixed version combinations only within the same minor version boundary. Mixed version combinations create untested scenarios that are difficult to reproduce and debug. The SDK team cannot guarantee compatibility testing coverage for all possible version combinations, and issues may require upgrading to matching versions to resolve. 
+
+Cross minor version mixing is not supported and may cause runtime exceptions when newer core components call methods that older service modules only implement as default stubs.
 
 ### Supported Version Combinations
 
@@ -36,6 +38,8 @@ The SDK supports limited mixed version combinations within the same minor versio
 
 - ❌ **Not Supported**: Cross minor-version mixing (e.g., `sdk-core 2.34.x` with `s3 2.32.y`)
 - ❌ **Not Supported**: Old core + new service (causes compile-time failures)
+
+Use the [SDK BOM (Bill of Materials)](https://github.com/aws/aws-sdk-java-v2/?tab=readme-ov-file#importing-the-bom) to automatically manage compatible versions across all SDK modules and prevent version mismatches.
 
 ## Internal APIs
 


### PR DESCRIPTION
Following https://github.com/aws/aws-sdk-java-v2/pull/6061 The Java SDK team has decided to add guidance that instructs customer to maintain the same versions across all SDK components. Mixed version compatibility is limited to the same minor version. 