### PR TITLE
Disable payload signing for https requests

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-c710394.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-c710394.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "HTTPS requests now skip payload signing by default for improved performance. HTTP and signing-dependent features are unaffected."
+}

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/ChecksumUtil.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/internal/signer/util/ChecksumUtil.java
@@ -28,7 +28,6 @@ import static software.amazon.awssdk.http.auth.aws.signer.SignerConstant.X_AMZ_T
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Locale;
-import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.checksums.SdkChecksum;
 import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
@@ -151,14 +150,6 @@ public final class ChecksumUtil {
                 return true;
             }
             return payloadSigningEnabled;
-        }
-
-        if (Objects.equals(request.property(CHUNK_ENCODING_ENABLED), Boolean.TRUE)) {
-            return true;
-        }
-
-        if (isEventStreaming(request.request())) {
-            return true;
         }
 
         // For HTTPS, skip payload signing by default

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4FamilyHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4FamilyHttpSigner.java
@@ -67,13 +67,16 @@ public interface AwsV4FamilyHttpSigner<T extends Identity> extends HttpSigner<T>
         SignerProperty.create(AwsV4FamilyHttpSigner.class, "ExpirationDuration");
 
     /**
-     * Whether to indicate that a payload is signed or not. This property defaults to true. This can be set false to disable
-     * payload signing.
+     * Whether to indicate that a payload is signed or not.
      * <p>
-     * When this value is true and {@link #CHUNK_ENCODING_ENABLED} is false, the whole payload must be read to generate
-     * the payload signature. For very large payloads, this could impact memory usage and call latency. Some services
-     * support this value being disabled, especially over HTTPS where SSL provides some of its own protections against
-     * payload tampering.
+     * <b>Default behavior (when not explicitly set):</b>
+     * <ul>
+     *   <li>HTTPS requests: Payload signing is <b>disabled</b> by default for better performance</li>
+     *   <li>HTTP requests: Payload signing is <b>enabled</b> by default for security</li>
+     * </ul>
+     * <p>
+     * <b>Note:</b> Certain features require payload signing regardless of this setting:
+     * chunk encoding ({@link #CHUNK_ENCODING_ENABLED}), event streaming, and flexible checksums with trailers.
      */
     SignerProperty<Boolean> PAYLOAD_SIGNING_ENABLED =
         SignerProperty.create(AwsV4FamilyHttpSigner.class, "PayloadSigningEnabled");

--- a/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4FamilyHttpSigner.java
+++ b/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/AwsV4FamilyHttpSigner.java
@@ -71,12 +71,9 @@ public interface AwsV4FamilyHttpSigner<T extends Identity> extends HttpSigner<T>
      * <p>
      * <b>Default behavior (when not explicitly set):</b>
      * <ul>
-     *   <li>HTTPS requests: Payload signing is <b>disabled</b> by default for better performance</li>
-     *   <li>HTTP requests: Payload signing is <b>enabled</b> by default for security</li>
+     *   <li>HTTPS requests: Payload signing is disabled by default</li>
+     *   <li>HTTP requests: Payload signing is enabled by default</li>
      * </ul>
-     * <p>
-     * <b>Note:</b> Certain features require payload signing regardless of this setting:
-     * chunk encoding ({@link #CHUNK_ENCODING_ENABLED}), event streaming, and flexible checksums with trailers.
      */
     SignerProperty<Boolean> PAYLOAD_SIGNING_ENABLED =
         SignerProperty.create(AwsV4FamilyHttpSigner.class, "PayloadSigningEnabled");

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -140,7 +140,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Date")).hasValue("20200803T174823Z");
         assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Region-Set")).hasValue("aws-global");
         assertThat(signedRequest.request().firstMatchingHeader("Authorization")).isPresent();
-        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).contains(PAYLOAD_SHA256_HEX);
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue("UNSIGNED-PAYLOAD");
     }
 
     @Test
@@ -172,7 +172,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
         assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Date")).hasValue("20200803T174823Z");
         assertThat(signedRequest.request().firstMatchingHeader("X-Amz-Region-Set")).hasValue("aws-global");
         assertThat(signedRequest.request().firstMatchingHeader("Authorization")).isPresent();
-        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).contains(PAYLOAD_SHA256_HEX);
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue("UNSIGNED-PAYLOAD");
     }
 
     @Test

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/crt/internal/signer/DefaultAwsCrtV4aHttpSignerTest.java
@@ -564,6 +564,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
                 .putHeader(Header.CONTENT_LENGTH, "20"),
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         SignedRequest signedRequest = signer.sign(request);
@@ -587,6 +588,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
                 .putHeader(Header.CONTENT_LENGTH, contentLength),
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         AsyncSignedRequest signedRequest = signer.signAsync(request).join();
@@ -610,6 +612,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
                 .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         SignedRequest signedRequest = signer.sign(request);
@@ -636,6 +639,7 @@ public class DefaultAwsCrtV4aHttpSignerTest {
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
                 .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         AsyncSignedRequest signedRequest = signer.signAsync(request).join();

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -320,6 +320,7 @@ public class DefaultAwsV4HttpSignerTest {
             httpRequest -> httpRequest
                 .putHeader("Content-Type", "application/vnd.amazon.eventstream"),
             signRequest -> {
+                signRequest.putProperty(PAYLOAD_SIGNING_ENABLED, true);
             }
         );
 
@@ -340,6 +341,7 @@ public class DefaultAwsV4HttpSignerTest {
             httpRequest -> httpRequest
                 .putHeader("Content-Type", "application/vnd.amazon.eventstream"),
             signRequest -> {
+                signRequest.putProperty(PAYLOAD_SIGNING_ENABLED, true);
             }
         );
 
@@ -373,6 +375,7 @@ public class DefaultAwsV4HttpSignerTest {
             httpRequest -> httpRequest
                 .putHeader("Content-Type", "application/vnd.amazon.eventstream"),
             signRequest -> {
+                signRequest.putProperty(PAYLOAD_SIGNING_ENABLED, true);
             }
         );
 
@@ -415,6 +418,7 @@ public class DefaultAwsV4HttpSignerTest {
                 .putHeader(Header.CONTENT_LENGTH, "20"),
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         SignedRequest signedRequest = signer.sign(request);
@@ -433,6 +437,7 @@ public class DefaultAwsV4HttpSignerTest {
                 .putHeader(Header.CONTENT_LENGTH, "20"),
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         AsyncSignedRequest signedRequest = signer.signAsync(request).join();
@@ -453,6 +458,7 @@ public class DefaultAwsV4HttpSignerTest {
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
                 .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         SignedRequest signedRequest = signer.sign(request);
@@ -473,6 +479,7 @@ public class DefaultAwsV4HttpSignerTest {
             signRequest -> signRequest
                 .putProperty(CHUNK_ENCODING_ENABLED, true)
                 .putProperty(CHECKSUM_ALGORITHM, CRC32)
+                .putProperty(PAYLOAD_SIGNING_ENABLED, true)
         );
 
         AsyncSignedRequest signedRequest = signer.signAsync(request).join();
@@ -1062,7 +1069,7 @@ public class DefaultAwsV4HttpSignerTest {
     }
 
     @Test
-    void asyncSign_WithHTTPAndNoProperties_UsesSignsPayload() {
+    void asyncSign_WithHTTPAndNoProperties_SignsPayload() {
         AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
             AwsCredentialsIdentity.create("access", "secret"),
             httpRequest -> {

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/DefaultAwsV4HttpSignerTest.java
@@ -38,6 +38,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -979,6 +980,103 @@ public class DefaultAwsV4HttpSignerTest {
             .hasMessageContaining("Content-Length header must be specified");
     }
 
+    @Test
+    void sign_WithHttpsAndNoProperties_UsesUnsignedPayload() {
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> {
+            },
+            signRequest -> {
+            }
+        );
+
+        SignedRequest signedRequest = signer.sign(request);
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue("UNSIGNED-PAYLOAD");
+    }
+
+    @Test
+    void asyncSign_WithHttpsAndNoProperties_UsesUnsignedPayload() {
+        AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> {
+            },
+            signRequest -> {
+            }
+        );
+
+        AsyncSignedRequest signedRequest = signer.signAsync(request).join();
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue("UNSIGNED-PAYLOAD");
+    }
+
+    @Test
+    void sign_WithHttpsExplicitSigning_SignsPayload() {
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> {
+            },
+            signRequest -> {
+                signRequest.putProperty(PAYLOAD_SIGNING_ENABLED, true);
+            }
+        );
+
+        byte[] sha256Value = computeChecksum(SHA256, testPayload());
+        SignedRequest signedRequest = signer.sign(request);
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue(BinaryUtils.toHex(sha256Value));
+    }
+
+    @Test
+    void asyncSign_WithHttpsExplicitSigning_SignsPayload() {
+        AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> {
+            },
+            signRequest -> {
+                signRequest.putProperty(PAYLOAD_SIGNING_ENABLED, true);
+            }
+        );
+
+        byte[] sha256Value = computeChecksum(SHA256, testPayload());
+        AsyncSignedRequest signedRequest = signer.signAsync(request).join();
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue(BinaryUtils.toHex(sha256Value));
+    }
+
+    @Test
+    void sign_WithHTTPAndNoProperties_SignsPayload() {
+        SignRequest<? extends AwsCredentialsIdentity> request = generateBasicRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> {
+                httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com"));
+            },
+            signRequest -> {
+            }
+        );
+
+        byte[] sha256Value = computeChecksum(SHA256, testPayload());
+        SignedRequest signedRequest = signer.sign(request);
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue(BinaryUtils.toHex(sha256Value));
+    }
+
+    @Test
+    void asyncSign_WithHTTPAndNoProperties_UsesSignsPayload() {
+        AsyncSignRequest<? extends AwsCredentialsIdentity> request = generateBasicAsyncRequest(
+            AwsCredentialsIdentity.create("access", "secret"),
+            httpRequest -> {
+                httpRequest.uri(URI.create("http://demo.us-east-1.amazonaws.com"));
+            },
+            signRequest -> {
+            }
+        );
+
+        byte[] sha256Value = computeChecksum(SHA256, testPayload());
+        AsyncSignedRequest signedRequest = signer.signAsync(request).join();
+
+        assertThat(signedRequest.request().firstMatchingHeader("x-amz-content-sha256")).hasValue(BinaryUtils.toHex(sha256Value));
+    }
 
     private static byte[] computeChecksum(ChecksumAlgorithm algorithm, byte[] data) {
         SdkChecksum checksum = SdkChecksum.forAlgorithm(algorithm);

--- a/services/docdb/src/test/java/software/amazon/awssdk/services/docdb/internal/PresignRequestHandlerTest.java
+++ b/services/docdb/src/test/java/software/amazon/awssdk/services/docdb/internal/PresignRequestHandlerTest.java
@@ -219,7 +219,7 @@ class PresignRequestHandlerTest {
             "&X-Amz-SignedHeaders=host" +
             "&X-Amz-Credential=foo%2F20161221%2Fus-east-1%2Frds%2Faws4_request" +
             "&X-Amz-Expires=604800" +
-            "&X-Amz-Signature=00822ebbba95e2e6ac09112aa85621fbef060a596e3e1480f9f4ac61493e9821";
+            "&X-Amz-Signature=c2ef95311d2d530c13b478b1bea9b8fcec9bc8f2160645b9533b648fe7fd2371";
     }
 
     private Map<String, List<String>> rawQueryParameters(SdkHttpFullRequest request) {

--- a/services/neptune/src/test/java/software/amazon/awssdk/services/neptune/internal/PresignRequestHandlerTest.java
+++ b/services/neptune/src/test/java/software/amazon/awssdk/services/neptune/internal/PresignRequestHandlerTest.java
@@ -223,7 +223,7 @@ class PresignRequestHandlerTest {
             "&X-Amz-SignedHeaders=host" +
             "&X-Amz-Credential=foo%2F20161221%2Fus-east-1%2Frds%2Faws4_request" +
             "&X-Amz-Expires=604800" +
-            "&X-Amz-Signature=00822ebbba95e2e6ac09112aa85621fbef060a596e3e1480f9f4ac61493e9821";
+            "&X-Amz-Signature=c2ef95311d2d530c13b478b1bea9b8fcec9bc8f2160645b9533b648fe7fd2371";
     }
 
     private Map<String, List<String>> rawQueryParameters(SdkHttpFullRequest request) {

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
@@ -240,7 +240,7 @@ class PresignRequestHandlerTest {
             "&X-Amz-SignedHeaders=host" +
             "&X-Amz-Credential=foo%2F20161221%2Fus-east-1%2Frds%2Faws4_request" +
             "&X-Amz-Expires=604800" +
-            "&X-Amz-Signature=00822ebbba95e2e6ac09112aa85621fbef060a596e3e1480f9f4ac61493e9821";
+            "&X-Amz-Signature=c2ef95311d2d530c13b478b1bea9b8fcec9bc8f2160645b9533b648fe7fd2371";
     }
 
     private Map<String, List<String>> rawQueryParameters(SdkHttpFullRequest request) {

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/signer/DynamoDbPayloadSigningBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/signer/DynamoDbPayloadSigningBenchmark.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.benchmark.signer;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.benchmark.utils.MockHttpClient;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@Fork(2)
+public class DynamoDbPayloadSigningBenchmark {
+
+    @Param({"10240", "409600"})
+    private int payloadSize;
+
+    private DynamoDbClient client;
+    private PutItemRequest putRequest;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        client = DynamoDbClient.builder()
+                               .region(Region.US_EAST_1)
+                               .endpointOverride(URI.create("https://dynamodb.us-east-1.amazonaws.com"))
+                               .credentialsProvider(StaticCredentialsProvider.create(
+                                   AwsBasicCredentials.create("AKIATEST", "testSecretKey")))
+                               .httpClient(new MockHttpClient("{}", "{}"))
+                               .build();
+
+        byte[] data = new byte[payloadSize];
+        new Random(42).nextBytes(data);
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("test-id").build());
+        item.put("data", AttributeValue.builder().b(SdkBytes.fromByteArray(data)).build());
+
+        putRequest = PutItemRequest.builder()
+                                   .tableName("test-table")
+                                   .item(item)
+                                   .build();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        client.close();
+    }
+
+    @Benchmark
+    public void putItem(Blackhole blackhole) {
+        PutItemResponse response = client.putItem(putRequest);
+        blackhole.consume(response);
+    }
+}


### PR DESCRIPTION
### ⚠️  AFTER REVIEW - NEEDS MINOR VERSION BUMP
--- 

Addresses: `JAVA-8739`

### Background 
The SDK currently signs payloads for all requests (HTTP and HTTPS). This differs from V1, which only signed payloads for HTTP requests. For HTTPS requests, payload signing is redundant since TLS already provides integrity protection, and it causes measurable performance degradation. This change follows the same behavior of v1 where HTTPS requests' payloads were not signed. 

### Benchmarking Approach

Performance was measured using JMH with a stubbed DynamoDB client to isolate signing overhead. I chose two binary payload a 10kb and 400kb (DDB limit) to see if this exacerbates the performance bottleneck. 

### Results
| Payload Size | Metric | Before (µs) | After (µs) | Improvement |
|--------------|--------|-------------|------------|-------------|
| 10KB | p50 | 92.160 | 55.168 | 40% faster |
| 10KB | p90 | 95.872 | 62.336 | 35% faster |
| 10KB | p95 | 108.288 | 68.608 | 37% faster |
| 10KB | p99 | 142.848 | 101.248 | 29% faster |
|     |     |     |     |
| 400KB | p50 | 2732.032 | 1249.280 | 54% faster |
| 400KB | p90 | 2818.048 | 1306.624 | 54% faster |
| 400KB | p95 | 2867.200 | 1335.296 | 53% faster |
| 400KB | p99 | 3796.992 | 2137.252 | 44% faster |

### Flamegraphs 

#### Before
<img width="1938" height="652" alt="image" src="https://github.com/user-attachments/assets/b1965a5b-0377-41fb-9a4b-ea917058fe22" />

#### After 
<img width="1938" height="647" alt="image" src="https://github.com/user-attachments/assets/534311c8-1087-4815-9fb8-a1ccaa0f482a" />





