### PR TITLE
Fix stackoverflow with large pages in paginator

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-03a897a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-03a897a.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix an issue where `StackOverflowError` can occur when iterating over large pages from an async paginator. This can manifest as the publisher hanging/never reaching the end of the stream. Fixes [#6411](https://github.com/aws/aws-sdk-java-v2/issues/6411)."
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/pagination/async/PaginatedItemsPublisherTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/pagination/async/PaginatedItemsPublisherTest.java
@@ -1,0 +1,125 @@
+package software.amazon.awssdk.core.pagination.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.core.SdkResponse;
+
+public class PaginatedItemsPublisherTest {
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.MINUTES)
+    void subscribe_largePage_doesNotFail() throws Exception {
+        int nItems = 100_000;
+
+        Function<SdkResponse, Iterator<String>> iteratorFn = resp ->
+            new Iterator<String>() {
+                private int count = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return count < nItems;
+                }
+
+                @Override
+                public String next() {
+                    ++count;
+                    return "item";
+                }
+            };
+
+        AsyncPageFetcher<SdkResponse> pageFetcher = new AsyncPageFetcher<SdkResponse>() {
+            @Override
+            public boolean hasNextPage(SdkResponse oldPage) {
+                return false;
+            }
+
+            @Override
+            public CompletableFuture<SdkResponse> nextPage(SdkResponse oldPage) {
+                return CompletableFuture.completedFuture(mock(SdkResponse.class));
+            }
+        };
+
+        PaginatedItemsPublisher<SdkResponse, String> publisher = PaginatedItemsPublisher.builder()
+                                                                                        .isLastPage(false)
+                                                                                        .nextPageFetcher(pageFetcher)
+                                                                                        .iteratorFunction(iteratorFn)
+                                                                                        .build();
+
+        AtomicLong counter = new AtomicLong();
+        publisher.subscribe(i -> counter.incrementAndGet()).join();
+        assertThat(counter.get()).isEqualTo(nItems);
+    }
+
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.MINUTES)
+    void subscribe_longStream_doesNotFail() throws Exception {
+        int nPages = 100_000;
+        int nItemsPerPage = 1;
+        Function<SdkResponse, Iterator<String>> iteratorFn = resp ->
+            new Iterator<String>() {
+                private int count = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return count < nItemsPerPage;
+                }
+
+                @Override
+                public String next() {
+                    ++count;
+                    return "item";
+                }
+            };
+
+        AsyncPageFetcher<TestResponse> pageFetcher = new AsyncPageFetcher<TestResponse>() {
+            @Override
+            public boolean hasNextPage(TestResponse oldPage) {
+                return oldPage.pageNumber() < nPages - 1;
+            }
+
+            @Override
+            public CompletableFuture<TestResponse> nextPage(TestResponse oldPage) {
+                int nextPageNum;
+                if (oldPage == null) {
+                    nextPageNum = 0;
+                } else {
+                    nextPageNum = oldPage.pageNumber() + 1;
+                }
+                return CompletableFuture.completedFuture(createResponse(nextPageNum));
+            }
+        };
+
+        PaginatedItemsPublisher<SdkResponse, String> publisher = PaginatedItemsPublisher.builder()
+                                                                                        .isLastPage(false)
+                                                                                        .nextPageFetcher(pageFetcher)
+                                                                                        .iteratorFunction(iteratorFn)
+                                                                                        .build();
+
+        AtomicLong counter = new AtomicLong();
+        publisher.subscribe(i -> counter.incrementAndGet()).join();
+        assertThat(counter.get()).isEqualTo(nPages * nItemsPerPage);
+    }
+
+    private abstract class TestResponse extends SdkResponse {
+
+        protected TestResponse(Builder builder) {
+            super(builder);
+        }
+
+        abstract Integer pageNumber();
+    }
+
+    private static TestResponse createResponse(Integer pageNumber) {
+        TestResponse mock = mock(TestResponse.class);
+        when(mock.pageNumber()).thenReturn(pageNumber);
+        return mock;
+    }
+}

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/PaginatorTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/PaginatorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.paginators.ScanIterable;
+import software.amazon.awssdk.services.dynamodb.paginators.ScanPublisher;
+
+public class PaginatorTest {
+    private static final WireMockServer wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static DynamoDbAsyncClient ddbAsync;
+    private static DynamoDbClient ddb;
+
+    @BeforeAll
+    static void setup() {
+        wireMock.start();
+
+        ddbAsync = DynamoDbAsyncClient.builder()
+                                      .region(Region.US_WEST_2)
+                                      .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                      .credentialsProvider(AnonymousCredentialsProvider.create())
+                                      .build();
+
+        ddb = DynamoDbClient.builder()
+                            .region(Region.US_WEST_2)
+                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                            .credentialsProvider(AnonymousCredentialsProvider.create())
+                            .build();
+    }
+
+    @AfterAll
+    static void teardown() {
+        ddb.close();
+        ddbAsync.close();
+        wireMock.stop();
+    }
+
+    @Test
+    void scanPaginator_async_largePage_subscribe_succeeds() {
+        int nItems = 10_000;
+        wireMock.stubFor(WireMock.any(anyUrl())
+                                 .willReturn(aResponse()
+                                                 .withStatus(200)
+                                                 .withJsonBody(createScanResponse(nItems))));
+
+        ScanPublisher publisher = ddbAsync.scanPaginator(ScanRequest.builder().build());
+
+        AtomicLong counter = new AtomicLong();
+        publisher.items().subscribe(item -> counter.incrementAndGet()).join();
+        assertThat(counter.get()).isEqualTo(nItems);
+    }
+
+    @Test
+    void scanPaginator_sync_largePage_subscribe_succeeds() {
+        int nItems = 10_000;
+        wireMock.stubFor(WireMock.any(anyUrl())
+                                 .willReturn(aResponse()
+                                                 .withStatus(200)
+                                                 .withJsonBody(createScanResponse(nItems))));
+
+        ScanIterable iterable = ddb.scanPaginator(ScanRequest.builder().build());
+
+        AtomicLong counter = new AtomicLong();
+        iterable.items().forEach(item -> counter.incrementAndGet());
+        assertThat(counter.get()).isEqualTo(nItems);
+    }
+
+    private static JsonNode createScanResponse(int nItems) {
+        ObjectNode resp = mapper.createObjectNode();
+        resp.set("Count", mapper.valueToTree(nItems));
+
+        ArrayNode items = mapper.createArrayNode();
+
+        for (int i = 0; i < nItems; i++) {
+            // {
+            //   "id": {
+            //     "N": 1
+            //   }
+            // }
+            ObjectNode item = mapper.createObjectNode();
+            ObjectNode idNode = mapper.createObjectNode();
+            idNode.put("N", mapper.valueToTree(i));
+            item.set("id", idNode);
+            items.add(item);
+        }
+
+        resp.set("Items", items);
+
+        return resp;
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Previously, signalig onNext() to the subscriber was done via recursion, pulling elements from an iterator over the current page returned by the service. However, this can quickly lead to a stackoverflow error since the stack will grow linearly with the size of the page.

 - Replace sendNextElement recursion with a loop
 - Ensure that handleRequests does not recurse into itself

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
