### PR TITLE
Deprecate `startAt` favor of `initialValue`

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
@@ -99,6 +99,11 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
             return VERSION_ATTRIBUTE;
         }
 
+        @Deprecated
+        public static StaticAttributeTag versionAttribute(Long startAt, Long incrementBy) {
+            return versionAttribute(startAt, incrementBy, null);
+        }
+
         public static StaticAttributeTag versionAttribute(Long startAt, Long incrementBy, Long initialValue) {
             return new VersionAttribute(startAt, incrementBy, initialValue);
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
@@ -268,15 +268,12 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
 
         /**
          * Sets the startAt used to compare if a record is the initial version of a record.
-         * <p>
-         * <b>DEPRECATED:</b> Use {@link #initialValue(Long)} instead.
-         * <p>
          * When startAt >= 0: First version = startAt + incrementBy.
          * Default value when not set: {@code -1}, which enables {@link #initialValue(Long)} behavior.
          * <p>
          * Cannot be used with {@link #initialValue(Long)} - setting both will throw IllegalArgumentException.
          *
-         * @param startAt the starting value for version comparison, must be -1 or non-negative
+         * @param startAt the starting value for version comparison. When null, defaults to -1. Must be -1 or positive number.
          * @return the builder instance
          * @deprecated Use {@link #initialValue(Long)} instead.
          */
@@ -310,7 +307,7 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
          * <p>
          * Cannot be used with deprecated {@link #startAt(Long)} when startAt >= 0.
          *
-         * @param initialValue the initial version for new records, must be non-negative
+         * @param initialValue the initial version for new records, must be a positive number
          * @return the builder instance
          * @throws IllegalArgumentException if initialValue is negative or if startAt >= 0 is also set
          */

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
@@ -27,6 +27,11 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.BeanTableSche
  * Denotes this attribute as recording the version record number to be used for optimistic locking. Every time a record
  * with this attribute is written to the database it will be incremented and a condition added to the request to check
  * for an exact match of the old version.
+ * <p>
+ * <b>Default behavior:</b> startAt=-1, incrementBy=1, initialValue=1. First version will be 1.
+ * <p>
+ * See {@link software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension.Builder#initialValue(Long)}
+ * for details on ambiguity handling and SDK v1 migration support.
  */
 @SdkPublicApi
 @Target({ElementType.METHOD})
@@ -35,18 +40,33 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.BeanTableSche
 public @interface DynamoDbVersionAttribute {
     /**
      * The starting value for the version attribute.
-     * Default value - {@code 0}.
+     * <p>
+     * <b>DEPRECATED:</b> Use {@link #initialValue()} instead.
+     * <p>
+     * Default value when not set: {@code -1}, which enables {@link #initialValue()} behavior.
+     * <p>
+     * Cannot be used with {@link #initialValue()} - setting both will throw IllegalArgumentException.
      *
-     * @return the starting value
+     * @return the starting value, must be -1 or non-negative
+     * @deprecated Use {@link #initialValue()} instead.
      */
-    long startAt() default 0;
+    @Deprecated
+    long startAt() default -1;
 
     /**
      * The amount to increment the version by with each update.
      * Default value - {@code 1}.
      *
-     * @return the increment value
+     * @return the increment value, must be greater than 0
      */
     long incrementBy() default 1;
 
+    /**
+     * The initial version value for new records.
+     * Default value - {@code 1}.
+     * Cannot be used with deprecated {@link #startAt()} when startAt >= 0.
+     *
+     * @return the initial version for new records, must be non-negative
+     */
+    long initialValue() default 1;
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
@@ -40,9 +40,6 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.BeanTableSche
 public @interface DynamoDbVersionAttribute {
     /**
      * The starting value for the version attribute.
-     * <p>
-     * <b>DEPRECATED:</b> Use {@link #initialValue()} instead.
-     * <p>
      * Default value when not set: {@code -1}, which enables {@link #initialValue()} behavior.
      * <p>
      * Cannot be used with {@link #initialValue()} - setting both will throw IllegalArgumentException.

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/VersionRecordAttributeTags.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/VersionRecordAttributeTags.java
@@ -26,6 +26,7 @@ public final class VersionRecordAttributeTags {
     }
 
     public static StaticAttributeTag attributeTagFor(DynamoDbVersionAttribute annotation) {
-        return VersionedRecordExtension.AttributeTags.versionAttribute(annotation.startAt(), annotation.incrementBy());
+        return VersionedRecordExtension.AttributeTags.versionAttribute(annotation.startAt(), annotation.incrementBy(),
+                                                                       annotation.initialValue());
     }
 }


### PR DESCRIPTION
This PR deprecates `startAt` in favor of `initialValue` to allow versioning starting from 0.

### API Changes

**Added:**
- `initialValue(Long)` - sets the first version for new records (default: null)

**Deprecated:**
- `startAt(Long)` - default changed from `0` to `-1`

```java
// Before: couldn't start from 0
builder.startAt(0).incrementBy(1).build(); // first version = 1

// After: can start from 0
builder.initialValue(0L).incrementBy(1L).build(); // first version = 0
```

### Behavior

When `startAt=-1` (default), the first version equals `initialValue` if provided, otherwise `incrementBy`. The extension uses an OR condition when the current version matches either `initialValue` or `0` to handle ambiguous cases where it cannot distinguish between a new record with an explicitly set version versus an existing record.

examples:
```java
VersionedRecordExtension.builder()
    .incrementBy(1L) // default
    .initialValue(null) // default
    .build();

table.putItem(record);    // version = 1
table.updateItem(record); // version = 2
table.updateItem(record); // version = 3
```

```java
VersionedRecordExtension.builder()
    .initialValue(0L)
    .build();

table.putItem(record);    // version = 0
table.updateItem(record); // version = 1  
table.updateItem(record); // version = 2
```


Legacy mode: When `startAt>=0` (now deprecated), the first version equals `startAt + incrementBy`. This maintains backwards compatibility. 

