### PR TITLE
Fix string converter null in map

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/StringAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/StringAttributeConverter.java
@@ -125,8 +125,14 @@ public final class StringAttributeConverter implements AttributeConverter<String
             };
 
             return value.entrySet().stream()
-                        .collect(Collectors.toMap(Map.Entry::getKey, i -> toString(i.getValue()),
-                                                  throwingMerger, LinkedHashMap::new))
+                        .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            i -> {
+                                String converted = toString(i.getValue());
+                                return converted == null ? "null" : converted;
+                            },
+                            throwingMerger,
+                            LinkedHashMap::new))
                         .toString();
         }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/StringAttributeConvertersTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/StringAttributeConvertersTest.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.enhanced.dynamodb.converters.attribute;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
 import static software.amazon.awssdk.enhanced.dynamodb.converters.attribute.ConverterTestUtils.assertFails;
 import static software.amazon.awssdk.enhanced.dynamodb.converters.attribute.ConverterTestUtils.transformFrom;
 import static software.amazon.awssdk.enhanced.dynamodb.converters.attribute.ConverterTestUtils.transformTo;

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/StringAttributeConvertersTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/StringAttributeConvertersTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.enhanced.dynamodb.converters.attribute;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
 import static software.amazon.awssdk.enhanced.dynamodb.converters.attribute.ConverterTestUtils.assertFails;
 import static software.amazon.awssdk.enhanced.dynamodb.converters.attribute.ConverterTestUtils.transformFrom;
 import static software.amazon.awssdk.enhanced.dynamodb.converters.attribute.ConverterTestUtils.transformTo;
@@ -56,6 +57,7 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.Url
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.UuidAttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZoneIdAttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZoneOffsetAttributeConverter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 public class StringAttributeConvertersTest {
@@ -253,5 +255,15 @@ public class StringAttributeConvertersTest {
     public void stringSetAttributeConverter_ReturnsSSType() {
         SetAttributeConverter<Set<String>> converter = SetAttributeConverter.setConverter(StringAttributeConverter.create());
         assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+    }
+
+    @Test
+    public void stringAttributeConverter_convertsMapWithNullValue() {
+        StringAttributeConverter converter = StringAttributeConverter.create();
+        
+        assertThat(transformTo(converter, fromMap(ImmutableMap.of(
+            "stringField", AttributeValue.builder().s("value").build(),
+            "nullField", AttributeValue.builder().nul(true).build()))))
+            .isEqualTo("{stringField=value, nullField=null}");
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/StringAttributeConvertersTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/StringAttributeConvertersTest.java
@@ -260,10 +260,12 @@ public class StringAttributeConvertersTest {
     @Test
     public void stringAttributeConverter_convertsMapWithNullValue() {
         StringAttributeConverter converter = StringAttributeConverter.create();
-        
-        assertThat(transformTo(converter, fromMap(ImmutableMap.of(
+
+        String result = transformTo(converter, fromMap(ImmutableMap.of(
             "stringField", AttributeValue.builder().s("value").build(),
-            "nullField", AttributeValue.builder().nul(true).build()))))
-            .isEqualTo("{stringField=value, nullField=null}");
+            "nullField", AttributeValue.builder().nul(true).build())));
+
+        assertThat(result).contains("stringField=value");
+        assertThat(result).contains("nullField=null");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-java-v2/issues/6693 

The StringAttributeConverter's `convertMap()` method throws a NPE when a map contains a NULL AttributeValue. This Happens because `Collectors.toMap()` does not accept null values because it uses `Map.merge()` internally which has a different semantic purpose that conflicts with null values.