### PR TITLE
fix: catch UncheckedIOException in RetryableStage to enable retry (#6578)

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -56,7 +57,7 @@ public final class RetryableStage<OutputT> implements RequestToResponsePipeline<
                 Response<OutputT> response = executeRequest(retryableStageHelper, context);
                 retryableStageHelper.recordAttemptSucceeded();
                 return response;
-            } catch (SdkExceptionWithRetryAfterHint | SdkException | IOException e) {
+            } catch (SdkExceptionWithRetryAfterHint | SdkException | IOException | UncheckedIOException e) {
                 Throwable throwable = e;
                 if (e instanceof SdkExceptionWithRetryAfterHint) {
                     SdkExceptionWithRetryAfterHint wrapper = (SdkExceptionWithRetryAfterHint) e;


### PR DESCRIPTION
## Description

`RetryableStage` catches `SdkException | IOException` but **not** `UncheckedIOException`. Since `UncheckedIOException` extends `RuntimeException` (not `IOException`), it bypasses the catch block and is never evaluated against user-supplied retry predicates. This means `retryOnException(UncheckedIOException.class)` has no effect.

## Root Cause

```java
// Before fix — UncheckedIOException escapes the catch and is never retried
} catch (SdkExceptionWithRetryAfterHint | SdkException | IOException e) {
```

## Fix

```java
} catch (SdkExceptionWithRetryAfterHint | SdkException | IOException | UncheckedIOException e) {
```

Adding `UncheckedIOException` to the multi-catch means it is forwarded to `RetryableStageHelper.tryRefreshToken`, which evaluates user-supplied retry predicates correctly. No other behavior changes — `UncheckedIOException` will only be retried when the user explicitly registers a predicate that matches it (e.g. `retryOnException(UncheckedIOException.class)`).

Fixes #6578