### PR TITLE
docs: fix Javadoc for StringUtils.equals() and repeat() null handling

### DIFF
--- a/utils/src/main/java/software/amazon/awssdk/utils/StringUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/StringUtils.java
@@ -299,10 +299,10 @@ public final class StringUtils {
      * equal sequences of characters.</p>
      *
      * <p>{@code null}s are handled without exceptions. Two {@code null}
-     * references are considered to be equal. The comparison is case sensitive.</p>
+     * references are considered to be unequal. The comparison is case sensitive.</p>
      *
      * <pre>
-     * StringUtils.equals(null, null)   = true
+     * StringUtils.equals(null, null)   = false
      * StringUtils.equals(null, "abc")  = false
      * StringUtils.equals("abc", null)  = false
      * StringUtils.equals("abc", "abc") = true
@@ -312,7 +312,7 @@ public final class StringUtils {
      * @see Object#equals(Object)
      * @param cs1  the first String, may be {@code null}
      * @param cs2  the second String, may be {@code null}
-     * @return {@code true} if the Strings are equal (case-sensitive), or both {@code null}
+     * @return {@code true} if the Strings are equal (case-sensitive), or {@code false} if either is {@code null}
      */
     public static boolean equals(final String cs1, final String cs2) {
         if (cs1 == null || cs2 == null) {
@@ -932,18 +932,19 @@ public final class StringUtils {
 
         throw new IllegalArgumentException("Value was defined as '" + value + "', but should be 'false' or 'true'");
     }
-    
+
     /**
      * Returns a string whose value is the concatenation of this string repeated {@code count} times.
      * <p>
      * If this string is empty or count is zero then the empty string is returned.
+     * A {@code null} input string returns {@code null}.
      * <p>
      * Logical clone of JDK11's {@link String#repeat(int)}.
      *
-     * @param value the string to repeat
+     * @param value the string to repeat, may be null
      * @param count number of times to repeat
-     * @return A string composed of this string repeated {@code count} times or the empty string if this string is empty or count
-     * is zero
+     * @return A string composed of this string repeated {@code count} times, the empty string if this string is empty or count
+     * is zero, or {@code null} if input is {@code null}
      * @throws IllegalArgumentException if the {@code count} is negative.
      */
     public static String repeat(String value, int count) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Updating Java docs for [6603](https://github.com/aws/aws-sdk-java-v2/issues/6603)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
- Java Docs StringUtils.equals() and repeat() 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
