### PR TITLE
Add granular allowlist for underscores in member names

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/CodeGenerator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/CodeGenerator.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ForkJoinTask;
 import software.amazon.awssdk.codegen.emitters.GeneratorTask;
@@ -29,6 +29,7 @@ import software.amazon.awssdk.codegen.emitters.tasks.AwsGeneratorTasks;
 import software.amazon.awssdk.codegen.internal.Jackson;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.validation.CustomizationConfigValidator;
 import software.amazon.awssdk.codegen.validation.ModelInvalidException;
 import software.amazon.awssdk.codegen.validation.ModelValidationContext;
 import software.amazon.awssdk.codegen.validation.ModelValidationReport;
@@ -41,8 +42,9 @@ public class CodeGenerator {
     private static final Logger log = Logger.loggerFor(CodeGenerator.class);
     private static final String MODEL_DIR_NAME = "models";
 
-    private static final List<ModelValidator> DEFAULT_MODEL_VALIDATORS = Collections.singletonList(
-        new SharedModelsValidator()
+    private static final List<ModelValidator> DEFAULT_MODEL_VALIDATORS = Arrays.asList(
+            new SharedModelsValidator(),
+            new CustomizationConfigValidator()
     );
 
     private final C2jModels c2jModels;

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -363,6 +363,11 @@ public class CustomizationConfig {
      */
     private boolean enableEndpointProviderUriCaching;
 
+    /**
+     * List of specific shape or member names that are allowed to contain underscores.
+     */
+    private List<String> allowedUnderscoreNames = new ArrayList<>();
+
     private CustomizationConfig() {
     }
 
@@ -950,5 +955,13 @@ public class CustomizationConfig {
 
     public void setEnableEndpointProviderUriCaching(boolean enableEndpointProviderUriCaching) {
         this.enableEndpointProviderUriCaching = enableEndpointProviderUriCaching;
+    }
+
+    public List<String> getAllowedUnderscoreNames() {
+        return allowedUnderscoreNames;
+    }
+
+    public void setAllowedUnderscoreNames(List<String> allowedUnderscoreNames) {
+        this.allowedUnderscoreNames = allowedUnderscoreNames;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -499,12 +499,11 @@ public class DefaultNamingStrategy implements NamingStrategy {
         }
 
         if (name.contains("_")) {
+            UnderscoresInNameBehavior behavior = customizationConfig.getUnderscoresInNameBehavior();
             List<String> allowedNames = customizationConfig.getAllowedUnderscoreNames();
             if (allowedNames != null && allowedNames.contains(name)) {
                 return;
             }
-
-            UnderscoresInNameBehavior behavior = customizationConfig.getUnderscoresInNameBehavior();
 
             String supportedBehaviors = Arrays.toString(UnderscoresInNameBehavior.values());
             if (behavior == null) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -28,6 +28,7 @@ import static software.amazon.awssdk.utils.internal.CodegenNamingUtils.splitOnWo
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -498,6 +499,11 @@ public class DefaultNamingStrategy implements NamingStrategy {
         }
 
         if (name.contains("_")) {
+            List<String> allowedNames = customizationConfig.getAllowedUnderscoreNames();
+            if (allowedNames != null && allowedNames.contains(name)) {
+                return;
+            }
+
             UnderscoresInNameBehavior behavior = customizationConfig.getUnderscoresInNameBehavior();
 
             String supportedBehaviors = Arrays.toString(UnderscoresInNameBehavior.values());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/validation/CustomizationConfigValidator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/validation/CustomizationConfigValidator.java
@@ -21,8 +21,9 @@ import software.amazon.awssdk.codegen.model.config.customization.CustomizationCo
 import software.amazon.awssdk.codegen.model.config.customization.UnderscoresInNameBehavior;
 
 /**
- * Validator that ensures CustomizationConfig settings are valid and not conflicting. This validator returns a validation
- * entry for each invalid or conflicting customization configuration detected.
+ * Validator that ensures CustomizationConfig settings are not conflicting. This validator returns a validation
+ * entry if mutually exclusive customization options are set simultaneously, such as both the global
+ * underscoresInNameBehavior and the granular allowedUnderscoreNames list.
  */
 public final class CustomizationConfigValidator implements ModelValidator {
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/validation/CustomizationConfigValidator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/validation/CustomizationConfigValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.validation;
+
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.config.customization.UnderscoresInNameBehavior;
+
+public class CustomizationConfigValidator implements ModelValidator{
+    @Override
+    public List<ValidationEntry> validateModels(ModelValidationContext context) {
+        CustomizationConfig config = context.intermediateModel().getCustomizationConfig();
+
+        if (config.getUnderscoresInNameBehavior() == UnderscoresInNameBehavior.ALLOW &&
+            config.getAllowedUnderscoreNames() != null &&
+            !config.getAllowedUnderscoreNames().isEmpty()) {
+
+            return Collections.singletonList(
+                ValidationEntry.create(
+                    ValidationErrorId.INVALID_CODEGEN_CUSTOMIZATION,
+                    ValidationErrorSeverity.DANGER,
+                    "Cannot set both 'underscoresInNameBehavior=ALLOW' and 'allowedUnderscoreNames'. " +
+                    "Use 'allowedUnderscoreNames' for granular control or 'underscoresInNameBehavior=ALLOW' for all underscores."
+                )
+            );
+        }
+
+        return Collections.emptyList();
+    }
+
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/validation/CustomizationConfigValidator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/validation/CustomizationConfigValidator.java
@@ -20,7 +20,11 @@ import java.util.List;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.config.customization.UnderscoresInNameBehavior;
 
-public class CustomizationConfigValidator implements ModelValidator{
+/**
+ * Validator that ensures CustomizationConfig settings are valid and not conflicting. This validator returns a validation
+ * entry for each invalid or conflicting customization configuration detected.
+ */
+public final class CustomizationConfigValidator implements ModelValidator {
     @Override
     public List<ValidationEntry> validateModels(ModelValidationContext context) {
         CustomizationConfig config = context.intermediateModel().getCustomizationConfig();

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.Before;
@@ -335,6 +336,36 @@ public class DefaultNamingStrategyTest {
         model.setMetadata(metadata);
 
         strategy.validateCustomerVisibleNaming(model);
+    }
+
+    @Test
+    public void validateAllowsSpecificUnderscoresWithAllowlist() {
+        CustomizationConfig customization =
+            CustomizationConfig.create();
+        customization.setAllowedUnderscoreNames(Arrays.asList("checksumXXHASH3_64", "foo_bar"));
+
+        NamingStrategy strategy = new DefaultNamingStrategy(serviceModel, customization);
+        Metadata metadata = new Metadata();
+
+        metadata.setAsyncBuilderInterface("foo_bar");
+        IntermediateModel model = new IntermediateModel();
+        model.setMetadata(metadata);
+        strategy.validateCustomerVisibleNaming(model);
+    }
+
+    @Test
+    public void validateRejectsSpecificUnderscoresWithAllowlist() {
+        CustomizationConfig customization =
+            CustomizationConfig.create();
+        customization.setAllowedUnderscoreNames(Arrays.asList("checksumXXHASH3_64", "foo_bar"));
+
+        NamingStrategy strategy = new DefaultNamingStrategy(serviceModel, customization);
+        Metadata metadata = new Metadata();
+
+        metadata.setAsyncBuilderInterface("fizz_buzz");
+        IntermediateModel model = new IntermediateModel();
+        model.setMetadata(metadata);
+        assertThatThrownBy(() -> strategy.validateCustomerVisibleNaming(model)).isInstanceOf(RuntimeException.class);
     }
 
     @Test


### PR DESCRIPTION
Addresses `JAVA-8585`

Introduces `allowedUnderscoreNames` customization config to allow specific shape or member names with underscores without enabling underscores for the entire service.