### PR TITLE
Allow errors as event stream output members

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-52218bd.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-52218bd.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Update codegen to allow errors as event stream output members"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -141,8 +141,6 @@ public class IntermediateModelBuilder {
 
         customization.postprocess(fullModel);
 
-        linkMembersToShapes(fullModel);
-
         log.info("{} shapes remained after applying customizations.", fullModel.getShapes().size());
 
         Map<String, ShapeModel> trimmedShapes = removeUnusedShapes(fullModel);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -141,6 +141,8 @@ public class IntermediateModelBuilder {
 
         customization.postprocess(fullModel);
 
+        linkMembersToShapes(fullModel);
+
         log.info("{} shapes remained after applying customizations.", fullModel.getShapes().size());
 
         Map<String, ShapeModel> trimmedShapes = removeUnusedShapes(fullModel);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/service-2.json
@@ -68,6 +68,9 @@
       "members": {
         "EventStream": {
           "shape": "EventStream"
+        },
+        "EventStreamError": {
+          "shape": "EventStreamError"
         }
       }
     },
@@ -126,6 +129,16 @@
         }
       },
       "event": true
+    },
+    "EventStreamError": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "fault": true
     },
     "EventStreamOperationWithOnlyInputRequest": {
       "type": "structure",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Smithy spec states:
> Event streams MAY target shapes marked with the [error trait](https://smithy.io/2.0/spec/type-refinement-traits.html#error-trait)

https://smithy.io/2.0/spec/streaming.html#modeled-errors-in-event-streams

Codegen currently throws a NPE if a exception shape is a member of an event stream output. This is because the Java SDK codegen stores exception shape names by appending a suffix `Exception`.
- https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java#L252

## Modifications
<!--- Describe your changes in detail -->
Update `RemoveUnusedShapes.resolveMemberShapes()`, so that if the shape type is `Exception`, and the `MemberModel` C2J shape name equals the `ShapeModel` C2J name, to resolve the shape name (original name) instead of returning the simple type (with `Exception` suffix)

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added exception shape to event stream output in codegen test model

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)