### PR TITLE
Bump jackson version to 2.19.4

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-e90b57c.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-e90b57c.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Update Jackson and Jackson jr to 2.19.4"
+}

--- a/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/JsonNodeParser.java
+++ b/core/json-utils/src/main/java/software/amazon/awssdk/protocols/jsoncore/JsonNodeParser.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.thirdparty.jackson.core.JsonFactory;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonParseException;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonParser;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonToken;
+import software.amazon.awssdk.thirdparty.jackson.core.StreamReadFeature;
 import software.amazon.awssdk.thirdparty.jackson.core.json.JsonReadFeature;
 
 /**
@@ -46,6 +47,7 @@ public final class JsonNodeParser {
      */
     public static final JsonFactory DEFAULT_JSON_FACTORY =
         JsonFactory.builder()
+                   .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
                    .configure(JsonReadFeature.ALLOW_JAVA_COMMENTS, true)
                    .build();
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/AwsStructuredPlainJsonFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/AwsStructuredPlainJsonFactory.java
@@ -33,6 +33,7 @@ public final class AwsStructuredPlainJsonFactory {
      * Recommended to share JsonFactory instances per http://wiki.fasterxml.com/JacksonBestPracticesPerformance
      */
     private static final JsonFactory JSON_FACTORY = JsonFactory.builder()
+                                                               .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
                                                                .enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)
                                                                .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
                                                                .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)

--- a/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/SdkJsonGeneratorTest.java
+++ b/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/SdkJsonGeneratorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonFactory;
+import software.amazon.awssdk.thirdparty.jackson.core.StreamReadFeature;
 import software.amazon.awssdk.utils.BinaryUtils;
 
 public class SdkJsonGeneratorTest {
@@ -40,7 +41,9 @@ public class SdkJsonGeneratorTest {
 
     @BeforeEach
     public void setup() {
-        jsonGenerator = new SdkJsonGenerator(JsonFactory.builder().build(), "application/json");
+        jsonGenerator = new SdkJsonGenerator(JsonFactory.builder()
+                                                        .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+                                                        .build(), "application/json");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,9 @@
         <awsjavasdk.version>${project.version}</awsjavasdk.version>
         <awsjavasdk.previous.version>2.37.3</awsjavasdk.previous.version>
         <awsjavasdk.previous-previous.version>2.37.2</awsjavasdk.previous-previous.version>
-        <jackson.version>2.15.2</jackson.version>
-        <jackson.databind.version>2.15.2</jackson.databind.version>
-        <jacksonjr.version>2.17.3</jacksonjr.version>
+        <jackson.version>2.19.4</jackson.version>
+        <jackson.databind.version>2.19.4</jackson.databind.version>
+        <jacksonjr.version>2.19.4</jacksonjr.version>
         <eventstream.version>1.0.1</eventstream.version>
         <commons.lang.version>3.14.0</commons.lang.version>
         <wiremock.version>2.32.0</wiremock.version>


### PR DESCRIPTION
Bump Jackson to 2.19.4

### Testing:
1. Tested in our Kinesis canary for 1 hour for each version, did not see any indication of a regression
2. Tested against the benchmarking suite from [this PR](https://github.com/aws/aws-sdk-java-v2/pull/6507) and did not see any indication of regression:

 | Benchmark | Old Jackson | New (2.19.4) | Change |
|-----------|-------------|--------------|--------|
| **getJson50b (p50)** | 0.167 µs | 0.167 µs | 0% |
| **getJson50b (p90)** | 0.250 µs | 0.250 µs | 0% |
| **getJson50b (p99)** | 0.458 µs | 0.459 µs | +0% |
| **getJson100b (p50)** | 0.250 µs | 0.250 µs | 0% |
| **getJson100b (p90)** | 0.292 µs | 0.333 µs | +14% |
| **getJson100b (p99)** | 0.458 µs | 0.500 µs | +9% |
| **getJson500b (p50)** | 0.584 µs | 0.625 µs | +7% |
| **getJson500b (p90)** | 0.625 µs | 0.667 µs | +7% |
| **getJson500b (p99)** | 0.792 µs | 0.792 µs | 0% |
| **getJson1kb (p50)** | 1.292 µs | 1.332 µs | +3% |
| **getJson1kb (p90)** | 1.458 µs | 1.374 µs | **-6%**  |
| **getJson1kb (p99)** | 4.120 µs | 1.708 µs | **-59%**  |
| **v2ToJson (p50)** | 532.480 µs | 537.600 µs | +1% |
| **v2ToJson (p90)** | 562.176 µs | 568.320 µs | +1% |
| **v2ToJson (p99)** | 754.688 µs | 667.648 µs | **-12%**  |
| **v2GetJsonEntireDoc (p50)** | 530.432 µs | 533.504 µs | +1% |
| **v2GetJsonEntireDoc (p90)** | 544.768 µs | 552.960 µs | +2% |
| **v2GetJsonEntireDoc (p99)** | 666.204 µs | 610.243 µs | **-8%**  |

The results seem flat aside from getJson1kb (p99) which might be an anomaly or related to code changes from that pr (the benchmark tests that test 2.19.4 have to use a new feature that has to do with escaping surrogate pairs but its unlikely to be related) 
