### PR TITLE
Increase timeout for s3 upload regression tests

### DIFF
--- a/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadAsyncRegressionTesting.java
+++ b/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadAsyncRegressionTesting.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.services.s3.regression.S3ChecksumsTestUtils.assumeNotAccessPointWithPathStyle;
 import static software.amazon.awssdk.services.s3.regression.S3ClientFlavor.STANDARD_ASYNC;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +77,7 @@ public class UploadAsyncRegressionTesting extends UploadStreamingRegressionTesti
         ClientOverrideConfiguration.Builder overrideConfiguration =
             ClientOverrideConfiguration.builder()
                                        .addExecutionInterceptor(recorder)
-                                       .apiCallTimeout(Duration.of(30, ChronoUnit.SECONDS));
+                                       .apiCallTimeout(API_CALL_TIMEOUT);
 
         if (config.isPayloadSigning()) {
             overrideConfiguration.addExecutionInterceptor(new EnablePayloadSigningInterceptor());

--- a/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadStreamingRegressionTesting.java
+++ b/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadStreamingRegressionTesting.java
@@ -30,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -76,6 +77,7 @@ public class UploadStreamingRegressionTesting extends BaseS3RegressionTest {
     private static final Logger LOG = Logger.loggerFor(UploadStreamingRegressionTesting.class);
 
     private static final ExecutorService ASYNC_REQUEST_BODY_EXECUTOR = Executors.newSingleThreadExecutor();
+    static final Duration API_CALL_TIMEOUT = Duration.ofMinutes(1);
 
     static final byte[] smallContent = "Hello world".getBytes(StandardCharsets.UTF_8);
     static final byte[] largeContent = largeContent();

--- a/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadSyncRegressionTesting.java
+++ b/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadSyncRegressionTesting.java
@@ -18,8 +18,6 @@ package software.amazon.awssdk.services.s3.regression.upload;
 import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.services.s3.regression.S3ChecksumsTestUtils.assumeNotAccessPointWithPathStyle;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -76,7 +74,7 @@ public class UploadSyncRegressionTesting extends UploadStreamingRegressionTestin
         ClientOverrideConfiguration.Builder overrideConfiguration =
             ClientOverrideConfiguration.builder()
                                        .addExecutionInterceptor(recorder)
-                                       .apiCallTimeout(Duration.of(30, ChronoUnit.SECONDS));
+                                       .apiCallTimeout(API_CALL_TIMEOUT);
 
         if (config.isPayloadSigning()) {
             overrideConfiguration.addExecutionInterceptor(new EnablePayloadSigningInterceptor());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Tests frequently fail of timeout issues, this PR increase timeout for s3 upload regression tests from 30 sec to 1 min

