### PR TITLE
Close XXHash properly to avoid resource leak

### DIFF
--- a/core/checksums/src/main/java/software/amazon/awssdk/checksums/internal/XxHashChecksum.java
+++ b/core/checksums/src/main/java/software/amazon/awssdk/checksums/internal/XxHashChecksum.java
@@ -45,9 +45,12 @@ public final class XxHashChecksum implements SdkChecksum {
 
     @Override
     public byte[] getChecksumBytes() {
-        return xxHash.digest();
+        try {
+            return xxHash.digest();
+        } finally {
+            xxHash.close();
+        }
     }
-
 
     @Override
     public void update(int b) {

--- a/core/checksums/src/test/java/software/amazon/awssdk/checksums/internal/XxHashChecksumTest.java
+++ b/core/checksums/src/test/java/software/amazon/awssdk/checksums/internal/XxHashChecksumTest.java
@@ -15,11 +15,13 @@
 
 package software.amazon.awssdk.checksums.internal;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -78,5 +80,15 @@ class XxHashChecksumTest {
         byte[] bytes = "Hello world".getBytes(StandardCharsets.UTF_8);
         checksum.update(bytes, 0, bytes.length);
         assertEquals(expectedBase64, BinaryUtils.toBase64(checksum.getChecksumBytes()));
+    }
+
+    @Test
+    void getChecksumBytes_closesResource_subsequentGetChecksumBytesThrows() {
+        SdkChecksum checksum = ChecksumProvider.crtXxHash(DefaultChecksumAlgorithm.XXHASH64);
+        checksum.update("Hello".getBytes(StandardCharsets.UTF_8));
+        checksum.getChecksumBytes();
+
+        // Second call should fail since resource is closed
+        assertThatThrownBy(() -> checksum.getChecksumBytes()).hasMessageContaining("failed to finalize hash");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`XXHash` is an instance of `CrtResource` and it needs to be closed once we are done with it. This PR closes XXHash properly to avoid resource leak. 