### PR TITLE
Add longPolling exec param and use in retries

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
@@ -103,6 +103,7 @@ public final class AwsExecutionContextBuilder {
             .putAttribute(AwsExecutionAttribute.ENDPOINT_PREFIX, clientConfig.option(AwsClientOption.ENDPOINT_PREFIX))
             .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, clientConfig.option(AwsClientOption.SIGNING_REGION))
             .putAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX, executionParams.isFullDuplex())
+            .putAttribute(SdkInternalExecutionAttribute.IS_LONG_POLLING, executionParams.isLongPolling())
             .putAttribute(SdkInternalExecutionAttribute.HAS_INITIAL_REQUEST_EVENT, executionParams.hasInitialRequestEvent())
             .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, clientConfig.option(SdkClientOption.CLIENT_TYPE))
             .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfig.option(SdkClientOption.SERVICE_NAME))

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilderTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilderTest.java
@@ -557,6 +557,16 @@ public class AwsExecutionContextBuilderTest {
         assertThat(businessMetrics.recordedMetrics()).contains("AL");
     }
 
+    @Test
+    public void invokeInterceptorsAndCreateExecutionContext_withLongPollingOperation_setsCorrectAttributeValue() {
+        SdkClientConfiguration clientConfig = testClientConfiguration().build();
+        ClientExecutionParams<SdkRequest, SdkResponse> executionParams = clientExecutionParams().withLongPolling(true);
+        ExecutionContext executionContext =
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams, clientConfig);
+
+        assertThat(executionContext.executionAttributes().getAttribute(SdkInternalExecutionAttribute.IS_LONG_POLLING)).isTrue();
+    }
+
     private ClientExecutionParams<SdkRequest, SdkResponse> clientExecutionParams() {
         return clientExecutionParams(sdkRequest);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
@@ -55,6 +55,7 @@ public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
     private AsyncResponseTransformer<OutputT, ?> asyncResponseTransformer;
     private boolean fullDuplex;
     private boolean hasInitialRequestEvent;
+    private boolean longPolling;
     private String hostPrefixExpression;
     private String operationName;
     private SdkProtocolMetadata protocolMetadata;
@@ -165,6 +166,19 @@ public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
      */
     public ClientExecutionParams<InputT, OutputT> withFullDuplex(boolean fullDuplex) {
         this.fullDuplex = fullDuplex;
+        return this;
+    }
+
+    /**
+     * Whether this is a long polling operation, i.e. a request where the service can wait extended period of time before
+     * sending a response back to the client.
+     */
+    public boolean isLongPolling() {
+        return longPolling;
+    }
+
+    public ClientExecutionParams<InputT, OutputT> withLongPolling(boolean longPolling) {
+        this.longPolling = longPolling;
         return this;
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -213,6 +213,11 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("ChecksumStore");
 
     /**
+     * Indicates whether this is a long polling operation.
+     */
+    public static final ExecutionAttribute<Boolean> IS_LONG_POLLING = new ExecutionAttribute<>("IsLongPolling");
+
+    /**
      * The backing attribute for RESOLVED_CHECKSUM_SPECS.
      * This holds the real ChecksumSpecs value, and is used to map to the ChecksumAlgorithm signer property
      * in the SELECTED_AUTH_SCHEME execution attribute.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.retry.ClockSkewAdjuster;
@@ -60,6 +61,7 @@ public final class RetryableStageHelper {
         new ExecutionAttribute<>("LastBackoffDuration");
 
     private final SdkHttpFullRequest request;
+    private final boolean isLongPollingOperation;
     private final RequestExecutionContext context;
     private RetryPolicyAdapter retryPolicyAdapter;
     private final RetryStrategy retryStrategy;
@@ -74,6 +76,7 @@ public final class RetryableStageHelper {
                                 HttpClientDependencies dependencies) {
         this.request = request;
         this.context = context;
+        this.isLongPollingOperation = isLongPollingOperation(this.context);
         RetryPolicy retryPolicy = dependencies.clientConfiguration().option(SdkClientOption.RETRY_POLICY);
         RetryStrategy retryStrategy = dependencies.clientConfiguration().option(SdkClientOption.RETRY_STRATEGY);
         if (retryPolicy != null) {
@@ -139,6 +142,7 @@ public final class RetryableStageHelper {
             RefreshRetryTokenRequest refreshRequest = RefreshRetryTokenRequest.builder()
                                                                               .failure(this.lastException)
                                                                               .token(retryToken)
+                                                                              .isLongPolling(isLongPollingOperation)
                                                                               .suggestedDelay(suggestedDelay)
                                                                               .build();
             refreshResponse = retryStrategy().refreshRetryToken(refreshRequest);
@@ -295,5 +299,11 @@ public final class RetryableStageHelper {
                                  .executionAttributes(context.executionAttributes())
                                  .httpStatusCode(lastResponse == null ? null : lastResponse.statusCode())
                                  .build();
+    }
+
+    private boolean isLongPollingOperation(RequestExecutionContext context) {
+        return context.executionAttributes()
+                      .getOptionalAttribute(SdkInternalExecutionAttribute.IS_LONG_POLLING)
+                      .orElse(false);
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelperTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelperTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenResponse;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenRequest;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenResponse;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.retries.api.RetryToken;
+
+public class RetryableStageHelperTest {
+
+    @ParameterizedTest(name = "IS_LONG_POLLING = {0}, expected = {1}")
+    @MethodSource("longPollingValueTestParams")
+    void tryRefreshToken_forwardsLongPollingAttrValue(Boolean attribute, boolean expected) {
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .uri(URI.create("https://my-service.amazonaws.com"))
+                                                           .build();
+
+        ExecutionAttributes.Builder attributes = ExecutionAttributes.builder();
+        if (attribute != null) {
+            attributes.put(SdkInternalExecutionAttribute.IS_LONG_POLLING, attribute);
+        }
+
+        ExecutionContext executionContext = ExecutionContext.builder().executionAttributes(attributes.build()).build();
+
+        RequestExecutionContext requestExecutionContext = RequestExecutionContext.builder()
+                                                                                 .originalRequest(mock(SdkRequest.class))
+                                                                                 .executionContext(executionContext)
+                                                                          .build();
+
+        RetryStrategy retryStrategy = mock(RetryStrategy.class);
+
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                                                                    .option(SdkClientOption.RETRY_STRATEGY, retryStrategy)
+                                                                    .build();
+
+        HttpClientDependencies dependencies = HttpClientDependencies.builder()
+                                                                    .clientConfiguration(clientConfig)
+                                                                    .build();
+
+        RetryableStageHelper helper = new RetryableStageHelper(httpRequest,
+                                                               requestExecutionContext,
+                                                               dependencies);
+
+        AcquireInitialTokenResponse mockAcquireResponse = mock(AcquireInitialTokenResponse.class);
+        RetryToken token = mock(RetryToken.class);
+        when(mockAcquireResponse.token()).thenReturn(token);
+        when(retryStrategy.acquireInitialToken(any())).thenReturn(mockAcquireResponse);
+
+        RefreshRetryTokenResponse mockRefreshResponse = mock(RefreshRetryTokenResponse.class);
+        when(mockRefreshResponse.delay()).thenReturn(Duration.ZERO);
+        ArgumentCaptor<RefreshRetryTokenRequest> refreshRequestCaptor = ArgumentCaptor.forClass(RefreshRetryTokenRequest.class);
+
+        when(retryStrategy.refreshRetryToken(any())).thenReturn(mockRefreshResponse);
+
+        helper.acquireInitialToken();
+
+        helper.setLastException(new RuntimeException());
+        helper.tryRefreshToken(Duration.ZERO);
+
+        verify(retryStrategy).refreshRetryToken(refreshRequestCaptor.capture());
+
+        assertThat(refreshRequestCaptor.getValue().isLongPolling()).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> longPollingValueTestParams() {
+        return Stream.of(
+            // Absent should default to false
+            Arguments.of(null, false),
+            Arguments.of(true, true),
+            Arguments.of(false, false)
+        );
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Retries 2.1 adds backoff even when there is insufficient retry quota if the operation is long polling. This is part of the work to enable that by plumbing context to the retry stage.

## Modifications
This commit
 - Adds an isLongPolling() property to ClientExecutionParams
 - Adds SdkInternalExecutionAttribute.IS_LONG_POLLING that reflects the value from ClientExecutionParams during execution
 - Sets the longPolling() property on teh RefreshRetryTokenRequest when refreshing, based on the value of the IS_LONG_POLLING exec attribute

## Testing
New unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
