### PR TITLE
Unsuppress deprecated IoT operations

### DIFF
--- a/.changes/next-release/feature-AWSIoT-e90fa27.json
+++ b/.changes/next-release/feature-AWSIoT-e90fa27.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS IoT",
+    "contributor": "",
+    "description": "Unsuppress the following operations that were previously suppressed:\n\n - AttachPrincipalPolicy\n - DetachPrincipalPolicy\n - ListPolicyPrincipals\n - ListPrincipalPolicies\n\nThese operations were previously supporessed because they were deprecated. However, this may be a blocker for customers moving from V1 to V2, so make these available for those customers."
+}

--- a/services/iot/src/main/resources/codegen-resources/customization.config
+++ b/services/iot/src/main/resources/codegen-resources/customization.config
@@ -44,12 +44,6 @@
         "listAuditFindings",
         "listV2LoggingLevels"
     ],
-    "deprecatedOperations": [
-        "AttachPrincipalPolicy",
-        "DetachPrincipalPolicy",
-        "ListPolicyPrincipals",
-        "ListPrincipalPolicies"
-    ],
     "shapeModifiers": {
         "AssetPropertyVariant": {
             "union": true


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
As customers move from V1 (which exposes these operations), to V2, they may not be able to move to the recommended operations because of external constraints such as IAM policies that only allow certain operations.

Note: IoT is not the only service that has suppressed operations. We will unsuppress them on need basis to avoid cluttering clients unnecessarily.

## Modifications
<!--- Describe your changes in detail -->

## Testing

```
mvn clean install -pl :iot
```

Verified the diffs of the generated clients (see comments).

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
