### PR TITLE
Add set -e to buildspecs with multi line commands

### DIFF
--- a/buildspecs/build.yml
+++ b/buildspecs/build.yml
@@ -15,8 +15,8 @@ phases:
       - echo $JAVA_VERSION
       - echo $MAVEN_OPTIONS
       - |
+        set -e
         if [ "$JAVA_VERSION" -ge "9" ]; then
-          set -e
           cd test/module-path-tests
           mvn package
           mvn exec:exec -P mock-tests

--- a/buildspecs/on-demand-integ-test.yml
+++ b/buildspecs/on-demand-integ-test.yml
@@ -11,8 +11,8 @@ phases:
       - JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-1)
       - echo $JAVA_VERSION
       - |
+        set -e
         if [ "$JAVA_VERSION" -ge "9" ]; then
-          set -e
           cd test/module-path-tests
           mvn package
           mvn exec:exec -P integ-tests

--- a/buildspecs/release-to-maven-central.yml
+++ b/buildspecs/release-to-maven-central.yml
@@ -23,8 +23,8 @@ phases:
       - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
       - ARTIFACT_URL="https://repo1.maven.org/maven2/software/amazon/awssdk/aws-sdk-java/$RELEASE_VERSION/"
       - |
+        set -e
         if ! curl -f --head $ARTIFACT_URL; then
-          set -e
           SONATYPE_USERNAME=`aws secretsmanager get-secret-value --secret-id $SONATYPE_USERNAME_ARN --query SecretString --output text`
           SONATYPE_PASSWORD=`aws secretsmanager get-secret-value --secret-id $SONATYPE_PASSWORD_ARN --query SecretString --output text`
           SDK_SIGNING_GPG_KEYNAME=`aws secretsmanager get-secret-value --secret-id $SDK_SIGNING_GPG_KEYNAME_ARN --query SecretString --output text`

--- a/buildspecs/release-to-maven.yml
+++ b/buildspecs/release-to-maven.yml
@@ -23,8 +23,8 @@ phases:
       - RELEASE_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
       - SONATYPE_URL="https://aws.oss.sonatype.org/service/local/repositories/releases/content/software/amazon/awssdk/aws-sdk-java/$RELEASE_VERSION/"
       - |
+        set -e
         if ! curl -f --head $SONATYPE_URL; then
-          set -e
           SONATYPE_USERNAME=`aws secretsmanager get-secret-value --secret-id $SONATYPE_USERNAME_ARN --query SecretString --output text`
           SONATYPE_PASSWORD=`aws secretsmanager get-secret-value --secret-id $SONATYPE_PASSWORD_ARN --query SecretString --output text`
           SDK_SIGNING_GPG_KEYNAME=`aws secretsmanager get-secret-value --secret-id $SDK_SIGNING_GPG_KEYNAME_ARN --query SecretString --output text`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
In multi line commands, a subsequent successful command will mask a previous command that fails
Re-adding previous PR that was reverted due to integ test failures - https://github.com/aws/aws-sdk-java-v2/pull/6524
## Modifications
<!--- Describe your changes in detail -->
Add set -e to beginning of multi line commands in buildpsecs
