### PR TITLE
Add S3 custom 503 throttling detection

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-0dda0b4.json
+++ b/.changes/next-release/bugfix-AmazonS3-0dda0b4.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Add custom 503 throttling detection for S3 head operations"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
@@ -75,15 +75,22 @@ public final class ExceptionTranslationInterceptor implements ExecutionIntercept
                                             .message(message)
                                             .build();
             }
-        } else if (exception.statusCode() == 503 && "Slow Down".equals(errorDetails.sdkHttpResponse().statusText().orElse(null))) {
-            return S3Exception.builder()
-                              .awsErrorDetails(fillErrorDetails(errorDetails, "SlowDown", "Please reduce your request rate."))
-                              .statusCode(503)
-                              .requestId(requestId)
-                              .extendedRequestId(extendedRequestId)
-                              .message(message)
-                              .build();
-        } else if (errorDetails.errorMessage() == null) {
+        }
+
+        if (exception.statusCode() == 503) {
+            if ("Slow Down".equals(errorDetails.sdkHttpResponse().statusText().orElse(null))) {
+                return S3Exception.builder()
+                                  .awsErrorDetails(fillErrorDetails(errorDetails, "SlowDown",
+                                                                    "Please reduce your request rate."))
+                                  .statusCode(503)
+                                  .requestId(requestId)
+                                  .extendedRequestId(extendedRequestId)
+                                  .message(message)
+                                  .build();
+            }
+        }
+
+        if (errorDetails.errorMessage() == null) {
             // Populate the error message using the HTTP response status text. Usually that's just the value from the
             // HTTP spec (e.g. "Forbidden"), but sometimes S3 throws some more useful things in there, like "Slow Down".
             String errorMessage = errorDetails.sdkHttpResponse().statusText().orElse(null);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
@@ -75,9 +75,7 @@ public final class ExceptionTranslationInterceptor implements ExecutionIntercept
                                             .message(message)
                                             .build();
             }
-        }
-
-        if (exception.statusCode() == 503) {
+        } else if (exception.statusCode() == 503) {
             if ("Slow Down".equals(errorDetails.sdkHttpResponse().statusText().orElse(null))) {
                 return S3Exception.builder()
                                   .awsErrorDetails(fillErrorDetails(errorDetails, "SlowDown",
@@ -88,9 +86,7 @@ public final class ExceptionTranslationInterceptor implements ExecutionIntercept
                                   .message(message)
                                   .build();
             }
-        }
-
-        if (errorDetails.errorMessage() == null) {
+        } else if (errorDetails.errorMessage() == null) {
             // Populate the error message using the HTTP response status text. Usually that's just the value from the
             // HTTP spec (e.g. "Forbidden"), but sometimes S3 throws some more useful things in there, like "Slow Down".
             String errorMessage = errorDetails.sdkHttpResponse().statusText().orElse(null);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
@@ -75,6 +75,14 @@ public final class ExceptionTranslationInterceptor implements ExecutionIntercept
                                             .message(message)
                                             .build();
             }
+        } else if (exception.statusCode() == 503 && "Slow Down".equals(errorDetails.sdkHttpResponse().statusText().orElse(null))) {
+            return S3Exception.builder()
+                              .awsErrorDetails(fillErrorDetails(errorDetails, "SlowDown", "Please reduce your request rate."))
+                              .statusCode(503)
+                              .requestId(requestId)
+                              .extendedRequestId(extendedRequestId)
+                              .message(message)
+                              .build();
         } else if (errorDetails.errorMessage() == null) {
             // Populate the error message using the HTTP response status text. Usually that's just the value from the
             // HTTP spec (e.g. "Forbidden"), but sometimes S3 throws some more useful things in there, like "Slow Down".

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/HeadOperationsThrottlingTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/HeadOperationsThrottlingTest.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -54,9 +55,9 @@ public class HeadOperationsThrottlingTest {
 
         assertThatThrownBy(() -> client.headObject(r -> r.bucket("bucket").key("key")))
             .isInstanceOfSatisfying(S3Exception.class, e -> {
-                assert e.statusCode() == 503;
-                assert e.isThrottlingException();
-                assert "SlowDown".equals(e.awsErrorDetails().errorCode());
+                assertThat(e.statusCode()).isEqualTo(503);
+                assertThat(e.isThrottlingException()).isTrue();
+                assertThat(e.awsErrorDetails().errorCode()).isEqualTo("SlowDown");
             });
     }
 
@@ -66,9 +67,9 @@ public class HeadOperationsThrottlingTest {
 
         assertThatThrownBy(() -> client.headBucket(r -> r.bucket("bucket")))
             .isInstanceOfSatisfying(S3Exception.class, e -> {
-                assert e.statusCode() == 503;
-                assert e.isThrottlingException();
-                assert "SlowDown".equals(e.awsErrorDetails().errorCode());
+                assertThat(e.statusCode()).isEqualTo(503);
+                assertThat(e.isThrottlingException()).isTrue();
+                assertThat(e.awsErrorDetails().errorCode()).isEqualTo("SlowDown");
             });
     }
 
@@ -78,9 +79,9 @@ public class HeadOperationsThrottlingTest {
 
         assertThatThrownBy(() -> client.headObject(r -> r.bucket("bucket").key("key")))
             .isInstanceOfSatisfying(S3Exception.class, e -> {
-                assert e.statusCode() == 503;
-                assert !e.isThrottlingException();
-                assert e.awsErrorDetails().errorCode() == null;
+                assertThat(e.statusCode()).isEqualTo(503);
+                assertThat(e.isThrottlingException()).isFalse();
+                assertThat(e.awsErrorDetails().errorCode()).isNull();
             });
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/HeadOperationsThrottlingTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/HeadOperationsThrottlingTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.functionaltests;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class HeadOperationsThrottlingTest {
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(0);
+
+    private S3Client client;
+
+    @Before
+    public void setup() {
+        client = S3Client.builder()
+                         .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
+                         .credentialsProvider(() -> AwsBasicCredentials.create("test", "test"))
+                         .forcePathStyle(true)
+                         .region(Region.US_EAST_1)
+                         .build();
+    }
+
+    @Test
+    public void headObject503SlowDown_shouldBeThrottlingException() {
+        stubFor(head(anyUrl()).willReturn(aResponse().withStatus(503).withStatusMessage("Slow Down")));
+
+        assertThatThrownBy(() -> client.headObject(r -> r.bucket("bucket").key("key")))
+            .isInstanceOfSatisfying(S3Exception.class, e -> {
+                assert e.statusCode() == 503;
+                assert e.isThrottlingException();
+                assert "SlowDown".equals(e.awsErrorDetails().errorCode());
+            });
+    }
+
+    @Test
+    public void headBucket503SlowDown_shouldBeThrottlingException() {
+        stubFor(head(anyUrl()).willReturn(aResponse().withStatus(503).withStatusMessage("Slow Down")));
+
+        assertThatThrownBy(() -> client.headBucket(r -> r.bucket("bucket")))
+            .isInstanceOfSatisfying(S3Exception.class, e -> {
+                assert e.statusCode() == 503;
+                assert e.isThrottlingException();
+                assert "SlowDown".equals(e.awsErrorDetails().errorCode());
+            });
+    }
+
+    @Test
+    public void headObject503OtherException_shouldNotBeThrottlingException() {
+        stubFor(head(anyUrl()).willReturn(aResponse().withStatus(503).withStatusMessage("Service Unavailable")));
+
+        assertThatThrownBy(() -> client.headObject(r -> r.bucket("bucket").key("key")))
+            .isInstanceOfSatisfying(S3Exception.class, e -> {
+                assert e.statusCode() == 503;
+                assert !e.isThrottlingException();
+                assert e.awsErrorDetails().errorCode() == null;
+            });
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptorTest.java
@@ -98,6 +98,46 @@ public class ExceptionTranslationInterceptorTest {
         assertThat(interceptor.modifyException(failedExecution, new ExecutionAttributes())).isEqualTo(s3Exception);
     }
 
+    @Test
+    public void headObject503SlowDown_shouldBeThrottlingException() {
+        S3Exception s3Exception = create503ThrottlingException();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     HeadObjectRequest.builder().build());
+        S3Exception modifiedException = (S3Exception) interceptor.modifyException(failedExecution, new ExecutionAttributes());
+        assertThat(modifiedException.awsErrorDetails().errorCode()).isEqualTo("SlowDown");
+        assertThat(modifiedException.isThrottlingException()).isTrue();
+    }
+
+    @Test
+    public void headBucket503SlowDown_shouldBeThrottlingException() {
+        S3Exception s3Exception = create503ThrottlingException();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     HeadBucketRequest.builder().build());
+        S3Exception modifiedException = (S3Exception) interceptor.modifyException(failedExecution, new ExecutionAttributes());
+        assertThat(modifiedException.awsErrorDetails().errorCode()).isEqualTo("SlowDown");
+        assertThat(modifiedException.isThrottlingException()).isTrue();
+    }
+
+    @Test
+    public void headBucket503ServiceUnavailable_shouldNotBeThrottlingException() {
+        S3Exception s3Exception = create503NonThrottlingException();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     HeadBucketRequest.builder().build());
+        S3Exception modifiedException = (S3Exception) interceptor.modifyException(failedExecution, new ExecutionAttributes());
+        assertThat(modifiedException.awsErrorDetails().errorCode()).isNull();
+        assertThat(modifiedException.isThrottlingException()).isFalse();
+    }
+
+    @Test
+    public void headObject503ServiceUnavailable_shouldNotBeThrottlingException() {
+        S3Exception s3Exception = create503NonThrottlingException();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     HeadObjectRequest.builder().build());
+        S3Exception modifiedException = (S3Exception) interceptor.modifyException(failedExecution, new ExecutionAttributes());
+        assertThat(modifiedException.awsErrorDetails().errorCode()).isNull();
+        assertThat(modifiedException.isThrottlingException()).isFalse();
+    }
+
     private S3Exception create404S3Exception() {
         return (S3Exception) S3Exception.builder()
                                         .awsErrorDetails(AwsErrorDetails.builder()
@@ -116,6 +156,29 @@ public class ExceptionTranslationInterceptorTest {
                                                                                                             .build())
                                                                         .build())
                                         .statusCode(403)
+                                        .build();
+    }
+
+    private S3Exception create503ThrottlingException() {
+        return (S3Exception) S3Exception.builder()
+                                        .awsErrorDetails(AwsErrorDetails.builder()
+                                                                        .sdkHttpResponse(SdkHttpFullResponse.builder()
+                                                                                                            .statusText(
+                                                                                                                "Slow Down")
+                                                                                                            .build())
+                                                                        .build())
+                                        .statusCode(503)
+                                        .build();
+    }
+
+    private S3Exception create503NonThrottlingException() {
+        return (S3Exception) S3Exception.builder()
+                                        .awsErrorDetails(AwsErrorDetails.builder()
+                                                                        .sdkHttpResponse(SdkHttpFullResponse.builder()
+                                                                                            .statusText("Service Unavailable")
+                                                                                            .build())
+                                                                        .build())
+                                        .statusCode(503)
                                         .build();
     }
 }


### PR DESCRIPTION
Addresses #5414 

S3's RestXML protocol sends the response's error information in the response body. Since S3 head* operations do not have a body, we need to infer what kind of exception it is from the error message. In case of throttling, S3 will send:

```
HTTP/1.1 503 Slow Down
```
We need to grab the status code (503) and status text ("Slow Down") and use those two to infer that the server throttled the request.

We already have an execution interceptor for S3 that extracts info from head operation responses. All this PR does is adds one more logic branch that handles extracting the error info from the slow down responses, and create the appropriate S3Exception that will get classified as ThrottlingException and will apply the appropriate retry mechanism