### PR TITLE
Improve docs for ParallelConfiguration

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/ParallelConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/ParallelConfiguration.java
@@ -22,8 +22,13 @@ import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
- * Class that holds configuration properties related to multipart operations for a {@link S3AsyncClient}, related specifically
- * to non-linear, parallel operations, that is, when the {@link AsyncResponseTransformer} supports non-serial split.
+ * Configuration for parallel multipart operations performed by a {@link S3AsyncClient}.
+ *
+ * <p>For uploads (putObject), this configuration applies to all multipart uploads regardless of whether the content
+ * length is known.
+ *
+ * <p>For downloads (getObject), this configuration applies only when the {@link AsyncResponseTransformer} supports
+ * parallel split.
  */
 @SdkPublicApi
 public class ParallelConfiguration implements ToCopyableBuilder<ParallelConfiguration.Builder, ParallelConfiguration> {
@@ -41,9 +46,11 @@ public class ParallelConfiguration implements ToCopyableBuilder<ParallelConfigur
     /**
      * The maximum number of concurrent part requests that are allowed for multipart operations, including both multipart
      * download (GetObject) and multipart upload (PutObject). This limits the number of parts that can be in flight at any
-     * given time, preventing the client from overwhelming the HTTP connection pool when transferring large objects. For
-     * getObject it applies only when the {@link AsyncResponseTransformer} supports parallel split.
-     * Defaults to 50.
+     * given time, preventing the client from overwhelming the HTTP connection pool when transferring large objects.
+     *
+     * <p>For getObject it applies only when the {@link AsyncResponseTransformer} supports parallel split.
+     *
+     * <p>Defaults to 50.
      *
      * @return The value for the maximum number of concurrent part requests.
      */


### PR DESCRIPTION
Improve docs for ParallelConfiguration from #6801

## Motivation and Context
The class docs suggested that the configuration applied only to GetObject.

## Modifications
Updates to javadocs.

## Testing
n/a

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
