### PR TITLE
Fix inaccurate progress tracking for in-memory uploads in Java-based S3TransferManager

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-60b3cdc.json
+++ b/.changes/next-release/bugfix-S3TransferManager-60b3cdc.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Fix inaccurate progress tracking for in-memory uploads in the Java-based S3TransferManager."
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -140,24 +140,38 @@ class GenericS3TransferManager implements S3TransferManager {
                                                                               requestBody.contentLength().orElse(null));
         progressUpdater.transferInitiated();
         boolean multipartEnabled = isS3ClientMultipartEnabled();
-        boolean isInMemoryBody = AsyncRequestBody.BodyType.BYTES.getName().equals(requestBody.body());
-        // Suppress wrapper progress for in-memory bodies when multipart is enabled. For these bodies,
-        // all bytes are delivered to the publisher instantly, so wrapper-based progress is misleading.
-        // Instead, uploadInOneChunk will report progress after the server responds.
-        // For file/stream bodies, the wrapper provides meaningful incremental progress as bytes are read.
-        boolean suppressWrapperProgress = multipartEnabled && isInMemoryBody;
-        requestBody = progressUpdater.wrapRequestBody(requestBody, suppressWrapperProgress);
+        boolean isByteBody = AsyncRequestBody.BodyType.BYTES.getName().equals(requestBody.body());
+        // Suppress wrapper progress for byte bodies. All bytes are delivered to the publisher instantly,
+        // so wrapper-based progress is misleading (jumps to 100% before data is sent over the wire).
+        requestBody = progressUpdater.wrapRequestBody(requestBody, isByteBody);
+
         progressUpdater.registerCompletion(returnFuture);
 
         PutObjectRequest putObjectRequest = uploadRequest.putObjectRequest();
         if (multipartEnabled) {
             Consumer<AwsRequestOverrideConfiguration.Builder> attachProgressAttributes =
                 b -> b.putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener())
-                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, isInMemoryBody);
+                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, isByteBody);
             putObjectRequest = attachSdkAttribute(uploadRequest.putObjectRequest(), attachProgressAttributes);
         }
 
-        doUpload(putObjectRequest, requestBody, returnFuture);
+        if (!multipartEnabled && isByteBody) {
+            // For in-memory bodies on the non-multipart path, use an intermediate future so we can
+            // report progress after the server responds but before completing returnFuture.
+            CompletableFuture<CompletedUpload> uploadFuture = new CompletableFuture<>();
+            doUpload(putObjectRequest, requestBody, uploadFuture);
+            CompletableFutureUtils.forwardExceptionTo(returnFuture, uploadFuture);
+            uploadFuture.whenComplete((result, error) -> {
+                if (error != null) {
+                    returnFuture.completeExceptionally(error);
+                } else {
+                    uploadRequest.requestBody().contentLength().ifPresent(progressUpdater::incrementBytesTransferred);
+                    returnFuture.complete(result);
+                }
+            });
+        } else {
+            doUpload(putObjectRequest, requestBody, returnFuture);
+        }
 
         return new DefaultUpload(returnFuture, progressUpdater.progress());
     }
@@ -202,9 +216,8 @@ class GenericS3TransferManager implements S3TransferManager {
                                                                               requestBody.contentLength().orElse(null));
         progressUpdater.transferInitiated();
         boolean multipartEnabled = isS3ClientMultipartEnabled();
-        boolean isInMemoryBody = AsyncRequestBody.BodyType.BYTES.getName().equals(requestBody.body());
-        boolean suppressWrapperProgress = multipartEnabled && isInMemoryBody;
-        requestBody = progressUpdater.wrapRequestBody(requestBody, suppressWrapperProgress);
+        requestBody = progressUpdater.wrapRequestBody(requestBody, false);
+
         progressUpdater.registerCompletion(returnFuture);
 
         PutObjectRequest putObjectRequest = uploadFileRequest.putObjectRequest();
@@ -213,8 +226,7 @@ class GenericS3TransferManager implements S3TransferManager {
             pauseObservable = new PauseObservable();
             Consumer<AwsRequestOverrideConfiguration.Builder> attachObservableAndListener =
                 b -> b.putExecutionAttribute(PAUSE_OBSERVABLE, pauseObservable)
-                      .putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener())
-                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, isInMemoryBody);
+                      .putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener());
             putObjectRequest = attachSdkAttribute(uploadFileRequest.putObjectRequest(), attachObservableAndListener);
         } else {
             pauseObservable = null;

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -215,14 +215,13 @@ class GenericS3TransferManager implements S3TransferManager {
         TransferProgressUpdater progressUpdater = new TransferProgressUpdater(uploadFileRequest,
                                                                               requestBody.contentLength().orElse(null));
         progressUpdater.transferInitiated();
-        boolean multipartEnabled = isS3ClientMultipartEnabled();
         requestBody = progressUpdater.wrapRequestBody(requestBody, false);
 
         progressUpdater.registerCompletion(returnFuture);
 
         PutObjectRequest putObjectRequest = uploadFileRequest.putObjectRequest();
         PauseObservable pauseObservable;
-        if (multipartEnabled) {
+        if (isS3ClientMultipartEnabled()) {
             pauseObservable = new PauseObservable();
             Consumer<AwsRequestOverrideConfiguration.Builder> attachObservableAndListener =
                 b -> b.putExecutionAttribute(PAUSE_OBSERVABLE, pauseObservable)

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -19,6 +19,7 @@ import static software.amazon.awssdk.services.s3.internal.multipart.MultipartDow
 import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.JAVA_PROGRESS_LISTENER;
 import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.MULTIPART_DOWNLOAD_RESUME_CONTEXT;
 import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.PAUSE_OBSERVABLE;
+import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.REPORT_PROGRESS_IN_SINGLE_CHUNK;
 import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.RESUME_TOKEN;
 import static software.amazon.awssdk.transfer.s3.internal.utils.ResumableRequestConverter.toDownloadFileRequestAndTransformer;
 
@@ -138,14 +139,16 @@ class GenericS3TransferManager implements S3TransferManager {
         TransferProgressUpdater progressUpdater = new TransferProgressUpdater(uploadRequest,
                                                                               requestBody.contentLength().orElse(null));
         progressUpdater.transferInitiated();
-        requestBody = progressUpdater.wrapRequestBody(requestBody);
+        boolean multipartEnabled = isS3ClientMultipartEnabled();
+        requestBody = progressUpdater.wrapRequestBody(requestBody, multipartEnabled);
         progressUpdater.registerCompletion(returnFuture);
 
         PutObjectRequest putObjectRequest = uploadRequest.putObjectRequest();
-        if (isS3ClientMultipartEnabled()) {
-            Consumer<AwsRequestOverrideConfiguration.Builder> attachProgressListener =
-                b -> b.putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener());
-            putObjectRequest = attachSdkAttribute(uploadRequest.putObjectRequest(), attachProgressListener);
+        if (multipartEnabled) {
+            Consumer<AwsRequestOverrideConfiguration.Builder> attachProgressAttributes =
+                b -> b.putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener())
+                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, Boolean.TRUE);
+            putObjectRequest = attachSdkAttribute(uploadRequest.putObjectRequest(), attachProgressAttributes);
         }
 
         doUpload(putObjectRequest, requestBody, returnFuture);
@@ -192,16 +195,18 @@ class GenericS3TransferManager implements S3TransferManager {
         TransferProgressUpdater progressUpdater = new TransferProgressUpdater(uploadFileRequest,
                                                                               requestBody.contentLength().orElse(null));
         progressUpdater.transferInitiated();
-        requestBody = progressUpdater.wrapRequestBody(requestBody);
+        boolean multipartEnabled = isS3ClientMultipartEnabled();
+        requestBody = progressUpdater.wrapRequestBody(requestBody, multipartEnabled);
         progressUpdater.registerCompletion(returnFuture);
 
         PutObjectRequest putObjectRequest = uploadFileRequest.putObjectRequest();
         PauseObservable pauseObservable;
-        if (isS3ClientMultipartEnabled()) {
+        if (multipartEnabled) {
             pauseObservable = new PauseObservable();
             Consumer<AwsRequestOverrideConfiguration.Builder> attachObservableAndListener =
                 b -> b.putExecutionAttribute(PAUSE_OBSERVABLE, pauseObservable)
-                      .putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener());
+                      .putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener())
+                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, Boolean.TRUE);
             putObjectRequest = attachSdkAttribute(uploadFileRequest.putObjectRequest(), attachObservableAndListener);
         } else {
             pauseObservable = null;

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -140,14 +140,20 @@ class GenericS3TransferManager implements S3TransferManager {
                                                                               requestBody.contentLength().orElse(null));
         progressUpdater.transferInitiated();
         boolean multipartEnabled = isS3ClientMultipartEnabled();
-        requestBody = progressUpdater.wrapRequestBody(requestBody, multipartEnabled);
+        boolean isInMemoryBody = AsyncRequestBody.BodyType.BYTES.getName().equals(requestBody.body());
+        // Suppress wrapper progress for in-memory bodies when multipart is enabled. For these bodies,
+        // all bytes are delivered to the publisher instantly, so wrapper-based progress is misleading.
+        // Instead, uploadInOneChunk will report progress after the server responds.
+        // For file/stream bodies, the wrapper provides meaningful incremental progress as bytes are read.
+        boolean suppressWrapperProgress = multipartEnabled && isInMemoryBody;
+        requestBody = progressUpdater.wrapRequestBody(requestBody, suppressWrapperProgress);
         progressUpdater.registerCompletion(returnFuture);
 
         PutObjectRequest putObjectRequest = uploadRequest.putObjectRequest();
         if (multipartEnabled) {
             Consumer<AwsRequestOverrideConfiguration.Builder> attachProgressAttributes =
                 b -> b.putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener())
-                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, Boolean.TRUE);
+                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, isInMemoryBody);
             putObjectRequest = attachSdkAttribute(uploadRequest.putObjectRequest(), attachProgressAttributes);
         }
 
@@ -196,7 +202,9 @@ class GenericS3TransferManager implements S3TransferManager {
                                                                               requestBody.contentLength().orElse(null));
         progressUpdater.transferInitiated();
         boolean multipartEnabled = isS3ClientMultipartEnabled();
-        requestBody = progressUpdater.wrapRequestBody(requestBody, multipartEnabled);
+        boolean isInMemoryBody = AsyncRequestBody.BodyType.BYTES.getName().equals(requestBody.body());
+        boolean suppressWrapperProgress = multipartEnabled && isInMemoryBody;
+        requestBody = progressUpdater.wrapRequestBody(requestBody, suppressWrapperProgress);
         progressUpdater.registerCompletion(returnFuture);
 
         PutObjectRequest putObjectRequest = uploadFileRequest.putObjectRequest();
@@ -206,7 +214,7 @@ class GenericS3TransferManager implements S3TransferManager {
             Consumer<AwsRequestOverrideConfiguration.Builder> attachObservableAndListener =
                 b -> b.putExecutionAttribute(PAUSE_OBSERVABLE, pauseObservable)
                       .putExecutionAttribute(JAVA_PROGRESS_LISTENER, progressUpdater.multipartClientProgressListener())
-                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, Boolean.TRUE);
+                      .putExecutionAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK, isInMemoryBody);
             putObjectRequest = attachSdkAttribute(uploadFileRequest.putObjectRequest(), attachObservableAndListener);
         } else {
             pauseObservable = null;

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
@@ -76,7 +76,18 @@ public class TransferProgressUpdater {
         listenerInvoker.transferInitiated(context);
     }
 
-    public AsyncRequestBody wrapRequestBody(AsyncRequestBody requestBody) {
+    /**
+     * Wraps the request body to track upload progress.
+     *
+     * @param requestBody the original request body
+     * @param suppressProgress when {@code true}, the wrapper will not report byte-level progress. This is used when
+     *     the multipart client is enabled, because progress is reported after the server responds instead:
+     *     by the JAVA_PROGRESS_LISTENER in {@code uploadInOneChunk} (single-chunk path) or
+     *     {@code sendIndividualUploadPartRequest} (multipart path). This avoids reporting progress based on bytes
+     *     read from the publisher, which can be significantly ahead of bytes actually sent over the wire.
+     *     When {@code false}, the wrapper reports progress as bytes flow through the publisher.
+     */
+    public AsyncRequestBody wrapRequestBody(AsyncRequestBody requestBody, boolean suppressProgress) {
         return AsyncRequestBodyListener.wrap(
             requestBody,
             new AsyncRequestBodyListener() {
@@ -89,12 +100,14 @@ public class TransferProgressUpdater {
 
                 @Override
                 public void subscriberOnNext(ByteBuffer byteBuffer) {
-                    incrementBytesTransferred(byteBuffer.limit());
-                    progress.snapshot().ratioTransferred().ifPresent(ratioTransferred -> {
-                        if (Double.compare(ratioTransferred, 1.0) == 0) {
-                            endOfStreamFutureCompleted();
-                        }
-                    });
+                    if (!suppressProgress) {
+                        incrementBytesTransferred(byteBuffer.limit());
+                        progress.snapshot().ratioTransferred().ifPresent(ratioTransferred -> {
+                            if (Double.compare(ratioTransferred, 1.0) == 0) {
+                                endOfStreamFutureCompleted();
+                            }
+                        });
+                    }
                 }
 
                 @Override
@@ -117,6 +130,10 @@ public class TransferProgressUpdater {
 
     /**
      * Progress listener for Java-based S3Client with multipart enabled.
+     * <p>
+     * For multipart uploads, this is the primary source of progress since the wrapper body is bypassed
+     * by {@code splitCloseable}. For single-chunk uploads via {@code uploadInOneChunk}, this listener
+     * reports progress after the server responds.
      */
     public PublisherListener<Long> multipartClientProgressListener() {
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
@@ -80,15 +80,11 @@ public class TransferProgressUpdater {
      * Wraps the request body to track upload progress.
      *
      * @param requestBody the original request body
-     * @param suppressProgress when {@code true}, the wrapper will not report byte-level progress. This is used
-     *     for in-memory bodies when the multipart client is enabled, because all bytes are delivered to the
-     *     publisher instantly and progress would jump to 100% before any data is sent over the wire. Instead,
-     *     progress is reported by the JAVA_PROGRESS_LISTENER in {@code uploadInOneChunk} (single-chunk path)
-     *     or {@code sendIndividualUploadPartRequest} (multipart path) after the server responds.
-     *     When {@code false}, the wrapper reports progress as bytes flow through the publisher, which provides
-     *     meaningful incremental progress for file and stream bodies.
+     * @param disableIncrementalProgress when {@code true}, the wrapper will not report byte-level progress. This is used
+     *     for in-memory byte bodies because all bytes are delivered to the publisher instantly and progress would jump to 100%
+     *     before any data is sent over the wire.
      */
-    public AsyncRequestBody wrapRequestBody(AsyncRequestBody requestBody, boolean suppressProgress) {
+    public AsyncRequestBody wrapRequestBody(AsyncRequestBody requestBody, boolean disableIncrementalProgress) {
         return AsyncRequestBodyListener.wrap(
             requestBody,
             new AsyncRequestBodyListener() {
@@ -101,7 +97,7 @@ public class TransferProgressUpdater {
 
                 @Override
                 public void subscriberOnNext(ByteBuffer byteBuffer) {
-                    if (!suppressProgress) {
+                    if (!disableIncrementalProgress) {
                         incrementBytesTransferred(byteBuffer.limit());
                         progress.snapshot().ratioTransferred().ifPresent(ratioTransferred -> {
                             if (Double.compare(ratioTransferred, 1.0) == 0) {
@@ -290,7 +286,7 @@ public class TransferProgressUpdater {
         progress.updateAndGet(b -> b.transferredBytes(0L));
     }
 
-    private void incrementBytesTransferred(long numBytes) {
+    public void incrementBytesTransferred(long numBytes) {
         TransferProgressSnapshot snapshot = progress.updateAndGet(b -> {
             b.transferredBytes(b.getTransferredBytes() + numBytes);
         });

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java
@@ -80,12 +80,13 @@ public class TransferProgressUpdater {
      * Wraps the request body to track upload progress.
      *
      * @param requestBody the original request body
-     * @param suppressProgress when {@code true}, the wrapper will not report byte-level progress. This is used when
-     *     the multipart client is enabled, because progress is reported after the server responds instead:
-     *     by the JAVA_PROGRESS_LISTENER in {@code uploadInOneChunk} (single-chunk path) or
-     *     {@code sendIndividualUploadPartRequest} (multipart path). This avoids reporting progress based on bytes
-     *     read from the publisher, which can be significantly ahead of bytes actually sent over the wire.
-     *     When {@code false}, the wrapper reports progress as bytes flow through the publisher.
+     * @param suppressProgress when {@code true}, the wrapper will not report byte-level progress. This is used
+     *     for in-memory bodies when the multipart client is enabled, because all bytes are delivered to the
+     *     publisher instantly and progress would jump to 100% before any data is sent over the wire. Instead,
+     *     progress is reported by the JAVA_PROGRESS_LISTENER in {@code uploadInOneChunk} (single-chunk path)
+     *     or {@code sendIndividualUploadPartRequest} (multipart path) after the server responds.
+     *     When {@code false}, the wrapper reports progress as bytes flow through the publisher, which provides
+     *     meaningful incremental progress for file and stream bodies.
      */
     public AsyncRequestBody wrapRequestBody(AsyncRequestBody requestBody, boolean suppressProgress) {
         return AsyncRequestBodyListener.wrap(

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/progress/TransferListener.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/progress/TransferListener.java
@@ -72,10 +72,14 @@ import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
  *     <li>Be mindful that {@link #bytesTransferred(Context.BytesTransferred)} may be called extremely often (subject to I/O
  *     buffer sizes). Be careful in implementing expensive operations as a side effect. Consider rate-limiting your side
  *     effect operations, if needed.</li>
- *     <li>In the case of uploads, there may be some delay between the bytes being fully transferred and the transfer
+ *     <li>In the case of multipart uploads, there may be some delay between the bytes being fully transferred and the transfer
  *     successfully completing. Internally, {@link S3TransferManager} uses the Amazon S3
  *     <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html">multipart upload API</a>
  *     and must finalize uploads with a {@link CompleteMultipartUploadRequest}.</li>
+ *     <li>For single part in-memory uploads, 100% of the bytes are read immediately into memory and progress is only
+ *     reported once, after all bytes are sent and the HTTP response is received.</li>
+ *     <li>For single part file uploads, progress is reported when bytes are read from the file rather than when bytes are sent
+ *     so there will be some delay between when progress reaching 100% and the transfer successfully completing.</li>
  *     <li>{@link TransferListener}s may be invoked by different threads. If your {@link TransferListener} is stateful,
  *     ensure that it is also thread-safe.</li>
  *     <li>{@link TransferListener}s are not intended to be used for control flow, and therefore your implementation

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferProgressUpdaterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferProgressUpdaterTest.java
@@ -256,7 +256,7 @@ class TransferProgressUpdaterTest {
 
 
     @Test
-    void wrapRequestBody_suppressProgress_doesNotReportProgress() {
+    void wrapRequestBody_disableIncrementalProgress_doesNotReportProgress() {
         byte[] data = new byte[1024];
         Arrays.fill(data, (byte) 'a');
         long contentLength = data.length;
@@ -293,7 +293,7 @@ class TransferProgressUpdaterTest {
             }
         });
 
-        // When suppressProgress is true, the wrapper should NOT report any progress.
+        // When disableIncrementalProgress is true, the wrapper should NOT report any progress.
         // Progress is instead reported by the JAVA_PROGRESS_LISTENER after the server responds.
         assertThat(bytesAfterOnNext.get()).isNotNull();
         assertThat(bytesAfterOnNext.get()).isEqualTo(0L);

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferProgressUpdaterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferProgressUpdaterTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -111,7 +112,7 @@ class TransferProgressUpdaterTest {
         sourceFile = new RandomTempFile(OBJ_SIZE);
         AsyncRequestBody requestBody = AsyncRequestBody.fromFile(sourceFile);
         TransferProgressUpdater transferProgressUpdater = new TransferProgressUpdater(transferRequest, givenContentLength);
-        AsyncRequestBody asyncRequestBody = transferProgressUpdater.wrapRequestBody(requestBody);
+        AsyncRequestBody asyncRequestBody = transferProgressUpdater.wrapRequestBody(requestBody, false);
 
         CompletableFuture<CompletedObjectTransfer> completionFuture = completedObjectResponse(10);
         transferProgressUpdater.registerCompletion(completionFuture);
@@ -144,7 +145,7 @@ class TransferProgressUpdaterTest {
             Executors.newSingleThreadExecutor());
 
         TransferProgressUpdater transferProgressUpdater = new TransferProgressUpdater(transferRequest, contentLength);
-        AsyncRequestBody asyncRequestBody = transferProgressUpdater.wrapRequestBody(requestFileBody);
+        AsyncRequestBody asyncRequestBody = transferProgressUpdater.wrapRequestBody(requestFileBody, false);
 
         CompletableFuture<CompletedObjectTransfer> future = completedObjectResponse(10);
         transferProgressUpdater.registerCompletion(future);
@@ -253,6 +254,103 @@ class TransferProgressUpdaterTest {
 
     }
 
+
+    @Test
+    void wrapRequestBody_suppressProgress_doesNotReportProgress() {
+        byte[] data = new byte[1024];
+        Arrays.fill(data, (byte) 'a');
+        long contentLength = data.length;
+
+        TransferObjectRequest transferRequest = Mockito.mock(TransferObjectRequest.class);
+        when(transferRequest.transferListeners()).thenReturn(Arrays.asList(captureTransferListener));
+
+        TransferProgressUpdater updater = new TransferProgressUpdater(transferRequest, contentLength);
+        AsyncRequestBody inMemoryBody = AsyncRequestBody.fromBytes(data);
+        AsyncRequestBody wrappedBody = updater.wrapRequestBody(inMemoryBody, true);
+
+        // Use a custom subscriber that captures progress snapshots at each stage
+        AtomicReference<Long> bytesAfterOnNext = new AtomicReference<>();
+        AtomicReference<Long> bytesAfterOnComplete = new AtomicReference<>();
+
+        wrappedBody.subscribe(new Subscriber<ByteBuffer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+                bytesAfterOnNext.set(updater.progress().snapshot().transferredBytes());
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+                bytesAfterOnComplete.set(updater.progress().snapshot().transferredBytes());
+            }
+        });
+
+        // When suppressProgress is true, the wrapper should NOT report any progress.
+        // Progress is instead reported by the JAVA_PROGRESS_LISTENER after the server responds.
+        assertThat(bytesAfterOnNext.get()).isNotNull();
+        assertThat(bytesAfterOnNext.get()).isEqualTo(0L);
+        assertThat(bytesAfterOnComplete.get()).isEqualTo(0L);
+        assertThat(updater.progress().snapshot().transferredBytes()).isEqualTo(0L);
+    }
+
+    @Test
+    void wrapRequestBody_noSuppression_reportsProgressPerByte() throws Exception {
+        long fileSize = 1024;
+        sourceFile = new RandomTempFile(fileSize);
+
+        TransferObjectRequest transferRequest = Mockito.mock(TransferObjectRequest.class);
+        when(transferRequest.transferListeners()).thenReturn(Arrays.asList(captureTransferListener));
+
+        TransferProgressUpdater updater = new TransferProgressUpdater(transferRequest, fileSize);
+        AsyncRequestBody fileBody = AsyncRequestBody.fromFile(sourceFile);
+        AsyncRequestBody wrappedBody = updater.wrapRequestBody(fileBody, false);
+
+        CompletableFuture<CompletedObjectTransfer> completionFuture = completedObjectResponse(10);
+        updater.registerCompletion(completionFuture);
+
+        // For file-based bodies, progress should be reported incrementally during onNext
+        AtomicBoolean progressReportedDuringOnNext = new AtomicBoolean(false);
+        CompletableFuture<Void> subscriberDone = new CompletableFuture<>();
+
+        wrappedBody.subscribe(new Subscriber<ByteBuffer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+                long transferred = updater.progress().snapshot().transferredBytes();
+                if (transferred > 0) {
+                    progressReportedDuringOnNext.set(true);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                subscriberDone.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                subscriberDone.complete(null);
+            }
+        });
+
+        subscriberDone.get(5, TimeUnit.SECONDS);
+
+        // File body should have reported progress during onNext, not deferred
+        assertThat(progressReportedDuringOnNext.get()).isTrue();
+        assertThat(updater.progress().snapshot().transferredBytes()).isEqualTo(fileSize);
+    }
 
     private static class ExceptionThrowingByteArrayInputStream extends ByteArrayInputStream {
         private final int exceptionPosition;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartUploadHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartUploadHelper.java
@@ -17,6 +17,8 @@ package software.amazon.awssdk.services.s3.internal.multipart;
 
 
 import static software.amazon.awssdk.services.s3.internal.multipart.SdkPojoConversionUtils.toAbortMultipartUploadRequest;
+import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.JAVA_PROGRESS_LISTENER;
+import static software.amazon.awssdk.services.s3.multipart.S3MultipartExecutionAttribute.REPORT_PROGRESS_IN_SINGLE_CHUNK;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -152,10 +154,28 @@ public final class MultipartUploadHelper {
     void uploadInOneChunk(PutObjectRequest putObjectRequest,
                           AsyncRequestBody asyncRequestBody,
                           CompletableFuture<PutObjectResponse> returnFuture) {
+        boolean reportProgress = putObjectRequest.overrideConfiguration()
+                                                 .map(c -> c.executionAttributes()
+                                                            .getAttribute(REPORT_PROGRESS_IN_SINGLE_CHUNK))
+                                                 .orElse(Boolean.FALSE);
+
         CompletableFuture<PutObjectResponse> putObjectResponseCompletableFuture = s3AsyncClient.putObject(putObjectRequest,
                                                                                                           asyncRequestBody);
         CompletableFutureUtils.forwardExceptionTo(returnFuture, putObjectResponseCompletableFuture);
-        CompletableFutureUtils.forwardResultTo(putObjectResponseCompletableFuture, returnFuture);
+
+        if (reportProgress) {
+            PublisherListener<Long> progressListener = putObjectRequest.overrideConfiguration()
+                                                                       .map(c -> c.executionAttributes()
+                                                                                  .getAttribute(JAVA_PROGRESS_LISTENER))
+                                                                       .orElseGet(PublisherListener::noOp);
+            putObjectResponseCompletableFuture.thenAccept(response -> {
+                asyncRequestBody.contentLength().ifPresent(progressListener::subscriberOnNext);
+                progressListener.subscriberOnComplete();
+                returnFuture.complete(response);
+            });
+        } else {
+            CompletableFutureUtils.forwardResultTo(putObjectResponseCompletableFuture, returnFuture);
+        }
     }
 
     static SdkClientException contentLengthMissingForPart(int currentPartNum) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/S3MultipartExecutionAttribute.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/S3MultipartExecutionAttribute.java
@@ -29,4 +29,11 @@ public final class S3MultipartExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("JavaProgressListener");
     public static final ExecutionAttribute<MultipartDownloadResumeContext> MULTIPART_DOWNLOAD_RESUME_CONTEXT =
         new ExecutionAttribute<>("MultipartDownloadResumeContext");
+
+    /**
+     * When true, indicates that the request body wrapper does not report progress (e.g., for in-memory bodies),
+     * so {@code uploadInOneChunk} should report progress after the server responds.
+     */
+    public static final ExecutionAttribute<Boolean> REPORT_PROGRESS_IN_SINGLE_CHUNK =
+        new ExecutionAttribute<>("ReportProgressInSingleChunk");
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/S3MultipartExecutionAttribute.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/S3MultipartExecutionAttribute.java
@@ -32,7 +32,8 @@ public final class S3MultipartExecutionAttribute extends SdkExecutionAttribute {
 
     /**
      * When true, indicates that the request body wrapper does not report progress (e.g., for in-memory bodies),
-     * so {@code uploadInOneChunk} should report progress after the server responds.
+     * so {@code uploadInOneChunk} should report progress after the server responds. When false or absent,
+     * the wrapper handles progress reporting and {@code uploadInOneChunk} should not report to avoid double-counting.
      */
     public static final ExecutionAttribute<Boolean> REPORT_PROGRESS_IN_SINGLE_CHUNK =
         new ExecutionAttribute<>("ReportProgressInSingleChunk");

--- a/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadAsyncRegressionTesting.java
+++ b/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadAsyncRegressionTesting.java
@@ -37,7 +37,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.regression.BucketType;
 import software.amazon.awssdk.services.s3.regression.S3ChecksumsTestUtils;
 import software.amazon.awssdk.services.s3.regression.TestCallable;
-import software.amazon.awssdk.testutils.retry.RetryableTest;
 import software.amazon.awssdk.utils.Logger;
 
 public class UploadAsyncRegressionTesting extends UploadStreamingRegressionTesting {
@@ -50,7 +49,6 @@ public class UploadAsyncRegressionTesting extends UploadStreamingRegressionTesti
     @ParameterizedTest
     @MethodSource("testConfigs")
     @Timeout(value = 120, unit = TimeUnit.SECONDS)
-    @RetryableTest(maxRetries = 3)
     void putObject(UploadConfig config) throws Exception {
         assumeNotAccessPointWithPathStyle(config);
 

--- a/test/test-utils/src/main/java/software/amazon/awssdk/testutils/retry/RetryableTestExtension.java
+++ b/test/test-utils/src/main/java/software/amazon/awssdk/testutils/retry/RetryableTestExtension.java
@@ -75,10 +75,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     }
 
     private boolean isRetryableException(ExtensionContext context, Throwable throwable) {
-        if (throwable instanceof TestAbortedException) {
-            return false;
-        }
-        return retryableException(context).isAssignableFrom(throwable.getClass());
+        return retryableException(context).isAssignableFrom(throwable.getClass()) || throwable instanceof TestAbortedException;
     }
 
     private int maxRetries(ExtensionContext context) {

--- a/test/test-utils/src/main/java/software/amazon/awssdk/testutils/retry/RetryableTestExtension.java
+++ b/test/test-utils/src/main/java/software/amazon/awssdk/testutils/retry/RetryableTestExtension.java
@@ -75,7 +75,10 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     }
 
     private boolean isRetryableException(ExtensionContext context, Throwable throwable) {
-        return retryableException(context).isAssignableFrom(throwable.getClass()) || throwable instanceof TestAbortedException;
+        if (throwable instanceof TestAbortedException) {
+            return false;
+        }
+        return retryableException(context).isAssignableFrom(throwable.getClass());
     }
 
     private int maxRetries(ExtensionContext context) {


### PR DESCRIPTION
Fix inaccurate progress tracking for in-memory uploads in Java-based S3TransferManager

## Motivation and Context
Fixes: #3670

The Java-based (non-CRT) S3 TransferManager reports inaccurate progress when uploading single-part streams or files  - it reports progress when bytes are read from the input stream rather than when they are sent to S3.   In extreme cases, such as a single-part in memory upload, this results in us immediately printing 100% complete because the bytes in the input stream are read immediately:

```
03-09T22:48:17.246906Z] [+16ms] Transfer initiated. Total bytes: 20,971,520
[2026-03-09T22:48:17.791068Z] [+561ms] Bytes transferred: 20,971,520 / 20,971,520 (100.0%)
[2026-03-09T22:48:23.400885Z] [+6,170ms] Transfer COMPLETE. Total transferred: 20,971,520 bytes
```

The [TransferProgressUpdater.wrapRequestBody](https://github.com/aws/aws-sdk-java-v2/blob/ed9e23760c60d5f781d595b63773df39e4cdd76a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/progress/TransferProgressUpdater.java#L76) implementation reports progress when the bytes are read from the body rather than when they are sent on the wire. 

This issue applies for all single-part Java-based S3 TM uploads, both in memory bodies and file based bodies. However, the issue is most pronounced when using a single-part in memory upload (such as with AsyncRequestBody.fromBytes) than with a file.  When using a file, we read from the input chunk by chunk, but this still causes a discrepancy between reporting 100% and when the transfer is actually complete.

Multi-part uploads do NOT have the same behavior - they report progress only when individual part uploads are complete for in-memory and file based uploads because uploadInParts calls splitAndSubscribe which bypasses the wrapper.

## Modifications
ThisPR prioritizes fixing the worst offender while still offering incremental progress on single-part file based uploads - for users with small files or fast networks, the gap between 100% and actual complete is relatively small.  We also improve documentation and describe these limitations.  

Changes:
* Add `disableIncrementalProgress` to `wrapRequestBody` - allowing us to disable progress updates in the body wrapper and instead calling `incrementBytesTransferred` when the HTTP response has been received.
* For multipart clients we report the complete progress in `uploadInOneChunk` when the new `REPORT_PROGRESS_IN_SINGLE_CHUNK` execution attribute is set.
* For single part clients, we create an intermediate future and report complete progress before completing the returned future.


One unrelated change to fix an issue that causes failures in our S3 regression tests:  This PR removes the @retryableTest annotation which is incompatible with the @paramterizedTest annotation (both use TestTemplate which causes a conflict in Junit).  The comparable [UploadSyncRegressionTesting class](https://github.com/aws/aws-sdk-java-v2/blob/master/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadSyncRegressionTesting.java#L51) does not have the @retryableTest and hasn't been a source of flaky test failures.

## Testing
Existing unit/integration tests.  Manual testing.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
