### PR TITLE
Fix handling of empty S3 objects in S3ChecksumValidatingInputStream

### DIFF
--- a/.changes/next-release/bugfix-S3-7ca353f.json
+++ b/.changes/next-release/bugfix-S3-7ca353f.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3",
+    "contributor": "",
+    "description": "Fixed single-byte `read()` on empty S3 objects returning checksum metadata instead of EOF"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/S3ChecksumValidatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/S3ChecksumValidatingInputStream.java
@@ -58,6 +58,18 @@ public class S3ChecksumValidatingInputStream extends InputStream implements Abor
      */
     @Override
     public int read() throws IOException {
+        if (strippedLength == 0 && lengthRead == 0) {
+            for (int i = 0; i < CHECKSUM_SIZE; i++) {
+                int b = inputStream.read();
+                if (b != -1) {
+                    streamChecksum[i] = (byte) b;
+                }
+            }
+            lengthRead = CHECKSUM_SIZE;
+            validateAndThrow();
+            return -1;
+        }
+
         int read = inputStream.read();
 
         if (read != -1 && lengthRead < strippedLength) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/S3ChecksumValidatingPublisherTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/S3ChecksumValidatingPublisherTest.java
@@ -169,6 +169,28 @@ public class S3ChecksumValidatingPublisherTest {
     assertFalse(s.hasCompleted());
   }
 
+  @Test
+  public void emptyObjectReturnsNoData() {
+    Md5Checksum checksum = new Md5Checksum();
+    byte[] checksumBytes = checksum.getChecksumBytes();
+    byte[] emptyWithChecksum = new byte[CHECKSUM_SIZE];
+    for (int i = 0; i < CHECKSUM_SIZE; i++) {
+      emptyWithChecksum[i] = checksumBytes[i];
+    }
+
+    final TestPublisher driver = new TestPublisher();
+    final TestSubscriber s = new TestSubscriber();
+    final S3ChecksumValidatingPublisher p = new S3ChecksumValidatingPublisher(driver, new Md5Checksum(), CHECKSUM_SIZE);
+    p.subscribe(s);
+
+    driver.doOnNext(ByteBuffer.wrap(emptyWithChecksum));
+    driver.doOnComplete();
+
+    assertArrayEquals(new byte[0], s.receivedData());
+    assertTrue(s.hasCompleted());
+    assertFalse(s.isOnErrorCalled());
+  }
+
   private class TestSubscriber implements Subscriber<ByteBuffer> {
     final List<ByteBuffer> received;
     boolean completed;


### PR DESCRIPTION
This PR fixes #3538 where reading empty S3 objects with synchronous `ResponseTransformer.toInputStream()` returned incorrect data instead of EOF. 

When retrieving an empty S3 object using the synchronous `getObject()` method with `toInputStream()`, the first call to read() incorrectly returned 212 (the first byte of the MD5 checksum of the empty payload) instead of -1 (EOF). This was likely an edge case that we didn't cover.

The fix was to add short circuit handling for empty objects in `S3ChecksumValidatingInputStream.read()` that validates the checksum and then returns -1 to signal EOF.

Added additional test coverage for the `read(byte[])` method and also the async path (both work correctly)

