### PR TITLE
Propagate exception to inputstream subscriber

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-4a99923.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-4a99923.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix an issue with `AsyncResponseTransformer.toBlockingInputStream()` where `read()` operations on the stream can hang if there if the transformer encounters an error while the stream is being read. Fixes [#5755](https://github.com/aws/aws-sdk-java-v2/issues/5755)."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamResponseTransformer.java
@@ -17,6 +17,8 @@ package software.amazon.awssdk.core.internal.async;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkResponse;
@@ -35,6 +37,7 @@ public class InputStreamResponseTransformer<ResponseT extends SdkResponse>
 
     private volatile CompletableFuture<ResponseInputStream<ResponseT>> future;
     private volatile ResponseT response;
+    private volatile WaitForSubscribeOnErrorWrapper subscriber;
 
     @Override
     public CompletableFuture<ResponseInputStream<ResponseT>> prepare() {
@@ -51,17 +54,74 @@ public class InputStreamResponseTransformer<ResponseT extends SdkResponse>
     @Override
     public void onStream(SdkPublisher<ByteBuffer> publisher) {
         AbortableInputStreamSubscriber inputStreamSubscriber = AbortableInputStreamSubscriber.builder().build();
-        publisher.subscribe(inputStreamSubscriber);
+        WaitForSubscribeOnErrorWrapper waitForSubscribeSubscriber = new WaitForSubscribeOnErrorWrapper(inputStreamSubscriber);
+
+        this.subscriber = waitForSubscribeSubscriber;
+
+        publisher.subscribe(waitForSubscribeSubscriber);
         future.complete(new ResponseInputStream<>(response, inputStreamSubscriber));
     }
 
     @Override
     public void exceptionOccurred(Throwable error) {
         future.completeExceptionally(error);
+        if (subscriber != null) {
+            this.subscriber.onError(error);
+        }
     }
 
     @Override
     public String name() {
         return TransformerType.STREAM.getName();
+    }
+
+    // Simple wrapper subscriber that ensures we don't forward the `onError` to the delegate until onSubscribe is called, to be
+    // compliant with the reactive streams spec. We use onError for forwarding the exception given to exceptionOccurred.
+    private static final class WaitForSubscribeOnErrorWrapper implements Subscriber<ByteBuffer> {
+        private final Object lock = new Object();
+        private final AbortableInputStreamSubscriber delegate;
+
+        private boolean subscribed = false;
+        private Throwable transformerException;
+
+
+        private WaitForSubscribeOnErrorWrapper(AbortableInputStreamSubscriber delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            synchronized (lock) {
+                subscribed = true;
+                delegate.onSubscribe(s);
+
+                if (transformerException != null) {
+                    delegate.onError(transformerException);
+                    transformerException = null;
+                }
+            }
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            this.delegate.onNext(byteBuffer);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            synchronized (lock) {
+                if (subscribed) {
+                    delegate.onError(t);
+                } else {
+                    // We're not subscribed yet, save the exception for until we are.
+                    transformerException = t;
+                }
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            this.delegate.onComplete();
+        }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Within InputStreamResponseTransformer, if exceptionOccurred is invoked after we already have an InputStream subscriber, propagate the exception to that subscriber.
## Modifications
<!--- Describe your changes in detail -->

## Testing
New unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
