### PR TITLE
Add resourceUrlPattern support to CloudFrontUtilities.getCookiesForCustomPolicy

### DIFF
--- a/.changes/next-release/feature-AmazonCloudfront-20342a6.json
+++ b/.changes/next-release/feature-AmazonCloudfront-20342a6.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon Cloudfront",
+    "contributor": "",
+    "description": "Add support for resourceUrlPattern to `CloudFrontUtilities.getCookiesForCustomPolicy`."
+}

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -409,13 +409,15 @@ public final class CloudFrontUtilities {
      *     PrivateKey privateKey = myPrivateKey;
      *     Instant activeDate = Instant.now().plus(Duration.ofDays(2));
      *     String ipRange = "192.168.0.1/24";
+     *     String resourceUrlPattern = "https://d111111abcdef8.cloudfront.net/*"; // If not supplied, defaults to the value of resourceUrl.
      *
      *     CookiesForCustomPolicy cookies = utilities.getCookiesForCustomPolicy(r -> r.resourceUrl(resourceUrl)
      *                                                                                .privateKey(privateKey)
      *                                                                                .keyPairId(keyPairId)
      *                                                                                .expirationDate(expirationDate)
      *                                                                                .activeDate(activeDate)
-     *                                                                                .ipRange(ipRange));
+     *                                                                                .ipRange(ipRange)
+     *                                                                                .resourceUrlPattern(resourceUrlPattern));
      *     // Generates Set-Cookie header values to send to the viewer to allow access
      *     String signatureHeaderValue = cookies.signatureHeaderValue();
      *     String keyPairIdHeaderValue = cookies.keyPairIdHeaderValue();
@@ -434,7 +436,13 @@ public final class CloudFrontUtilities {
      *
      * @param request
      *            A {@link CustomSignerRequest} configured with the following values:
-     *            resourceUrl, privateKey, keyPairId, expirationDate, activeDate (optional), ipRange (optional)
+     *            resourceUrl,
+     *            privateKey,
+     *            keyPairId,
+     *            expirationDate,
+     *            activeDate (optional),
+     *            ipRange (optional),
+     *            resourceUrlPattern (optional)
      * @return The signed cookies with custom policy.
      *
      * <p><b>Example Usage</b>
@@ -450,14 +458,16 @@ public final class CloudFrontUtilities {
      *     Path keyFile = myKeyFile;
      *     Instant activeDate = Instant.now().plus(Duration.ofDays(2));
      *     String ipRange = "192.168.0.1/24";
+     *     String resourceUrlPattern = "https://d111111abcdef8.cloudfront.net/*"; // If not supplied, defaults to the value of resourceUrl.
      *
      *     CustomSignerRequest customRequest = CustomSignerRequest.builder()
      *                                                            .resourceUrl(resourceUrl)
      *                                                            .privateKey(keyFile)
-     *                                                            .keyPairId(keyFile)
+     *                                                            .keyPairId(keyPairId)
      *                                                            .expirationDate(expirationDate)
      *                                                            .activeDate(activeDate)
      *                                                            .ipRange(ipRange)
+     *                                                            .resourceUrlPattern(resourceUrlPattern)
      *                                                            .build();
      *     CookiesForCustomPolicy cookies = utilities.getCookiesForCustomPolicy(customRequest);
      *     // Generates Set-Cookie header values to send to the viewer to allow access
@@ -468,7 +478,11 @@ public final class CloudFrontUtilities {
      */
     public CookiesForCustomPolicy getCookiesForCustomPolicy(CustomSignerRequest request) {
         try {
-            String policy = SigningUtils.buildCustomPolicy(request.resourceUrl(), request.activeDate(), request.expirationDate(),
+            String resourceUrlPattern = request.resourceUrlPattern() == null
+                                        ? request.resourceUrl()
+                                        : request.resourceUrlPattern();
+
+            String policy = SigningUtils.buildCustomPolicy(resourceUrlPattern, request.activeDate(), request.expirationDate(),
                                                            request.ipRange());
             byte[] signatureBytes = signPolicy(policy.getBytes(UTF_8), request.privateKey());
             String urlSafePolicy = SigningUtils.makeStringUrlSafe(policy);

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.security.Key;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
@@ -66,7 +65,6 @@ import software.amazon.awssdk.services.cloudfront.model.Distribution;
 import software.amazon.awssdk.services.cloudfront.model.DistributionConfig;
 import software.amazon.awssdk.services.cloudfront.model.DistributionSummary;
 import software.amazon.awssdk.services.cloudfront.model.GetKeyGroupResponse;
-import software.amazon.awssdk.services.cloudfront.model.KeyGroup;
 import software.amazon.awssdk.services.cloudfront.model.KeyGroupConfig;
 import software.amazon.awssdk.services.cloudfront.model.KeyGroupSummary;
 import software.amazon.awssdk.services.cloudfront.model.Origin;
@@ -317,6 +315,108 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                                                                .build()).call();
         int expectedStatus = 403;
         assertThat(response.httpResponse().statusCode()).isEqualTo(expectedStatus);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard(KeyTestCase testCase) throws Exception {
+        Instant expirationDate = LocalDate.of(2050, 1, 1)
+                                          .atStartOfDay()
+                                          .toInstant(ZoneOffset.of("Z"));
+
+        Instant activeDate = LocalDate.of(2022, 1, 1)
+                                      .atStartOfDay()
+                                      .toInstant(ZoneOffset.of("Z"));
+
+        CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(r -> r.resourceUrl(resourceUrl)
+                                                                                             .privateKey(testCase.privateKey)
+                                                                                             .keyPairId(testCase.keyPairId)
+                                                                                             .resourceUrlPattern(resourceUrl + "*")
+                                                                                             .activeDate(activeDate)
+                                                                                             .expirationDate(expirationDate));
+
+        // Request the same resource with an additional query parameter - should still be allowed by the wildcard policy
+        URI uri = URI.create(resourceUrl + "?foo=bar");
+        SdkHttpClient client = ApacheHttpClient.create();
+        HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                               .request(SdkHttpRequest.builder()
+                                                                                                      .uri(uri)
+                                                                                                      .appendHeader("Cookie", cookies.policyHeaderValue())
+                                                                                                      .appendHeader("Cookie", cookies.signatureHeaderValue())
+                                                                                                      .appendHeader("Cookie", cookies.keyPairIdHeaderValue())
+                                                                                                      .method(SdkHttpMethod.GET)
+                                                                                                      .build())
+                                                                               .build()).call();
+        assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_wildCardPath(KeyTestCase testCase) throws Exception {
+        String resourceUri = "https://" + domainName;
+        Instant expirationDate = LocalDate.of(2050, 1, 1)
+                                          .atStartOfDay()
+                                          .toInstant(ZoneOffset.of("Z"));
+
+        Instant activeDate = LocalDate.of(2022, 1, 1)
+                                      .atStartOfDay()
+                                      .toInstant(ZoneOffset.of("Z"));
+
+        CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(
+            r -> r.resourceUrl(resourceUri + "/foo/specific-file")
+                  .privateKey(testCase.privateKey)
+                  .keyPairId(testCase.keyPairId)
+                  .resourceUrlPattern(resourceUri + "/foo/*")
+                  .activeDate(activeDate)
+                  .expirationDate(expirationDate));
+
+        // Use the cookies to access a different file under the same wildcard path
+        URI otherFileUri = URI.create(resourceUri + "/foo/other-file");
+        SdkHttpClient client = ApacheHttpClient.create();
+        HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                               .request(SdkHttpRequest.builder()
+                                                                                                      .uri(otherFileUri)
+                                                                                                      .appendHeader("Cookie", cookies.policyHeaderValue())
+                                                                                                      .appendHeader("Cookie", cookies.signatureHeaderValue())
+                                                                                                      .appendHeader("Cookie", cookies.keyPairIdHeaderValue())
+                                                                                                      .method(SdkHttpMethod.GET)
+                                                                                                      .build())
+                                                                               .build()).call();
+        assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_wildCardPolicyResource_allowsAnyPath(KeyTestCase testCase) throws Exception {
+        Instant expirationDate = LocalDate.of(2050, 1, 1)
+                                          .atStartOfDay()
+                                          .toInstant(ZoneOffset.of("Z"));
+
+        Instant activeDate = LocalDate.of(2022, 1, 1)
+                                      .atStartOfDay()
+                                      .toInstant(ZoneOffset.of("Z"));
+
+        CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(
+            r -> r.resourceUrl(resourceUrl)
+                  .privateKey(testCase.privateKey)
+                  .keyPairId(testCase.keyPairId)
+                  .resourceUrlPattern("*")
+                  .activeDate(activeDate)
+                  .expirationDate(expirationDate));
+
+        // Use the cookies to access a completely different path - the "*" pattern should allow any path
+        URI differentPathUri = URI.create(resourceUrl.replace("/s3ObjectKey", "/foo/other-file"));
+        SdkHttpClient client = ApacheHttpClient.create();
+        HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                               .request(SdkHttpRequest.builder()
+                                                                                                      .uri(differentPathUri)
+                                                                                                      .appendHeader("Cookie", cookies.policyHeaderValue())
+                                                                                                      .appendHeader("Cookie", cookies.signatureHeaderValue())
+                                                                                                      .appendHeader("Cookie", cookies.keyPairIdHeaderValue())
+                                                                                                      .method(SdkHttpMethod.GET)
+                                                                                                      .build())
+                                                                               .build()).call();
+        assertThat(response.httpResponse().statusCode()).isEqualTo(200);
     }
 
     @ParameterizedTest(name = "{0}")

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -438,6 +438,74 @@ class CloudFrontUtilitiesTest {
     }
 
 
+    @ParameterizedTest
+    @MethodSource("provideUrlPatternsAndExpectedResources")
+    void getCookiesForCustomPolicy_policyResourceUrlShouldHandleVariousPatterns(
+        String resourceUrlPattern, String expectedResource) {
+        KeyTestCase testCase = KeyTestCase.createRsaTestCase();
+        String baseUrl = "https://d1234.cloudfront.net/images/photo.jpg";
+        Instant expiration = Instant.now().plusSeconds(3600);
+        CustomSignerRequest request = CustomSignerRequest.builder()
+                                                         .resourceUrl(baseUrl)
+                                                         .privateKey(testCase.keyPair.getPrivate())
+                                                         .keyPairId("keyPairId")
+                                                         .resourceUrlPattern(resourceUrlPattern)
+                                                         .expirationDate(expiration)
+                                                         .build();
+
+        CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(request);
+
+        // Extract and decode the policy from the cookie header value
+        String policyHeaderValue = cookies.policyHeaderValue();
+        String encodedPolicy = policyHeaderValue.split("CloudFront-Policy=")[1];
+        String standardBase64 = encodedPolicy
+            .replace('-', '+')
+            .replace('_', '=')
+            .replace('~', '/');
+        String decodedPolicy = new String(Base64.getDecoder().decode(standardBase64), UTF_8);
+
+        // Build expected policy
+        StringBuilder expectedPolicy = new StringBuilder();
+        StringJoiner conditions = new StringJoiner(",", "{", "}");
+        conditions.add("\"DateLessThan\":{\"AWS:EpochTime\":" + expiration.getEpochSecond() + "}");
+
+        expectedPolicy.append("{\"Statement\":[{")
+                      .append("\"Resource\":\"").append(expectedResource).append("\",")
+                      .append("\"Condition\":").append(conditions)
+                      .append("}]}");
+
+        assertThat(decodedPolicy.trim()).isEqualTo(expectedPolicy.toString().trim());
+        // resourceUrl on the cookie object should still be the concrete URL, not the pattern
+        assertThat(cookies.resourceUrl()).isEqualTo(baseUrl);
+    }
+
+    @Test
+    void getCookiesForCustomPolicy_withoutResourceUrlPattern_usesResourceUrlInPolicy() {
+        KeyTestCase testCase = KeyTestCase.createRsaTestCase();
+        String baseUrl = "https://d1234.cloudfront.net/images/photo.jpg";
+        Instant expiration = Instant.now().plusSeconds(3600);
+        CustomSignerRequest request = CustomSignerRequest.builder()
+                                                         .resourceUrl(baseUrl)
+                                                         .privateKey(testCase.keyPair.getPrivate())
+                                                         .keyPairId("keyPairId")
+                                                         .expirationDate(expiration)
+                                                         .build();
+
+        CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(request);
+
+        // Extract and decode the policy
+        String policyHeaderValue = cookies.policyHeaderValue();
+        String encodedPolicy = policyHeaderValue.split("CloudFront-Policy=")[1];
+        String standardBase64 = encodedPolicy
+            .replace('-', '+')
+            .replace('_', '=')
+            .replace('~', '/');
+        String decodedPolicy = new String(Base64.getDecoder().decode(standardBase64), UTF_8);
+
+        // When resourceUrlPattern is not set, the policy should use resourceUrl
+        assertThat(decodedPolicy).contains("\"Resource\":\"" + baseUrl + "\"");
+    }
+
     private static Stream<Arguments> provideUrlPatternsAndExpectedResources() {
         return Stream.of(
             Arguments.of("*", "*"),


### PR DESCRIPTION
Add resourceUrlPattern support to CloudFrontUtilities.getCookiesForCustomPolicy

Fixes: #6127 

## Motivation and Context
`CloudFrontUtilities.getCookiesForCustomPolicy` was missing support for resourceUrlPattern.  resourceUrlPattern was already supported in `getSignedUrlWithCustomPolicy`.  resourceUrlPatterns should be supported in both, see:
 * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-cookies.html
 * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html#private-content-custom-policy-statement-cookies-values

## Modifications
* Mimic the logic from getSignedUrlWithCustomPolicy in getCookiesForCustomPolicy.

## Testing
New and existing unit and integration tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
