### PR TITLE
Eliminate lambda indirection overhead in DynamoDB Enhanced Client

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/ImmutableAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/ImmutableAttribute.java
@@ -173,7 +173,7 @@ public final class ImmutableAttribute<T, B, R> {
     }
 
 
-    ResolvedImmutableAttribute<T, B> resolve(AttributeConverterProvider attributeConverterProvider) {
+    ResolvedImmutableAttribute<T, B, R> resolve(AttributeConverterProvider attributeConverterProvider) {
         return ResolvedImmutableAttribute.create(this,
                                                  converterFrom(attributeConverterProvider));
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/ImmutableAttributeTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/ImmutableAttributeTest.java
@@ -219,7 +219,7 @@ public class ImmutableAttributeTest {
                               .attributeConverter(attributeConverter)
                               .build();
 
-        ResolvedImmutableAttribute<SimpleItem, SimpleItem> resolvedAttribute =
+        ResolvedImmutableAttribute<SimpleItem, SimpleItem, String> resolvedAttribute =
             staticAttribute.resolve(AttributeConverterProvider.defaultProvider());
 
         Function<SimpleItem, AttributeValue> attributeValueFunction = resolvedAttribute.attributeGetterMethod();


### PR DESCRIPTION
### Motivation and Context

The DynamoDB Enhanced Client v2 shows significant performance regression compared to v1 DynamoDB Mapper, with 32-98% slower operations across all operations. One theory was that lambda allocation overhead in `ResolvedImmutableAttribute.attributeGetterMethod()` is a key bottleneck affecting all operations in the serialization hot path.

The change refactors how attribute values are extracted during serialization by replacing an inline lambda expression with a method reference to a dedicated instance method. Profiling shows this reduces allocations of iterator and builder objects, with `LinkedHashMap$LinkedEntryIterator` allocations dropping 44% and `DefaultDynamoDbExtensionContext$Builder` allocations dropping 30%. The method reference approach appears to allow the JVM to optimize the call path more effectively, though the exact mechanism linking the code change to these specific allocation reductions is not fully clear from profiling data. 

### Changes

#### Before:
```java
Function<T, AttributeValue> getAttributeValueWithTransform = item -> {
    R value = immutableAttribute.getter().apply(item);  // Lambda indirection
    return value == null ? nullAttributeValue() : attributeType.objectToAttributeValue(value);
};
```

#### Put with SMALL data set
<img width="1374" height="546" alt="image" src="https://github.com/user-attachments/assets/24edff14-6c83-4895-8e52-616e99291ec3" />


#### After:
```java
public Function<T, AttributeValue> attributeGetterMethod() {
    return this::getAttributeValue; 
}

AttributeValue getAttributeValue(T item) {
    R value = getter.apply(item);
    return value == null ? nullAttributeValue() : attributeType.objectToAttributeValue(value);
}
```

#### Put with SMALL data set (lambda$create is eliminated)

<img width="1099" height="544" alt="image" src="https://github.com/user-attachments/assets/e8282fd1-dda2-4159-bd20-5d6057738eaf" />

---

## Results
running existing benchmarks for `test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/enhanced/dynamodb`

### Java 21

Operation | Size | V1 Mean (us/op) | V2 Mean (us/op) | V2 Regression | Optimization (us/op) | Improvement from v2 | Gap to v1
-- | -- | -- | -- | -- | -- | -- | --
Delete | TINY | 0.175 | 0.308 | 76% | 0.209 | 32% | 19%
Delete | SMALL | 0.174 | 0.298 | 71% | 0.207 | 31% | 19%
Delete | HUGE | 0.176 | 0.304 | 73% | 0.213 | 30% | 21%
Delete | HUGE_FLAT | 0.175 | 0.3 | 71% | 0.213 | 29% | 22%
Get | TINY | 0.31 | 0.357 | 15% | 0.291 | 18% | -6%
Get | SMALL | 0.506 | 0.981 | 94% | 0.66 | 33% | 30%
Get | HUGE | 3.863 | 8.837 | 129% | 8.077 | 9% | 109%
Get | HUGE_FLAT | 4.321 | 3.427 | -26% | 2.966 | 13% | -31%
Put | TINY | 0.394 | 0.523 | 33% | 0.43 | 18% | 9%
Put | SMALL | 0.538 | 1.204 | 124% | 1.041 | 14% | 94%
Put | HUGE | 4.297 | 14.061 | 227% | 13.506 | 4% | 214%
Put | HUGE_FLAT | 5.94 | 7.07 | 19% | 6.64 | 6% | 12%
Query | TINY | 0.93 | 2.079 | 124% | 1.721 | 17% | 85%
Query | SMALL | 1.604 | 3.45 | 115% | 2.919 | 15% | 82%
Query | HUGE | 11.729 | 29.116 | 148% | 26.825 | 8% | 129%
Query | HUGE_FLAT | 13.546 | 11.727 | -15% | 10.528 | 10% | -22%
Scan | TINY | 0.675 | 0.871 | 29% | 0.856 | 2% | 27%
Scan | SMALL | 1.24 | 2.014 | 62% | 1.994 | 1% | 61%
Scan | HUGE | 10.995 | 28.252 | 157% | 26.745 | 5% | 143%
Scan | HUGE_FLAT | 11.481 | 11.565 | 1% | 10.028 | 13% | -13%
Update | TINY | 0.424 | 1.044 | 146% | 0.818 | 22% | 93%
Update | SMALL | 0.85 | 7.597 | 794% | 7.277 | 4% | 756%
Update | HUGE | 4.972 | 37.253 | 649% | 36.299 | 3% | 630%
Update | HUGE_FLAT | 11.87 | 267.091 | 2150% | 244.241 | 9% | 1958%

### Java 17

Operation | Size | V1 Mean (us/op) | V2 Mean (us/op) | V2 Regression | Optimization (us/op) | Improvement from v2 | Gap to v1
-- | -- | -- | -- | -- | -- | -- | --
Delete | TINY | 0.161 | 0.317 | 97% | 0.22 | 31% | 37%
Delete | SMALL | 0.173 | 0.306 | 77% | 0.222 | 27% | 28%
Delete | HUGE | 0.166 | 0.316 | 90% | 0.222 | 30% | 34%
Delete | HUGE_FLAT | 0.17 | 0.321 | 89% | 0.221 | 31% | 30%
Get | TINY | 0.275 | 0.33 | 20% | 0.23 | 30% | -16%
Get | SMALL | 0.592 | 0.732 | 24% | 0.565 | 23% | -5%
Get | HUGE | 3.691 | 8.254 | 124% | 7.176 | 13% | 94%
Get | HUGE_FLAT | 3.507 | 3.539 | 1% | 4.066 | -15% | 16%
Put | TINY | 0.298 | 0.488 | 64% | 0.377 | 23% | 27%
Put | SMALL | 0.628 | 1.371 | 118% | 1.157 | 16% | 84%
Put | HUGE | 4.059 | 17.728 | 337% | 16.891 | 5% | 316%
Put | HUGE_FLAT | 6.186 | 11.099 | 79% | 10.419 | 6% | 68%
Query | TINY | 0.897 | 1.964 | 119% | 1.525 | 22% | 70%
Query | SMALL | 1.502 | 3.243 | 116% | 2.464 | 24% | 64%
Query | HUGE | 10.981 | 24.338 | 122% | 32.552 | -34% | 196%
Query | HUGE_FLAT | 10.928 | 13.705 | 25% | 11.561 | 16% | 6%
Scan | TINY | 0.64 | 0.681 | 6% | 0.659 | 3% | 3%
Scan | SMALL | 1.176 | 1.7 | 45% | 1.755 | -3% | 49%
Scan | HUGE | 10.57 | 22.841 | 116% | 23.425 | -3% | 122%
Scan | HUGE_FLAT | 11.53 | 9.564 | -17% | 8.565 | 10% | -26%
Update | TINY | 0.481 | 0.953 | 98% | 0.754 | 21% | 57%
Update | SMALL | 0.858 | 9.053 | 955% | 8.796 | 3% | 925%
Update | HUGE | 4.776 | 45.16 | 846% | 45.485 | -1% | 852%
Update | HUGE_FLAT | 9.323 | 237.816 | 2451% | 232.854 | 2% | 2398%

### Java 8

Operation | Size | V1 Mean (us/op) | V2 Mean (us/op) | V2 Regression | Optimization (us/op) | Improvement from v2 | Gap to v1
-- | -- | -- | -- | -- | -- | -- | --
Delete | TINY | 0.170 | 0.304 | 79% | 0.216 | 29% | 27%
Delete | SMALL | 0.160 | 0.311 | 94% | 0.222 | 29% | 39%
Delete | HUGE | 0.165 | 0.311 | 88% | 0.215 | 31% | 30%
Delete | HUGE_FLAT | 0.158 | 0.321 | 103% | 0.213 | 34% | 35%
Get | TINY | 0.272 | 0.332 | 22% | 0.231 | 30% | -15%
Get | SMALL | 0.470 | 0.727 | 55% | 0.55 | 24% | 17%
Get | HUGE | 3.671 | 8.271 | 125% | 7.175 | 13% | 95%
Get | HUGE_FLAT | 3.488 | 3.6 | 3% | 3.296 | 8% | -6%
Put | TINY | 0.298 | 0.478 | 60% | 0.389 | 19% | 31%
Put | SMALL | 0.525 | 1.249 | 138% | 1.133 | 9% | 116%
Put | HUGE | 4.006 | 17.892 | 347% | 17.536 | 2% | 338%
Put | HUGE_FLAT | 7.222 | 10.89 | 51% | 10.465 | 4% | 45%
Query | TINY | 0.933 | 1.965 | 11% | 1.535 | 22% | 65%
Query | SMALL | 1.490 | 3.387 | 127% | 2.436 | 28% | 63%
Query | HUGE | 11.004 | 26.021 | 136% | 23.599 | 9% | 114%
Query | HUGE_FLAT | 12.513 | 11.575 | -7% | 10.809 | 7% | -14%
Scan | TINY | 0.655 | 0.697 | 6% | 0.630 | 10% | -4%
Scan | SMALL | 1.174 | 1.697 | 45% | 1.668 | 2% | 42%
Scan | HUGE | 10.576 | 25.55 | 142% | 22.912 | 10% | 117%
Scan | HUGE_FLAT | 15.330 | 9.934 | -35% | 9.119 | 8% | -41%
Update | TINY | 0.486 | 1.017 | 109% | 0.730 | 28% | 50%
Update | SMALL | 0.866 | 9.123 | 954% | 8.870 | 3% | 924%
Update | HUGE | 4.842 | 44.323 | 815% | 45.452 | -3% | 839%
Update | HUGE_FLAT | 8.068 | 235.056 | 2814% | 238.332 | -1% | 2854%


#### JFR Profiling (Get TINY benchmark):

Allocation Impact:

Object Type | Before | After | Change | %
-- | -- | -- | -- | --
LinkedHashMap$LinkedEntryIterator | 1,000 | 565 | -435 | -44%
DefaultDynamoDbExtensionContext$Builder | 1,390 | 974 | -416 | -30%
DefaultDynamoDbExtensionContext | 1,431 | 1,170 | -261 | -18%
EnhancedAttributeValue$InternalBuilder | 871 | 678 | -193 | -22%
GetItemEnhancedResponse | 320 | 170 | -150 | -47%
HashMap$Node[] | 1,865 | 1,627 | -238 | -13%
LinkedHashMap | 1,404 | 1,211 | -193 | -14%
HashMap | 871 | 543 | -328 | -38%
EnhancedAttributeValue | 664 | 836 | +172 | +26%
LinkedHashMap$Entry | 590 | 466 | -124 | -21%

