### PR TITLE
Fix long overflow in CachedSupplier.maxStaleFailureJitter() that permanently disables credential refresh after 58 consecutive failures

### DIFF
--- a/utils/src/main/java/software/amazon/awssdk/utils/cache/CachedSupplier.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/cache/CachedSupplier.java
@@ -334,7 +334,10 @@ public class CachedSupplier<T> implements Supplier<T>, SdkAutoCloseable {
     }
 
     private Duration maxStaleFailureJitter(int numFailures) {
-        long exponentialBackoffMillis = (1L << numFailures - 1) * 100;
+        long exponentialBackoffMillis = (1L << (numFailures - 1)) * 100;
+        if (exponentialBackoffMillis <= 0) {
+            exponentialBackoffMillis = Long.MAX_VALUE;
+        }
         return ComparableUtils.minimum(Duration.ofMillis(exponentialBackoffMillis), Duration.ofSeconds(10));
     }
 


### PR DESCRIPTION
## Description

CachedSupplier.maxStaleFailureJitter() has a long overflow that permanently disables credential refresh after 58 consecutive failures.

When numFailures reaches 58, (1L << 57) * 100 overflows signed long, wrapping to a negative value.
ComparableUtils.minimum(negativeDuration, 10s) returns the negative duration (since it's "less than" 10s), which flows into
jitterTime() and produces a stale time millions of years in the future. The SDK never attempts to refresh credentials again.

### Observed in production

During the recent outage, InstanceProfileCredentialsProvider with StaleValueBehavior.ALLOW hit 58 consecutive failures:

(consecutive failures: 57) Cached value expiration has been extended to 2026-03-18T04:45:56Z
(consecutive failures: 58) Cached value expiration has been extended to +75191085-06-13T12:51:54Z


Entire application restart was required to restore credential refresh.

### Fix

Clamp overflowed negative values to Long.MAX_VALUE, ensuring ComparableUtils.minimum() always caps at 10 seconds as intended.

### Testing

Verified that for numFailures values 1 through 100, maxStaleFailureJitter() always returns a positive duration ≤ 10 seconds.