### PR TITLE
Fix cloudfront ecdsa integration tests

### DIFF
--- a/.changes/next-release/feature-AmazonCloudFront-51e8b2d.json
+++ b/.changes/next-release/feature-AmazonCloudFront-51e8b2d.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon CloudFront",
+    "contributor": "",
+    "description": "Add support for ECDSA signed URLs."
+}

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -490,7 +490,7 @@ public final class CloudFrontUtilities {
                 return SigningUtils.signWithSha1Rsa(policyToSign, privateKey);
             case "EC":
             case "ECDSA":
-                    return SigningUtils.signWithSha1ECDSA(policyToSign, privateKey);
+                return SigningUtils.signWithSha1ECDSA(policyToSign, privateKey);
             default:
                 // do not attempt to use a generic Signer based on the privateKey algorithm:
                 // future supported key types likely require different hash algorithms (eg, SHA256 or higher instead of SHA1)

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -495,7 +495,7 @@ public final class CloudFrontUtilities {
                 // do not attempt to use a generic Signer based on the privateKey algorithm:
                 // future supported key types likely require different hash algorithms (eg, SHA256 or higher instead of SHA1)
                 throw new IllegalArgumentException(
-                    "Unsupported key algorithm for for CloudFront signed URL: " + privateKey.getAlgorithm());
+                    "Unsupported key algorithm for CloudFront signed URL: " + privateKey.getAlgorithm());
         }
     }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.net.URI;
 import java.security.InvalidKeyException;
+import java.security.PrivateKey;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -140,7 +141,7 @@ public final class CloudFrontUtilities {
         try {
             String resourceUrl = request.resourceUrl();
             String cannedPolicy = SigningUtils.buildCannedPolicy(resourceUrl, request.expirationDate());
-            byte[] signatureBytes = SigningUtils.signWithSha1Rsa(cannedPolicy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(cannedPolicy.getBytes(UTF_8), request.privateKey());
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
             URI uri = URI.create(resourceUrl);
             String protocol = uri.getScheme();
@@ -266,7 +267,7 @@ public final class CloudFrontUtilities {
                                                                        request.expirationDate(),
                                                                        request.ipRange());
 
-            byte[] signatureBytes = SigningUtils.signWithSha1Rsa(policy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(policy.getBytes(UTF_8), request.privateKey());
             String urlSafePolicy = SigningUtils.makeStringUrlSafe(policy);
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
             URI uri = URI.create(resourceUrl);
@@ -368,7 +369,7 @@ public final class CloudFrontUtilities {
     public CookiesForCannedPolicy getCookiesForCannedPolicy(CannedSignerRequest request) {
         try {
             String cannedPolicy = SigningUtils.buildCannedPolicy(request.resourceUrl(), request.expirationDate());
-            byte[] signatureBytes = SigningUtils.signWithSha1Rsa(cannedPolicy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(cannedPolicy.getBytes(UTF_8), request.privateKey());
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
             String expiry = String.valueOf(request.expirationDate().getEpochSecond());
             return DefaultCookiesForCannedPolicy.builder()
@@ -469,7 +470,7 @@ public final class CloudFrontUtilities {
         try {
             String policy = SigningUtils.buildCustomPolicy(request.resourceUrl(), request.activeDate(), request.expirationDate(),
                                                            request.ipRange());
-            byte[] signatureBytes = SigningUtils.signWithSha1Rsa(policy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(policy.getBytes(UTF_8), request.privateKey());
             String urlSafePolicy = SigningUtils.makeStringUrlSafe(policy);
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
             return DefaultCookiesForCustomPolicy.builder()
@@ -479,6 +480,22 @@ public final class CloudFrontUtilities {
                                                 .policyHeaderValue(POLICY_KEY + "=" + urlSafePolicy).build();
         } catch (InvalidKeyException e) {
             throw SdkClientException.create("Could not sign custom policy cookie", e);
+        }
+    }
+
+    private static byte[] signPolicy(byte[] policyToSign, PrivateKey privateKey) throws InvalidKeyException {
+        // all CloudFront signed urls currently require the SHA1 and currently only support RSA and EC
+        switch (privateKey.getAlgorithm()) {
+            case "RSA":
+                return SigningUtils.signWithSha1Rsa(policyToSign, privateKey);
+            case "EC":
+            case "ECDSA":
+                    return SigningUtils.signWithSha1ECDSA(policyToSign, privateKey);
+            default:
+                // do not attempt to use a generic Signer based on the privateKey algorithm:
+                // future supported key types likely require different hash algorithms (eg, SHA256 or higher instead of SHA1)
+                throw new IllegalArgumentException(
+                    "Unsupported key algorithm for for CloudFront signed URL: " + privateKey.getAlgorithm());
         }
     }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/auth/Pem.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/auth/Pem.java
@@ -27,6 +27,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.regex.Pattern;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 
 @SdkInternalApi
 public final class Pem {
@@ -51,15 +52,18 @@ public final class Pem {
         for (PemObject object : objects) {
             switch (object.getPemObjectType()) {
                 case PRIVATE_KEY_PKCS1:
+                    // only supports RSA keys, so load it as RSA.
                     return Rsa.privateKeyFromPkcs1(object.getDerBytes());
                 case PRIVATE_KEY_PKCS8:
-                    return Rsa.privateKeyFromPkcs8(object.getDerBytes());
+                    return SigningUtils.privateKeyFromPkcs8(object.getDerBytes());
                 default:
                     break;
             }
         }
         throw new IllegalArgumentException("Found no private key");
     }
+
+
 
     /**
      * Returns the first public key that is found from the input stream of a PEM

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -226,12 +226,14 @@ public final class SigningUtils {
     /**
      * Attempt to load a private key from PKCS8 DER
      */
-    public static PrivateKey privateKeyFromPkcs8(byte[] derBytes) throws InvalidKeySpecException {
+    public static PrivateKey privateKeyFromPkcs8(byte[] derBytes) {
         EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(derBytes);
         try {
             return tryKeyLoadFromSpec(privateKeySpec);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalArgumentException(e);
+        } catch (InvalidKeySpecException e) {
+            throw new IllegalArgumentException("Invalid private key, unable to load as either RSA or ECDSA", e);
         }
     }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -238,7 +238,8 @@ public final class SigningUtils {
     /**
      * We don't have a way to determine which algorithm to use, so we try to load as RSA and EC
      */
-    private static PrivateKey tryKeyLoadFromSpec(EncodedKeySpec privateKeySpec) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    private static PrivateKey tryKeyLoadFromSpec(EncodedKeySpec privateKeySpec)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
         try {
             return KeyFactory.getInstance("RSA").generatePrivate(privateKeySpec);
         } catch (InvalidKeySpecException rsaFail) {

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -25,9 +25,11 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.security.Key;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
+import java.security.spec.ECGenParameterSpec;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -35,8 +37,11 @@ import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.HttpExecuteRequest;
@@ -85,11 +90,17 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     private static String bucket;
     private static String domainName;
     private static String resourceUrl;
-    private static String keyPairId;
-    private static PrivateKey privateKey;
-    private static File keyFile;
-    private static Path keyFilePath;
+    private static String rsaKeyPairId;
+    private static PrivateKey rsaPrivateKey;
+    private static File rsaKeyFile;
+    private static Path rsaKeyFilePath;
     private static String keyGroupId;
+
+    private static String ecKeyPairId;
+    private static PrivateKey ecPrivateKey;
+    private static File ecKeyFile;
+    private static Path ecKeyFilePath;
+
     private static String originAccessId;
     private static String distributionId;
 
@@ -98,6 +109,33 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         IntegrationTestBase.setUp();
         initStaticFields();
     }
+
+    private static class KeyTestCase {
+        final String name;
+        final String keyPairId;
+        final PrivateKey privateKey;
+        final Path keyFilePath;
+
+        KeyTestCase(String name, String keyPairId, PrivateKey privateKey, Path keyFilePath) {
+            this.name = name;
+            this.keyPairId = keyPairId;
+            this.privateKey = privateKey;
+            this.keyFilePath = keyFilePath;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<KeyTestCase> keyCases() throws Exception {
+        return Stream.of(
+            new KeyTestCase("RSA", rsaKeyPairId, rsaPrivateKey, rsaKeyFilePath),
+            new KeyTestCase("ECDSA", ecKeyPairId, ecPrivateKey, ecKeyFilePath)
+        );
+    }
+
 
     @Test
     void unsignedUrl_shouldReturn403Response() throws Exception {
@@ -115,14 +153,15 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
     }
 
-    @Test
-    void getSignedUrlWithCannedPolicy_producesValidUrl() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedUrlWithCannedPolicy_producesValidUrl(KeyTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CannedSignerRequest request = CannedSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(keyFilePath)
-                                                         .keyPairId(keyPairId)
+                                                         .privateKey(testCase.keyFilePath)
+                                                         .keyPairId(testCase.keyPairId)
                                                          .expirationDate(expirationDate).build();
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(request);
         SdkHttpClient client = ApacheHttpClient.create();
@@ -136,12 +175,13 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(retrievedBucketContent).hasSameContentAs(originalBucketContent);
     }
 
-    @Test
-    void getSignedUrlWithCannedPolicy_withExpiredDate_shouldReturn403Response() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedUrlWithCannedPolicy_withExpiredDate_shouldReturn403Response(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2020, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                      .privateKey(privateKey)
-                                                                                      .keyPairId(keyPairId)
+                                                                                      .privateKey(testCase.privateKey)
+                                                                                      .keyPairId(testCase.keyPairId)
                                                                                       .expirationDate(expirationDate));
         SdkHttpClient client = ApacheHttpClient.create();
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
@@ -151,15 +191,16 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
     }
 
-    @Test
-    void getSignedUrlWithCustomPolicy_producesValidUrl() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedUrlWithCustomPolicy_producesValidUrl(KeyTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(keyFilePath)
-                                                         .keyPairId(keyPairId)
+                                                         .privateKey(testCase.keyFilePath)
+                                                         .keyPairId(testCase.keyPairId)
                                                          .expirationDate(expirationDate)
                                                          .activeDate(activeDate).build();
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
@@ -179,8 +220,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         Instant activeDate = LocalDate.of(2040, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                      .privateKey(privateKey)
-                                                                                      .keyPairId(keyPairId)
+                                                                                      .privateKey(rsaPrivateKey)
+                                                                                      .keyPairId(rsaKeyPairId)
                                                                                       .expirationDate(expirationDate)
                                                                                       .activeDate(activeDate));
         SdkHttpClient client = ApacheHttpClient.create();
@@ -191,13 +232,14 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
     }
 
-    @Test
-    void getCookiesForCannedPolicy_producesValidCookies() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCannedPolicy_producesValidCookies(KeyTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CookiesForCannedPolicy cookies = cloudFrontUtilities.getCookiesForCannedPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                             .privateKey(privateKey)
-                                                                                             .keyPairId(keyPairId)
+                                                                                             .privateKey(testCase.privateKey)
+                                                                                             .keyPairId(testCase.keyPairId)
                                                                                              .expirationDate(expirationDate));
 
         SdkHttpClient client = ApacheHttpClient.create();
@@ -216,8 +258,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         Instant expirationDate = LocalDate.of(2020, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CannedSignerRequest request = CannedSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(keyFilePath)
-                                                         .keyPairId(keyPairId)
+                                                         .privateKey(rsaKeyFilePath)
+                                                         .keyPairId(rsaKeyPairId)
                                                          .expirationDate(expirationDate).build();
         CookiesForCannedPolicy cookies = cloudFrontUtilities.getCookiesForCannedPolicy(request);
 
@@ -229,14 +271,15 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
     }
 
-    @Test
-    void getCookiesForCustomPolicy_producesValidCookies() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_producesValidCookies(KeyTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                             .privateKey(privateKey)
-                                                                                             .keyPairId(keyPairId)
+                                                                                             .privateKey(testCase.privateKey)
+                                                                                             .keyPairId(testCase.keyPairId)
                                                                                              .expirationDate(expirationDate)
                                                                                              .activeDate(activeDate));
 
@@ -257,8 +300,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(keyFilePath)
-                                                         .keyPairId(keyPairId)
+                                                         .privateKey(rsaKeyFilePath)
+                                                         .keyPairId(rsaKeyPairId)
                                                          .expirationDate(expirationDate)
                                                          .activeDate(activeDate).build();
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(request);
@@ -271,8 +314,9 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
     }
 
-    @Test
-    void getSignedUrlWithCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedUrlWithCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
                                           .toInstant(ZoneOffset.of("Z"));
@@ -283,8 +327,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(keyFilePath)
-                                                         .keyPairId(keyPairId)
+                                                         .privateKey(testCase.keyFilePath)
+                                                         .keyPairId(testCase.keyPairId)
                                                          .resourceUrlPattern(resourceUrl + "*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
@@ -308,8 +352,9 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(200);
     }
 
-    @Test
-    void getSignedUrlWithCustomPolicy_wildCardPath() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedUrlWithCustomPolicy_wildCardPath(KeyTestCase testCase) throws Exception {
         String resourceUri = "https://" + domainName;
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
@@ -321,8 +366,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUri + "/foo/specific-file")
-                                                         .privateKey(keyFilePath)
-                                                         .keyPairId(keyPairId)
+                                                         .privateKey(testCase.keyFilePath)
+                                                         .keyPairId(testCase.keyPairId)
                                                          .resourceUrlPattern(resourceUri + "/foo/*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
@@ -344,8 +389,9 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         assertThat(response.httpResponse().statusCode()).isEqualTo(200);
     }
 
-    @Test
-    void getSignedUrlWithCustomPolicy_wildCardPolicyResource_allowsAnyPath() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedUrlWithCustomPolicy_wildCardPolicyResource_allowsAnyPath(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
                                           .toInstant(ZoneOffset.of("Z"));
@@ -356,8 +402,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(keyFilePath)
-                                                         .keyPairId(keyPairId)
+                                                         .privateKey(testCase.keyFilePath)
+                                                         .keyPairId(testCase.keyPairId)
                                                          .resourceUrlPattern("*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
@@ -380,7 +426,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     private static void initStaticFields() throws Exception {
-        initializeKeyFileAndPair();
+        initializeRsaKeyFileAndPair();
+        initializeEcKeyFileAndPair();
         originAccessId = getOrCreateOriginAccessIdentity();
         keyGroupId = getOrCreateKeyGroup();
         bucket = getOrCreateBucket();
@@ -392,16 +439,16 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         distributionId = distribution.id;
     }
 
-    private static void initializeKeyFileAndPair() throws Exception {
-        keyFile = new RandomTempFile(UUID.randomUUID() + "-key.pem", 0);
-        keyFile.deleteOnExit();
-        keyFilePath = keyFile.toPath();
+    private static void initializeRsaKeyFileAndPair() throws Exception {
+        rsaKeyFile = new RandomTempFile(UUID.randomUUID() + "-key.pem", 0);
+        rsaKeyFile.deleteOnExit();
+        rsaKeyFilePath = rsaKeyFile.toPath();
 
         String privateKeyName = RESOURCE_PREFIX + "private-key";
         String publicKeyName = RESOURCE_PREFIX + "public-key";
         try {
             GetSecretValueResponse getSecretResponse = secretsManagerClient.getSecretValue(r -> r.secretId(privateKeyName));
-            Files.write(keyFile.toPath(), getSecretResponse.secretBinary().asByteArray(), StandardOpenOption.TRUNCATE_EXISTING);
+            Files.write(rsaKeyFile.toPath(), getSecretResponse.secretBinary().asByteArray(), StandardOpenOption.TRUNCATE_EXISTING);
 
             Optional<PublicKeySummary> key = cloudFrontClient.listPublicKeys()
                                                              .publicKeyList()
@@ -410,8 +457,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                              .filter(k -> publicKeyName.equals(k.name()))
                                                              .findAny();
             if (key.isPresent()) {
-                privateKey = SigningUtils.loadPrivateKey(keyFilePath);
-                keyPairId = key.get().id();
+                rsaPrivateKey = SigningUtils.loadPrivateKey(rsaKeyFilePath);
+                rsaKeyPairId = key.get().id();
                 return;
             }
         } catch (ResourceNotFoundException e) {
@@ -425,13 +472,13 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         kpg.initialize(2048);
         KeyPair keyPair = kpg.generateKeyPair();
 
-        FileWriter writer = new FileWriter(keyFile);
+        FileWriter writer = new FileWriter(rsaKeyFile);
         writer.write("-----BEGIN PRIVATE KEY-----\n");
         writer.write(ENCODER.encodeToString(keyPair.getPrivate().getEncoded()));
         writer.write("\n-----END PRIVATE KEY-----\n");
         writer.close();
 
-        SdkBytes keyFileBytes = SdkBytes.fromByteArray(Files.readAllBytes(keyFilePath));
+        SdkBytes keyFileBytes = SdkBytes.fromByteArray(Files.readAllBytes(rsaKeyFilePath));
         try {
             secretsManagerClient.createSecret(r -> r.name(privateKeyName)
                                                     .secretBinary(keyFileBytes));
@@ -449,8 +496,71 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
             cloudFrontClient.createPublicKey(r -> r.publicKeyConfig(k -> k.callerReference(CALLER_REFERENCE)
                                                                           .name(publicKeyName)
                                                                           .encodedKey(encodedKey)));
-        privateKey = keyPair.getPrivate();
-        keyPairId = publicKeyResponse.publicKey().id();
+        rsaPrivateKey = keyPair.getPrivate();
+        rsaKeyPairId = publicKeyResponse.publicKey().id();
+    }
+
+    private static void initializeEcKeyFileAndPair() throws Exception {
+        ecKeyFile = new RandomTempFile(UUID.randomUUID() + "-key.pem", 0);
+        ecKeyFile.deleteOnExit();
+        ecKeyFilePath = ecKeyFile.toPath();
+
+        String privateKeyName = RESOURCE_PREFIX + "private-key-ecdsa";
+        String publicKeyName = RESOURCE_PREFIX + "public-key-ecdsa";
+
+        try {
+            GetSecretValueResponse getSecretResponse = secretsManagerClient.getSecretValue(r -> r.secretId(privateKeyName));
+            Files.write(ecKeyFile.toPath(), getSecretResponse.secretBinary().asByteArray(),
+                        StandardOpenOption.TRUNCATE_EXISTING);
+
+            Optional<PublicKeySummary> key = cloudFrontClient.listPublicKeys()
+                                                             .publicKeyList()
+                                                             .items()
+                                                             .stream()
+                                                             .filter(k -> publicKeyName.equals(k.name()))
+                                                             .findAny();
+            if (key.isPresent()) {
+                ecPrivateKey = SigningUtils.loadPrivateKey(ecKeyFilePath);
+                ecKeyPairId = key.get().id();
+                return;
+            }
+        } catch (ResourceNotFoundException e) {
+            // No private key, don't bother checking for a public one.
+        }
+
+        System.out.println("Creating keys.");
+
+        // We were missing a private or public key. Initialize them both.
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        FileWriter writer = new FileWriter(ecKeyFile);
+        writer.write("-----BEGIN PRIVATE KEY-----\n");
+        writer.write(ENCODER.encodeToString(keyPair.getPrivate().getEncoded()));
+        writer.write("\n-----END PRIVATE KEY-----\n");
+        writer.close();
+
+        SdkBytes keyFileBytes = SdkBytes.fromByteArray(Files.readAllBytes(ecKeyFilePath));
+        try {
+            secretsManagerClient.createSecret(r -> r.name(privateKeyName)
+                                                    .secretBinary(keyFileBytes));
+        } catch (ResourceExistsException e) {
+            secretsManagerClient.putSecretValue(r -> r.secretId(privateKeyName)
+                                                      .secretBinary(keyFileBytes));
+        }
+
+        String encodedKey = "-----BEGIN PUBLIC KEY-----\n"
+                            + ENCODER.encodeToString(keyPair.getPublic().getEncoded())
+                            + "\n-----END PUBLIC KEY-----\n";
+
+
+        CreatePublicKeyResponse publicKeyResponse =
+            cloudFrontClient.createPublicKey(r -> r.publicKeyConfig(k -> k.callerReference(CALLER_REFERENCE)
+                                                                          .name(publicKeyName)
+                                                                          .encodedKey(encodedKey)));
+        ecPrivateKey = keyPair.getPrivate();
+        ecKeyPairId = publicKeyResponse.publicKey().id();
     }
 
     private static String getOrCreateOriginAccessIdentity() {
@@ -496,7 +606,7 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         System.out.println("Creating key group.");
 
         return cloudFrontClient.createKeyGroup(r -> r.keyGroupConfig(c -> c.name(keyGroupName)
-                                                                           .items(keyPairId)))
+                                                                           .items(rsaKeyPairId, ecKeyPairId)))
                                .keyGroup()
                                .id();
     }

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -619,13 +619,12 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                 });
 
                 // KeyGroups update quickly, but it takes up to 1 minute to propagate to the cache
+                // and there is not any other state we can easily query to wait on.
                 System.out.println("Waiting for key group update to propagate.");
                 Instant expectedPropagationTime = Instant.now().plusSeconds(60);
                 Waiter.run(Instant::now)
                       .until((t) -> t.isAfter(expectedPropagationTime))
                       .orFailAfter(Duration.ofMinutes(1));
-
-                System.out.println("Waited for: " + expectedPropagationTime.compareTo(Instant.now()) + " seconds");
             }
             return keyGroupSummary.get().keyGroup().id();
         }

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -22,24 +22,35 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.spec.ECGenParameterSpec;
 import java.time.LocalDate;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
+import junit.framework.TestCase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCannedPolicy;
 import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCustomPolicy;
+import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
@@ -48,45 +59,82 @@ import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
 class CloudFrontUtilitiesTest {
     private static final String RESOURCE_URL = "https://d1npcfkc2mojrf.cloudfront.net/s3ObjectKey";
     private static final String RESOURCE_URL_WITH_PORT = "https://d1npcfkc2mojrf.cloudfront.net:65535/s3ObjectKey";
-    private static KeyPairGenerator kpg;
-    private static KeyPair keyPair;
-    private static File keyFile;
-    private static Path keyFilePath;
     private static CloudFrontUtilities cloudFrontUtilities;
+
+    @TempDir
+    static Path tempDir;
+
+    private static class KeyTestCase {
+        final String name;
+        final KeyPair keyPair;
+        final Path keyFilePath;
+
+        KeyTestCase(String name, KeyPair keyPair, Path keyFilePath) {
+            this.name = name;
+            this.keyPair = keyPair;
+            this.keyFilePath = keyFilePath;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        static KeyTestCase createRsaTestCase() {
+            try {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+                kpg.initialize(2048);
+                KeyPair keyPair = kpg.generateKeyPair();
+                return new KeyTestCase("RSA", keyPair, writeKeyToFile("rsa", keyPair));
+            } catch(NoSuchAlgorithmException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        static KeyTestCase createECDSATestCase() {
+            try {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+                kpg.initialize(new ECGenParameterSpec("secp256r1"));
+                KeyPair keyPair = kpg.generateKeyPair();
+                return new KeyTestCase("ECDSA", keyPair, writeKeyToFile("ec", keyPair));
+            } catch(NoSuchAlgorithmException | IOException | InvalidAlgorithmParameterException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Path writeKeyToFile(String name, KeyPair keyPair) throws IOException {
+            Path keyFilePath = tempDir.resolve(name + "_key.pem");
+            try (Writer writer = Files.newBufferedWriter(keyFilePath)) {
+                writer.write("-----BEGIN PRIVATE KEY-----\n");
+                writer.write(Base64.getEncoder()
+                                   .encodeToString(keyPair.getPrivate().getEncoded()));
+                writer.write("\n-----END PRIVATE KEY-----\n");
+            }
+            return keyFilePath;
+        }
+
+    }
+
+    static Stream<KeyTestCase> keyCases() throws Exception {
+        return Stream.of(
+            KeyTestCase.createRsaTestCase(),
+            KeyTestCase.createECDSATestCase()
+        );
+    }
 
     @BeforeAll
     static void setUp() throws Exception {
-        initKeys();
         cloudFrontUtilities = CloudFrontUtilities.create();
     }
 
-    @AfterAll
-    static void tearDown() {
-        keyFile.deleteOnExit();
-    }
-
-    static void initKeys() throws Exception {
-        kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(2048);
-        keyPair = kpg.generateKeyPair();
-
-        Base64.Encoder encoder = Base64.getEncoder();
-        keyFile = new File("key.pem");
-        FileWriter writer = new FileWriter(keyFile);
-        writer.write("-----BEGIN PRIVATE KEY-----\n");
-        writer.write(encoder.encodeToString(keyPair.getPrivate().getEncoded()));
-        writer.write("\n-----END PRIVATE KEY-----\n");
-        writer.close();
-        keyFilePath = keyFile.toPath();
-    }
-
-    @Test
-    void getSignedURLWithCannedPolicy_producesValidUrl() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCannedPolicy_producesValidUrl(KeyTestCase testCase) {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
                 .resourceUrl(RESOURCE_URL)
-                .privateKey(keyPair.getPrivate())
+                .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate));
         String url = signedUrl.url();
@@ -97,14 +145,15 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCannedPolicy_withQueryParams_producesValidUrl() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCannedPolicy_withQueryParams_producesValidUrl(KeyTestCase testCase) {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         String resourceUrlWithQueryParams = "https://d1npcfkc2mojrf.cloudfront.net/s3ObjectKey?a=b&c=d";
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
                 .resourceUrl(resourceUrlWithQueryParams)
-                .privateKey(keyPair.getPrivate())
+                .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate));
         String url = signedUrl.url();
@@ -116,15 +165,16 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_producesValidUrl() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_producesValidUrl(KeyTestCase testCase) throws Exception {
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         String ipRange = "1.2.3.4";
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> {
             try {
                 r.resourceUrl(RESOURCE_URL)
-                 .privateKey(keyFilePath)
+                 .privateKey(testCase.keyFilePath)
                  .keyPairId("keyPairId")
                  .expirationDate(expirationDate)
                  .activeDate(activeDate)
@@ -143,8 +193,9 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_withQueryParams_producesValidUrl() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_withQueryParams_producesValidUrl(KeyTestCase testCase) throws Exception {
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         String ipRange = "1.2.3.4";
@@ -152,7 +203,7 @@ class CloudFrontUtilitiesTest {
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r
                 .resourceUrl(resourceUrlWithQueryParams)
-                .privateKey(keyPair.getPrivate())
+                .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate)
                 .activeDate(activeDate)
@@ -167,13 +218,14 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_withIpRangeOmitted_producesValidUrl() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_withIpRangeOmitted_producesValidUrl(KeyTestCase testCase) throws Exception {
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(RESOURCE_URL)
-                                                         .privateKey(keyFilePath)
+                                                         .privateKey(testCase.keyFilePath)
                                                          .keyPairId("keyPairId")
                                                          .expirationDate(expirationDate)
                                                          .activeDate(activeDate)
@@ -189,13 +241,14 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_withActiveDateOmitted_producesValidUrl() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_withActiveDateOmitted_producesValidUrl(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         String ipRange = "1.2.3.4";
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(RESOURCE_URL)
-                                                         .privateKey(keyFilePath)
+                                                         .privateKey(testCase.keyFilePath)
                                                          .keyPairId("keyPairId")
                                                          .expirationDate(expirationDate)
                                                          .ipRange(ipRange)
@@ -211,25 +264,27 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_withMissingExpirationDate_shouldThrowException() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_withMissingExpirationDate_shouldThrowException(KeyTestCase testCase) throws Exception {
         NullPointerException exception = assertThrows(NullPointerException.class, () ->
             cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r
                 .resourceUrl(RESOURCE_URL)
-                .privateKey(keyPair.getPrivate())
+                .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId"))
         );
         assertThat(exception.getMessage().contains("Expiration date must be provided to sign CloudFront URLs"));
     }
 
-    @Test
-    void getSignedURLWithCannedPolicy_withEncodedUrl_doesNotDecodeUrl() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCannedPolicy_withEncodedUrl_doesNotDecodeUrl(KeyTestCase testCase) throws Exception {
         String encodedUrl = "https://distributionDomain/s3ObjectKey/%40blob?v=1n1dm%2F01n1dm0";
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
                 .resourceUrl(encodedUrl)
-                .privateKey(keyPair.getPrivate())
+                .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate));
         String url = signedUrl.url();
@@ -240,8 +295,9 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_withEncodedUrl_doesNotDecodeUrl() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_withEncodedUrl_doesNotDecodeUrl(KeyTestCase testCase) throws Exception {
         String encodedUrl = "https://distributionDomain/s3ObjectKey/%40blob?v=1n1dm%2F01n1dm0";
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
@@ -249,7 +305,7 @@ class CloudFrontUtilitiesTest {
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> {
             try {
                 r.resourceUrl(encodedUrl)
-                 .privateKey(keyFilePath)
+                 .privateKey(testCase.keyFilePath)
                  .keyPairId("keyPairId")
                  .expirationDate(expirationDate)
                  .activeDate(activeDate)
@@ -268,36 +324,39 @@ class CloudFrontUtilitiesTest {
         assertThat(expected).isEqualTo(url);
     }
 
-    @Test
-    void getSignedURLWithCannedPolicy_withPortNumber_returnsPortNumber() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCannedPolicy_withPortNumber_returnsPortNumber(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
                 .resourceUrl(RESOURCE_URL_WITH_PORT)
-                .privateKey(keyPair.getPrivate())
+                .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate));
         assertThat(signedUrl.url()).contains("65535");
     }
 
-    @Test
-    void getSignedURLWithCustomPolicy_withPortNumber_returnsPortNumber() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_withPortNumber_returnsPortNumber(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r
                 .resourceUrl(RESOURCE_URL_WITH_PORT)
-                .privateKey(keyPair.getPrivate())
+                .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate));
         assertThat(signedUrl.url()).contains("65535");
     }
 
-    @Test
-    void getCookiesForCannedPolicy_producesValidCookies() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCannedPolicy_producesValidCookies(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CannedSignerRequest request = CannedSignerRequest.builder()
                                                          .resourceUrl(RESOURCE_URL)
-                                                         .privateKey(keyFilePath)
+                                                         .privateKey(testCase.keyFilePath)
                                                          .keyPairId("keyPairId")
                                                          .expirationDate(expirationDate)
                                                          .build();
@@ -306,14 +365,15 @@ class CloudFrontUtilitiesTest {
         assertThat(cookiesForCannedPolicy.keyPairIdHeaderValue()).isEqualTo("CloudFront-Key-Pair-Id=keyPairId");
     }
 
-    @Test
-    void getCookiesForCustomPolicy_producesValidCookies() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_producesValidCookies(KeyTestCase testCase) throws Exception {
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         String ipRange = "1.2.3.4";
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(RESOURCE_URL)
-                                                         .privateKey(keyFilePath)
+                                                         .privateKey(testCase.keyFilePath)
                                                          .keyPairId("keyPairId")
                                                          .expirationDate(expirationDate)
                                                          .activeDate(activeDate)
@@ -324,12 +384,13 @@ class CloudFrontUtilitiesTest {
         assertThat(cookiesForCustomPolicy.keyPairIdHeaderValue()).isEqualTo("CloudFront-Key-Pair-Id=keyPairId");
     }
 
-    @Test
-    void getCookiesForCustomPolicy_withActiveDateAndIpRangeOmitted_producesValidCookies() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_withActiveDateAndIpRangeOmitted_producesValidCookies(KeyTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(RESOURCE_URL)
-                                                         .privateKey(keyPair.getPrivate())
+                                                         .privateKey(testCase.keyPair.getPrivate())
                                                          .keyPairId("keyPairId")
                                                          .expirationDate(expirationDate)
                                                          .build();
@@ -342,11 +403,12 @@ class CloudFrontUtilitiesTest {
     @MethodSource("provideUrlPatternsAndExpectedResources")
     void getSignedURLWithCustomPolicy_policyResourceUrlShouldHandleVariousPatterns(
         String resourceUrlPattern, String expectedResource) {
+        KeyTestCase testCase = KeyTestCase.createRsaTestCase();
         String baseUrl = "https://d1234.cloudfront.net/images/photo.jpg";
         Instant expiration = Instant.now().plusSeconds(3600);
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(baseUrl)
-                                                         .privateKey(keyPair.getPrivate())
+                                                         .privateKey(testCase.keyPair.getPrivate())
                                                          .keyPairId("keyPairId")
                                                          .resourceUrlPattern(resourceUrlPattern)
                                                          .expirationDate(expiration)


### PR DESCRIPTION
Re-release #6627 with fixes for integration test.

## Motivation and Context
#6627 was reverted because of failing integration tests before being released.



## Modifications
This PR includes all of the changes from #6627 but updates the integration test to fix the gap - it ensures that if the distribution's key group exists that it has all required public keys.  The key group on the release account had only the RSA key and not the ECDSA key - we now check that the keys are all int he group and if not, make an update to it.


## Testing
Ran on an integ account with the key group existing BUT missing the ECDSA key.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)



## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
