### PR TITLE
Replace nested Stream.concat with direct iteration in expression merging

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-15a5c11.json
+++ b/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-15a5c11.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Improved performance of UpdateExpression conversion by replacing Stream.concat chains and String.format with direct iteration and StringJoiner."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
@@ -176,13 +176,12 @@ public final class UpdateExpressionConverter {
             return;
         }
         source.forEach((key, value) -> {
-            String oldValue = target.get(key);
+            String oldValue = target.put(key, value);
             if (oldValue != null && !oldValue.equals(value)) {
                 throw new IllegalArgumentException(
                     String.format("Attempt to coalesce two expressions with conflicting expression names. "
                                   + "Expression name key = '%s'", key));
             }
-            target.put(key, value);
         });
     }
 
@@ -191,13 +190,12 @@ public final class UpdateExpressionConverter {
             return;
         }
         source.forEach((key, value) -> {
-            AttributeValue oldValue = target.get(key);
+            AttributeValue oldValue = target.put(key, value);
             if (oldValue != null && !oldValue.equals(value)) {
                 throw new IllegalArgumentException(
                     String.format("Attempt to coalesce two expressions with conflicting expression values. "
                                   + "Expression value key = '%s'", key));
             }
-            target.put(key, value);
         });
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -114,24 +115,24 @@ public final class UpdateExpressionConverter {
     private static List<String> groupExpressions(UpdateExpression expression) {
         List<String> groupExpressions = new ArrayList<>();
         if (!expression.setActions().isEmpty()) {
-            groupExpressions.add(SET + expression.setActions().stream()
-                                                 .map(a -> a.path() + " = " + a.value())
-                                                 .collect(Collectors.joining(ACTION_SEPARATOR)));
+            StringJoiner joiner = new StringJoiner(ACTION_SEPARATOR, SET, "");
+            expression.setActions().forEach(a -> joiner.add(a.path() + " = " + a.value()));
+            groupExpressions.add(joiner.toString());
         }
         if (!expression.removeActions().isEmpty()) {
-            groupExpressions.add(REMOVE + expression.removeActions().stream()
-                                                    .map(RemoveAction::path)
-                                                    .collect(Collectors.joining(ACTION_SEPARATOR)));
+            StringJoiner joiner = new StringJoiner(ACTION_SEPARATOR, REMOVE, "");
+            expression.removeActions().forEach(a -> joiner.add(a.path()));
+            groupExpressions.add(joiner.toString());
         }
         if (!expression.deleteActions().isEmpty()) {
-            groupExpressions.add(DELETE + expression.deleteActions().stream()
-                                                    .map(a -> a.path() + " " + a.value())
-                                                    .collect(Collectors.joining(ACTION_SEPARATOR)));
+            StringJoiner joiner = new StringJoiner(ACTION_SEPARATOR, DELETE, "");
+            expression.deleteActions().forEach(a -> joiner.add(a.path() + " " + a.value()));
+            groupExpressions.add(joiner.toString());
         }
         if (!expression.addActions().isEmpty()) {
-            groupExpressions.add(ADD + expression.addActions().stream()
-                                                 .map(a -> a.path() + " " + a.value())
-                                                 .collect(Collectors.joining(ACTION_SEPARATOR)));
+            StringJoiner joiner = new StringJoiner(ACTION_SEPARATOR, ADD, "");
+            expression.addActions().forEach(a -> joiner.add(a.path() + " " + a.value()));
+            groupExpressions.add(joiner.toString());
         }
         return groupExpressions;
     }


### PR DESCRIPTION
## Overview
This PR targets two bottlenecks in `UpdateExpressionConverter.toExpression` as part of the Update operation request pipeline. `toExpression` scales and becomes the most noticable bottleneck the bigger the input is: ~40% cpu time in SMALL datasets, and ~74% in HUGE_FLAT datasets.

[Interactive Flamegraph](https://htmlpreview.github.io/?https://gist.githubusercontent.com/RanVaknin/cd7960dbe0a91c7aff4c394f6d7e42be/raw/2ccb03b99200f41ba17d4c0fb9008cda13532ee1/Update_SMALL.html)

<img width="1935" height="295" alt="image" src="https://github.com/user-attachments/assets/e949650f-6a23-4379-b784-f27cb0ec27f4" />

### Testing

We have fairly good test coverage already: `convert_mixedActions_uniqueNameTokens` and `convert_mixedActions` verify the string output for correctness. This PR changes the underlying implementation but the API surface remains unchanged. 

---

## 

### 1. String.format overhead (~18% CPU time)
`groupExpressions` uses String.format to build the update expression for each attribute. Can replace with a StringJoiner which avoids the formatter's overhead.

<img width="1939" height="309" alt="image" src="https://github.com/user-attachments/assets/30de7782-5b34-4ffd-896b-a26d8aa10ab5" />

### 2. Nested `Stream.concat()` in `mergeExpressionNames()` and `mergeExpressionValues()`  (15-50% CPU time)

<img width="1940" height="326" alt="image" src="https://github.com/user-attachments/assets/666e9696-a237-4402-b696-ad1fa3c634c4" />


#### Current implementation:
```java
private static Map<String, String> mergeExpressionNames(UpdateExpression expression) {
    return streamOfExpressionNames(expression)
        .reduce(Expression::joinNames)
        .orElseGet(Collections::emptyMap);
}

private static Stream<Map<String, String>> streamOfExpressionNames(UpdateExpression expression) {
    return Stream.concat(
        expression.setActions().stream().map(SetAction::expressionNames),
        Stream.concat(
            expression.removeActions().stream().map(RemoveAction::expressionNames),
            Stream.concat(
                expression.deleteActions().stream().map(DeleteAction::expressionNames),
                expression.addActions().stream().map(AddAction::expressionNames)
            )
        )
    );
}
```

The problem is that `Stream.reduce()` operation calls `Expression.joinNames()` for each action type (SET, ADD, REMOVE, DELETE). This method creates a new HashMap and copies all existing entries on every iteration:

```java
public static Map<String, String> joinNames(Map<String, String> map1, Map<String, String> map2) {
    Map<String, String> result = new HashMap<>(map1);  // <- Allocate + copy all entries
    map2.forEach((key, value) -> {
        String oldValue = result.put(key, value);
        if (oldValue != null && !oldValue.equals(value)) {
            throw new IllegalArgumentException(...);
        }
    });
    return Collections.unmodifiableMap(result);
}
```

Example: With N attributes distributed across 4 action types, Stream.reduce() creates 3 intermediate HashMaps. For example, with 20 attributes (5 per action type), it copies 5 entries, then 10, then 15, before producing the final 20 entry result. The cost scales poorly with dataset size.

Instead we can iterate directly on each action and use a single HashMap:

```java
private static Map<String, String> mergeExpressionNames(UpdateExpression expression) {
    Map<String, String> merged = new HashMap<>();
    
    for (SetAction action : expression.setActions()) {
        mergeNamesInto(merged, action.expressionNames());
    }
    for (RemoveAction action : expression.removeActions()) {
        mergeNamesInto(merged, action.expressionNames());
    }
    for (DeleteAction action : expression.deleteActions()) {
        mergeNamesInto(merged, action.expressionNames());
    }
    for (AddAction action : expression.addActions()) {
        mergeNamesInto(merged, action.expressionNames());
    }
    
    return merged.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(merged);
}

private static void mergeNamesInto(Map<String, String> target, Map<String, String> source) {
    if (source == null || source.isEmpty()) {
        return;
    }
    source.forEach((key, value) -> {
        String oldValue = target.get(key);
        if (oldValue != null && !oldValue.equals(value)) {
            throw new IllegalArgumentException(
                String.format("Attempt to coalesce two expressions with conflicting expression names. "
                            + "Expression name key = '%s'", key));
        }
        target.put(key, value);
    });
}
```

This eliminates intermediate HashMap allocations and theredundant entry copying. The same proposed optimization also applies to `mergeExpressionValues()`.

---

## Results:

`toExpression` went from ~40% CPU time to ~15%
- `groupExpressions` went from 18% CPU time to ~2.5%
- `mergeExpressionValues` and `mergeExpressionNames` went down from 18% to  ~4%

<img width="1927" height="392" alt="image" src="https://github.com/user-attachments/assets/40d0ec69-b23a-40ee-8883-49cf4d189757" />


| Operation | Size | Master (μs) | String Fix (μs/op) | Δ | +Stream flattening (μs/op) | Total Δ |
|-----------|------|-------------|------------------|---|------------------|---------|
| Update | TINY | 1.38 | 1.395 | +1.09% | 1.366 | -1.01% |
| Update | SMALL | 9.174 | 8.62 | -6.43% | 7.202 | -21.50% |
| Update | HUGE | 39.23 | 37.51 | -4.38% | 34.438 | -12.22% |
| Update | HUGE_FLAT | 232.677 | 224.088 | -3.69% | 81.248 | -65.08% |





