### PR TITLE
Simplify generated error unmarshalling code in json protocol based clients

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-5e43973.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-5e43973.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "apache-hb",
+    "description": "Simplify generated error unmarshalling code in json protocol based clients."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -172,6 +172,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
                                                           model));
         protocolSpec.createErrorResponseHandler().ifPresent(type::addMethod);
         protocolSpec.createEventstreamErrorResponseHandler().ifPresent(type::addMethod);
+        protocolSpec.errorResponseHandlerProvider(model).ifPresent(type::addMethod);
     }
 
     @Override
@@ -331,10 +332,10 @@ public final class AsyncClientClass extends AsyncClientInterface {
                              CoreMetric.class, "SERVICE_ID", model.getMetadata().getServiceId());
         builder.addStatement("apiCallMetricCollector.reportMetric($T.$L, $S)",
                              CoreMetric.class, "OPERATION_NAME", opModel.getOperationName());
-        
+
         if (opModel.hasStreamingOutput()) {
             ClassName responseType = poetExtensions.getModelClass(opModel.getReturnType().getReturnType());
-            
+
             builder.addStatement("$T<$T<$T, ReturnT>, $T<$T>> $N = $T.wrapWithEndOfStreamFuture($N)",
                                  Pair.class,
                                  AsyncResponseTransformer.class,
@@ -344,11 +345,11 @@ public final class AsyncClientClass extends AsyncClientInterface {
                                  "pair",
                                  AsyncResponseTransformerUtils.class,
                                  "asyncResponseTransformer");
-            
+
             builder.addStatement("$N = $N.left()",
                                  "asyncResponseTransformer",
                                  "pair");
-            
+
             builder.addStatement("$T<$T> $N = $N.right()",
                                  CompletableFuture.class,
                                  Void.class,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -140,6 +140,8 @@ public class SyncClientClass extends SyncClientInterface {
         type.addMethod(updateSdkClientConfigurationMethod(configurationUtils.serviceClientConfigurationBuilderClassName(),
                                                           model));
         type.addMethod(protocolSpec.initProtocolFactory(model));
+
+        protocolSpec.errorResponseHandlerProvider(model).ifPresent(type::addMethod);
     }
 
     private FieldSpec logger() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.codegen.poet.client.specs;
 
 import static software.amazon.awssdk.codegen.model.intermediate.Protocol.AWS_JSON;
+import static javax.lang.model.element.Modifier.PRIVATE;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -167,12 +168,18 @@ public class JsonProtocolSpec implements ProtocolSpec {
         String protocolFactory = protocolFactoryLiteral(model, opModel);
 
         CodeBlock.Builder builder = CodeBlock.builder();
-        ParameterizedTypeName metadataMapperType = ParameterizedTypeName.get(
-            ClassName.get(Function.class),
-            ClassName.get(String.class),
-            ParameterizedTypeName.get(Optional.class, ExceptionMetadata.class));
 
-        builder.add("\n$T exceptionMetadataMapper = errorCode -> {\n", metadataMapperType);
+        builder.add("$T<$T> errorResponseHandler = createErrorResponseHandler($L, operationMetadata, this::exceptionMetadataMapper);",
+                    HttpResponseHandler.class, AwsServiceException.class, protocolFactory);
+
+        return Optional.of(builder.build());
+    }
+
+    @Override
+    public Optional<MethodSpec> errorResponseHandlerProvider(IntermediateModel model) {
+
+        CodeBlock.Builder builder = CodeBlock.builder();
+
         builder.add("if (errorCode == null) {\n");
         builder.add("return $T.empty();\n", Optional.class);
         builder.add("}\n");
@@ -194,12 +201,13 @@ public class JsonProtocolSpec implements ProtocolSpec {
 
         builder.add("default: return $T.empty();\n", Optional.class);
         builder.add("}\n");
-        builder.add("};\n");
 
-        builder.add("$T<$T> errorResponseHandler = createErrorResponseHandler($L, operationMetadata, exceptionMetadataMapper);",
-                    HttpResponseHandler.class, AwsServiceException.class, protocolFactory);
-
-        return Optional.of(builder.build());
+        MethodSpec.Builder method = MethodSpec.methodBuilder("exceptionMetadataMapper")
+                                    .addModifiers(PRIVATE)
+                                    .addParameter(String.class, "errorCode")
+                                    .addCode(builder.build())
+                                    .returns(ParameterizedTypeName.get(Optional.class, ExceptionMetadata.class));
+        return Optional.of(method.build());
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
@@ -51,6 +51,10 @@ public interface ProtocolSpec {
 
     Optional<CodeBlock> errorResponseHandler(OperationModel opModel);
 
+    default Optional<MethodSpec> errorResponseHandlerProvider(IntermediateModel model) {
+        return Optional.empty();
+    }
+
     CodeBlock executionHandler(OperationModel opModel);
 
     /**


### PR DESCRIPTION
## Motivation and Context
This reduces the size of the generated client jars by about ~1%, as an example the acm client jar is 0.8% smaller but this scales with the number of operations a service has.

```
elliothb@ELLIOT-SERVER:~/github/aws-sdk-java-v2-elliothb$ ls -lh acm-before.jar acm-after.jar 
-rw-r--r-- 1 elliothb elliothb 844K Apr  9 12:22 acm-after.jar
-rw-r--r-- 1 elliothb elliothb 850K Apr  9 12:21 acm-before.jar
```

## Modifications
This reduces the amount of code generated for error unmarhsalling in json protocol clients by moving the error response handlers body into a helper method instead of generating a copy in each operation handler.

## Testing
* I did a full rebuild and ran unit tests.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
