### PR TITLE
perf: optimize metric processing

### DIFF
--- a/.changes/next-release/feature-CloudWatchMetricPublisher-36c8c51.json
+++ b/.changes/next-release/feature-CloudWatchMetricPublisher-36c8c51.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "CloudWatch Metric Publisher",
+    "contributor": "",
+    "description": "Optimize metric processing by replacing stream-based operations with direct iteration to reduce allocations and GC pressure."
+}

--- a/.kiro/settings/lsp.json
+++ b/.kiro/settings/lsp.json
@@ -1,0 +1,41 @@
+{
+  "languages": {
+    "java": {
+      "name": "jdtls",
+      "command": "jdtls",
+      "args": [],
+      "file_extensions": [
+        "java"
+      ],
+      "project_patterns": [
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        ".project"
+      ],
+      "exclude_patterns": [
+        "**/target/**",
+        "**/build/**",
+        "**/.gradle/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {
+        "settings": {
+          "java": {
+            "compile": {
+              "nullAnalysis": {
+                "mode": "automatic"
+              }
+            },
+            "configuration": {
+              "annotationProcessing": {
+                "enabled": true
+              }
+            }
+          }
+        }
+      },
+      "request_timeout_secs": 60
+    }
+  }
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/SignerUtils.java
@@ -184,9 +184,8 @@ public final class SignerUtils {
 
         String host = requestBuilder.host();
         if (!SdkHttpUtils.isUsingStandardPort(requestBuilder.protocol(), requestBuilder.port())) {
-            StringBuilder hostHeaderBuilder = new StringBuilder(host);
-            hostHeaderBuilder.append(":").append(requestBuilder.port());
-            requestBuilder.putHeader(SignerConstant.HOST, hostHeaderBuilder.toString());
+            String hostHeaderValue = host + ":" + requestBuilder.port();
+            requestBuilder.putHeader(SignerConstant.HOST, hostHeaderValue);
         } else {
             requestBuilder.putHeader(SignerConstant.HOST, host);
         }

--- a/metric-publishers/cloudwatch-metric-publisher/src/main/java/software/amazon/awssdk/metrics/publishers/cloudwatch/internal/transform/TimeBucketedMetrics.java
+++ b/metric-publishers/cloudwatch-metric-publisher/src/main/java/software/amazon/awssdk/metrics/publishers/cloudwatch/internal/transform/TimeBucketedMetrics.java
@@ -128,13 +128,23 @@ class TimeBucketedMetrics {
 
     private void aggregateMetrics(MetricCollection metrics, Map<MetricAggregatorKey, MetricAggregator> bucket) {
         List<Dimension> dimensions = dimensions(metrics);
-        extractAllMetrics(metrics).forEach(metricRecord -> {
+        processMetricsRecursively(metrics, dimensions, bucket);
+    }
+
+    private void processMetricsRecursively(MetricCollection metrics,
+                                           List<Dimension> dimensions,
+                                           Map<MetricAggregatorKey, MetricAggregator> bucket) {
+        for (MetricRecord<?> metricRecord : metrics) {
             MetricAggregatorKey aggregatorKey = new MetricAggregatorKey(metricRecord.metric(), dimensions);
             valueFor(metricRecord).ifPresent(metricValue -> {
                 bucket.computeIfAbsent(aggregatorKey, m -> newAggregator(aggregatorKey))
                       .addMetricValue(MetricValueNormalizer.normalize(metricValue));
             });
-        });
+        }
+
+        for (MetricCollection child : metrics.children()) {
+            processMetricsRecursively(child, dimensions, bucket);
+        }
     }
 
     private List<Dimension> dimensions(MetricCollection metricCollection) {
@@ -152,19 +162,6 @@ class TimeBucketedMetrics {
         // We use descending order just so that "ServiceName" is before "OperationName" when we use the default dimensions.
         result.sort(Comparator.comparing(Dimension::name).reversed());
         return result;
-    }
-
-    private List<MetricRecord<?>> extractAllMetrics(MetricCollection metrics) {
-        List<MetricRecord<?>> result = new ArrayList<>();
-        extractAllMetrics(metrics, result);
-        return result;
-    }
-
-    private void extractAllMetrics(MetricCollection metrics, List<MetricRecord<?>> extractedMetrics) {
-        for (MetricRecord<?> metric : metrics) {
-            extractedMetrics.add(metric);
-        }
-        metrics.children().forEach(child -> extractAllMetrics(child, extractedMetrics));
     }
 
     private MetricAggregator newAggregator(MetricAggregatorKey aggregatorKey) {
@@ -214,11 +211,15 @@ class TimeBucketedMetrics {
     }
 
     private boolean isSupportedCategory(MetricRecord<?> metricRecord) {
-        return metricCategoriesContainsAll ||
-               metricRecord.metric()
-                           .categories()
-                           .stream()
-                           .anyMatch(metricCategories::contains);
+        if (metricCategoriesContainsAll) {
+            return true;
+        }
+        for (MetricCategory category : metricRecord.metric().categories()) {
+            if (metricCategories.contains(category)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isSupportedLevel(MetricRecord<?> metricRecord) {


### PR DESCRIPTION
## Motivation and Context

Optimize metric processing in CloudWatch Metric Publisher to reduce memory allocations and GC pressure in high-throughput scenarios.

## Modifications

- Replace stream-based extractAllMetrics() with processMetricsRecursively() that processes metrics in-place without intermediate list allocation
- Convert stream().anyMatch() to for-loop in isSupportedCategory() to avoid iterator/stream object creation
- Simplify StringBuilder to string concatenation in SignerUtils.addHostHeader() (minor cleanup)
- Add kiro lsp config

## Testing

- Existing unit tests pass
- No behavioral changes, only internal implementation optimization

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] Local run of mvn clean install -pl :cloudwatch-metric-publisher succeeds
- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have added a changelog entry

## License
- [x] I confirm that this pull request can be released under the Apache 2 license