### PR TITLE
fix(dynamodb-enhanced): Fix NPE in ConverterUtils for null input

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-converter-utils-npe.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-converter-utils-npe.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Fix NullPointerException in `ConverterUtils.validateDouble()` and `ConverterUtils.validateFloat()` when input is null."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterUtils.java
@@ -36,18 +36,24 @@ public class ConverterUtils {
 
     /**
      * Validates that a given Double input is a valid double supported by {@link DoubleAttributeConverter}.
-     * @param input
+     * @param input the Double value to validate, may be null
      */
     public static void validateDouble(Double input) {
+        if (input == null) {
+            return;
+        }
         Validate.isTrue(!Double.isNaN(input), "NaN is not supported by the default converters.");
         Validate.isTrue(Double.isFinite(input), "Infinite numbers are not supported by the default converters.");
     }
 
     /**
-     * Validates that a given Float input is a valid double supported by {@link FloatAttributeConverter}.
-     * @param input
+     * Validates that a given Float input is a valid float supported by {@link FloatAttributeConverter}.
+     * @param input the Float value to validate, may be null
      */
     public static void validateFloat(Float input) {
+        if (input == null) {
+            return;
+        }
         Validate.isTrue(!Float.isNaN(input), "NaN is not supported by the default converters.");
         Validate.isTrue(Float.isFinite(input), "Infinite numbers are not supported by the default converters.");
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterUtilsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ConverterUtilsTest {
+
+    @Test
+    void validateDouble_withNull_doesNotThrowException() {
+        assertThatCode(() -> ConverterUtils.validateDouble(null))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateDouble_withValidValue_doesNotThrowException() {
+        assertThatCode(() -> ConverterUtils.validateDouble(1.5))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateDouble_withNaN_throwsException() {
+        assertThatThrownBy(() -> ConverterUtils.validateDouble(Double.NaN))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("NaN is not supported");
+    }
+
+    @Test
+    void validateDouble_withPositiveInfinity_throwsException() {
+        assertThatThrownBy(() -> ConverterUtils.validateDouble(Double.POSITIVE_INFINITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Infinite numbers are not supported");
+    }
+
+    @Test
+    void validateDouble_withNegativeInfinity_throwsException() {
+        assertThatThrownBy(() -> ConverterUtils.validateDouble(Double.NEGATIVE_INFINITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Infinite numbers are not supported");
+    }
+
+    @Test
+    void validateFloat_withNull_doesNotThrowException() {
+        assertThatCode(() -> ConverterUtils.validateFloat(null))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateFloat_withValidValue_doesNotThrowException() {
+        assertThatCode(() -> ConverterUtils.validateFloat(1.5f))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateFloat_withNaN_throwsException() {
+        assertThatThrownBy(() -> ConverterUtils.validateFloat(Float.NaN))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("NaN is not supported");
+    }
+
+    @Test
+    void validateFloat_withPositiveInfinity_throwsException() {
+        assertThatThrownBy(() -> ConverterUtils.validateFloat(Float.POSITIVE_INFINITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Infinite numbers are not supported");
+    }
+
+    @Test
+    void validateFloat_withNegativeInfinity_throwsException() {
+        assertThatThrownBy(() -> ConverterUtils.validateFloat(Float.NEGATIVE_INFINITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Infinite numbers are not supported");
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes a NullPointerException bug in the DynamoDB Enhanced Client where `ConverterUtils.validateDouble()` and `validateFloat()` throw NPE when the input is `null` due to auto-unboxing before the null check.

## Root Cause

The `validateDouble` and `validateFloat` methods used `Double.isNaN(input)` and `Double.isFinite(input)` which auto-unbox the `Double`/`Float` wrapper to a primitive, causing NPE when input is `null`.

## Changes

- **ConverterUtils.java**: Add early return for null input in `validateDouble()` and `validateFloat()`
- **ConverterUtils.java**: Fix Javadoc typo in `validateFloat()` ("double" → "float")
- **ConverterUtilsTest.java**: New test class with 10 tests covering null, valid, NaN, and infinite values

## Test Plan

- [x] All 10 new `ConverterUtilsTest` tests pass
- [x] Tests verify: null input handling, valid values, NaN rejection, infinity rejection

## Test Command
```bash
./mvnw test -pl services-custom/dynamodb-enhanced -Dtest=ConverterUtilsTest
```

Fixes #6639

---
*Split from #6745 per maintainer request.*