### PR TITLE
remove the assume role logic in integration test buildspec

### DIFF
--- a/buildspecs/integ-test.yml
+++ b/buildspecs/integ-test.yml
@@ -10,14 +10,6 @@ phases:
 
   build:
     commands:
-      - |
-        if [ ! -z "$INTEGRATION_TEST_ROLE_ARN" ]; then
-          ASSUME_ROLE_OUTPUT=`aws sts assume-role --role-arn "$INTEGRATION_TEST_ROLE_ARN" --role-session-name "integration-tests" --duration-seconds 7200 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text`
-          AWS_ACCESS_KEY_ID=`echo $ASSUME_ROLE_OUTPUT | awk '{ print $1 }'`
-          AWS_SECRET_ACCESS_KEY=`echo $ASSUME_ROLE_OUTPUT | awk '{ print $2 }'`
-          AWS_SESSION_TOKEN=`echo $ASSUME_ROLE_OUTPUT | awk '{ print $3 }'`
-          echo "Using role $INTEGRATION_TEST_ROLE_ARN with access key $AWS_ACCESS_KEY_ID."
-        fi
       - mvn clean install -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -T1C $MAVEN_OPTIONS
       - JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-1)
       - echo $JAVA_VERSION


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The integration test buildspec was failing due to AWS role chaining limitations when attempting to assume the integration test role. We are requesting two hours for the assumed role yet the limit is one hour. Our integration test run more than 1 hour. We should remove the logic here and put the logic in other places. 
## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
