### PR TITLE
Add keepalive to responseInputStream timeout scheduler executor to ma…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix resource leak in ResponseInputStream"
+}

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Fixed a thread leak in ResponseInputStream and ResponsePublisher where the internal timeout scheduler thread persisted for the lifetime of the JVM, even when no streams were active. The thread now terminates after being idle for 60 seconds.\n"
+    "description": "Fixed a thread leak in ResponseInputStream and ResponsePublisher where the internal timeout scheduler thread persisted for the lifetime of the JVM, even when no streams were active. The thread now terminates after being idle for 60 seconds."
 }

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Fix resource leak in ResponseInputStream and ResponsePublisher"
+    "description": "Fixed a thread leak in ResponseInputStream and ResponsePublisher where the internal timeout scheduler thread persisted for the lifetime of the JVM, even when no streams were active. The thread now terminates after being idle for 60 seconds.\n"
 }

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7d9ef28.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Fix resource leak in ResponseInputStream"
+    "description": "Fix resource leak in ResponseInputStream and ResponsePublisher"
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.core;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -142,6 +141,7 @@ public final class ResponseInputStream<ResponseT> extends SdkFilterInputStream i
 
     private static final class TimeoutScheduler {
         static final ScheduledExecutorService INSTANCE;
+
         static {
             ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, r -> {
                 Thread t = new Thread(r, "response-input-stream-timeout-scheduler");

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
@@ -61,6 +61,7 @@ public final class ResponseInputStream<ResponseT> extends SdkFilterInputStream i
 
     private static final Logger log = Logger.loggerFor(ResponseInputStream.class);
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(60);
+    private static final long THREAD_IDLE_TIMEOUT_SECONDS = 60;
     private final ResponseT response;
     private final Abortable abortable;
     private ScheduledFuture<?> timeoutTask;
@@ -148,7 +149,7 @@ public final class ResponseInputStream<ResponseT> extends SdkFilterInputStream i
                 t.setDaemon(true);
                 return t;
             });
-            executor.setKeepAliveTime(DEFAULT_TIMEOUT.getSeconds(), TimeUnit.SECONDS);
+            executor.setKeepAliveTime(THREAD_IDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             executor.allowCoreThreadTimeOut(true);
             INSTANCE = executor;
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
@@ -140,12 +141,17 @@ public final class ResponseInputStream<ResponseT> extends SdkFilterInputStream i
     }
 
     private static final class TimeoutScheduler {
-        static final ScheduledExecutorService INSTANCE =
-            Executors.newScheduledThreadPool(1, r -> {
+        static final ScheduledExecutorService INSTANCE;
+        static {
+            ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, r -> {
                 Thread t = new Thread(r, "response-input-stream-timeout-scheduler");
                 t.setDaemon(true);
                 return t;
             });
+            executor.setKeepAliveTime(DEFAULT_TIMEOUT.getSeconds(), TimeUnit.SECONDS);
+            executor.allowCoreThreadTimeOut(true);
+            INSTANCE = executor;
+        }
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/ResponsePublisher.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/ResponsePublisher.java
@@ -18,9 +18,9 @@ package software.amazon.awssdk.core.async;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -50,6 +50,7 @@ public final class ResponsePublisher<ResponseT extends SdkResponse> implements S
 
     private static final Logger log = Logger.loggerFor(ResponsePublisher.class);
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(60);
+    private static final long THREAD_IDLE_TIMEOUT_SECONDS = 60;
     private final ResponseT response;
     private final SdkPublisher<ByteBuffer> publisher;
     private ScheduledFuture<?> timeoutTask;
@@ -101,12 +102,18 @@ public final class ResponsePublisher<ResponseT extends SdkResponse> implements S
     }
 
     private static final class TimeoutScheduler {
-        static final ScheduledExecutorService INSTANCE =
-            Executors.newScheduledThreadPool(1, r -> {
+        static final ScheduledExecutorService INSTANCE;
+
+        static {
+            ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, r -> {
                 Thread t = new Thread(r, "response-publisher-timeout-scheduler");
                 t.setDaemon(true);
                 return t;
             });
+            executor.setKeepAliveTime(THREAD_IDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            executor.allowCoreThreadTimeOut(true);
+            INSTANCE = executor;
+        }
     }
 
     private static class CancellingSubscriber implements Subscriber<ByteBuffer> {


### PR DESCRIPTION
Addresses: https://github.com/aws/aws-sdk-java-v2/issues/6567

### Background and context

`ResponseInputStream` uses a static `ScheduledExecutorService` to abort streams that aren't read within 60 seconds (to prevent connection leaks). The executor's thread never terminates because core threads are kept alive indefinitely by default. This causes the `response-input-stream-timeout-scheduler` thread to persist for the lifetime of the JVM, even when no streams exist.

To fix this, we can set `allowCoreThreadTimeOut(true)` and a 60s keep-alive on the executor. The thread now dies after 60 seconds of idleness and respawns on demand (matches [`TransferManagerConfiguration.java`](https://github.com/aws/aws-sdk-java-v2/blob/896684523b0e7f3ded58b5082d8cb795143c37c1/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfiguration.java#L90)).


### Testing
Since there is a timeout and a keep alive mechanism it's hard to write a deterministic test to prove the fix works. Additionally, adding a test with a sleep method of >1min is not feasible.
The following test fails on Master, and passes after the code change introduced in the PR:


```java
    @Test
    void schedulerThread_shouldTerminateAfterIdleTimeout() throws Exception {
        ResponseInputStream<Object> responseInputStream = responseInputStream(Duration.ofSeconds(1));
        responseInputStream.read();
        responseInputStream.close();

        Thread.sleep(65000);

        Set<String> schedulerThreads = new HashSet<>();

        for (Thread thread : Thread.getAllStackTraces().keySet()) {
            if (thread.getName().contains("response-input-stream-timeout-scheduler")) {
                schedulerThreads.add(thread.getName());
            }
        }
        assertThat(schedulerThreads).isEmpty();
    }
```