### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/api-surface-area-review-verification.yml
+++ b/.github/workflows/api-surface-area-review-verification.yml
@@ -15,7 +15,7 @@ jobs:
   api-surface-area-review-verification:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Verifies updates to protected/public APIs have been reviewed and approved by the team, if any
         id: api-surface-area-review-verification
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-api-surface-area-change') }}

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -15,7 +15,7 @@ jobs:
   changelog-verification:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check for changelog entry
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'changelog-not-required') }}
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/lock-conversation-closed-pr.yml
+++ b/.github/workflows/lock-conversation-closed-pr.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Lock PR conversation on Close
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:

--- a/.github/workflows/mixed-version-compatibility-review.yml
+++ b/.github/workflows/mixed-version-compatibility-review.yml
@@ -15,7 +15,7 @@ jobs:
   mixed-version-compatibility-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       

--- a/.github/workflows/new-module-verification.yml
+++ b/.github/workflows/new-module-verification.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       

--- a/.github/workflows/s3-regression-tests.yml
+++ b/.github/workflows/s3-regression-tests.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       run_tests: ${{ contains(github.event.pull_request.labels.*.name, 'force-s3-regression-tests') || steps.check-changes.outputs.has_s3_related_changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check for changes related to s3


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | api-surface-area-review-verification.yml, changelog-verification.yml, codeql.yml, mixed-version-compatibility-review.yml, new-module-verification.yml, s3-regression-tests.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | issue-regression-labeler.yml, lock-conversation-closed-pr.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
