### PR TITLE
Fix credential reloading by default + gracefully handle missing files

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1c5bd30.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1c5bd30.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix credential reloading in defaults when shared credential/config files are modified."
+}

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-b3c8f2c.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-b3c8f2c.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Gracefully handle missing file in ProfileFileSupplier.reloadWhenModified."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -105,7 +105,7 @@ public final class InstanceProfileCredentialsProvider
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
         this.asyncThreadName = builder.asyncThreadName;
         this.profileFile = Optional.ofNullable(builder.profileFile)
-                                   .orElseGet(() -> ProfileFileSupplier.fixedProfileFile(ProfileFile.defaultProfileFile()));
+                                   .orElseGet(ProfileFileSupplier::defaultSupplier);
         this.profileName = Optional.ofNullable(builder.profileName)
                                    .orElseGet(ProfileFileSystemSetting.AWS_PROFILE::getStringValueOrThrow);
         this.sourceChain = builder.sourceChain;

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
@@ -73,7 +73,7 @@ public final class ProfileCredentialsProvider
                                           .orElseGet(ProfileFileSystemSetting.AWS_PROFILE::getStringValueOrThrow);
             selectedProfileSupplier =
                 Optional.ofNullable(builder.profileFile)
-                        .orElseGet(() -> ProfileFileSupplier.fixedProfileFile(builder.defaultProfileFileLoader.get()));
+                        .orElse(defaultProfileFileLoader);
 
         } catch (RuntimeException e) {
             // If we couldn't load the credentials provider for some reason, save an exception describing why. This exception
@@ -216,7 +216,7 @@ public final class ProfileCredentialsProvider
     static final class BuilderImpl implements Builder {
         private Supplier<ProfileFile> profileFile;
         private String profileName;
-        private Supplier<ProfileFile> defaultProfileFileLoader = ProfileFile::defaultProfileFile;
+        private Supplier<ProfileFile> defaultProfileFileLoader = ProfileFileSupplier.defaultSupplier();
 
         BuilderImpl() {
         }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProviderTest.java
@@ -17,15 +17,9 @@ package software.amazon.awssdk.auth.credentials;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.google.common.jimfs.Jimfs;
-import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProviderTest.java
@@ -17,9 +17,15 @@ package software.amazon.awssdk.auth.credentials;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.google.common.jimfs.Jimfs;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
@@ -262,7 +262,7 @@ public class ProfileCredentialsProviderTest {
         generateTestCredentialsFile("updatedAccessKey", "updatedSecretAccessKey");
 
         // ProfileFileRefresher has a stale time of 1000 ms.
-        Thread.sleep(1000);
+        Thread.sleep(1100);
 
         assertThat(provider.resolveCredentials()).satisfies(credentials -> {
             assertThat(credentials.accessKeyId()).isEqualTo("updatedAccessKey");

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
@@ -25,6 +25,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,6 +34,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.testutils.Waiter;
 import software.amazon.awssdk.utils.StringInputStream;
 
 /**
@@ -244,29 +246,28 @@ public class ProfileCredentialsProviderTest {
     }
 
     @Test
-    void resolveCredentials_defaultProfileFileSupplier_refreshesCredentials() throws InterruptedException {
-        Path credentialsFile = generateTestCredentialsFile("defaultAccessKey", "defaultSecretAccessKey");
+    void resolveCredentials_defaultProfileFileSupplier_refreshesCredentials() {
+        AtomicBoolean firstCall = new AtomicBoolean(true);
+        ProfileFile file1 = profileFile("[default]\naws_access_key_id = akid1\n"
+                                        + "aws_secret_access_key = sak1\n");
+        ProfileFile file2 = profileFile("[default]\naws_access_key_id = akid2\n"
+                                        + "aws_secret_access_key = sak2\n");
+        Supplier<ProfileFile> refreshingSupplier = () ->  firstCall.getAndSet(false) ? file1 : file2;
 
         ProfileCredentialsProvider provider =  new ProfileCredentialsProvider
             .BuilderImpl()
-            .defaultProfileFileLoader(ProfileFileSupplier.reloadWhenModified(credentialsFile, ProfileFile.Type.CREDENTIALS))
+            .defaultProfileFileLoader(refreshingSupplier)
                                       .profileName("default")
                                       .build();
 
         assertThat(provider.resolveCredentials()).satisfies(credentials -> {
-            assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
-            assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
+            assertThat(credentials.accessKeyId()).isEqualTo("akid1");
+            assertThat(credentials.secretAccessKey()).isEqualTo("sak1");
         });
 
-        // modify the file
-        generateTestCredentialsFile("updatedAccessKey", "updatedSecretAccessKey");
-
-        // ProfileFileRefresher has a stale time of 1000 ms.
-        Thread.sleep(1100);
-
         assertThat(provider.resolveCredentials()).satisfies(credentials -> {
-            assertThat(credentials.accessKeyId()).isEqualTo("updatedAccessKey");
-            assertThat(credentials.secretAccessKey()).isEqualTo("updatedSecretAccessKey");
+            assertThat(credentials.accessKeyId()).isEqualTo("akid2");
+            assertThat(credentials.secretAccessKey()).isEqualTo("sak2");
         });
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterAll;

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileSupplierBuilder.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileSupplierBuilder.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.profiles;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.util.Objects;
@@ -33,10 +34,14 @@ final class ProfileFileSupplierBuilder {
     private Consumer<ProfileFile> onProfileFileLoad;
 
     public ProfileFileSupplierBuilder reloadWhenModified(Path path, ProfileFile.Type type) {
-        ProfileFile.Builder builder = ProfileFile.builder()
-                                                 .content(path)
-                                                 .type(type);
-        this.profileFile = builder::build;
+        this.profileFile = () -> {
+            if (Files.isRegularFile(path) && Files.isReadable(path)) {
+                return ProfileFile.builder()
+                                  .content(path)
+                                  .type(type).build();
+            }
+            return ProfileFile.empty();
+        };
         this.profileFilePath = path;
         this.reloadingSupplier = true;
         return this;

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/ProfileFileRefresher.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/ProfileFileRefresher.java
@@ -122,7 +122,7 @@ public final class ProfileFileRefresher {
     }
 
     private boolean canReloadProfileFile() {
-        if (Objects.isNull(profileFilePath)) {
+        if (Objects.isNull(profileFilePath) || !Files.exists(profileFilePath)) {
             return false;
         }
 

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
@@ -593,8 +593,9 @@ class ProfileFileSupplierTest {
     }
 
     @Test
-    public void reloadWhenModified_noCredentialsFiles_returnsEmptyProvider_andRefreshes() {
+    public void reloadWhenModified_noCredentialsFiles_returnsEmptyProvider_andRefreshes() throws IOException {
         Path credentialsFilePath = getTestCredentialsFilePath();
+        Files.deleteIfExists(credentialsFilePath);
 
         AdjustableClock clock = new AdjustableClock();
         ProfileFileSupplier supplier = builderWithClock(clock)

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
@@ -592,6 +592,27 @@ class ProfileFileSupplierTest {
         });
     }
 
+    @Test
+    public void reloadWhenModified_noCredentialsFiles_returnsEmptyProvider_andRefreshes() {
+        Path credentialsFilePath = getTestCredentialsFilePath();
+
+        AdjustableClock clock = new AdjustableClock();
+        ProfileFileSupplier supplier = builderWithClock(clock)
+            .reloadWhenModified(credentialsFilePath, ProfileFile.Type.CREDENTIALS)
+            .build();
+
+        assertThat(supplier.get().profiles()).isEmpty();
+
+        generateTestCredentialsFile("modifiedAccessKey", "modifiedSecretAccessKey", "modifiedAccountId");
+        updateModificationTime(credentialsFilePath, clock.instant().plusMillis(1));
+
+        clock.tickForward(Duration.ofSeconds(10));
+
+        // supplied ProfileFile should refreshed and now have data under the `default` profile
+        Optional<Profile> fileOptional = supplier.get().profile("default");
+        assertThat(fileOptional).isPresent();
+    }
+
     private Path writeTestFile(String contents, Path path) {
         try {
             Files.createDirectories(testDirectory);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -105,6 +105,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.profiles.ProfileProperty;
 import software.amazon.awssdk.retries.api.RetryStrategy;
@@ -280,7 +281,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
      * Apply global default configuration
      */
     private SdkClientConfiguration mergeGlobalDefaults(SdkClientConfiguration configuration) {
-        Supplier<ProfileFile> defaultProfileFileSupplier = new Lazy<>(ProfileFile::defaultProfileFile)::getValue;
+        Supplier<ProfileFile> defaultProfileFileSupplier = ProfileFileSupplier.defaultSupplier();
 
         configuration = configuration.merge(c -> c.option(EXECUTION_INTERCEPTORS, new ArrayList<>())
                                                   .option(METRIC_PUBLISHERS, new ArrayList<>())

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -112,7 +112,6 @@ import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.AttributeMap.LazyValueSource;
 import software.amazon.awssdk.utils.Either;
-import software.amazon.awssdk.utils.Lazy;
 import software.amazon.awssdk.utils.OptionalUtils;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
@@ -44,8 +44,13 @@ import com.google.common.collect.ImmutableSet;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,7 +64,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -81,6 +88,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.StringInputStream;
 
@@ -99,6 +107,9 @@ public class DefaultClientBuilderTest {
     private static final URI DEFAULT_ENDPOINT = URI.create("https://defaultendpoint.com");
     private static final URI ENDPOINT = URI.create("https://example.com");
     private static final NoOpSigner TEST_SIGNER = new NoOpSigner();
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Mock
     private SdkHttpClient.Builder defaultHttpClientFactory;
@@ -419,6 +430,39 @@ public class DefaultClientBuilderTest {
         assertThat(secondGet).isSameAs(firstGet);
     }
 
+    @Test
+    public void defaultProfileFileSupplier_refreshesWhenFileModified() {
+        EnvironmentVariableHelper.run(env -> {
+            try {
+                File credentialFile = tempFolder.newFile();
+                writeTestCredentialsFile(credentialFile, "akid1", "sak");
+                env.set("AWS_SHARED_CREDENTIALS_FILE", credentialFile.getPath());
+                SdkClientConfiguration config =
+                    testClientBuilder().build().clientConfiguration;
+
+                Supplier<ProfileFile> defaultProfileFileSupplier = config.option(PROFILE_FILE_SUPPLIER);
+                ProfileFile firstGet = defaultProfileFileSupplier.get();
+
+                writeTestCredentialsFile(credentialFile, "updatedAkid", "updatedSak");
+                Thread.sleep(1000);
+                ProfileFile secondGet = defaultProfileFileSupplier.get();
+
+                assertThat(secondGet).isNotSameAs(firstGet);
+                assertThat(secondGet.profile("default")).isPresent();
+                assertThat(secondGet.profile("default").get()).satisfies(profile -> {
+                    assertThat(profile.property("aws_access_key_id"))
+                        .isEqualTo(Optional.of("updatedAkid"));
+                    assertThat(profile.property("aws_secret_access_key"))
+                        .isEqualTo(Optional.of("updatedSak"));
+                });
+
+            }
+            catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
     private SdkDefaultClientBuilder<TestClientBuilder, TestClient> testClientBuilder() {
         ClientOverrideConfiguration overrideConfig =
                 ClientOverrideConfiguration.builder()
@@ -435,6 +479,13 @@ public class DefaultClientBuilderTest {
                                            .build();
 
         return new TestAsyncClientBuilder().overrideConfiguration(overrideConfig);
+    }
+
+    private void writeTestCredentialsFile(File file, String accessKeyId, String secretAccessKey)
+            throws IOException {
+        String contents = String.format("[default]\naws_access_key_id = %s\naws_secret_access_key = %s\n",
+                                        accessKeyId, secretAccessKey);
+        Files.write(file.toPath(), contents.getBytes(StandardCharsets.UTF_8));
     }
 
     private static class TestClient {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
@@ -50,7 +50,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -444,7 +443,7 @@ public class DefaultClientBuilderTest {
                 ProfileFile firstGet = defaultProfileFileSupplier.get();
 
                 writeTestCredentialsFile(credentialFile, "updatedAkid", "updatedSak");
-                Thread.sleep(1000);
+                Thread.sleep(1100);
                 ProfileFile secondGet = defaultProfileFileSupplier.get();
 
                 assertThat(secondGet).isNotSameAs(firstGet);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
@@ -121,7 +121,7 @@ public final class S3Utilities {
         this.region = Validate.paramNotNull(builder.region, "Region");
         this.endpoint = builder.endpoint;
         this.profileFile = Optional.ofNullable(builder.profileFile)
-                                   .orElseGet(() -> ProfileFileSupplier.fixedProfileFile(ProfileFile.defaultProfileFile()));
+                                   .orElseGet(ProfileFileSupplier::defaultSupplier);
         this.profileName = builder.profileName;
 
         if (builder.s3Configuration == null) {


### PR DESCRIPTION
Fix credential reloading by default + gracefully handle missing files

## Motivation and Context
* Fixes #4268 
* Fixes #6615 

## Modifications
This PR addresses two, related issues by:
1.  Using a more dynamic supplier in the `ProfileFileSupplier.reloadWhenModified` method - this ensures that credential provider chains that rely on this method will fallback to the next available provider AND that if the file is eventually created, it can be used.
2. Replace static/fixedProfileFile default suppliers with the `ProfileFileSupplier.defaultSupplier` which uses refreshable suppliers which correctly cache ProfileFiles (mitigating the performance impact seen in some earlier versions) while also allowing updates by checking the file modification time.

**Q: What about the performance impact?**
There were a few previous PRs (#4850 and #3950) that made changes to default profile file suppliers to mitigate performance impacts.  However, the performance degredation (loading profileFile on every request) comes from using `ProfileFile::defaultProfileFile` as a supplier and **not** from using the `ProfileFileSupplier.defaultSupplier`.  Using ``ProfileFile::defaultProfileFile` has NO caching and no refresh logic - every single `get` call will always re-load the file(s).  The `ProfileFileSupplier.defaultSupplier` uses file modification times to ensure that the file(s) are reloaded only when changed. 

**Benchmark Results**
#3950 identified performance issues when running `JsonProtocolBenchmark`, so we use the same here (since this would load a default client and make many requests):

```
Benchmark Mode Cnt Score Error Units
JsonProtocolBenchmark.before         thrpt 10 49365.788 ± 2169.444 ops/s
JsonProtocolBenchmark.after          thrpt 10 49959.522 ± 1983.392 ops/s
```

## Testing
New and existing unit tests.

Ran reproduction test cases from both #4268 and #6615. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
