### PR TITLE
Fix v1 S3 getUserMetaDataOf transform

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-370c8cd.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2MigrationTool-370c8cd.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 Migration Tool",
+    "contributor": "",
+    "description": "Fix bug for v1 getUserMetaDataOf transform"
+}

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/after/src/main/java/foo/bar/S3Streaming.java
@@ -50,6 +50,8 @@ public class S3Streaming {
 
         String etag = /*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
 objectMetadata.eTag().replaceAll("^\"|\"$", "");
+
+        String value = s3Object.response().metadata().get("key");
     }
 
     void putObject_bucketKeyContent(String bucket, String key, String content) {

--- a/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
+++ b/test/v2-migration-tests/src/test/resources/software/amazon/awssdk/v2migrationtests/maven/before/src/main/java/foo/bar/S3Streaming.java
@@ -45,6 +45,8 @@ public class S3Streaming {
         ObjectMetadata objectMetadata = s3.getObject(new GetObjectRequest(bucket, key), file);
 
         String etag = objectMetadata.getETag();
+
+        String value = s3Object.getObjectMetadata().getUserMetaDataOf("key");
     }
 
     void putObject_bucketKeyContent(String bucket, String key, String content) {

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3PutObjectRequestToV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/S3PutObjectRequestToV2.java
@@ -420,6 +420,9 @@ public class S3PutObjectRequestToV2 extends Recipe {
         }
 
         private J.MethodInvocation saveMetadataValueAndRemoveStatement(J.MethodInvocation method) {
+            if (!(method.getSelect() instanceof J.Identifier)) {
+                return method;
+            }
             J.Identifier metadataPojo = (J.Identifier) method.getSelect();
             String variableName = metadataPojo.getSimpleName();
 

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/V1GetterToV2.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/V1GetterToV2.java
@@ -17,7 +17,9 @@ package software.amazon.awssdk.v2migration;
 
 import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.changeBucketNameToBucket;
 import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.isS3ETagGetter;
+import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.isS3UserMetaDataOfGetter;
 import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.transformETagGetter;
+import static software.amazon.awssdk.v2migration.internal.utils.S3TransformUtils.transformUserMetaDataOfGetter;
 import static software.amazon.awssdk.v2migration.internal.utils.SdkTypeUtils.isV2ModelClass;
 
 import org.openrewrite.ExecutionContext;
@@ -67,6 +69,10 @@ public class V1GetterToV2 extends Recipe {
 
             if (isS3ETagGetter(methodName, fullyQualified)) {
                 return transformETagGetter(getCursor(), method);
+            }
+
+            if (isS3UserMetaDataOfGetter(methodName, fullyQualified)) {
+                return transformUserMetaDataOfGetter(getCursor(), method);
             }
 
             methodName = changeBucketNameToBucket(methodName);

--- a/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
+++ b/v2-migration/src/main/java/software/amazon/awssdk/v2migration/internal/utils/S3TransformUtils.java
@@ -315,6 +315,18 @@ public final class S3TransformUtils {
                            .withComments(createCommentsWithNewline(comment));
     }
 
+    public static boolean isS3UserMetaDataOfGetter(String methodName, JavaType.FullyQualified declaringType) {
+        return "getUserMetaDataOf".equals(methodName)
+               && declaringType.getFullyQualifiedName().startsWith(V2_S3_MODEL_PKG);
+    }
+
+    public static J.MethodInvocation transformUserMetaDataOfGetter(Cursor cursor, J.MethodInvocation method) {
+        String template = "#{any()}.metadata().get(#{any()})";
+        return JavaTemplate.builder(template).build()
+                           .apply(cursor, method.getCoordinates().replace(),
+                                  method.getSelect(), method.getArguments().get(0));
+    }
+
     public static List<Comment> inputStreamBufferingWarningComment() {
         String warning = "When using InputStream to upload with S3Client, Content-Length should be specified and used "
                          + "with RequestBody.fromInputStream(). Otherwise, the entire stream will be buffered in memory. If"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws/aws-sdk-java-v2/issues/6821

## Modifications
<!--- Describe your changes in detail -->
- Add check in `S3PutObjectRequestToV2` for chained methods on `ObjectMetadata`
- Add transform for `getUserMetaDataOf` in `V1GetterToV2` , to `.metadata().get()`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added E2E tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
