### PR TITLE
Add Slack notification for potential regression issues

### DIFF
--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -31,3 +31,16 @@ jobs:
         else
           gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
         fi
+    - name: Notify Slack
+      if: steps.check_regression.outputs.is_regression == 'true' && github.event.action == 'opened'
+      run: |
+        curl -sfS -X POST "$SLACK_WEBHOOK_URL" \
+          -H 'Content-type: application/json' \
+          --data "$(jq -n \
+            --arg text "🚨 Potential regression reported: <$ISSUE_URL|#$ISSUE_NUM: $ISSUE_TITLE>" \
+            '{text: $text}')"
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
+        ISSUE_URL: ${{ github.event.issue.html_url }}
+        ISSUE_NUM: ${{ github.event.issue.number }}
+        ISSUE_TITLE: ${{ github.event.issue.title }}


### PR DESCRIPTION
## Motivation and Context
Add a Slack notification when a potential regression issue is filed on the repo. This gives the team immediate visibility into regression reports without having to manually monitor GitHub issues.

## Modifications
Added a `Notify Slack` step to the existing `issue-regression-labeler` workflow to notify the team channel when a potential regression issue is opened.

- Only triggers on `opened` events (not edits) to avoid duplicate notifications
- Uses `CI_SLACK_WEBHOOK_URL` repo secret (already configured)

## Testing
Validated end-to-end in a private test repo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
