### PR TITLE
Add codgen customization to allow underscores in S3 member names

### DIFF
--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -358,5 +358,6 @@
       "methodName": "modifyUploadPartCopyRequest",
       "className": "software.amazon.awssdk.services.s3.internal.CustomRequestTransformerUtils"
     }
-  }
+  },
+  "underscoresInNameBehavior": "ALLOW"
 }


### PR DESCRIPTION
Allow underscore in member name for S3. ref `bb379f40-8c41-4082-bec7-7865cb55e35b`