### PR TITLE
Ddb versioned record extension fix

### DIFF
--- a/.changes/next-release/bugfix-DynamoDBEnhancedClient-191a1f8.json
+++ b/.changes/next-release/bugfix-DynamoDBEnhancedClient-191a1f8.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Allow versioning to start from 0"
+}

--- a/.changes/next-release/bugfix-DynamoDBEnhancedClient-191a1f8.json
+++ b/.changes/next-release/bugfix-DynamoDBEnhancedClient-191a1f8.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "DynamoDB Enhanced Client",
     "contributor": "",
-    "description": "Allow versioning to start from 0"
+    "description": "Allow new records to start at version=0 by supporting startAt=-1 in VersionedRecordExtension"
 }

--- a/.changes/next-release/bugfix-DynamoDBEnhancedClient-191a1f8.json
+++ b/.changes/next-release/bugfix-DynamoDBEnhancedClient-191a1f8.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "DynamoDB Enhanced Client",
     "contributor": "",
-    "description": "Allow new records to start at version=0 by supporting startAt=-1 in VersionedRecordExtension"
+    "description": "Allow new records to be initialized with version=0 by supporting startAt=-1 in VersionedRecordExtension"
 }

--- a/.changes/next-release/feature-DynamoDBEnhancedClient-2025f0e.json
+++ b/.changes/next-release/feature-DynamoDBEnhancedClient-2025f0e.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "modify VersionedRecordExtension to support updating existing records with version=0 using OR condition"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
@@ -158,7 +158,7 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
                                                    .orElse(this.incrementBy);
 
 
-        if (isInitialVersion(existingVersionValue, versionStartAtFromAnnotation)) {
+        if (existingVersionValue == null || isNullAttributeValue(existingVersionValue)) {
             newVersionValue = AttributeValue.builder()
                                             .n(Long.toString(versionStartAtFromAnnotation + versionIncrementByFromAnnotation))
                                             .build();
@@ -175,7 +175,6 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
 
             long existingVersion = Long.parseLong(existingVersionValue.n());
             String existingVersionValueKey = VERSIONED_RECORD_EXPRESSION_VALUE_KEY_MAPPER.apply(versionAttributeKey.get());
-
             long increment = versionIncrementByFromAnnotation;
 
             /*
@@ -190,12 +189,25 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
 
             newVersionValue = AttributeValue.builder().n(Long.toString(existingVersion + increment)).build();
 
-            condition = Expression.builder()
-                                  .expression(String.format("%s = %s", attributeKeyRef, existingVersionValueKey))
-                                  .expressionNames(Collections.singletonMap(attributeKeyRef, versionAttributeKey.get()))
-                                  .expressionValues(Collections.singletonMap(existingVersionValueKey,
-                                                                             existingVersionValue))
-                                  .build();
+            // When version equals startAt, we can't distinguish between new and existing records
+            // Use OR condition to handle both cases
+            if (existingVersion == versionStartAtFromAnnotation) {
+                condition = Expression.builder()
+                                      .expression(String.format("attribute_not_exists(%s) OR %s = %s",
+                                                              attributeKeyRef, attributeKeyRef, existingVersionValueKey))
+                                      .expressionNames(Collections.singletonMap(attributeKeyRef, versionAttributeKey.get()))
+                                      .expressionValues(Collections.singletonMap(existingVersionValueKey,
+                                                                                 existingVersionValue))
+                                      .build();
+            } else {
+                // Normal case - version doesn't equal startAt, must be existing record
+                condition = Expression.builder()
+                                      .expression(String.format("%s = %s", attributeKeyRef, existingVersionValueKey))
+                                      .expressionNames(Collections.singletonMap(attributeKeyRef, versionAttributeKey.get()))
+                                      .expressionValues(Collections.singletonMap(existingVersionValueKey,
+                                                                                 existingVersionValue))
+                                      .build();
+            }
         }
 
         itemToTransform.put(versionAttributeKey.get(), newVersionValue);
@@ -204,21 +216,6 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
                                 .transformedItem(Collections.unmodifiableMap(itemToTransform))
                                 .additionalConditionalExpression(condition)
                                 .build();
-    }
-
-    private boolean isInitialVersion(AttributeValue existingVersionValue, Long versionStartAtFromAnnotation) {
-        if (existingVersionValue == null || isNullAttributeValue(existingVersionValue)) {
-            return true;
-        }
-
-        if (existingVersionValue.n() != null) {
-            long currentVersion = Long.parseLong(existingVersionValue.n());
-            // If annotation value is present, use it, otherwise fall back to the extension's value
-            Long effectiveStartAt = versionStartAtFromAnnotation != null ? versionStartAtFromAnnotation : this.startAt;
-            return currentVersion == effectiveStartAt;
-        }
-
-        return false;
     }
 
     @NotThreadSafe

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
@@ -27,6 +27,10 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.BeanTableSche
  * Denotes this attribute as recording the version record number to be used for optimistic locking. Every time a record
  * with this attribute is written to the database it will be incremented and a condition added to the request to check
  * for an exact match of the old version.
+ * <p>
+ * <b>Version Calculation:</b> The first version written to a new record is calculated as {@code startAt + incrementBy}.
+ * For example, with {@code startAt=0} and {@code incrementBy=1} (defaults), the first version is 1.
+ * To start versioning from 0, use {@code startAt=-1} and {@code incrementBy=1}, which produces first version = 0.
  */
 @SdkPublicApi
 @Target({ElementType.METHOD})

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
@@ -212,7 +212,7 @@ public class VersionedRecordExtensionTest {
                                             .operationContext(PRIMARY_CONTEXT).build());
 
         assertThat(result.additionalConditionalExpression().expression(),
-                   is("attribute_not_exists(#AMZN_MAPPED_version)"));
+                   is("attribute_not_exists(#AMZN_MAPPED_version) OR #AMZN_MAPPED_version = :old_version_value"));
     }
 
     @ParameterizedTest
@@ -321,7 +321,7 @@ public class VersionedRecordExtensionTest {
                                             .operationContext(PRIMARY_CONTEXT).build());
 
         assertThat(result.additionalConditionalExpression().expression(),
-                   is("attribute_not_exists(#AMZN_MAPPED_version)"));
+                   is("attribute_not_exists(#AMZN_MAPPED_version) OR #AMZN_MAPPED_version = :old_version_value"));
     }
 
 
@@ -633,6 +633,26 @@ public class VersionedRecordExtensionTest {
         assertThat(result.additionalConditionalExpression().expression(),
                    is("#AMZN_MAPPED_version = :old_version_value"));
     }
+
+    @Test
+    public void updateItem_existingRecordWithVersionEqualToStartAt_shouldSucceed() {
+        VersionedRecordExtension recordExtension = VersionedRecordExtension.builder().build();
+        FakeItem item = createUniqueFakeItem();
+        item.setVersion(0);
+
+        Map<String, AttributeValue> inputMap = new HashMap<>(FakeItem.getTableSchema().itemToMap(item, true));
+
+        WriteModification result =
+            recordExtension.beforeWrite(DefaultDynamoDbExtensionContext
+                                            .builder()
+                                            .items(inputMap)
+                                            .tableMetadata(FakeItem.getTableMetadata())
+                                            .operationContext(PRIMARY_CONTEXT).build());
+
+        assertThat(result.additionalConditionalExpression().expression(),
+                   is("attribute_not_exists(#AMZN_MAPPED_version) OR #AMZN_MAPPED_version = :old_version_value"));
+    }
+
 
     public static Stream<Arguments> customIncrementForExistingVersionValues() {
         return Stream.of(

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
@@ -653,6 +653,26 @@ public class VersionedRecordExtensionTest {
                    is("attribute_not_exists(#AMZN_MAPPED_version) OR #AMZN_MAPPED_version = :old_version_value"));
     }
 
+    @Test
+    public void beforeWrite_startAtNegativeOne_firstVersionIsZero() {
+        VersionedRecordExtension extension = VersionedRecordExtension.builder()
+                                                                     .startAt(-1L)
+                                                                     .incrementBy(1L)
+                                                                     .build();
+        FakeItem fakeItem = createUniqueFakeItem();
+        Map<String, AttributeValue> expectedItem =
+            new HashMap<>(FakeItem.getTableSchema().itemToMap(fakeItem, true));
+        expectedItem.put("version", AttributeValue.builder().n("0").build());
+
+        WriteModification result =
+            extension.beforeWrite(DefaultDynamoDbExtensionContext
+                                      .builder()
+                                      .items(FakeItem.getTableSchema().itemToMap(fakeItem, true))
+                                      .tableMetadata(FakeItem.getTableMetadata())
+                                      .operationContext(PRIMARY_CONTEXT).build());
+
+        assertThat(result.transformedItem(), is(expectedItem));
+    }
 
     public static Stream<Arguments> customIncrementForExistingVersionValues() {
         return Stream.of(


### PR DESCRIPTION
Fixes: #6435  

## Background

In July 2024, PR #6019 introduced custom versioning support for VersionedRecordExtension, allowing developers to configure startAt and incrementBy values. However, it left two critical gaps: (1) SDK v1 → v2 migration was blocked for tables containing records with version=0, as the SDK threw `ConditionalCheckFailedException` when updating these records, and (2) new records still couldn't start at version 0, they always started at startAt + incrementBy (e.g., default config produced version 1, not 0). This PR addresses both issues.

## The bugs and the fixes

### Issue 1: v1 Existing Records with version 0 can't be updated
Users migrating from v1 to v2 cannot update existing records that were created with version=0. v1 allowed records with version=0, but when these records are retrieved via v2's GetItem and then updated via UpdateItem, the operation fails with `ConditionalCheckFailedException`.  This occurs because the SDK cannot distinguish between:
• A new record where the user explicitly set a certain version (was covered)
• An existing record retrieved from DynamoDB that happens to have that same version (was not covered)

#### Solution:
Since the client code cannot distinguish between these two states, a way we can disambiguate this is by pushing the logic to the DDB server with an OR condition:

```java
if (suppliedVersion == record.version) {
    condition = "attribute_not_exists(version) OR version = :val";
}
```

How it works:
• **New records**: attribute_not_exists(version) → TRUE, operation succeeds
• **Existing records**: version = startAt → TRUE, operation succeeds

### Issue 2: New Records Cannot Start at 0

Even after PR #6019 introduced custom versioning configuration, new records still cannot start at version 0. With the default configuration (startAt=0, incrementBy=1), the first version assigned to a new record is 1, not 0. This is because the initial version calculation uses startAt + incrementBy, meaning startAt doesn't actually control where versions begin—it's an offset that gets added to incrementBy.

#### Solution:

Remove validation blocking negative startAt values. This allows users to set startAt=-1, which produces the desired result:
• First version: -1 + 1 = 0
• Subsequent versions: 1, 2, 3...

```java
VersionedRecordExtension.builder()
    .startAt(-1L)
    .incrementBy(1L)
    .build();
// First version: -1 + 1 = 0
```