### PR TITLE
fix(test): update AlpnHttpTest to use available port instead of fixed port 8080 that can be occupied by parallel tests

### DIFF
--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/h2/AlpnHttpTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/h2/AlpnHttpTest.java
@@ -18,10 +18,13 @@ package software.amazon.awssdk.services.h2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.net.ConnectException;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
@@ -47,6 +50,7 @@ public class AlpnHttpTest {
         assertThat(e.getCause()).hasCauseInstanceOf(ConnectException.class);
         assertThat(e.getMessage()).contains("Connection refused");
         assertThat(e.getMessage()).doesNotContain("ALPN can only be used with HTTPS, not HTTP. Use ProtocolNegotiation.ASSUME_PROTOCOL instead.");
+        client.close();
     }
 
     @Test
@@ -62,11 +66,12 @@ public class AlpnHttpTest {
         assertThat(e).hasCauseInstanceOf(SdkClientException.class);
         assertThat(e.getCause()).hasCauseInstanceOf(UnsupportedOperationException.class);
         assertThat(e.getMessage()).contains("ALPN can only be used with HTTPS, not HTTP. Use ProtocolNegotiation.ASSUME_PROTOCOL instead.");
+        client.close();
     }
 
     private H2AsyncClientBuilder clientBuilderWithHttpEndpoint() {
         return H2AsyncClient.builder()
-                            .endpointOverride(URI.create("http://localhost:8080"));
+                            .endpointOverride(URI.create("http://localhost:" + getUnusedPort()));
     }
 
     private void makeRequest(H2AsyncClient client) {
@@ -88,6 +93,15 @@ public class AlpnHttpTest {
             return true;
         } catch (Throwable t) {
             return false;
+        }
+    }
+
+    private static int getUnusedPort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- AlpnHttpTest test intermittently failed with 
```

java.lang.AssertionError: 

Expecting a throwable with cause being an instance of:
  software.amazon.awssdk.core.exception.SdkClientException
but was an instance of:
  software.amazon.awssdk.services.h2.model.H2Exception: Service returned HTTP status code 500 (Service: H2, Status Code: 500, Request ID: null) (SDK Attempt 
```

This was because it got connected to port 8080 since parallel test were getting executed

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
- The fix is to get a unused port at the time of the test and close it immediately and then use that port for testing so that we dont pick up a port which is used by other parallel tests
## Testing
- Ran in loop and it passed 

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
