### PR TITLE
Fix SimplePublisher allowing re-subscription after cancellation

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-df5e702.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-df5e702.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue where using a getObject ResponsePublisher as a putObject request body with the CRT HTTP client could cause the SDK to hang on retry when the server returns a retryable error."
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/PutObjectRequestBodyFromSimplePublisherRetryTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/PutObjectRequestBodyFromSimplePublisherRetryTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.functionaltests;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.utils.async.SimplePublisher;
+
+/**
+ * Tests that when a {@link SimplePublisher} is used as the putObject request body
+ * and putObject fails with a retryable error, the SDK retry completes promptly instead of hanging.
+ */
+@WireMockTest
+public class PutObjectRequestBodyFromSimplePublisherRetryTest {
+
+    private static final String BUCKET = "test-bucket";
+    private static final String WRITE_KEY = "dest-object";
+    private static final byte[] BODY = "hello world test data".getBytes(StandardCharsets.UTF_8);
+
+    private S3AsyncClient s3Client;
+
+    @BeforeEach
+    void setup(WireMockRuntimeInfo wiremock) {
+        URI endpoint = URI.create("http://localhost:" + wiremock.getHttpPort());
+
+        s3Client = S3AsyncClient.builder()
+                                .region(Region.US_EAST_1)
+                                .endpointOverride(endpoint)
+                                .credentialsProvider(StaticCredentialsProvider.create(
+                                    AwsBasicCredentials.create("key", "secret")))
+                                .forcePathStyle(true)
+                                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        s3Client.close();
+    }
+
+    @Test
+    void putObjectRetry_withSimplePublisherAsRequestBody_shouldFailFast() {
+        stubFor(put(urlPathEqualTo("/" + BUCKET + "/" + WRITE_KEY))
+                    .willReturn(aResponse()
+                                    .withStatus(500)
+                                    .withBody("<Error><Code>InternalError</Code>"
+                                              + "<Message>Internal Server Error</Message></Error>")));
+
+        // Simulate a ResponsePublisher backed by SimplePublisher (e.g., from getObject)
+        SimplePublisher<ByteBuffer> sourcePublisher = new SimplePublisher<>();
+        sourcePublisher.send(ByteBuffer.wrap(BODY));
+        sourcePublisher.complete();
+
+        AsyncRequestBody requestBody = new AsyncRequestBody() {
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                sourcePublisher.subscribe(subscriber);
+            }
+
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of((long) BODY.length);
+            }
+        };
+
+        CompletableFuture<?> putFuture =
+            s3Client.putObject(r -> r.bucket(BUCKET).key(WRITE_KEY), requestBody);
+
+        // Should fail fast, not hang for 30+ seconds.
+        assertThatThrownBy(() -> putFuture.get(5, TimeUnit.SECONDS))
+            .isNotInstanceOf(TimeoutException.class)
+            .hasCauseInstanceOf(SdkClientException.class);
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/AddingTrailingDataSubscriber.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/AddingTrailingDataSubscriber.java
@@ -72,6 +72,7 @@ public class AddingTrailingDataSubscriber<T> extends DelegatingSubscriber<T, T> 
         if (upstreamSubscription != null) {
             log.warn(() -> "Received duplicate subscription, cancelling the duplicate.", new IllegalStateException());
             subscription.cancel();
+            onError(new IllegalStateException("Received duplicate subscription."));
             return;
         }
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
@@ -199,7 +199,9 @@ public final class SimplePublisher<T> implements Publisher<T> {
         if (subscriber != null) {
             s.onSubscribe(new NoOpSubscription());
             s.onError(new IllegalStateException("Only one subscription may be active at a time."));
+            return;
         }
+
         this.subscriber = s;
         s.onSubscribe(new SubscriptionImpl());
         processEventQueue();
@@ -284,8 +286,6 @@ public final class SimplePublisher<T> implements Publisher<T> {
                         break;
                     case CANCEL:
                         failureMessage.trySet(() -> new CancellationException("subscription has been cancelled."));
-
-                        subscriber = null; // Allow subscriber to be garbage collected after cancellation.
                         break;
                     default:
                         // Should never happen. Famous last words?

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/AddingTrailingDataSubscriberTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/AddingTrailingDataSubscriberTest.java
@@ -17,14 +17,14 @@ package software.amazon.awssdk.utils.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 public class AddingTrailingDataSubscriberTest {
 
@@ -95,5 +95,55 @@ public class AddingTrailingDataSubscriberTest {
             simplePublisher.send(i);
         }
         simplePublisher.complete();
+    }
+
+    @Test
+    void duplicateOnSubscribe_shouldPropagateErrorToDownstream() {
+        AtomicReference<Throwable> downstreamError = new AtomicReference<>();
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        Subscriber<Integer> downstream = new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(Integer item) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                downstreamError.set(t);
+                future.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                future.complete(null);
+            }
+        };
+
+        AddingTrailingDataSubscriber<Integer> subscriber =
+            new AddingTrailingDataSubscriber<>(downstream, ArrayList::new);
+
+        // First subscription
+        Subscription firstSub = new Subscription() {
+            @Override
+            public void request(long n) {
+            }
+
+            @Override
+            public void cancel() {
+            }
+        };
+        subscriber.onSubscribe(firstSub);
+
+        // Duplicate subscription should propagate error to downstream
+        subscriber.onSubscribe(firstSub);
+
+        assertThat(downstreamError.get())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Received duplicate subscription");
     }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/SimplePublisherTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/SimplePublisherTest.java
@@ -563,4 +563,44 @@ public class SimplePublisherTest {
         }
     }
 
+    @Test
+    public void subscribeAfterCancel_rejectsWithError() {
+        SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        ControllableSubscriber<Integer> subscriber = new ControllableSubscriber<>();
+        publisher.subscribe(subscriber);
+
+        subscriber.subscription.cancel();
+
+        // Second subscriber after cancel should get onError immediately
+        StoringSubscriber<Integer> secondSubscriber = new StoringSubscriber<>(1);
+        publisher.subscribe(secondSubscriber);
+
+        assertThat(secondSubscriber.peek().get().type()).isEqualTo(EventType.ON_ERROR);
+        assertThat(secondSubscriber.peek().get().runtimeError())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Only one subscription may be active");
+    }
+
+    @Test
+    public void subscribeAfterCancelAndDataConsumed_rejectsWithError() {
+        SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        StoringSubscriber<Integer> subscriber = new StoringSubscriber<>(Integer.MAX_VALUE);
+        publisher.subscribe(subscriber);
+
+        publisher.send(1);
+        publisher.send(2);
+        publisher.complete();
+
+        while (subscriber.poll().isPresent()) {
+            // drain
+        }
+
+        // Now re-subscribe — should be rejected immediately
+        StoringSubscriber<Integer> secondSubscriber = new StoringSubscriber<>(1);
+        publisher.subscribe(secondSubscriber);
+
+        assertThat(secondSubscriber.peek().get().type()).isEqualTo(EventType.ON_ERROR);
+        assertThat(secondSubscriber.peek().get().runtimeError())
+            .isInstanceOf(IllegalStateException.class);
+    }
 }


### PR DESCRIPTION
## Motivation and Context

When a `getObject` `ResponsePublisher` is used as a `putObject` request body and the server returns a retryable error (e.g., 500), the SDK retries and re-subscribes to the same publisher chain. The `SimplePublisher` backing the `ResponsePublisher` (used by CRT HTTP client) had two bugs that caused the retry to hang:

1. `subscribe()` was missing a `return` after rejecting a duplicate subscriber, causing it to fall through and replace the subscriber reference.
2. On cancellation (triggered by [`ContentLengthAwareSubscriber.java#L60`](https://github.com/aws/aws-sdk-java-v2/blob/master/utils/src/main/java/software/amazon/awssdk/utils/async/ContentLengthAwareSubscriber.java#L60) after all bytes are consumed), `subscriber` was set to `null`, which allowed a new subscriber to be accepted into an exhausted stream with no data or terminal signal. 

## Modifications

- **`SimplePublisher.subscribe()`**: Added missing `return` after the duplicate subscriber error branch.
- **`SimplePublisher` cancel handling**: Removed `subscriber = null` on cancellation. The subscriber reference is kept so that re-subscription is properly rejected by the existing `subscriber != null` guard.
- **`AddingTrailingDataSubscriber.onSubscribe()`**: Propagate `onError` to downstream on duplicate subscription instead of silently swallowing it (defensive fix).

## Testing

- `SimplePublisherTest`: Added `subscribeAfterCancel_rejectsWithError` and `subscribeAfterCancelAndDataConsumed_rejectsWithError`
- `AddingTrailingDataSubscriberTest`: Added `duplicateOnSubscribe_shouldPropagateErrorToDownstream`
- `PutObjectRequestBodyFromSimplePublisherRetryTest`: End-to-end test using WireMock — verifies putObject retry with a `SimplePublisher`-backed request body completes promptly instead of hanging

- [x] Added unit tests
- [x] Ran existing tests
- [x] All new and existing tests passed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn clean install -pl :utils` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
