### PR TITLE
Raise exceptions in resolveCredentials instead of creation for StsWebIdentityTokenFileCredentialsProvider

### DIFF
--- a/.changes/next-release/bugfix-AWSSTS-e3e9e7c.json
+++ b/.changes/next-release/bugfix-AWSSTS-e3e9e7c.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS STS",
+    "contributor": "",
+    "description": "Raise exceptions in resolveCredentials instead of creation for StsWebIdentityTokenFileCredentialsProvider"
+}

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialProviderTest.java
@@ -97,4 +97,18 @@ class StsWebIdentityTokenCredentialProviderTest {
         provider.resolveCredentials();
         Mockito.verify(stsClient, Mockito.times(1)).assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class));
     }
+
+    @Test
+    void createAssumeRoleWithWebIdentityTokenCredentialsProvider_raisesInResolveCredentials() {
+        ENVIRONMENT_VARIABLE_HELPER.remove(SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE.environmentVariable());
+
+        StsWebIdentityTokenFileCredentialsProvider provider =
+            StsWebIdentityTokenFileCredentialsProvider.builder().stsClient(stsClient)
+                                                      .refreshRequest(r -> r.build())
+                                                      .roleArn("someRole")
+                                                      .roleSessionName("tempRoleSession")
+                                                      .build();
+        // exception should be raised lazily when resolving credentials, not at creation time.
+        Assert.assertThrows(IllegalStateException.class, provider::resolveCredentials);
+    }
 }


### PR DESCRIPTION
Raise exceptions in resolveCredentials instead of creation for StsWebIdentityTokenFileCredentialsProvider

## Motivation and Context

* Fixes #6529
* Fixes #3952

Unlike other credential providers, the StsWebIdentityTokenFileCredentialsProvider was previously raising exceptions during construction instead of when `resolveCredentials` was called - this impacts its usage in a credentials provider chain.  The logic to capture exceptions during construction exited previously, but the scope was not wide enough.

## Modifications
* Expand the existing `try` to cover all of the places in construction where exceptions are raised.

## Testing
New unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
