### PR TITLE
Strip quotes in getETag response during migration tool transform

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-d9fe48f.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-d9fe48f.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 Migration Tool",
+    "contributor": "",
+    "description": "Strip quotes in getETag response"
+}

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
@@ -47,6 +47,9 @@ public class S3Streaming {
 
         GetObjectResponse objectMetadata = s3.getObject(GetObjectRequest.builder().bucket(bucket).key(key)
                 .build(), file.toPath());
+
+        String etag = /*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
+objectMetadata.eTag().replaceAll("^\"|\"$", "");
     }
 
     void putObject_bucketKeyContent(String bucket, String key, String content) {

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
@@ -43,6 +43,8 @@ public class S3Streaming {
         String cacheControl = s3Object.getObjectMetadata().getCacheControl();
 
         ObjectMetadata objectMetadata = s3.getObject(new GetObjectRequest(bucket, key), file);
+
+        String etag = objectMetadata.getETag();
     }
 
     void putObject_bucketKeyContent(String bucket, String key, String content) {

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/V1GetterToV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/V1GetterToV2.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.v2migration;
 
 import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.changeBucketNameToBucket;
+import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.isS3ETagGetter;
+import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.transformETagGetter;
 import static software.amazon.awssdk.v2migration.internal.utils.SdkTypeUtils.isV2ModelClass;
 
 import org.openrewrite.ExecutionContext;
@@ -61,6 +63,10 @@ public class V1GetterToV2 extends Recipe {
 
             if (!shouldChangeGetter(fullyQualified)) {
                 return method;
+            }
+
+            if (isS3ETagGetter(methodName, fullyQualified)) {
+                return transformETagGetter(getCursor(), method);
             }
 
             methodName = changeBucketNameToBucket(methodName);

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
@@ -22,10 +22,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TextComment;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markers;
@@ -294,6 +297,22 @@ public final class S3TransformUtils {
 
     public static boolean isUnsupportedHttpMethod(String httpMethod) {
         return Arrays.asList("Head", "Post", "Patch").contains(httpMethod);
+    }
+
+    public static boolean isS3ETagGetter(String methodName, JavaType.FullyQualified declaringType) {
+        return "getETag".equals(methodName)
+               && declaringType.getFullyQualifiedName().startsWith(V2_S3_MODEL_PKG);
+    }
+
+    public static J.MethodInvocation transformETagGetter(Cursor cursor, J.MethodInvocation method) {
+        String comment = "NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - "
+                         + "https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html"
+                         + "#V1s-ObjectMetadata-using-V1s-getETag";
+
+        String template = "#{any()}.eTag().replaceAll(\"^\\\"|\\\"$\", \"\")";
+        return JavaTemplate.builder(template).build()
+                           .apply(cursor, method.getCoordinates().replace(), method.getSelect())
+                           .withComments(createCommentsWithNewline(comment));
     }
 
     public static List<Comment> inputStreamBufferingWarningComment() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag

## Modifications
<!--- Describe your changes in detail -->
Update `V1GetterToV2` recipe to strip quotes in response String and add comment referencing dev guide

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

