### PR TITLE
Update assertion in ProcessCredentialsProviderTest after JDK21 error message change

### DIFF
--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
@@ -355,8 +355,8 @@ public class ProcessCredentialsProviderTest {
             // executed not in a shell
             assertThat(e.getCause()).isInstanceOf(IOException.class);
             assertThat(e.getCause().getMessage())
-                .isEqualTo("Cannot run program \"echo \"Hello, World!\" > output.txt; rm output.txt\": error=2, "
-                           + "No such file or directory");
+                .startsWith("Cannot run program \"echo \"Hello, World!\" > output.txt; rm output.txt\":")
+                .contains("No such file or directory");
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
JDK21 builds started failing today:

```
[ERROR]   ProcessCredentialsProviderTest.commandAsListOfStrings_isNotExecutedInAShell:358
--
expected: "Cannot run program "echo "Hello, World!" > output.txt; rm output.txt": error=2, No such file or directory"
but was: "Cannot run program "echo "Hello, World!" > output.txt; rm output.txt": Exec failed, error: 2 (No such file or directory) "
```

Still passes with JDK 8, 11,17.

Tested locally, with JDK 25, fails with same as JDK 21

## Modifications
<!--- Describe your changes in detail -->
Updated test assertion 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests passed locally