### PR TITLE
Fix NPE when using AnonymousCredentials in a credential provider chain with S3 CRT client.

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-c6497dc.json
+++ b/.changes/next-release/bugfix-AmazonS3-c6497dc.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fix NullPointerException when using AnonymousCredentials in a CredentialsChain with the S3 CRT Client."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialsProviderAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialsProviderAdapter.java
@@ -48,6 +48,11 @@ public final class CrtCredentialsProviderAdapter implements SdkAutoCloseable {
 
                 AwsCredentialsIdentity sdkCredentials =
                     CompletableFutureUtils.joinLikeSync(credentialsProvider.resolveIdentity());
+
+                if (sdkCredentials.providerName().map("AnonymousCredentialsProvider"::equals).orElse(false)) {
+                    return Credentials.createAnonymousCredentials();
+                }
+
                 byte[] accessKey = sdkCredentials.accessKeyId().getBytes(StandardCharsets.UTF_8);
                 byte[] secreteKey = sdkCredentials.secretAccessKey().getBytes(StandardCharsets.UTF_8);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialProviderAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialProviderAdapterTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.HttpCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -87,6 +88,23 @@ public class CrtCredentialProviderAdapterTest {
     @Test
     void crtCredentials_anonymousCredentialsProvider_shouldWork() {
         IdentityProvider<? extends AwsCredentialsIdentity> awsCredentialsProvider = AnonymousCredentialsProvider.create();
+
+        CrtCredentialsProviderAdapter adapter = new CrtCredentialsProviderAdapter(awsCredentialsProvider);
+        CredentialsProvider crtCredentialsProvider = adapter.crtCredentials();
+
+        Credentials crtCredentials = crtCredentialsProvider.getCredentials().join();
+
+        assertThat(crtCredentials.getAccessKeyId()).isNull();
+        assertThat(crtCredentials.getSecretAccessKey()).isNull();
+    }
+
+    @Test
+    void crtCredentials_anonymousCredentialsProviderFromChain_shouldWork() {
+        IdentityProvider<? extends AwsCredentialsIdentity> awsCredentialsProvider =
+            AwsCredentialsProviderChain
+                .builder()
+                .addCredentialsProvider(AnonymousCredentialsProvider.create())
+                .build();
 
         CrtCredentialsProviderAdapter adapter = new CrtCredentialsProviderAdapter(awsCredentialsProvider);
         CredentialsProvider crtCredentialsProvider = adapter.crtCredentials();


### PR DESCRIPTION
Fix NPE when using AnonymousCredentials in a credential provider chain with S3 CRT client.

## Motivation and Context
Fixes #5810 

## Modifications
Add an additional check that resolved credentials are from the AnonymousCredentialsProvider before trying to use accessKey/secretAccessKey.

## Testing
New unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
