### PR TITLE
Change integ test to use assumerole

### DIFF
--- a/buildspecs/integ-test.yml
+++ b/buildspecs/integ-test.yml
@@ -19,8 +19,6 @@ phases:
         role_arn = $INTEGRATION_TEST_ROLE_ARN
         EOF
           echo "Created AWS config for assuming role $INTEGRATION_TEST_ROLE_ARN with auto-refresh."
-          echo "Verifying assumed role identity:"
-          aws sts get-caller-identity --profile aws-test-account
         fi
       - mvn clean install -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -T1C $MAVEN_OPTIONS
       - JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-1)

--- a/buildspecs/integ-test.yml
+++ b/buildspecs/integ-test.yml
@@ -12,11 +12,15 @@ phases:
     commands:
       - |
         if [ ! -z "$INTEGRATION_TEST_ROLE_ARN" ]; then
-          ASSUME_ROLE_OUTPUT=`aws sts assume-role --role-arn "$INTEGRATION_TEST_ROLE_ARN" --role-session-name "integration-tests" --duration-seconds 7200 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text`
-          AWS_ACCESS_KEY_ID=`echo $ASSUME_ROLE_OUTPUT | awk '{ print $1 }'`
-          AWS_SECRET_ACCESS_KEY=`echo $ASSUME_ROLE_OUTPUT | awk '{ print $2 }'`
-          AWS_SESSION_TOKEN=`echo $ASSUME_ROLE_OUTPUT | awk '{ print $3 }'`
-          echo "Using role $INTEGRATION_TEST_ROLE_ARN with access key $AWS_ACCESS_KEY_ID."
+          mkdir -p ~/.aws
+          cat > ~/.aws/config << EOF
+        [profile aws-test-account]
+        credential_source = EcsContainer
+        role_arn = $INTEGRATION_TEST_ROLE_ARN
+        EOF
+          echo "Created AWS config for assuming role $INTEGRATION_TEST_ROLE_ARN with auto-refresh."
+          echo "Verifying assumed role identity:"
+          aws sts get-caller-identity --profile aws-test-account
         fi
       - mvn clean install -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -T1C $MAVEN_OPTIONS
       - JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-1)

--- a/services/datapipeline/src/it/java/software/amazon/awssdk/services/datapipeline/DataPipelineIntegrationTest.java
+++ b/services/datapipeline/src/it/java/software/amazon/awssdk/services/datapipeline/DataPipelineIntegrationTest.java
@@ -66,6 +66,7 @@ public class DataPipelineIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    @org.junit.Ignore("DataPipeline is deprecated and not allowlisted in integ test account")
     public void testPipelineOperations() throws InterruptedException {
         // Create a pipeline.
         CreatePipelineResponse createPipelineResult = dataPipeline.createPipeline(

--- a/services/datapipeline/src/it/java/software/amazon/awssdk/services/datapipeline/DataPipelineIntegrationTest.java
+++ b/services/datapipeline/src/it/java/software/amazon/awssdk/services/datapipeline/DataPipelineIntegrationTest.java
@@ -65,6 +65,7 @@ public class DataPipelineIntegrationTest extends IntegrationTestBase {
         }
     }
 
+    // TODO: replace with wiremock test
     @Test
     @org.junit.Ignore("DataPipeline is deprecated and not allowlisted in integ test account")
     public void testPipelineOperations() throws InterruptedException {

--- a/services/datapipeline/src/it/java/software/amazon/awssdk/services/datapipeline/DataPipelineIntegrationTest.java
+++ b/services/datapipeline/src/it/java/software/amazon/awssdk/services/datapipeline/DataPipelineIntegrationTest.java
@@ -65,7 +65,6 @@ public class DataPipelineIntegrationTest extends IntegrationTestBase {
         }
     }
 
-    // TODO: replace with wiremock test
     @Test
     @org.junit.Ignore("DataPipeline is deprecated and not allowlisted in integ test account")
     public void testPipelineOperations() throws InterruptedException {

--- a/services/s3/src/it/java/software/amazon/awssdk/services/SelectObjectContentIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/SelectObjectContentIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,6 +82,7 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         }
     }
 
+    @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")
     public void selectObjectContent_onResponseInvokedWithResponse(S3AsyncClient client) {
@@ -90,6 +92,7 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         assertThat(handler.response).isNotNull();
     }
 
+    @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")
     public void selectObjectContent_recordsEventUnmarshalledCorrectly(S3AsyncClient client) {
@@ -104,6 +107,7 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         assertThat(recordsEvent.payload().asUtf8String()).contains("A\nC");
     }
 
+    @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")
     public void selectObjectContent_invalidQuery_unmarshallsErrorResponse(S3AsyncClient client) {

--- a/services/s3/src/it/java/software/amazon/awssdk/services/SelectObjectContentIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/SelectObjectContentIntegrationTest.java
@@ -82,7 +82,6 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         }
     }
 
-    // TODO: replace with wiremock test
     @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")
@@ -93,7 +92,6 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         assertThat(handler.response).isNotNull();
     }
 
-    // TODO: replace with wiremock test
     @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")
@@ -109,7 +107,6 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         assertThat(recordsEvent.payload().asUtf8String()).contains("A\nC");
     }
 
-    // TODO: replace with wiremock test
     @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")

--- a/services/s3/src/it/java/software/amazon/awssdk/services/SelectObjectContentIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/SelectObjectContentIntegrationTest.java
@@ -82,6 +82,7 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         }
     }
 
+    // TODO: replace with wiremock test
     @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")
@@ -92,6 +93,7 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         assertThat(handler.response).isNotNull();
     }
 
+    // TODO: replace with wiremock test
     @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")
@@ -107,6 +109,7 @@ public class SelectObjectContentIntegrationTest extends S3IntegrationTestBase {
         assertThat(recordsEvent.payload().asUtf8String()).contains("A\nC");
     }
 
+    // TODO: replace with wiremock test
     @Disabled("S3 Select not supported for new accounts")
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("s3AsyncClients")

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionAsyncIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionAsyncIntegrationTest.java
@@ -40,6 +40,7 @@ public class S3CrossRegionAsyncIntegrationTest extends S3CrossRegionAsyncIntegra
     public void initialize() {
         crossRegionS3Client = S3AsyncClient.builder()
                                            .region(CROSS_REGION)
+                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                            .crossRegionAccessEnabled(true)
                                            .build();
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionCrtIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionCrtIntegrationTest.java
@@ -47,6 +47,7 @@ public class S3CrossRegionCrtIntegrationTest extends S3CrossRegionAsyncIntegrati
     public void initialize() {
         crossRegionS3Client = S3AsyncClient.crtBuilder()
                                            .region(Region.AWS_GLOBAL)
+                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                            .crossRegionAccessEnabled(true)
                                              .build();
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionSyncIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crossregion/S3CrossRegionSyncIntegrationTest.java
@@ -63,6 +63,7 @@ public class S3CrossRegionSyncIntegrationTest extends S3CrossRegionIntegrationTe
     public void initialize() {
         crossRegionS3Client = S3Client.builder()
                                       .region(Region.US_EAST_1)
+                                      .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                       .crossRegionAccessEnabled(true)
                                       .build();
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/s3express/S3ExpressIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/s3express/S3ExpressIntegrationTest.java
@@ -292,7 +292,7 @@ public class S3ExpressIntegrationTest extends S3ExpressIntegrationTestBase {
 
         S3Presigner presigner = S3Presigner.builder()
                                            .region(TEST_REGION)
-                                           .s3Client(s3)
+                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                            .build();
 
         GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(testBucket).key(KEY).build();
@@ -319,7 +319,7 @@ public class S3ExpressIntegrationTest extends S3ExpressIntegrationTestBase {
 
         S3Presigner presigner = S3Presigner.builder()
                                            .region(TEST_REGION)
-                                           .s3Client(s3)
+                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                            .build();
 
         GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(testBucket).key(KEY).build();
@@ -346,6 +346,7 @@ public class S3ExpressIntegrationTest extends S3ExpressIntegrationTestBase {
 
         S3Presigner presigner = S3Presigner.builder()
                                            .region(TEST_REGION)
+                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                            .build();
 
         GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(testBucket).key(KEY).build();

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/urlconnection/EmptyFileS3IntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/urlconnection/EmptyFileS3IntegrationTest.java
@@ -94,7 +94,7 @@ public class EmptyFileS3IntegrationTest extends UrlHttpConnectionS3IntegrationTe
 
     @Test
     public void asyncEmptyObjectWithChecksumValidation_returnsEmpty() throws Exception {
-        try (S3AsyncClient s3Async = S3AsyncClient.builder().region(DEFAULT_REGION).build()) {
+        try (S3AsyncClient s3Async = S3AsyncClient.builder().region(DEFAULT_REGION).credentialsProvider(CREDENTIALS_PROVIDER_CHAIN).build()) {
             s3Async.putObject(r -> r.bucket(BUCKET).key("x"),AsyncRequestBody.empty()).join();
 
 

--- a/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3AccessPointsIntegrationTest.java
+++ b/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3AccessPointsIntegrationTest.java
@@ -131,7 +131,10 @@ public class S3AccessPointsIntegrationTest extends S3ControlIntegrationTestBase 
     private void testAccessPointPresigning(String accessPointArn, String key) throws IOException {
         String data = "Hello";
 
-        S3Presigner presigner = S3Presigner.builder().region(Region.US_WEST_2).build();
+        S3Presigner presigner = S3Presigner.builder()
+                                           .region(Region.US_WEST_2)
+                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                           .build();
 
         SdkHttpRequest presignedPut = presigner.presignPutObject(r -> r.signatureDuration(Duration.ofDays(7))
                                                                        .putObjectRequest(por -> por.bucket(accessPointArn)


### PR DESCRIPTION
Changing the integ test buildspec to assume a cross account role to provision resources and run integ tests.
The new buildspec writes assume role into an INI config file in memory, which then the SDK integ test clients use to automatically refresh credentials.

Some tests are disabled because the specific service / operation they test is no longer supported on new accounts (essentially EOL). 

- Disabled selectObjectContent tests - this failed with a 405 despite having the right permissions. The only explanation I was able to find is this [RE:post response ](https://repost.aws/questions/QU90P47em-Q-qgI78bxYZF6Q/error-using-s3-select-the-specified-method-is-not-allowed-against-this-resource#ANrQ4zYDVnT5uNRCajwohA_Q) mentioning access to select was cut off for newer accounts. 
- Disabled DataPipeline tests - access to this service was cut off. [Blogpost](https://aws.amazon.com/blogs/big-data/category/analytics/aws-data-pipeline/)