### PR TITLE
Add WriteThroughput tracking for async code path

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -151,32 +151,6 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("ResponseBytesRead");
 
     /**
-     * The running count of bytes in the request body that have been written by the client. This is updated atomically as the
-     * request is being sent.
-     * <p>
-     * This attribute is set before every API call attempt.
-     */
-    public static final ExecutionAttribute<AtomicLong> REQUEST_BYTES_WRITTEN =
-        new ExecutionAttribute<>("RequestBytesWritten");
-
-    /**
-     * The nano time when the first byte of the request body was written. This is set atomically on the first read from the
-     * request body stream.
-     * <p>
-     * This attribute is set before every API call attempt.
-     */
-    public static final ExecutionAttribute<AtomicLong> REQUEST_BODY_FIRST_BYTE_WRITTEN_NANO_TIME =
-        new ExecutionAttribute<>("RequestBodyFirstByteWrittenNanoTime");
-
-    /**
-     * Nano time when the last byte of the request body was written. Used to calculate WRITE_THROUGHPUT metric.
-     * <p>
-     * This attribute is set before every API call attempt.
-     */
-    public static final ExecutionAttribute<AtomicLong> REQUEST_BODY_LAST_BYTE_WRITTEN_NANO_TIME =
-        new ExecutionAttribute<>("RequestBodyLastByteWrittenNanoTime");
-
-    /**
      * The auth scheme provider used to resolve the auth scheme for a request.
      */
     public static final ExecutionAttribute<AuthSchemeProvider> AUTH_SCHEME_RESOLVER =

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/InternalCoreExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/InternalCoreExecutionAttribute.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.internal;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.internal.metrics.RequestBodyMetrics;
 import software.amazon.awssdk.retries.api.RetryToken;
 
 /**
@@ -35,6 +36,12 @@ public final class InternalCoreExecutionAttribute extends SdkExecutionAttribute 
 
     public static final ExecutionAttribute<RetryToken> RETRY_TOKEN =
         new ExecutionAttribute<>("SdkInternalRetryToken");
+
+    /**
+     * Metrics for tracking request body bytes written and timing for WRITE_THROUGHPUT calculation.
+     */
+    public static final ExecutionAttribute<RequestBodyMetrics> REQUEST_BODY_METRICS =
+        new ExecutionAttribute<>("RequestBodyMetrics");
 
     private InternalCoreExecutionAttribute() {
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptMetricCollectionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptMetricCollectionStage.java
@@ -23,10 +23,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.Response;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.internal.InternalCoreExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestToResponsePipeline;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper;
+import software.amazon.awssdk.core.internal.metrics.RequestBodyMetrics;
 import software.amazon.awssdk.core.internal.metrics.SdkErrorType;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -71,11 +73,8 @@ public final class ApiCallAttemptMetricCollectionStage<OutputT> implements Reque
     }
 
     private void resetBytesWritten(RequestExecutionContext context) {
-        context.executionAttributes().putAttribute(SdkInternalExecutionAttribute.REQUEST_BYTES_WRITTEN, new AtomicLong(0));
-        context.executionAttributes().putAttribute(SdkInternalExecutionAttribute.REQUEST_BODY_FIRST_BYTE_WRITTEN_NANO_TIME,
-                                                   new AtomicLong(0));
-        context.executionAttributes().putAttribute(SdkInternalExecutionAttribute.REQUEST_BODY_LAST_BYTE_WRITTEN_NANO_TIME,
-                                                   new AtomicLong(0));
+        context.executionAttributes().putAttribute(InternalCoreExecutionAttribute.REQUEST_BODY_METRICS,
+                                                   new RequestBodyMetrics());
     }
 
     private void reportBackoffDelay(RequestExecutionContext context) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/metrics/BytesWrittenTrackingPublisher.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/metrics/BytesWrittenTrackingPublisher.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.metrics;
+
+import java.nio.ByteBuffer;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Publisher that tracks how many bytes are published from the wrapped publisher to the downstream subscriber,
+ * along with timing information for throughput calculation.
+ */
+@SdkInternalApi
+public final class BytesWrittenTrackingPublisher implements Publisher<ByteBuffer> {
+    private final Publisher<ByteBuffer> upstream;
+    private final RequestBodyMetrics metrics;
+
+    public BytesWrittenTrackingPublisher(Publisher<ByteBuffer> upstream, RequestBodyMetrics metrics) {
+        this.upstream = upstream;
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        upstream.subscribe(new BytesWrittenTracker(subscriber, metrics));
+    }
+
+    private static final class BytesWrittenTracker implements Subscriber<ByteBuffer> {
+        private final Subscriber<? super ByteBuffer> downstream;
+        private final RequestBodyMetrics metrics;
+
+        private BytesWrittenTracker(Subscriber<? super ByteBuffer> downstream, RequestBodyMetrics metrics) {
+            this.downstream = downstream;
+            this.metrics = metrics;
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            downstream.onSubscribe(subscription);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            int bytes = byteBuffer.remaining();
+            if (bytes > 0) {
+                metrics.firstByteWrittenNanoTime().compareAndSet(0, System.nanoTime());
+                metrics.bytesWritten().addAndGet(bytes);
+                metrics.lastByteWrittenNanoTime().set(System.nanoTime());
+            }
+            downstream.onNext(byteBuffer);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            downstream.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/metrics/RequestBodyMetrics.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/metrics/RequestBodyMetrics.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Container for request body metrics used to calculate WRITE_THROUGHPUT.
+ */
+@SdkInternalApi
+public final class RequestBodyMetrics {
+    private final AtomicLong bytesWritten;
+    private final AtomicLong firstByteWrittenNanoTime;
+    private final AtomicLong lastByteWrittenNanoTime;
+
+    public RequestBodyMetrics() {
+        this.bytesWritten = new AtomicLong(0);
+        this.firstByteWrittenNanoTime = new AtomicLong(0);
+        this.lastByteWrittenNanoTime = new AtomicLong(0);
+    }
+
+    public AtomicLong bytesWritten() {
+        return bytesWritten;
+    }
+
+    public AtomicLong firstByteWrittenNanoTime() {
+        return firstByteWrittenNanoTime;
+    }
+
+    public AtomicLong lastByteWrittenNanoTime() {
+        return lastByteWrittenNanoTime;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/MetricUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/MetricUtils.java
@@ -172,23 +172,6 @@ public final class MetricUtils {
         return OptionalLong.of(read.get());
     }
 
-    public static OptionalLong apiCallAttemptRequestBytesWritten(RequestExecutionContext context) {
-        AtomicLong written = context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.REQUEST_BYTES_WRITTEN);
-        if (written == null || written.get() == 0) {
-            return OptionalLong.empty();
-        }
-        return OptionalLong.of(written.get());
-    }
-
-    public static OptionalLong requestBodyFirstByteWrittenNanoTime(RequestExecutionContext context) {
-        AtomicLong firstByteWrittenTime = context.executionAttributes()
-                                      .getAttribute(SdkInternalExecutionAttribute.REQUEST_BODY_FIRST_BYTE_WRITTEN_NANO_TIME);
-        if (firstByteWrittenTime == null || firstByteWrittenTime.get() == 0) {
-            return OptionalLong.empty();
-        }
-        return OptionalLong.of(firstByteWrittenTime.get());
-    }
-
     public static OptionalLong responseHeadersReadEndNanoTime(RequestExecutionContext context) {
         Long startTime = context.executionAttributes().getAttribute(SdkInternalExecutionAttribute.HEADERS_READ_END_NANO_TIME);
         if (startTime == null) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/metrics/BytesWrittenTrackingPublisherTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/metrics/BytesWrittenTrackingPublisherTckTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.metrics;
+
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+/**
+ * TCK verification class for {@link BytesWrittenTrackingPublisher}.
+ */
+public class BytesWrittenTrackingPublisherTckTest extends PublisherVerification<ByteBuffer> {
+    public BytesWrittenTrackingPublisherTckTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long l) {
+        return new BytesWrittenTrackingPublisher(createUpstreamPublisher(l), new RequestBodyMetrics());
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        return null;
+    }
+
+    private Publisher<ByteBuffer> createUpstreamPublisher(long elements) {
+        return Flowable.fromIterable(Stream.generate(() -> ByteBuffer.wrap(new byte[1]))
+                                           .limit(elements)
+                                           .collect(Collectors.toList()));
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/metrics/BytesWrittenTrackingPublisherTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/metrics/BytesWrittenTrackingPublisherTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+
+public class BytesWrittenTrackingPublisherTest {
+
+    @Test
+    public void onNext_updatesCounter() {
+        RequestBodyMetrics metrics = new RequestBodyMetrics();
+        Publisher<ByteBuffer> upstream = AsyncRequestBody.fromString("hello");
+        BytesWrittenTrackingPublisher publisher = new BytesWrittenTrackingPublisher(upstream, metrics);
+
+        publisher.subscribe(new TestSubscriber());
+
+        assertThat(metrics.bytesWritten().get()).isEqualTo(5);
+    }
+
+    @Test
+    public void onNext_recordsFirstByteTime() {
+        RequestBodyMetrics metrics = new RequestBodyMetrics();
+        Publisher<ByteBuffer> upstream = AsyncRequestBody.fromString("hello");
+        BytesWrittenTrackingPublisher publisher = new BytesWrittenTrackingPublisher(upstream, metrics);
+
+        assertThat(metrics.firstByteWrittenNanoTime().get()).isEqualTo(0);
+
+        publisher.subscribe(new TestSubscriber());
+
+        assertThat(metrics.firstByteWrittenNanoTime().get()).isGreaterThan(0);
+    }
+
+    @Test
+    public void onNext_updatesLastByteTime() {
+        RequestBodyMetrics metrics = new RequestBodyMetrics();
+        Publisher<ByteBuffer> upstream = AsyncRequestBody.fromString("hello");
+        BytesWrittenTrackingPublisher publisher = new BytesWrittenTrackingPublisher(upstream, metrics);
+
+        publisher.subscribe(new TestSubscriber());
+
+        assertThat(metrics.lastByteWrittenNanoTime().get()).isGreaterThan(0);
+        assertThat(metrics.lastByteWrittenNanoTime().get()).isGreaterThanOrEqualTo(metrics.firstByteWrittenNanoTime().get());
+    }
+
+    @Test
+    public void emptyBuffer_doesNotUpdateCounters() {
+        RequestBodyMetrics metrics = new RequestBodyMetrics();
+        Publisher<ByteBuffer> upstream = AsyncRequestBody.fromString("");
+        BytesWrittenTrackingPublisher publisher = new BytesWrittenTrackingPublisher(upstream, metrics);
+
+        publisher.subscribe(new TestSubscriber());
+
+        assertThat(metrics.bytesWritten().get()).isEqualTo(0);
+        assertThat(metrics.firstByteWrittenNanoTime().get()).isEqualTo(0);
+        assertThat(metrics.lastByteWrittenNanoTime().get()).isEqualTo(0);
+    }
+
+    private static class TestSubscriber implements Subscriber<ByteBuffer> {
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            // consume
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/AsyncWriteThroughputMetricTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/metrics/AsyncWriteThroughputMetricTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.metrics;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.testutil.MockIdentityProviderUtil;
+
+/**
+ * Functional tests for WRITE_THROUGHPUT metric for async client using WireMock.
+ */
+@WireMockTest
+public class AsyncWriteThroughputMetricTest {
+
+    private MetricPublisher mockPublisher;
+    private ProtocolRestJsonAsyncClient client;
+
+    @BeforeEach
+    public void setup(WireMockRuntimeInfo wmRuntimeInfo) {
+        mockPublisher = Mockito.mock(MetricPublisher.class);
+        client = ProtocolRestJsonAsyncClient.builder()
+                                            .region(Region.US_WEST_2)
+                                            .endpointOverride(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
+                                            .credentialsProvider(MockIdentityProviderUtil.mockIdentityProvider())
+                                            .overrideConfiguration(c -> c.addMetricPublisher(mockPublisher))
+                                            .build();
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    public void streamingInputOperation_withRequestBody_writeThroughputReported() {
+        stubFor(post(anyUrl())
+                    .willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        client.streamingInputOperation(r -> r.build(), AsyncRequestBody.fromString("test body content")).join();
+
+        ArgumentCaptor<MetricCollection> collectionCaptor = ArgumentCaptor.forClass(MetricCollection.class);
+        verify(mockPublisher).publish(collectionCaptor.capture());
+
+        MetricCollection capturedCollection = collectionCaptor.getValue();
+        List<MetricCollection> attemptMetrics = capturedCollection.children();
+
+        assertThat(attemptMetrics).hasSize(1);
+        List<Double> writeThroughputValues = attemptMetrics.get(0).metricValues(CoreMetric.WRITE_THROUGHPUT);
+        assertThat(writeThroughputValues).hasSize(1);
+        assertThat(writeThroughputValues.get(0)).isGreaterThan(0);
+    }
+
+    @Test
+    public void operationWithNoInputOrOutput_noRequestBody_writeThroughputNotReported() {
+        stubFor(post(anyUrl())
+                    .willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        client.operationWithNoInputOrOutput().join();
+
+        ArgumentCaptor<MetricCollection> collectionCaptor = ArgumentCaptor.forClass(MetricCollection.class);
+        verify(mockPublisher).publish(collectionCaptor.capture());
+
+        MetricCollection capturedCollection = collectionCaptor.getValue();
+        List<MetricCollection> attemptMetrics = capturedCollection.children();
+
+        assertThat(attemptMetrics).hasSize(1);
+        List<Double> writeThroughputValues = attemptMetrics.get(0).metricValues(CoreMetric.WRITE_THROUGHPUT);
+        assertThat(writeThroughputValues).isEmpty();
+    }
+}


### PR DESCRIPTION
## Motivation and Context

This PR adds `WRITE_THROUGHPUT` metric support for the async client, completing the feature started in the sync client implementation. The
`WRITE_THROUGHPUT` metric measures the rate at which request body bytes are uploaded to the service (bytes/sec).


## Modifications

- Added `BytesWrittenTrackingPublisher` to wrap async request body and track bytes/timing (mirrors sync BytesWrittenTrackingInputStream)
- Created `RequestBodyMetrics` container class to consolidate 3 execution attributes into 1, improving code organization
- Moved request body metrics attribute from `SdkInternalExecutionAttribute` (protected API) to `InternalCoreExecutionAttribute` (internal API)
- Updated async pipeline stages to initialize metrics and report `WRITE_THROUGHPUT`
- Refactored sync implementation to use the new RequestBodyMetrics container

## Testing

- Unit tests for BytesWrittenTrackingPublisher
- Reactive Streams TCK compliance tests
- Functional tests with WireMock for both sync and async clients
- S3 integration tests for sync and async putObject
- JMH benchmark validated negligible overhead (<0.015% of network I/O time)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of mvn install succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/
docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
