### PR TITLE
Add Apache5, give highest priority

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-d5acff4.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d5acff4.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Make `Apache5HttpClient` the preferred default HTTP client for sync SDK clients. This means that when `apache5-client` is on the classpath, and an HTTP client is *not* explicitly configured on client builder, the SDK client will use `Apache5HttpClient`."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/ClasspathSdkHttpServiceProvider.java
@@ -38,9 +38,10 @@ final class ClasspathSdkHttpServiceProvider<T> implements SdkHttpServiceProvider
 
     static final Map<String, Integer> SYNC_HTTP_SERVICES_PRIORITY =
         ImmutableMap.<String, Integer>builder()
-                    .put("software.amazon.awssdk.http.apache.ApacheSdkHttpService", 1)
-                    .put("software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService", 2)
-                    .put("software.amazon.awssdk.http.crt.AwsCrtSdkHttpService", 3)
+                    .put("software.amazon.awssdk.http.apache5.Apache5SdkHttpService", 1)
+                    .put("software.amazon.awssdk.http.apache.ApacheSdkHttpService", 2)
+                    .put("software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService", 3)
+                    .put("software.amazon.awssdk.http.crt.AwsCrtSdkHttpService", 4)
                     .build();
 
     static final Map<String, Integer> ASYNC_HTTP_SERVICES_PRIORITY =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This commit updates `ClasspathSdkHttpServiceProvider` to give `Apache5HttpClient` the highest preference for sync HTTP clients. If `apache5-client` is on the classpath, Sync SDK clients not not explicitly configured with an HTTP client will use Apache 5.

## Modifications
<!--- Describe your changes in detail -->

## Testing
One off testing with a simple project

`pom.xml`
```xml
    <dependencies>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>s3</artifactId>
        </dependency>
        <dependency>
            <groupId>software.amazon.awssdk</groupId>
            <artifactId>apache5-client</artifactId>
            <version>2.41.9-SNAPSHOT</version>
        </dependency>
        <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-slf4j2-impl</artifactId>
            <version>2.20.0</version>
        </dependency>
    </dependencies>
```

Test code:
```java
        S3Client s3 = S3Client.builder().region(Region.US_WEST_2).build();
        s3.listBuckets();
```

Verify user-agent in wire logs
```
2026-01-15 16:08:57 [main] DEBUG org.apache.hc.client5.http.headers:211 - http-outgoing-0 >> User-Agent: aws-sdk-java/2.41.9-SNAPSHOT md/io#sync md/http#Apache5 ua/2.1 api/S3#2.41.x-SNAPSHOT os/Mac_OS_X#15.7.1 lang/java#21.0.8 md/OpenJDK_64-Bit_Server_VM#21.0.8+9-LTS md/vendor#Amazon.com_Inc. md/en_US m/D,Z,b,n

```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
