### PR TITLE
Fix NPE for null values in Map and List collection attribute converters

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-f887fc6.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-f887fc6.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Fix NullPointerException when converting null values in `Map` and `List` attributes by handling nulls in `MapAttributeConverter` and `ListAttributeConverter` before delegating to element converters. Fixes [#6639](https://github.com/aws/aws-sdk-java-v2/issues/6639)"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ListAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ListAttributeConverter.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.TypeConvertingVisitor;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -145,7 +146,9 @@ public class ListAttributeConverter<T extends Collection<?>> implements Attribut
         @Override
         public AttributeValue transformFrom(T input) {
             return EnhancedAttributeValue.fromListOfAttributeValues(input.stream()
-                                                                         .map(elementConverter::transformFrom)
+                                                                         .map(e -> e == null
+                                                                             ? AttributeValues.nullAttributeValue()
+                                                                             : elementConverter.transformFrom(e))
                                                                          .collect(toList()))
                                          .toAttributeValue();
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/MapAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/MapAttributeConverter.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.TypeConvertingVisitor;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -163,7 +164,9 @@ public class MapAttributeConverter<T extends Map<?, ?>> implements AttributeConv
 
         public EnhancedAttributeValue toAttributeValue(T input) {
             Map<String, AttributeValue> result = new LinkedHashMap<>();
-            input.forEach((k, v) -> result.put(keyConverter.toString(k), valueConverter.transformFrom(v)));
+            input.forEach((k, v) -> result.put(keyConverter.toString(k),
+                                               v == null ? AttributeValues.nullAttributeValue()
+                                                         : valueConverter.transformFrom(v)));
             return EnhancedAttributeValue.fromMap(result);
         }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/CollectionNullValueConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/CollectionNullValueConverterTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converters.attribute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BigDecimalAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BooleanAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DoubleAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.FloatAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.InstantAsStringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.IntegerAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.LongAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.StringStringConverter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Verifies that {@link MapAttributeConverter} and {@link ListAttributeConverter} correctly handle null
+ * values/elements by converting them to DynamoDB NULL type, regardless of the element converter type.
+ */
+public class CollectionNullValueConverterTest {
+
+    private static final AttributeValue NULL_ATTR = AttributeValue.builder().nul(true).build();
+
+    private static Stream<Arguments> elementConverters() {
+        return Stream.of(
+            Arguments.of("String", StringAttributeConverter.create()),
+            Arguments.of("Boolean", BooleanAttributeConverter.create()),
+            Arguments.of("Integer", IntegerAttributeConverter.create()),
+            Arguments.of("Long", LongAttributeConverter.create()),
+            Arguments.of("Float", FloatAttributeConverter.create()),
+            Arguments.of("Double", DoubleAttributeConverter.create()),
+            Arguments.of("BigDecimal", BigDecimalAttributeConverter.create()),
+            Arguments.of("Instant", InstantAsStringAttributeConverter.create())
+        );
+    }
+
+    @ParameterizedTest(name = "Map with null {0} value produces DynamoDB NULL")
+    @MethodSource("elementConverters")
+    void mapConverter_nullValue_producesNullAttributeValue(String name, AttributeConverter<?> elementConverter) {
+        @SuppressWarnings("unchecked")
+        AttributeConverter<Object> converter = (AttributeConverter<Object>) elementConverter;
+        MapAttributeConverter<Map<String, Object>> mapConverter =
+            MapAttributeConverter.mapConverter(StringStringConverter.create(), converter);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("key1", null);
+
+        AttributeValue result = mapConverter.transformFrom(input);
+
+        assertThat(result.hasM()).isTrue();
+        assertThat(result.m().get("key1")).isEqualTo(NULL_ATTR);
+    }
+
+    @ParameterizedTest(name = "List with null {0} element produces DynamoDB NULL")
+    @MethodSource("elementConverters")
+    void listConverter_nullElement_producesNullAttributeValue(String name, AttributeConverter<?> elementConverter) {
+        @SuppressWarnings("unchecked")
+        AttributeConverter<Object> converter = (AttributeConverter<Object>) elementConverter;
+        ListAttributeConverter<List<Object>> listConverter = ListAttributeConverter.create(converter);
+
+        List<Object> input = Arrays.asList(null, null);
+
+        AttributeValue result = listConverter.transformFrom(input);
+
+        assertThat(result.hasL()).isTrue();
+        assertThat(result.l()).hasSize(2);
+        assertThat(result.l().get(0)).isEqualTo(NULL_ATTR);
+        assertThat(result.l().get(1)).isEqualTo(NULL_ATTR);
+    }
+}


### PR DESCRIPTION
MapAttributeConverter and ListAttributeConverter pass null collection values/elements directly to element converters without null-checking. For converters like DoubleAttributeConverter and FloatAttributeConverter, this causes a NullPointerException due to auto-unboxing in ConverterUtils.validateDouble()/validateFloat(). This occurs when users persist a Map<String, Double> or List<Double> containing null values.

## Motivation and Context
DynamoDB has a first-class NULL type for representing absent values. When a Java collection contains null elements, the SDK should convert them to DynamoDB NULL(nul(true)) rather than passing them to element converters that aren't designed to handle null. The existing pattern in ResolvedImmutableAttribute already does this for top-level attributes — this fix applies the same approach to collection converters.

## Modifications
- MapAttributeConverter.Delegate.toAttributeValue(): null map values are now converted to AttributeValues.nullAttributeValue() before delegating to the value converter
- ListAttributeConverter.Delegate.transformFrom(): null list elements are now converted to AttributeValues.nullAttributeValue() before delegating to the element converter

## Testing
- Added parameterized CollectionNullValueConverterTest covering null handling for both MapAttributeConverter and ListAttributeConverter across 8 element converter types(String, Boolean, Integer, Long, Float, Double, BigDecimal, Instant)
   - Existing tests continue to pass — no behavioral change for non-null values
   
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
