### PR TITLE
Update SDK benchmarks to be able to run with Java 25

### DIFF
--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -279,12 +279,15 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.8.0</version>
                     <!-- Override the configuration in the parent-->
                     <configuration combine.self="override">
                         <compilerVersion>${javac.target}</compilerVersion>
                         <source>${javac.target}</source>
                         <target>${javac.target}</target>
+                        <annotationProcessors>
+                            <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+                        </annotationProcessors>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When running the benchmark JAR built from Java 25, it fails of the following error today
```
Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
        at org.openjdk.jmh.runner.AbstractResourceReader.getReaders(AbstractResourceReader.java:98)
        at org.openjdk.jmh.runner.BenchmarkList.find(BenchmarkList.java:124)
        at org.openjdk.jmh.runner.Runner.internalRun(Runner.java:252)
        at org.openjdk.jmh.runner.Runner.run(Runner.java:208)
        at org.openjdk.jmh.Main.main(Main.java:71)
```

## Modifications
Update SDK benchmarks pom.xml to be able to run with Java 25. See https://mail.openjdk.org/pipermail/jmh-dev/2024-December/004031.html 

## Testing
Tested it locally with Java 25