### PR TITLE
Add external contributor unit tests workflow

### DIFF
--- a/.github/workflows/external-contributor-unit-tests.yml
+++ b/.github/workflows/external-contributor-unit-tests.yml
@@ -1,0 +1,31 @@
+name: External Contributor Unit Tests
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11, 17, 21]
+      fail-fast: false
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: Run unit tests
+        run: mvn clean install -T0.4C
+      - name: Run module path tests
+        if: matrix.java != 8
+        working-directory: test/module-path-tests
+        run: |
+          mvn package
+          mvn exec:exec -P mock-tests


### PR DESCRIPTION
### Context
Adding a "pure" Github workflow to allow external contributors to run our CI unit tests. 
With this change external contributors can fork our repo, and run the same CI test suite using infrastructure provided by the Github workflow feature. This eliminates the need for authentication, as the workflow is read only. 

In their fork, external contributors will be able to visit the `actions` tab, and run this new workflow on their desired branch: 

<img width="941" height="714" alt="image" src="https://github.com/user-attachments/assets/387f7fd4-31f6-477a-8255-64ef56428ed7" />


### Testing
Tested on my private fork: https://github.com/RanVaknin/aws-sdk-java-v2/actions/runs/23517845706