### PR TITLE
Fix VersionedRecordExtension to sanitize attribute names in expression value keys

### DIFF
--- a/.changes/next-release/bugfix-DynamoDBEnhancedClient-2a54d62.json
+++ b/.changes/next-release/bugfix-DynamoDBEnhancedClient-2a54d62.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "The DynamoDB Enhanced Client now properly sanitizes version attribute names when building conditional expressions for optimistic locking. Version attributes with special characters in their names will now work correctly. See [#3279](https://github.com/aws/aws-sdk-java-v2/issues/3279)"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.extensions;
 
+import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.cleanAttributeName;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.isNullAttributeValue;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.keyRef;
 
@@ -58,7 +59,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkPublicApi
 @ThreadSafe
 public final class VersionedRecordExtension implements DynamoDbEnhancedClientExtension {
-    private static final Function<String, String> VERSIONED_RECORD_EXPRESSION_VALUE_KEY_MAPPER = key -> ":old_" + key + "_value";
+    private static final Function<String, String> VERSIONED_RECORD_EXPRESSION_VALUE_KEY_MAPPER =
+        key -> ":old_" + cleanAttributeName(key) + "_value";
     private static final String CUSTOM_METADATA_KEY = "VersionedRecordExtension:VersionAttribute";
     private static final VersionAttribute VERSION_ATTRIBUTE = new VersionAttribute();
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/VersionedRecordWithSpecialCharactersTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/VersionedRecordWithSpecialCharactersTest.java
@@ -97,7 +97,7 @@ public class VersionedRecordWithSpecialCharactersTest extends LocalDynamoDbSyncT
                          .addAttribute(String.class, a -> a.name("_attribute")
                                                            .getter(Record::get_attribute)
                                                            .setter(Record::set_attribute))
-                         .addAttribute(Integer.class, a -> a.name("_version")
+                         .addAttribute(Integer.class, a -> a.name("_my-:.version")
                                                             .getter(Record::get_version)
                                                             .setter(Record::set_version)
                                                             .tags(versionAttribute()))


### PR DESCRIPTION
## Motivation and Context

Fixes https://github.com/aws/aws-sdk-java-v2/issues/3279

When using @DynamoDbVersionAttribute with attribute names containing special characters (hyphens, dots, colons, etc.), DynamoDB operations fail with:
```
DynamoDbException: ExpressionAttributeValues contains invalid key: Syntax error; key: ":old_my-version-attribute_value"
```


The issue occurs because VersionedRecordExtension generates expression value placeholder keys directly from the attribute name without sanitizing special characters, which are not allowed in DynamoDB
expression value placeholders.

## Modifications
Updated `VERSIONED_RECORD_EXPRESSION_VALUE_KEY_MAPPER` to use cleanAttributeName() when generating expression value placeholder keys. This ensures special characters in version attribute names are replaced with underscores, making the placeholders valid

Changed:
```java
// Before
private static final Function<String, String> VERSIONED_RECORD_EXPRESSION_VALUE_KEY_MAPPER =
    key -> ":old_" + key + "_value";

// After
private static final Function<String, String> VERSIONED_RECORD_EXPRESSION_VALUE_KEY_MAPPER =
    key -> ":old_" + cleanAttributeName(key) + "_value";
```


Note that this will not introduce breaking behavior as it only affects the Bug Case
- Attribute names without special characters generate the same placeholder as before:
  - "version" → :old_version_value (unchanged)
- Attribute names with special characters now work instead of failing:
  - "my-version" → :old_my_version_value (was throwing exception before)

## Testing
Updated existing test case to use an attribute key name with invalid character

## Types of changes

• [x] Bug fix (non-breaking change which fixes an issue)
• [ ] New feature (non-breaking change which adds functionality)

## Checklist

• [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
• [x] Local run of mvn install succeeds
• [x] My code follows the code style of this project
• [ ] My change requires a change to the Javadoc documentation
• [ ] I have updated the Javadoc documentation accordingly
• [x] I have added tests to cover my changes
• [x] All new and existing tests passed
• [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the scripts/new-change script and following the instructions. Commit the new file created by the script in
.changes/next-release with your changes.
• [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

• [x] I confirm that this pull request can be released under the Apache 2 license