### PR TITLE
Skip DDB Enhanced Client extension processing for unusued extensions

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClientExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClientExtension.java
@@ -32,6 +32,21 @@ import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
 @SdkPublicApi
 @ThreadSafe
 public interface DynamoDbEnhancedClientExtension {
+
+    /**
+     * Determines whether this extension should process operations for the given table.
+     * <p>
+     * This method is called before invoking {@link #beforeWrite} or {@link #afterRead} to allow
+     * extensions to skip processing when they are not configured for a particular table schema.
+     *
+     * @param metadata the table metadata to check
+     * @return {@code true} if this extension should process operations for the table,
+     * {@code false} to skip this extension for the table
+     */
+    default boolean shouldProcess(TableMetadata metadata) {
+        return true;
+    }
+
     /**
      * This hook is called just before an operation is going to write data to the database. The extension that
      * implements this method can choose to transform the item itself, or add a condition to the write operation

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/AtomicCounterExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/AtomicCounterExtension.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.enhanced.dynamodb.extensions;
 
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.keyRef;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.valueRef;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.extensions.AtomicCounterTag.CUSTOM_METADATA_KEY_PREFIX;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.update.UpdateExpressionUtils.ifNotExists;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbExtensionContext;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.annotations.DynamoDbAtomicCounter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.AtomicCounterTag;
 import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.AtomicCounter;
@@ -104,6 +106,11 @@ public final class AtomicCounterExtension implements DynamoDbEnhancedClientExten
 
     public static AtomicCounterExtension.Builder builder() {
         return new AtomicCounterExtension.Builder();
+    }
+
+    @Override
+    public boolean shouldProcess(TableMetadata metadata) {
+        return metadata.customMetadataObject(CUSTOM_METADATA_KEY_PREFIX, Map.class).isPresent();
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbExtensionContext;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTag;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableMetadata;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -139,6 +140,11 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
                                        .addCustomMetadataObject(INCREMENT_BY_METADATA_KEY, incrementBy)
                                        .markAttributeAsKey(attributeName, attributeValueType);
         }
+    }
+
+    @Override
+    public boolean shouldProcess(TableMetadata metadata) {
+        return metadata.customMetadataObject(CUSTOM_METADATA_KEY, String.class).isPresent();
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -166,13 +166,8 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
         Iterator<DynamoDbEnhancedClientExtension> iterator = extensionChain.descendingIterator();
 
         while (iterator.hasNext()) {
-            DynamoDbEnhancedClientExtension extension = iterator.next();
-            if (!extension.shouldProcess(context.tableMetadata())) {
-                continue;
-            }
             Map<String, AttributeValue> itemToTransform =
                 transformedItem == null ? context.items() : transformedItem;
-
 
             DynamoDbExtensionContext.AfterRead afterRead =
                 DefaultDynamoDbExtensionContext.builder().items(itemToTransform)
@@ -181,7 +176,7 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
                                                .tableSchema(context.tableSchema())
                                                .build();
 
-            ReadModification readModification = extension.afterRead(afterRead);
+            ReadModification readModification = iterator.next().afterRead(afterRead);
 
             if (readModification.transformedItem() != null) {
                 transformedItem = readModification.transformedItem();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -166,8 +166,13 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
         Iterator<DynamoDbEnhancedClientExtension> iterator = extensionChain.descendingIterator();
 
         while (iterator.hasNext()) {
+            DynamoDbEnhancedClientExtension extension = iterator.next();
+            if (!extension.shouldProcess(context.tableMetadata())) {
+                continue;
+            }
             Map<String, AttributeValue> itemToTransform =
                 transformedItem == null ? context.items() : transformedItem;
+
 
             DynamoDbExtensionContext.AfterRead afterRead =
                 DefaultDynamoDbExtensionContext.builder().items(itemToTransform)
@@ -176,7 +181,7 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
                                                .tableSchema(context.tableSchema())
                                                .build();
 
-            ReadModification readModification = iterator.next().afterRead(afterRead);
+            ReadModification readModification = extension.afterRead(afterRead);
 
             if (readModification.transformedItem() != null) {
                 transformedItem = readModification.transformedItem();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -99,6 +99,9 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
         UpdateExpression updateExpression = null;
 
         for (DynamoDbEnhancedClientExtension extension : this.extensionChain) {
+            if (!extension.shouldProcess(context.tableMetadata())) {
+                continue;
+            }
             Map<String, AttributeValue> itemToTransform = transformedItem == null ? context.items() : transformedItem;
 
             DynamoDbExtensionContext.BeforeWrite beforeWrite =


### PR DESCRIPTION
[SURFACE API CHANGE - NEEDS REVIEW]

## Context 
The extension system creates context objects and invokes all configured extensions on every operation. By default, the Enhanced Client includes VersionedRecordExtension and AtomicCounterExtension, which run even when beans don't use either extension.

ChainExtension invokes each extension's beforeWrite() and afterRead() methods, creating a context object for each invocation. With 2 default extensions, this overhead accounts for ~2-15% CPU time, including extension invocation, context creation,  and result merging.

This PR adds `shouldProcess()` method to the `DynamoDbEnhancedClientExtension` interface with a default implementation returning true for backwards compatibility. 
Extensions can override this method to check if they're configured for a specific table schema.

## Flamegrahps

### Put SMALL
Before
two calls ~8% + ~3% around ~11%
<img width="1929" height="358" alt="image" src="https://github.com/user-attachments/assets/1aaff3ab-abc9-4252-a79a-52f3b8d727a5" />

After
<img width="1930" height="379" alt="image" src="https://github.com/user-attachments/assets/e7101afd-500c-4157-b9e5-0507093ae7c2" />

## Results:

Operation | Size | V2 Master Mean (us/op) | optimized | Improvement
-- | -- | -- | -- | --
Delete | TINY | 0.396 | 0.431 | -8.12%
Delete | SMALL | 0.387 | 0.387 | 0.00%
Delete | HUGE | 0.392 | 0.384 | 2.08%
Delete | HUGE_FLAT | 0.397 | 0.39 | 1.79%
Get | TINY | 0.462 | 0.489 | -5.52%
Get | SMALL | 0.975 | 0.98 | -0.51%
Get | HUGE | 10.198 | 9.821 | 3.84%
Get | HUGE_FLAT | 3.024 | 3.056 | -1.05%
Put | TINY | 0.688 | 0.625 | 10.08%
Put | SMALL | 1.345 | 1.22 | 10.25%
Put | HUGE | 13.482 | 13.107 | 2.86%
Put | HUGE_FLAT | 7.595 | 7.964 | -4.63%
Query | TINY | 2.557 | 2.487 | 2.81%
Query | SMALL | 4.162 | 4.084 | 1.91%
Query | HUGE | 31.065 | 29.631 | 4.84%
Query | HUGE_FLAT | 8.975 | 9.165 | -2.07%
Scan | TINY | 1.080 | 1.082 | -0.18%
Scan | SMALL | 2.577 | 2.671 | -3.52%
Scan | HUGE | 30.366 | 30.25 | 0.38%
Scan | HUGE_FLAT | 8.105 | 8.357 | -3.02%
Update | TINY | 1.277 | 1.259 | 1.43%
Update | SMALL | 9.241 | 9.305 | -0.69%
Update | HUGE | 39.486 | 38.944 | 1.39%
Update | HUGE_FLAT | 232.677 | 243.128 | -4.30%

