### PR TITLE
Make MavenNoCompileTest more reliable

### DIFF
--- a/test/v2-migration-tests/src/test/java/software/amazon/awssdk/v2migrationtests/MavenNoCompileTest.java
+++ b/test/v2-migration-tests/src/test/java/software/amazon/awssdk/v2migrationtests/MavenNoCompileTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.v2migrationtests;
 
+import static software.amazon.awssdk.v2migrationtests.TestUtils.assertTwoDirectoriesHaveSameStructure;
+import static software.amazon.awssdk.v2migrationtests.TestUtils.normalizeImports;
 import static software.amazon.awssdk.v2migrationtests.TestUtils.replaceVersion;
 
 import java.io.File;
@@ -50,6 +52,8 @@ public class MavenNoCompileTest extends MavenTestBase {
     @Test
     @EnabledIf("versionAvailable")
     void mavenProject_shouldConvert() throws IOException {
-        verifyTransformation();
+        runTransformation();
+        normalizeImports(mavenActual);
+        assertTwoDirectoriesHaveSameStructure(mavenActual, mavenExpected);
     }
 }

--- a/test/v2-migration-tests/src/test/java/software/amazon/awssdk/v2migrationtests/MavenTestBase.java
+++ b/test/v2-migration-tests/src/test/java/software/amazon/awssdk/v2migrationtests/MavenTestBase.java
@@ -47,7 +47,7 @@ public class MavenTestBase {
         FileUtils.deleteDirectory(mavenExpected.toFile());
     }
 
-    protected static void verifyTransformation() throws IOException {
+    protected static void runTransformation() throws IOException {
         String recipeCmd = "-Drewrite.activeRecipes=software.amazon.awssdk.v2migration.AwsSdkJavaV1ToV2";
         List<String> rewriteArgs = new ArrayList<>();
         // pin version since updates have broken tests
@@ -57,6 +57,10 @@ public class MavenTestBase {
 
         run(mavenActual, rewriteArgs.toArray(new String[0]));
         FileUtils.deleteDirectory(mavenActual.resolve("target").toFile());
+    }
+
+    protected static void verifyTransformation() throws IOException {
+        runTransformation();
         assertTwoDirectoriesHaveSameStructure(mavenActual, mavenExpected);
     }
 

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3EnDateTime.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3EnDateTime.java
@@ -14,11 +14,11 @@
  */
 
 package foo.bar;
+import org.joda.time.DateTime;
+import software.amazon.awssdk.eventnotifications.s3.model.GlacierEventData;
+import software.amazon.awssdk.eventnotifications.s3.model.RestoreEventData;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotification;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotificationRecord;
-import software.amazon.awssdk.eventnotifications.s3.model.RestoreEventData;
-import software.amazon.awssdk.eventnotifications.s3.model.GlacierEventData;
-import org.joda.time.DateTime;
 
 public class S3EnDateTime {
 

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven-nocompile/after/src/main/java/foo/bar/S3Transforms.java
@@ -18,6 +18,10 @@ package foo.bar;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AccessControlPolicy;
@@ -29,11 +33,6 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Date;
 
 public class S3Transforms {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix flaky migration tool test failures by ordering imports before validating content