### PR TITLE
Support backoff for long-polling

### DIFF
--- a/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/RefreshRetryTokenRequest.java
+++ b/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/RefreshRetryTokenRequest.java
@@ -49,6 +49,7 @@ public interface RefreshRetryTokenRequest extends ToCopyableBuilder<RefreshRetry
     default boolean isLongPolling() {
         return false;
     }
+
     /**
      * The cause of the last attempt failure.
      */

--- a/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/RefreshRetryTokenRequest.java
+++ b/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/RefreshRetryTokenRequest.java
@@ -44,6 +44,12 @@ public interface RefreshRetryTokenRequest extends ToCopyableBuilder<RefreshRetry
     Optional<Duration> suggestedDelay();
 
     /**
+     * Whether the operation that is being retried is a long polling operation. Returns {@code false} by default.
+     */
+    default boolean isLongPolling() {
+        return false;
+    }
+    /**
      * The cause of the last attempt failure.
      */
     Throwable failure();
@@ -65,6 +71,13 @@ public interface RefreshRetryTokenRequest extends ToCopyableBuilder<RefreshRetry
          * Configures the suggested delay to used when refreshing the token.
          */
         Builder suggestedDelay(Duration duration);
+
+        /**
+         * Configures whether this refresh request is for a long polling operation. The default implementation is a no-op.
+         */
+        default Builder isLongPolling(boolean isLongPolling) {
+            return this;
+        }
 
         /**
          * Configures the latest caught exception.

--- a/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/TokenAcquisitionFailedException.java
+++ b/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/TokenAcquisitionFailedException.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.retries.api;
 
+import java.time.Duration;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
@@ -23,6 +25,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 @SdkPublicApi
 public final class TokenAcquisitionFailedException extends RuntimeException {
     private final transient RetryToken token;
+    private final transient Duration delay;
 
     /**
      * Exception construction accepting message with no root cause.
@@ -30,6 +33,7 @@ public final class TokenAcquisitionFailedException extends RuntimeException {
     public TokenAcquisitionFailedException(String msg) {
         super(msg);
         token = null;
+        delay = null;
     }
 
     /**
@@ -38,6 +42,7 @@ public final class TokenAcquisitionFailedException extends RuntimeException {
     public TokenAcquisitionFailedException(String msg, Throwable cause) {
         super(msg, cause);
         token = null;
+        delay = null;
     }
 
     /**
@@ -46,6 +51,23 @@ public final class TokenAcquisitionFailedException extends RuntimeException {
     public TokenAcquisitionFailedException(String msg, RetryToken token, Throwable cause) {
         super(msg, cause);
         this.token = token;
+        this.delay = null;
+    }
+
+    /**
+     * Exception constructor accepting message, retry token, a root cause, and delay.
+     */
+    public TokenAcquisitionFailedException(String msg, RetryToken token, Throwable cause, Duration delay) {
+        super(msg, cause);
+        this.token = token;
+        this.delay = delay;
+    }
+
+    /**
+     * The amount of time to wait before returning to the caller.
+     */
+    public Optional<Duration> delay() {
+        return Optional.ofNullable(delay);
     }
 
     /**

--- a/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/internal/RefreshRetryTokenRequestImpl.java
+++ b/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/internal/RefreshRetryTokenRequestImpl.java
@@ -29,12 +29,14 @@ import software.amazon.awssdk.utils.Validate;
 public final class RefreshRetryTokenRequestImpl implements RefreshRetryTokenRequest {
     private final RetryToken token;
     private final Duration suggestedDelay;
+    private final boolean isLongPolling;
     private final Throwable failure;
 
     private RefreshRetryTokenRequestImpl(Builder builder) {
         this.token = Validate.paramNotNull(builder.token, "token");
         this.suggestedDelay = Validate.paramNotNull(builder.suggestedDelay, "suggestedDelay");
         Validate.isNotNegative(this.suggestedDelay, "suggestedDelay");
+        this.isLongPolling = builder.isLongPolling;
         this.failure = Validate.paramNotNull(builder.failure, "failure");
     }
 
@@ -46,6 +48,11 @@ public final class RefreshRetryTokenRequestImpl implements RefreshRetryTokenRequ
     @Override
     public Optional<Duration> suggestedDelay() {
         return Optional.of(suggestedDelay);
+    }
+
+    @Override
+    public boolean isLongPolling() {
+        return isLongPolling;
     }
 
     @Override
@@ -68,11 +75,13 @@ public final class RefreshRetryTokenRequestImpl implements RefreshRetryTokenRequ
     public static final class Builder implements RefreshRetryTokenRequest.Builder {
         private RetryToken token;
         private Duration suggestedDelay = Duration.ZERO;
+        private boolean isLongPolling;
         private Throwable failure;
 
         Builder(RefreshRetryTokenRequestImpl refreshRetryTokenRequest) {
             this.token = refreshRetryTokenRequest.token;
             this.suggestedDelay = refreshRetryTokenRequest.suggestedDelay;
+            this.isLongPolling = refreshRetryTokenRequest.isLongPolling;
             this.failure = refreshRetryTokenRequest.failure;
         }
 
@@ -88,6 +97,12 @@ public final class RefreshRetryTokenRequestImpl implements RefreshRetryTokenRequ
         @Override
         public Builder suggestedDelay(Duration duration) {
             this.suggestedDelay = duration;
+            return this;
+        }
+
+        @Override
+        public RefreshRetryTokenRequest.Builder isLongPolling(boolean isLongPolling) {
+            this.isLongPolling = isLongPolling;
             return this;
         }
 

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/StandardRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/StandardRetryStrategy.java
@@ -76,6 +76,7 @@ public interface StandardRetryStrategy extends RetryStrategy {
                                                 : exceptionCost;
         return DefaultStandardRetryStrategy
             .builder()
+            .retries2026Enabled(retries2026Enabled)
             .maxAttempts(DefaultRetryStrategy.Standard.MAX_ATTEMPTS)
             .tokenBucketStore(TokenBucketStore
                                   .builder()

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -166,7 +166,7 @@ public abstract class BaseRetryStrategy implements DefaultAwareRetryStrategy {
 
     /**
      * Computes the backoff before a retry using the configured backoff strategy. Extending classes can override this method to
-     * compute different a different depending on their logic.
+     * compute different a different duration depending on their logic.
      */
     protected Duration computeBackoff(RefreshRetryTokenRequest request, DefaultRetryToken token) {
         Duration backoff;
@@ -177,6 +177,17 @@ public abstract class BaseRetryStrategy implements DefaultAwareRetryStrategy {
         }
         Duration suggested = request.suggestedDelay().orElse(Duration.ZERO);
         return maxOf(suggested, backoff);
+    }
+
+    /**
+     * Computes the backoff before exiting the retry loop using the configured backoff strategy. Extending classes can override
+     * this method to compute different a different duration depending on their logic. The default implementation returns
+     * 0 delay.
+     *
+     * @param request The refresh request that failed to acquire sufficient capacity.
+     */
+    protected Duration computeAcquireFailureBackoff(RefreshRetryTokenRequest request) {
+        return Duration.ZERO;
     }
 
     /**
@@ -299,7 +310,8 @@ public abstract class BaseRetryStrategy implements DefaultAwareRetryStrategy {
                      .build();
             String message = acquisitionFailedMessage(acquireResponse);
             log.debug(() -> message, failure);
-            throw new TokenAcquisitionFailedException(message, refreshedToken, failure);
+            Duration delay = computeAcquireFailureBackoff(request);
+            throw new TokenAcquisitionFailedException(message, refreshedToken, failure, delay);
         }
     }
 

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -158,7 +158,7 @@ public abstract class BaseRetryStrategy implements DefaultAwareRetryStrategy {
 
     /**
      * Computes the backoff before the first attempt, by default {@link Duration#ZERO}. Extending classes can override this method
-     * to compute different a different depending on their logic.
+     * to compute a different duration depending on their logic.
      */
     protected Duration computeInitialBackoff(AcquireInitialTokenRequest request) {
         return Duration.ZERO;
@@ -166,7 +166,7 @@ public abstract class BaseRetryStrategy implements DefaultAwareRetryStrategy {
 
     /**
      * Computes the backoff before a retry using the configured backoff strategy. Extending classes can override this method to
-     * compute different a different duration depending on their logic.
+     * compute a different duration depending on their logic.
      */
     protected Duration computeBackoff(RefreshRetryTokenRequest request, DefaultRetryToken token) {
         Duration backoff;
@@ -181,7 +181,7 @@ public abstract class BaseRetryStrategy implements DefaultAwareRetryStrategy {
 
     /**
      * Computes the backoff before exiting the retry loop using the configured backoff strategy. Extending classes can override
-     * this method to compute different a different duration depending on their logic. The default implementation returns
+     * this method to compute a different duration depending on their logic. The default implementation returns
      * 0 delay.
      *
      * @param request The refresh request that failed to acquire sufficient capacity.

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/DefaultStandardRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/DefaultStandardRetryStrategy.java
@@ -15,10 +15,12 @@
 
 package software.amazon.awssdk.retries.internal;
 
+import java.time.Duration;
 import java.util.function.Predicate;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.retries.StandardRetryStrategy;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenRequest;
 import software.amazon.awssdk.retries.internal.circuitbreaker.TokenBucketStore;
 import software.amazon.awssdk.utils.Logger;
 
@@ -26,9 +28,11 @@ import software.amazon.awssdk.utils.Logger;
 public final class DefaultStandardRetryStrategy
     extends BaseRetryStrategy implements StandardRetryStrategy {
     private static final Logger LOG = Logger.loggerFor(DefaultStandardRetryStrategy.class);
+    private final boolean retries2026Enabled;
 
     DefaultStandardRetryStrategy(Builder builder) {
         super(LOG, builder);
+        this.retries2026Enabled = builder.retries2026Enabled;
     }
 
     @Override
@@ -40,7 +44,20 @@ public final class DefaultStandardRetryStrategy
         return new Builder();
     }
 
+    @Override
+    protected Duration computeAcquireFailureBackoff(RefreshRetryTokenRequest request) {
+        if (!retries2026Enabled || !request.isLongPolling()) {
+            return super.computeAcquireFailureBackoff(request);
+        }
+
+        DefaultRetryToken attemptIncremented = asDefaultRetryToken(request.token()).toBuilder()
+                                                                                   .increaseAttempt()
+                                                                                   .build();
+        return computeBackoff(request, attemptIncremented);
+    }
+
     public static class Builder extends BaseRetryStrategy.Builder implements StandardRetryStrategy.Builder {
+        private boolean retries2026Enabled;
 
         Builder() {
         }
@@ -103,6 +120,14 @@ public final class DefaultStandardRetryStrategy
         @Override
         public Builder useClientDefaults(boolean useClientDefaults) {
             setUseClientDefaults(useClientDefaults);
+            return this;
+        }
+
+        /**
+         * Whether retries 2.1 behavior is enabled.
+         */
+        public Builder retries2026Enabled(boolean retries2026Enabled) {
+            this.retries2026Enabled = retries2026Enabled;
             return this;
         }
 

--- a/core/retries/src/test/java/software/amazon/awssdk/retries/internal/StandardRetryStrategyTest.java
+++ b/core/retries/src/test/java/software/amazon/awssdk/retries/internal/StandardRetryStrategyTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.internal;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.retries.DefaultRetryStrategy;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenRequest;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenResponse;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenRequest;
+import software.amazon.awssdk.retries.api.RetryToken;
+import software.amazon.awssdk.retries.api.TokenAcquisitionFailedException;
+import software.amazon.awssdk.retries.internal.circuitbreaker.TokenBucketStore;
+
+public class StandardRetryStrategyTest {
+    @ParameterizedTest
+    @MethodSource("longPollingScenarios")
+    void refreshRetryToken_v2_1_longPolling_behavesCorrectly(Scenario scenario) {
+        DefaultStandardRetryStrategy.Builder builder =
+            (DefaultStandardRetryStrategy.Builder) DefaultRetryStrategy.standardStrategyBuilder(true);
+
+        StandardRetryStrategy strategy = builder.tokenBucketStore(TokenBucketStore.builder()
+                                                                                  .tokenBucketMaxCapacity(0)
+                                                                                  .build())
+                                                .retryOnException(e -> true)
+                                                .build();
+
+        AcquireInitialTokenResponse initialToken = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("test"));
+
+        RetryToken token = initialToken.token();
+
+        Given given = scenario.given;
+
+        for (Response response : scenario.responses) {
+
+            Expected expected = response.expected;
+
+            switch (expected.outcome) {
+                case RETRY_QUOTA_EXCEEDED: {
+                    ScenarioTestException scenarioTestException = new ScenarioTestException(response.statusCode);
+                    RefreshRetryTokenRequest refreshRequest = RefreshRetryTokenRequest.builder()
+                                                                                      .failure(scenarioTestException)
+                                                                                      .isLongPolling(given.isLongPolling)
+                                                                                      .token(token)
+                                                                                      .build();
+
+
+                    assertThatThrownBy(() -> strategy.refreshRetryToken(refreshRequest))
+                        .isInstanceOf(TokenAcquisitionFailedException.class)
+                        .matches(e -> {
+                            TokenAcquisitionFailedException acquireException = (TokenAcquisitionFailedException) e;
+                            Optional<Duration> delay = acquireException.delay();
+                            return delay.get().compareTo(expected.delay) <= 0;
+                        }, String.format("Token acquire exception has a delay between 0 and %s (jittered)", expected.delay));
+                }
+                break;
+                default:
+                    throw new RuntimeException("unknown outcome");
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("longPollingScenarios")
+    void refreshRetryToken_v2_0_longPolling_behavesCorrectly(Scenario scenario) {
+        DefaultStandardRetryStrategy.Builder builder =
+            (DefaultStandardRetryStrategy.Builder) DefaultRetryStrategy.standardStrategyBuilder(false);
+
+        StandardRetryStrategy strategy = builder.tokenBucketStore(TokenBucketStore.builder()
+                                                                                  .tokenBucketMaxCapacity(0)
+                                                                                  .build())
+                                                .retryOnException(e -> true)
+                                                .build();
+
+        AcquireInitialTokenResponse initialToken = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("test"));
+
+        RetryToken token = initialToken.token();
+
+        Given given = scenario.given;
+
+        for (Response response : scenario.responses) {
+
+            Expected expected = response.expected;
+
+            switch (expected.outcome) {
+                case RETRY_QUOTA_EXCEEDED: {
+                    ScenarioTestException scenarioTestException = new ScenarioTestException(response.statusCode);
+                    RefreshRetryTokenRequest refreshRequest = RefreshRetryTokenRequest.builder()
+                                                                                      .failure(scenarioTestException)
+                                                                                      .isLongPolling(given.isLongPolling)
+                                                                                      .token(token)
+                                                                                      .build();
+
+
+                    assertThatThrownBy(() -> strategy.refreshRetryToken(refreshRequest))
+                        .isInstanceOf(TokenAcquisitionFailedException.class)
+                        .matches(e -> {
+                            TokenAcquisitionFailedException acquireException = (TokenAcquisitionFailedException) e;
+                            Optional<Duration> delay = acquireException.delay();
+                            return delay.get().isZero();
+                        }, "Token acquire exception has no delay");
+                }
+                break;
+                default:
+                    throw new RuntimeException("unknown outcome");
+            }
+        }
+    }
+
+    private static class ScenarioTestException extends RuntimeException {
+        private final int statusCode;
+
+        public ScenarioTestException(int statusCode) {
+            this.statusCode = statusCode;
+        }
+    }
+
+    private static Stream<Scenario> longPollingScenarios() {
+        return Stream.of(
+            aScenario("Long-Polling Backoff When Token Bucket Empty")
+                .given(g -> g.isLongPolling(true))
+                .addResponse(r -> r.statusCode(500)
+                                   .expected(e -> e.retryQuota(0)
+                                                   .delay(Duration.ofMillis(50))
+                                                   .outcome(Outcome.RETRY_QUOTA_EXCEEDED))),
+            aScenario("Not Long-Polling, Does Not Backoff When Token Bucket Empty")
+                .given(g -> g.isLongPolling(false))
+                .addResponse(r -> r.statusCode(500)
+                                   .expected(e -> e.retryQuota(0)
+                                                   .delay(Duration.ZERO)
+                                                   .outcome(Outcome.RETRY_QUOTA_EXCEEDED)))
+        );
+    }
+
+    private static Scenario aScenario(String description) {
+        return new Scenario(description);
+    }
+
+    private static class Given {
+        private int maxAttempts;
+        private boolean isLongPolling;
+        private Duration maxBackoff;
+
+        public Given maxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public Given isLongPolling(boolean isLongPolling) {
+            this.isLongPolling = isLongPolling;
+            return this;
+        }
+
+        public Given maxBackoff(Duration maxBackoff) {
+            this.maxBackoff = maxBackoff;
+            return this;
+        }
+    }
+
+    private static class Response {
+        private int statusCode;
+        private Expected expected;
+
+        public Response statusCode(int statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+
+        public Response expected(Consumer<Expected> acceptor) {
+            this.expected = new Expected();
+            acceptor.accept(this.expected);
+            return this;
+        }
+    }
+
+    private static class Expected {
+        private Outcome outcome;
+        private int retryQuota;
+        private Duration delay;
+
+        public Expected outcome(Outcome outcome) {
+            this.outcome = outcome;
+            return this;
+        }
+
+        public Expected retryQuota(int retryQuota) {
+            this.retryQuota = retryQuota;
+            return this;
+        }
+
+        public Expected delay(Duration delay) {
+            this.delay = delay;
+            return this;
+        }
+    }
+
+    private enum Outcome {
+        RETRY_REQUEST,
+        RETRY_QUOTA_EXCEEDED,
+        MAX_ATTEMPTS_EXCEEDED,
+        SUCCESS
+    }
+
+    private static class Scenario {
+        private String description;
+        private Given given;
+        private List<Response> responses = new ArrayList<>();
+
+        public Scenario(String description) {
+            this.description = description;
+        }
+
+        public Scenario given(Consumer<Given> acceptor) {
+            this.given = new Given();
+            acceptor.accept(this.given);
+            return this;
+        }
+
+        public Scenario addResponse(Consumer<Response> acceptor) {
+            Response response = new Response();
+            acceptor.accept(response);
+            responses.add(response);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+    }
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
For operations that are long-polling, support backoffs in the Standard retry strategy even there is insufficient retry quota.

This aligns the `StandardRetryStrategy` with the new retries 2.1 revision.

## Modifications
 - Add `boolean isLongPolling()` to `RefreshRetryTokenRequest`.
 - Add `Optional<Duration> delay()` to `TokenAcquisitionFailedException`.
 - Add protected `Duration computeAcquireFailureBackoff()` to `BaseRetryStrategy` that is a no-op, but is available to subclasses to implement; implemented by `DefaultStandardRetryStrategy`.

## Testing
 - New unit tests that verify behavior for 2.0 and 2.1 retries.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
