### PR TITLE
Fix race conditions in aggregate ProfileFileSupplier

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-0caa9ea.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-0caa9ea.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix a race condition in aggregate ProfileFileSupplier that could cause credential resolution failures with shared DefaultCredentialsProvider."
+}

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/AggregateProfileFileSupplier.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/AggregateProfileFileSupplier.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.profiles.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSupplier;
+
+/**
+ * A {@link ProfileFileSupplier} that combines the {@link ProfileFile} objects from multiple
+ * {@code ProfileFileSupplier}s. Objects are passed into {@link ProfileFile.Aggregator}.
+ */
+@SdkInternalApi
+public class AggregateProfileFileSupplier implements  ProfileFileSupplier {
+    final List<ProfileFileSupplier> suppliers;
+
+    // supplier values and the resulting aggregate must always be updated atomically together
+    final AtomicReference<SupplierState> state =
+        new AtomicReference<>(new SupplierState(Collections.emptyMap(), null));
+
+    public AggregateProfileFileSupplier(ProfileFileSupplier... suppliers) {
+        this.suppliers = Collections.unmodifiableList(Arrays.asList(suppliers));
+    }
+
+    @Override
+    public ProfileFile get() {
+        SupplierState currentState = state.get();
+        Map<Supplier<ProfileFile>, ProfileFile> currentValues = currentState.values;
+        Map<Supplier<ProfileFile>, ProfileFile> changedValues = changedSupplierValues(currentValues);
+
+        if (changedValues == null) {
+            // no suppliers have changed values, return the current aggregate
+            return currentState.aggregate;
+        }
+
+        // one or more supplier values have changed, we need to update the aggregate (and the state)
+        // the order of the suppliers matters so we MUST preserve it using LinkedHashMap with insertion ordering
+        Map<Supplier<ProfileFile>, ProfileFile> nextValues = new LinkedHashMap<>(currentValues);
+        nextValues.putAll(changedValues);
+
+        ProfileFile.Aggregator aggregator = ProfileFile.aggregator();
+        nextValues.values().forEach(aggregator::addFile);
+        ProfileFile nextAggregate = aggregator.build();
+
+        SupplierState nextState = new SupplierState(nextValues, nextAggregate);
+        if (state.compareAndSet(currentState, nextState)) {
+            return nextAggregate;
+        }
+        // else: another thread has modified the state in between, assume it is up to date and use the new state
+        return state.get().aggregate;
+    }
+
+    // return the suppliers with changed values.  Returns null if no values have changed
+    private Map<Supplier<ProfileFile>, ProfileFile> changedSupplierValues(Map<Supplier<ProfileFile>, ProfileFile> currentValues) {
+        Map<Supplier<ProfileFile>, ProfileFile> changedValues = null;
+        for (ProfileFileSupplier supplier : suppliers) {
+            ProfileFile next = supplier.get();
+            ProfileFile prev = currentValues.get(supplier);
+            // we ONLY care about if the reference has changed, we don't care about object equality here
+            if (prev != next) {
+                if (changedValues == null) {
+                    // changed values must also preserve supplier order
+                    changedValues = new LinkedHashMap<>();
+                }
+                changedValues.put(supplier, next);
+            }
+        }
+        return changedValues;
+    }
+
+    private static final class SupplierState {
+        final Map<Supplier<ProfileFile>, ProfileFile> values;
+        final ProfileFile aggregate;
+
+        private SupplierState(Map<Supplier<ProfileFile>, ProfileFile> values, ProfileFile aggregate) {
+            this.values = values;
+            this.aggregate = aggregate;
+        }
+    }
+}

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/AggregateProfileFileSupplier.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/AggregateProfileFileSupplier.java
@@ -32,10 +32,10 @@ import software.amazon.awssdk.profiles.ProfileFileSupplier;
  */
 @SdkInternalApi
 public class AggregateProfileFileSupplier implements  ProfileFileSupplier {
-    final List<ProfileFileSupplier> suppliers;
+    private final List<ProfileFileSupplier> suppliers;
 
     // supplier values and the resulting aggregate must always be updated atomically together
-    final AtomicReference<SupplierState> state =
+    private final AtomicReference<SupplierState> state =
         new AtomicReference<>(new SupplierState(Collections.emptyMap(), null));
 
     public AggregateProfileFileSupplier(ProfileFileSupplier... suppliers) {
@@ -88,9 +88,13 @@ public class AggregateProfileFileSupplier implements  ProfileFileSupplier {
         return changedValues;
     }
 
+    /**
+     * Supplier values and the resulting aggregate must always be updated atomically together.
+     * This record class tracks all mutable elements of the supplier's state together.
+     */
     private static final class SupplierState {
-        final Map<Supplier<ProfileFile>, ProfileFile> values;
-        final ProfileFile aggregate;
+        private final Map<Supplier<ProfileFile>, ProfileFile> values;
+        private final ProfileFile aggregate;
 
         private SupplierState(Map<Supplier<ProfileFile>, ProfileFile> values, ProfileFile aggregate) {
             this.values = values;

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileSupplierTest.java
@@ -31,12 +31,20 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -501,6 +509,50 @@ class ProfileFileSupplierTest {
         accessKeyId = profileFile.profile("default").get().property("aws_access_key_id").get();
 
         assertThat(accessKeyId).isEqualTo("defaultAccessKey2");
+    }
+
+    @Test
+    void aggregate_concurrentGetAlwaysReturnsCorrectAggregate() throws ExecutionException, InterruptedException {
+        ProfileFile credentialFile = credentialProfileFile("test1", "key1", "secret1");
+        ProfileFile configFile = configProfileFile("profile test",
+                                                   Pair.of("region", "us-west-2"),
+                                                   Pair.of("aws_account_id", "012354678922"));
+
+
+        ProfileFile expectedAggregate = ProfileFile.aggregator().addFile(credentialFile).addFile(configFile).build();
+
+        ProfileFileSupplier supplier = ProfileFileSupplier.aggregate(() -> credentialFile, () -> configFile);
+
+        ExecutorService executor = Executors.newFixedThreadPool(24);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<Boolean>> tasks = new ArrayList<>();
+
+        for(int i = 0; i < 24; i++) {
+            tasks.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    ProfileFile resolved = supplier.get();
+                    return Objects.equals(expectedAggregate, resolved);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        }
+        // All tasks are now submitted — release them
+        startLatch.countDown();
+        executor.shutdown();
+        try {
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS))
+                .as("executor did not terminate")
+                .isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        // assert that all concurrent get's returned the same, expected aggregate
+        for(Future<Boolean> task : tasks) {
+            assertThat(task.get()).isTrue();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix race conditions in aggregate ProfileFileSupplier.


## Motivation and Context
This change fixes multiple race conditions in the aggregate ProfileFileSupplier.  #6632  re-introduced profile file reloading which exposed these issues, resulting in credentials resolution failure if a shared DefaultCredentialsProvider instance with a profile name configured is used across multiple threads.

The most series issues is that `get()` determines whether to recompute the aggregate based on a snapshot of `currentValuesBySupplier`, but `refreshCurrentAggregate()` then reads a different snapshot of that same map — and nothing prevents another thread from mutating it in between. The AtomicReference and synchronizedMap give us local thread safety, but not atomicity across the whole operation.

## Modifications
* Use a single atomic state that captures both elements and ensure that its updated consistently.

## Testing
Added a new unit test + manual testing.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
