### PR TITLE
Improve error message thrown from mismatched checksum for S3 GetObject

### DIFF
--- a/.changes/next-release/bugfix-AWS-5dd0c1d.json
+++ b/.changes/next-release/bugfix-AWS-5dd0c1d.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fixed misleading checksum mismatch error message for S3 GetObject that incorrectly referenced uploading. See [#6324](https://github.com/aws/aws-sdk-java-v2/issues/6324)."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/ChecksumConstant.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/ChecksumConstant.java
@@ -55,6 +55,13 @@ public final class ChecksumConstant {
      */
     public static final int S3_MD5_CHECKSUM_LENGTH = 16;
 
+    public static final String CHECKSUM_MISMATCH_ERROR_MESSAGE_TEMPLATE =
+        "Data read has a different checksum than expected. Was 0x%s, "
+        + "but expected 0x%s. Common causes: (1) The data was corrupted during transfer between S3 and the client. "
+        + "(2) A custom ExecutionInterceptor modified the HTTP response content before checksum validation. "
+        + "Note: The response data may have already been delivered to the configured response transformer "
+        + "and should not be considered reliable.";
+
     private ChecksumConstant() {
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/S3ChecksumValidatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/S3ChecksumValidatingInputStream.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.s3.internal.checksums;
 
+import static software.amazon.awssdk.services.s3.internal.checksums.ChecksumConstant.CHECKSUM_MISMATCH_ERROR_MESSAGE_TEMPLATE;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -182,9 +184,8 @@ public class S3ChecksumValidatingInputStream extends InputStream implements Abor
 
         if (!Arrays.equals(computedChecksum, streamChecksum)) {
             throw RetryableException.create(
-                String.format("Data read has a different checksum than expected. Was 0x%s, but expected 0x%s. " +
-                              "This commonly means that the data was corrupted between the client and " +
-                              "service.", BinaryUtils.toHex(computedChecksum), BinaryUtils.toHex(streamChecksum)));
+                String.format(CHECKSUM_MISMATCH_ERROR_MESSAGE_TEMPLATE, BinaryUtils.toHex(computedChecksum),
+                              BinaryUtils.toHex(streamChecksum)));
         }
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/S3ChecksumValidatingPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/checksums/S3ChecksumValidatingPublisher.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.internal.checksums;
 
 import static java.lang.Math.toIntExact;
+import static software.amazon.awssdk.services.s3.internal.checksums.ChecksumConstant.CHECKSUM_MISMATCH_ERROR_MESSAGE_TEMPLATE;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -135,12 +136,7 @@ public final class S3ChecksumValidatingPublisher implements SdkPublisher<ByteBuf
                 byte[] computedChecksum = sdkChecksum.getChecksumBytes();
                 if (!Arrays.equals(computedChecksum, streamChecksum)) {
                     onError(RetryableException.create(
-                        String.format("Data read has a different checksum than expected. Was 0x%s, but expected 0x%s. "
-                                      + "Common causes: (1) You modified a request ByteBuffer before it could be "
-                                      + "written to the service. Please ensure your data source does not modify the "
-                                      + " byte buffers after you pass them to the SDK. (2) The data was corrupted between the "
-                                      + "client and service. Note: Despite this error, the upload still completed and was "
-                                      + "persisted in S3.",
+                        String.format(CHECKSUM_MISMATCH_ERROR_MESSAGE_TEMPLATE,
                                       BinaryUtils.toHex(computedChecksum), BinaryUtils.toHex(streamChecksum))));
                     return; // Return after onError and not call onComplete below
                 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/S3ChecksumValidatingInputStreamTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/S3ChecksumValidatingInputStreamTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.s3.checksums;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -107,7 +108,7 @@ public class S3ChecksumValidatingInputStreamTest {
                 IoUtils.toByteArray(validatingInputStream);
                 fail("Corruption at byte " + i + " was not detected.");
             } catch (SdkClientException e) {
-                // Expected
+                assertThat(e.getMessage()).contains("Data read has a different checksum than expected");
             }
         }
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/S3ChecksumValidatingPublisherTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/S3ChecksumValidatingPublisherTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.s3.checksums;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -91,6 +92,7 @@ public class S3ChecksumValidatingPublisherTest {
 
     assertFalse(s.hasCompleted());
     assertTrue(s.isOnErrorCalled());
+    assertThat(s.getError().getMessage()).contains("Data read has a different checksum than expected");
   }
 
   @Test
@@ -195,6 +197,7 @@ public class S3ChecksumValidatingPublisherTest {
     final List<ByteBuffer> received;
     boolean completed;
     boolean onErrorCalled;
+    Throwable error;
 
     TestSubscriber() {
       this.received = new ArrayList<>();
@@ -216,6 +219,7 @@ public class S3ChecksumValidatingPublisherTest {
     @Override
     public void onError(Throwable t) {
       onErrorCalled = true;
+      error = t;
     }
 
     @Override
@@ -241,6 +245,10 @@ public class S3ChecksumValidatingPublisherTest {
 
     public boolean isOnErrorCalled() {
       return onErrorCalled;
+    }
+
+    public Throwable getError() {
+      return error;
     }
   }
 


### PR DESCRIPTION
## Motivation and Context

Fix #6324

The checksum mismatch error message thrown during async `S3AsyncClient#getObject` incorrectly referenced
uploading and request ByteBuffer modification. This was confusing for customers since the error only
occurs during downloads (response path). The sync path (`S3ChecksumValidatingInputStream`) had a
different but also incomplete error message.

## Modifications
- Consolidated both `S3ChecksumValidatingInputStream` and `S3ChecksumValidatingPublisher` to use the
  shared `CHECKSUM_MISMATCH_ERROR_MESSAGE_TEMPLATE` constant in `ChecksumConstant`
- Updated the error message 

## Testing

- Updated existing tests `invalidChecksumFails` and `testLastChecksumByteCorrupted` to assert on
  the error message content

- [ ] Added unit tests
- [x] Ran existing tests
- [ ] Manual testing performed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn clean install -pl :s3` succeeds for affected modules
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license