### PR TITLE
Added cache for computation of partition keys

### DIFF
--- a/.changes/next-release/bugfix-foo-85b64de.json
+++ b/.changes/next-release/bugfix-foo-85b64de.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Improved performance by caching partition and sort key name lookups in StaticTableMetadata."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadata.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadata.java
@@ -87,7 +87,13 @@ public final class StaticTableMetadata implements TableMetadata {
 
     @Override
     public List<String> indexPartitionKeys(String indexName) {
-        return partitionKeyCache.computeIfAbsent(indexName, this::computePartitionKeys);
+        List<String> cached = partitionKeyCache.get(indexName);
+        if (cached != null) {
+            return cached;
+        }
+        List<String> computedKeys = computePartitionKeys(indexName);
+        List<String> existingKeys = partitionKeyCache.putIfAbsent(indexName, computedKeys);
+        return existingKeys == null ? computedKeys : existingKeys;
     }
 
     private List<String> computePartitionKeys(String indexName) {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadataTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadataTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static software.amazon.awssdk.enhanced.dynamodb.TableMetadata.primaryIndexName;
 
 import java.util.Collection;
@@ -357,6 +358,43 @@ public class StaticTableMetadataTest {
         builder.addIndexPartitionKey("gsi1", "key2", AttributeValueType.S, Order.SECOND);
         StaticTableMetadata metadata2 = builder.build();
         assertThat(metadata2.indexPartitionKeys("gsi1"), contains("key1", "key2"));
+    }
+
+    @Test
+    public void indexPartitionKeys_shouldReturnCachedPartitionKeysList() {
+        StaticTableMetadata metadata = StaticTableMetadata.builder()
+                                                                 .addIndexPartitionKey(primaryIndexName(),
+                                                                                       ATTRIBUTE_NAME,
+                                                                                       AttributeValueType.S)
+                                                                 .build();
+        List<String> first = metadata.indexPartitionKeys(primaryIndexName());
+        List<String> second = metadata.indexPartitionKeys(primaryIndexName());
+
+        assertThat(first, sameInstance(second));
+    }
+
+    @Test
+    public void indexSortKeys_shouldReturnCachedSortKeysList() {
+        StaticTableMetadata metadata = StaticTableMetadata.builder()
+                                                          .addIndexSortKey(primaryIndexName(),
+                                                                                ATTRIBUTE_NAME,
+                                                                                AttributeValueType.S)
+                                                          .build();
+        List<String> first = metadata.indexSortKeys(primaryIndexName());
+        List<String> second = metadata.indexSortKeys(primaryIndexName());
+
+        assertThat(first, sameInstance(second));
+    }
+
+    @Test
+    public void indexSortKeys_shouldReturnUnmodifiableList() {
+        StaticTableMetadata metadata = StaticTableMetadata.builder()
+                                                          .addIndexSortKey(primaryIndexName(),
+                                                                           ATTRIBUTE_NAME,
+                                                                           AttributeValueType.S)
+                                                          .build();
+        List<String> result = metadata.indexSortKeys(primaryIndexName());
+        assertThatThrownBy(() -> result.add("foo")).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadataTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadataTest.java
@@ -398,6 +398,17 @@ public class StaticTableMetadataTest {
     }
 
     @Test
+    public void indexPartitionKeys_shouldReturnUnmodifiableList() {
+        StaticTableMetadata metadata = StaticTableMetadata.builder()
+                                                          .addIndexPartitionKey(primaryIndexName(),
+                                                                           ATTRIBUTE_NAME,
+                                                                           AttributeValueType.S)
+                                                          .build();
+        List<String> result = metadata.indexPartitionKeys(primaryIndexName());
+        assertThatThrownBy(() -> result.add("foo")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
     public void getIndexKeys_partitionAndSort() {
         TableMetadata tableMetadata = StaticTableMetadata.builder()
                                                          .addIndexPartitionKey(primaryIndexName(), "primary_id", AttributeValueType.S)


### PR DESCRIPTION
The DDB Enhanced Client originally used direct field access to retrieve single partition key names from table metadata on every operation. PR [#6574](https://github.com/aws/aws-sdk-java-v2/pull/6574) extended this to support composite keys (up to 4 partition + 4 sort keys) by introducing stream processing to extract key names from lists of metadata objects. 

Profiling revealed this stream processing is a performance bottleneck. For smaller payload this bottleneck accounts for roughly 20%~ of overall CPU time, with larger and more nested the payloads, the performance profile shifts away from this (for example an item with 80 nested objects that is 4 levels deep this accounts for 4%~ of overall CPU time). 

In the current implementation `Key.keyMap()` is repeatedly calling `indexPartitionKeys()` to build request key maps for every operation. This PR adds a cache to `StaticTableMetadata` that computes the key name lists once on first access and return the cached results on subsequent access.

### Design Considerations:
Do we need a bounded cache? 

While technically nothing prevents the user from creating an infinite amount of indexes, the DDB service side limits on the number of indexes per table:
- [up to 20 GSIs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.OnlineOps.html)
- [up to 5 LSIs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-secondary-indexes)
- 1 primary index 

Since `StaticTableMetadata` is immutable, the cache contents are fixed for the lifetime of the instance.


### Flamegraphs:

#### Before: 
<img width="1947" height="834" alt="image" src="https://github.com/user-attachments/assets/08585b62-2518-4d5c-a462-f944b850d443" />


#### After:
<img width="1933" height="827" alt="image" src="https://github.com/user-attachments/assets/d90e69ba-3c0c-4738-96ab-f3dd87f119cb" />

---

Operation | Size | Master (us/op) | Optimization (us/op) | Improvement
-- | -- | -- | -- | --
Delete | TINY | 0.396 | 0.263 | -33.59%
Delete | SMALL | 0.387 | 0.26 | -32.82%
Delete | HUGE | 0.392 | 0.263 | -32.91%
Delete | HUGE_FLAT | 0.397 | 0.262 | -34.01%
Get | TINY | 0.462 | 0.312 | -32.47%
Get | SMALL | 0.975 | 0.695 | -28.72%
Get | HUGE | 10.198 | 9.289 | -8.91%
Get | HUGE_FLAT | 3.024 | 2.698 | -10.78%
Put | TINY | 0.688 | 0.552 | -19.77%
Put | SMALL | 1.284 | 1.108 | -13.71%
Put | HUGE | 13.482 | 13.047 | -3.23%
Put | HUGE_FLAT | 7.595 | 7.301 | -3.87%
Query | TINY | 2.557 | 2.339 | -8.53%
Query | SMALL | 4.142 | 3.923 | -5.29%
Query | HUGE | 31.065 | 30.026 | -3.34%
Query | HUGE_FLAT | 8.975 | 9.202 | 2.53%
Scan | TINY | 1.080 | 1.082 | 0.19%
Scan | SMALL | 2.479 | 2.585 | 4.28%
Scan | HUGE | 30.366 | 29.667 | -2.30%
Scan | HUGE_FLAT | 8.105 | 8.273 | 2.07%
Update | TINY | 1.277 | 1.247 | -2.35%
Update | SMALL | 9.241 | 9.122 | -1.29%
Update | HUGE | 39.486 | 38.822 | -1.68%
Update | HUGE_FLAT | 232.677 | 232.115 | -0.24%

