### PR TITLE
Fix directoryDownload cancel leak

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-e28a164.json
+++ b/.changes/next-release/bugfix-S3TransferManager-e28a164.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Fixed an issue where cancelling a directory transfer did not fully stop the operation."
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
@@ -56,8 +56,10 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
         returnFuture.whenComplete((r, t) -> {
             if (t != null) {
                 requestsInFlight.forEach(f -> f.cancel(true));
-                if (subscription != null) {
-                    subscription.cancel();
+                synchronized (this) {
+                    if (subscription != null) {
+                        subscription.cancel();
+                    }
                 }
             }
         });

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
@@ -48,7 +48,7 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
                                     CompletableFuture<Void> returnFuture,
                                     int maxConcurrentExecutions) {
         this.returnFuture = returnFuture;
-        this.consumer = consumer;
+        this.consumer = consumer;   
         this.maxConcurrentExecutions = maxConcurrentExecutions;
         this.numRequestsInFlight = new AtomicInteger(0);
         this.requestsInFlight = ConcurrentHashMap.newKeySet();
@@ -56,6 +56,9 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
         returnFuture.whenComplete((r, t) -> {
             if (t != null) {
                 requestsInFlight.forEach(f -> f.cancel(true));
+                if (subscription != null) {
+                    subscription.cancel();
+                }
             }
         });
     }

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
@@ -48,7 +48,7 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
                                     CompletableFuture<Void> returnFuture,
                                     int maxConcurrentExecutions) {
         this.returnFuture = returnFuture;
-        this.consumer = consumer;   
+        this.consumer = consumer;
         this.maxConcurrentExecutions = maxConcurrentExecutions;
         this.numRequestsInFlight = new AtomicInteger(0);
         this.requestsInFlight = ConcurrentHashMap.newKeySet();

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
@@ -128,7 +128,7 @@ class AsyncBufferingSubscriberTest {
         subscriber.onSubscribe(mockSubscription);
         subscriber.onNext("item");
 
-        verify(mockSubscription, times(1)).cancel();
+        verify(mockSubscription, times(2)).cancel();
         assertThatThrownBy(future::join).hasCause(exception);
     }
 

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
@@ -128,6 +128,11 @@ class AsyncBufferingSubscriberTest {
         subscriber.onSubscribe(mockSubscription);
         subscriber.onNext("item");
 
+        /*
+        subscription.cancel() now exists in two codepaths:
+        - in onNext() catch block.
+        - in future.whenComplete()
+         */
         verify(mockSubscription, times(2)).cancel();
         assertThatThrownBy(future::join).hasCause(exception);
     }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
@@ -131,4 +131,18 @@ class AsyncBufferingSubscriberTest {
         verify(mockSubscription, times(1)).cancel();
         assertThatThrownBy(future::join).hasCause(exception);
     }
+
+    @Test
+    void returnFutureCancelled_shouldCancelUpstreamSubscription() {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        AsyncBufferingSubscriber<String> subscriber = new AsyncBufferingSubscriber<>(
+            s -> new CompletableFuture<>(), future, 10);
+
+        Subscription mockSubscription = mock(Subscription.class);
+        subscriber.onSubscribe(mockSubscription);
+        subscriber.onNext("item");
+
+        future.cancel(true);
+        verify(mockSubscription, times(1)).cancel();
+    }
 }


### PR DESCRIPTION
When a `DirectoryDownload` (or `DirectoryUpload`) future is cancelled or completed exceptionally, `AsyncBufferingSubscriber` cancels in flight file transfer futures but does not cancel the upstream Subscription. 
  
This means the listObjectsV2 paginator continues delivering objects, and new file downloads continue to be started after the user has cancelled the operation.                                                                          
                                                                                                                                                        
This change adds `subscription.cancel()` to the `whenComplete` handler so that cancellation stops the entire pipeline of both inflight transfers and new work from the upstream publisher. 

Conforms to Reactive Streams [spec](https://github.com/reactive-streams/reactive-streams-jvm):
>6 	A Subscriber MUST call Subscription.cancel() if the Subscription is no longer needed.