### PR TITLE
Returning correct operation name for DeleteTableOperation

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-d29ad20.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-d29ad20.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Returning correct operation name for DeleteTableOperation"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/DeleteTableOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/DeleteTableOperation.java
@@ -38,7 +38,7 @@ public class DeleteTableOperation<T> implements TableOperation<T, DeleteTableReq
 
     @Override
     public OperationName operationName() {
-        return OperationName.DELETE_ITEM;
+        return OperationName.DELETE_TABLE;
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/DeleteTableOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/DeleteTableOperationTest.java
@@ -15,6 +15,13 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.internal.operations;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -24,14 +31,10 @@ import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithIndices;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithSort;
-import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.verify;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableResponse;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteTableOperationTest {
@@ -46,6 +49,14 @@ public class DeleteTableOperationTest {
     @Mock
     private DynamoDbClient mockDynamoDbClient;
 
+    @Mock
+    private DynamoDbAsyncClient mockDynamoDbAsyncClient;
+
+    @Test
+    public void operationName_returnsDeleteTable() {
+        DeleteTableOperation<FakeItem> operation = DeleteTableOperation.create();
+        assertThat(operation.operationName(), is(OperationName.DELETE_TABLE));
+    }
 
     @Test
     public void getServiceCall_makesTheRightCall() {
@@ -55,11 +66,26 @@ public class DeleteTableOperationTest {
         verify(mockDynamoDbClient).deleteTable(same(deleteTableRequest));
     }
 
+    @Test
+    public void getAsyncServiceCall_makesTheRightCallAndReturnsResponse() {
+        DeleteTableOperation<FakeItem> operation = DeleteTableOperation.create();
+        DeleteTableRequest deleteTableRequest = DeleteTableRequest.builder().build();
+        CompletableFuture<DeleteTableResponse> expectedResponse =
+            CompletableFuture.completedFuture(DeleteTableResponse.builder().build());
+
+        when(mockDynamoDbAsyncClient.deleteTable(same(deleteTableRequest))).thenReturn(expectedResponse);
+
+        CompletableFuture<DeleteTableResponse> response = operation.asyncServiceCall(mockDynamoDbAsyncClient)
+                                                                 .apply(deleteTableRequest);
+
+        assertThat(response, is(expectedResponse));
+        verify(mockDynamoDbAsyncClient).deleteTable(same(deleteTableRequest));
+    }
 
     @Test
     public void generateRequest_from_deleteTableOperation() {
         DeleteTableOperation<FakeItemWithSort> deleteTableOperation = DeleteTableOperation.create();
-        final DeleteTableRequest deleteTableRequest = deleteTableOperation
+        DeleteTableRequest deleteTableRequest = deleteTableOperation
                 .generateRequest(FakeItemWithSort.getTableSchema(),
                         PRIMARY_CONTEXT,
                         null);
@@ -70,6 +96,18 @@ public class DeleteTableOperationTest {
     public void generateRequest_doesNotWorkForIndex() {
         DeleteTableOperation<FakeItemWithIndices> operation = DeleteTableOperation.create();
         operation.generateRequest(FakeItemWithIndices.getTableSchema(), GSI_1_CONTEXT, null);
+    }
+
+    @Test
+    public void transformResponse_returnsNull() {
+        DeleteTableOperation<FakeItem> operation = DeleteTableOperation.create();
+
+        Void response = operation.transformResponse(DeleteTableResponse.builder().build(),
+                                                    FakeItem.getTableSchema(),
+                                                    PRIMARY_CONTEXT,
+                                                    null);
+
+        assertThat(response, is((Void) null));
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This PR addresses the bug reported here: [DeleteTableOperation uses OperationName.DELETE_ITEM instead of OperationName.DELETE_TABLE #6760](https://github.com/aws/aws-sdk-java-v2/issues/6760).

Without this fix, `DeleteTableOperation#operationName()` will continue to return a wrong operation name (`OperationName.DELETE_ITEM`). This is important because the operation actually performs a table deletion, and the reported name can be used by shared framework flows such as routing, logging, metrics, tracing, interceptors, error handling, and tests, where an incorrect value would mislabel the operation and create misleading behavior or observability data.

## Modifications
Replaced the operation name returned by `DeleteTableOperation#operationName()`, from `OperationName.DELETE_ITEM` to `OperationName.DELETE_TABLE`.

## Testing

Added unit tests for modified operation name (from `DeleteTableOperation.java`):
- `operationName_returnsDeleteTable()` - Confirms `operationName()` returns `OperationName.DELETE_TABLE`

Added additional tests to increase the class coverage (`DeleteTableOperation.java`):
- `getAsyncServiceCall_makesTheRightCallAndReturnsResponse()` - Confirms `asyncServiceCall(...)` calls `deleteTable(...)`, passes the same request object, and returns the same `CompletableFuture`.
- `transformResponse_returnsNull()` - Confirms `transformResponse(...)` returns `null`

## Screenshots (if appropriate)
### Test coverage on modified classes
<img width="877" height="80" alt="image" src="https://github.com/user-attachments/assets/a2908b22-0216-44f2-888b-713bffd3a0a5" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
