### PR TITLE
Bump lakeformation plugin version

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-e6600bb.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-e6600bb.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Updating Lakeformation Access Grants Plugin version to 1.4"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <!-- S3 Access Grants plugin version -->
         <s3accessgrants.version>2.4.1</s3accessgrants.version>
 
-        <lakeformations3accessgrants.version>1.3</lakeformations3accessgrants.version>
+        <lakeformations3accessgrants.version>1.4</lakeformations3accessgrants.version>
 
         <skip.unit.tests>${skipTests}</skip.unit.tests>
         <v2.migration.tests.skip>true</v2.migration.tests.skip>


### PR DESCRIPTION
Version 1.3 has a dependency on Caffeine 3.x which is precompiled for java 11. Version 1.4 downgrades Caffeine to a version compiled for java 8.