### PR TITLE
Add enforceBytecodeVersion rule to bundle-sdk

### DIFF
--- a/bundle-sdk/pom.xml
+++ b/bundle-sdk/pom.xml
@@ -351,7 +351,39 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.9.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>enforce-bytecode-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>${jre.version}</maxJdkVersion>
+                                    <excludes>
+                                        <exclude>software.amazon.awssdk:aws-sdk-java</exclude>
+                                    </excludes>
+                                </enforceBytecodeVersion>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     
     <profiles>


### PR DESCRIPTION
Our CI already has build validations to ensure all of our code is compiled for Java 8. However, this does not apply to third party dependencies that we consume. If a transitive dependency is compiled for a higher JDK version, it can silently end up in the shaded SDK bundle and break customers running on Java 8 at runtime.

Example of desired check:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31:03 min (Wall Clock)
[INFO] Finished at: 2026-03-10T17:58:30Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce-bytecode-version) on project bundle-sdk: 
[ERROR] Rule 0: org.codehaus.mojo.extraenforcer.dependencies.EnforceBytecodeVersion failed with message:
[ERROR] Found Banned Dependency: com.github.ben-manes.caffeine:caffeine:jar:3.2.3
[ERROR] Use 'mvn dependency:tree' to locate the source of the banned dependencies.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :bundle-sdk
```
The build failed because the maven-enforcer-plugin flagged Caffeine 3.x as as being non compliant.
