### PR TITLE
Set longPoll ops for SQS,SWF,SFN

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
@@ -42,7 +42,8 @@ public final class DefaultCustomizationProcessor {
                 new S3RemoveBucketFromUriProcessor(),
                 new S3ControlRemoveAccountIdHostPrefixProcessor(),
                 new ExplicitStringPayloadQueryProtocolProcessor(),
-                new LowercaseShapeValidatorProcessor()
+                new LowercaseShapeValidatorProcessor(),
+                new LongPollingOperationProcessor()
                 );
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessor.java
@@ -22,9 +22,11 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.codegen.customization.CodegenCustomizationProcessor;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.model.intermediate.Protocol;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 
 // TODO: Remove this when the long polling trait is formalized as a c2j trait.
@@ -48,6 +50,17 @@ public class LongPollingOperationProcessor implements CodegenCustomizationProces
         SERVICE_ID_TO_OPERATIONS_MAP = Collections.unmodifiableMap(serviceIdToOperationsMap);
     }
 
+    private final Map<String, List<String>> serviceIdToOperations;
+
+    public LongPollingOperationProcessor() {
+        this(SERVICE_ID_TO_OPERATIONS_MAP);
+    }
+
+    @SdkTestInternalApi
+    LongPollingOperationProcessor(Map<String, List<String>> serviceIdToOperations) {
+        this.serviceIdToOperations = serviceIdToOperations;
+    }
+
     @Override
     public void preprocess(ServiceModel serviceModel) {
         // no-op
@@ -56,7 +69,16 @@ public class LongPollingOperationProcessor implements CodegenCustomizationProces
     @Override
     public void postprocess(IntermediateModel intermediateModel) {
         String serviceId = intermediateModel.getMetadata().getServiceId();
-        List<String> longPollingOperations = SERVICE_ID_TO_OPERATIONS_MAP.getOrDefault(serviceId, Collections.emptyList());
+
+        if (!serviceIdToOperations.containsKey(serviceId)) {
+            return;
+        }
+
+        if (intermediateModel.getMetadata().getProtocol() != Protocol.AWS_JSON) {
+            throw new IllegalArgumentException("Currently only AWS-JSON services can use the longPoll trait");
+        }
+
+        List<String> longPollingOperations = serviceIdToOperations.getOrDefault(serviceId, Collections.emptyList());
 
         for (String longPollingOperation : longPollingOperations) {
             OperationModel opModel = intermediateModel.getOperation(longPollingOperation);
@@ -64,7 +86,7 @@ public class LongPollingOperationProcessor implements CodegenCustomizationProces
                 log.info("Setting the longPoll trait for {}#{}", serviceId, longPollingOperation);
                 opModel.setLongPolling(true);
             } else {
-                log.warn("Did not find operation {}#{}", serviceId, longPollingOperation);
+               throw new RuntimeException("Operation " + longPollingOperation + " not found for service " + serviceId);
             }
         }
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessor.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.codegen.model.intermediate.Protocol;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 
 // TODO: Remove this when the long polling trait is formalized as a c2j trait.
+
 /**
  * Marks specific service operations as having the long polling trait.
  */
@@ -86,7 +87,7 @@ public class LongPollingOperationProcessor implements CodegenCustomizationProces
                 log.info("Setting the longPoll trait for {}#{}", serviceId, longPollingOperation);
                 opModel.setLongPolling(true);
             } else {
-               throw new RuntimeException("Operation " + longPollingOperation + " not found for service " + serviceId);
+                throw new RuntimeException("Operation " + longPollingOperation + " not found for service " + serviceId);
             }
         }
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.customization.processors;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.codegen.customization.CodegenCustomizationProcessor;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+
+// TODO: Remove this when the long polling trait is formalized as a c2j trait.
+/**
+ * Marks specific service operations as having the long polling trait.
+ */
+public class LongPollingOperationProcessor implements CodegenCustomizationProcessor {
+    private static final Logger log = LoggerFactory.getLogger(LongPollingOperationProcessor.class);
+
+    // Note: static mapping instead of exposed via CustomizationConfig to avoid exposing it for wider use unless necessary.
+    private static final Map<String, List<String>> SERVICE_ID_TO_OPERATIONS_MAP;
+
+    static {
+        Map<String, List<String>> serviceIdToOperationsMap = new HashMap<>();
+
+        serviceIdToOperationsMap.put("SQS", Collections.singletonList("ReceiveMessage"));
+        serviceIdToOperationsMap.put("SFN", Collections.singletonList("GetActivityTask"));
+        serviceIdToOperationsMap.put("SWF", Collections.unmodifiableList(Arrays.asList("PollForActivityTask",
+                                                                                       "PollForDecisionTask")));
+
+        SERVICE_ID_TO_OPERATIONS_MAP = Collections.unmodifiableMap(serviceIdToOperationsMap);
+    }
+
+    @Override
+    public void preprocess(ServiceModel serviceModel) {
+        // no-op
+    }
+
+    @Override
+    public void postprocess(IntermediateModel intermediateModel) {
+        String serviceId = intermediateModel.getMetadata().getServiceId();
+        List<String> longPollingOperations = SERVICE_ID_TO_OPERATIONS_MAP.getOrDefault(serviceId, Collections.emptyList());
+
+        for (String longPollingOperation : longPollingOperations) {
+            OperationModel opModel = intermediateModel.getOperation(longPollingOperation);
+            if (opModel != null) {
+                log.info("Setting the longPoll trait for {}#{}", serviceId, longPollingOperation);
+                opModel.setLongPolling(true);
+            } else {
+                log.warn("Did not find operation {}#{}", serviceId, longPollingOperation);
+            }
+        }
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
@@ -90,6 +90,8 @@ public class OperationModel extends DocumentationModel {
 
     private boolean unsignedPayload;
 
+    private boolean longPolling;
+
     public String getOperationName() {
         return operationName;
     }
@@ -381,6 +383,14 @@ public class OperationModel extends DocumentationModel {
         this.unsignedPayload = unsignedPayload;
     }
 
+    public boolean isLongPolling() {
+        return longPolling;
+    }
+
+    public void setLongPolling(boolean longPolling) {
+        this.longPolling = longPolling;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {
@@ -395,7 +405,8 @@ public class OperationModel extends DocumentationModel {
                && hasStringMemberAsPayload == that.hasStringMemberAsPayload && isAuthenticated == that.isAuthenticated
                && isPaginated == that.isPaginated && endpointOperation == that.endpointOperation
                && endpointCacheRequired == that.endpointCacheRequired && httpChecksumRequired == that.httpChecksumRequired
-               && unsignedPayload == that.unsignedPayload && Objects.equals(operationName, that.operationName)
+               && unsignedPayload == that.unsignedPayload && longPolling == that.longPolling
+               && Objects.equals(operationName, that.operationName)
                && Objects.equals(serviceProtocol, that.serviceProtocol)
                && Objects.equals(deprecatedMessage, that.deprecatedMessage) && Objects.equals(input, that.input)
                && Objects.equals(returnType, that.returnType) && Objects.equals(exceptions, that.exceptions)
@@ -437,6 +448,7 @@ public class OperationModel extends DocumentationModel {
         result = 31 * result + Objects.hashCode(staticContextParams);
         result = 31 * result + Objects.hashCode(operationContextParams);
         result = 31 * result + Boolean.hashCode(unsignedPayload);
+        result = 31 * result + Boolean.hashCode(longPolling);
         return result;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeType;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumRequiredTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumTrait;
+import software.amazon.awssdk.codegen.poet.client.traits.LongPollTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.RequestCompressionTrait;
 import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.codegen.poet.model.EventStreamSpecHelper;
@@ -219,6 +220,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                      .add(hostPrefixExpression(opModel))
                      .add(discoveredEndpoint(opModel))
                      .add(credentialType(opModel, model))
+                     .add(LongPollTrait.executionParamSetter(opModel))
                      .add(".withRequestConfiguration(clientConfiguration)")
                      .add(".withInput($L)\n", opModel.getInput().getVariableName())
                      .add(".withMetricCollector(apiCallMetricCollector)")
@@ -290,6 +292,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                .add(".withMarshaller($L)\n", asyncMarshaller(model, opModel, marshaller, protocolFactory))
                .add(asyncRequestBody(opModel))
                .add(fullDuplex(opModel))
+               .add(LongPollTrait.executionParamSetter(opModel))
                .add(hasInitialRequestEvent(opModel, isRestJson))
                .add(".withResponseHandler($L)\n", responseHandlerName(opModel, isRestJson))
                .add(".withErrorResponseHandler(errorResponseHandler)\n")

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/LongPollTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/LongPollTrait.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.client.traits;
+
+import com.squareup.javapoet.CodeBlock;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+
+/**
+ * Helper methods for working with the long poll trait for operations.
+ */
+public final class LongPollTrait {
+    private LongPollTrait() {
+    }
+    public static CodeBlock executionParamSetter(OperationModel operationModel) {
+        if (operationModel.isLongPolling()) {
+            return CodeBlock.of(".withLongPolling(true)");
+        }
+        return CodeBlock.of("");
+    }
+
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/LongPollTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/LongPollTrait.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 public final class LongPollTrait {
     private LongPollTrait() {
     }
+
     public static CodeBlock executionParamSetter(OperationModel operationModel) {
         if (operationModel.isLongPolling()) {
             return CodeBlock.of(".withLongPolling(true)");

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/customization/processors/LongPollingOperationProcessTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.customization.processors;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.codegen.C2jModels;
+import software.amazon.awssdk.codegen.IntermediateModelBuilder;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.Protocol;
+import software.amazon.awssdk.codegen.model.service.ServiceMetadata;
+import software.amazon.awssdk.codegen.poet.ClientTestModels;
+
+public class LongPollingOperationProcessTest {
+
+    @ParameterizedTest
+    @MethodSource("nonJsonProtocols")
+    void postprocess_serviceInMap_serviceNotJson_throws(Protocol protocol) {
+        C2jModels c2jModels = ClientTestModels.awsJsonServiceC2jModels();
+
+        ServiceMetadata metadata = c2jModels.serviceModel().getMetadata();
+        metadata.setProtocols(Collections.singletonList(protocol.getValue()));
+
+        IntermediateModel intermediateModel = new IntermediateModelBuilder(c2jModels).build();
+
+        Map<String, List<String>> serviceToOperations = new HashMap<>();
+        serviceToOperations.put(metadata.getServiceId(), Collections.emptyList());
+        LongPollingOperationProcessor processor = new LongPollingOperationProcessor(serviceToOperations);
+
+        assertThatThrownBy(() -> processor.postprocess(intermediateModel))
+            .hasMessage("Currently only AWS-JSON services can use the longPoll trait");
+    }
+
+    @Test
+    void postprocess_operationNotFound_throws() {
+        IntermediateModel intermediateModel = ClientTestModels.awsJsonServiceModels();
+
+        Map<String, List<String>> serviceToOperations = new HashMap<>();
+        serviceToOperations.put(intermediateModel.getMetadata().getServiceId(), Collections.singletonList("SomeOperation"));
+        LongPollingOperationProcessor processor = new LongPollingOperationProcessor(serviceToOperations);
+
+        assertThatThrownBy(() -> processor.postprocess(intermediateModel))
+            .hasMessage("Operation SomeOperation not found for service Json Service");
+    }
+
+    private static Stream<Protocol> nonJsonProtocols() {
+        return Stream.of(Protocol.values()).filter(p -> p != Protocol.AWS_JSON);
+    }
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Enable retries 2.1 behavior for long polling operations.

## Modifications
Add a customization to set the long polling trait for the following service operations:

 - SQS#ReceiveMessage
 - SFN#GetActivityTask
 - SWF#PollForActivityTask
 - SWF#PollForDecisionTask

## Testing
Inspect the diffs of SQS,SFN, and SWF generated clients. Also check that there is no diff for another JSON service with no long polling (DDB).

<details>
<summary>SQS diff</summary>

```diff
diff --color -U 5 -r sqs-old/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsAsyncClient.java sqs-new/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsAsyncClient.java
--- sqs-old/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsAsyncClient.java	2026-04-24 15:19:34
+++ sqs-new/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsAsyncClient.java	2026-04-24 15:22:06
@@ -3408,11 +3408,11 @@
                     operationMetadata, exceptionMetadataMapper);

             CompletableFuture<ReceiveMessageResponse> executeFuture = clientHandler
                     .execute(new ClientExecutionParams<ReceiveMessageRequest, ReceiveMessageResponse>()
                             .withOperationName("ReceiveMessage").withProtocolMetadata(protocolMetadata)
-                            .withMarshaller(new ReceiveMessageRequestMarshaller(protocolFactory))
+                            .withMarshaller(new ReceiveMessageRequestMarshaller(protocolFactory)).withLongPolling(true)
                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                             .withRequestConfiguration(clientConfiguration).withMetricCollector(apiCallMetricCollector)
                             .withInput(receiveMessageRequest));
             CompletableFuture<ReceiveMessageResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
diff --color -U 5 -r sqs-old/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsClient.java sqs-new/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsClient.java
--- sqs-old/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsClient.java	2026-04-24 15:19:34
+++ sqs-new/generated-sources/sdk/software/amazon/awssdk/services/sqs/DefaultSqsClient.java	2026-04-24 15:22:06
@@ -3349,11 +3349,11 @@
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "SQS");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "ReceiveMessage");

             return clientHandler.execute(new ClientExecutionParams<ReceiveMessageRequest, ReceiveMessageResponse>()
                     .withOperationName("ReceiveMessage").withProtocolMetadata(protocolMetadata)
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler).withLongPolling(true)
                     .withRequestConfiguration(clientConfiguration).withInput(receiveMessageRequest)
                     .withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new ReceiveMessageRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));

```

</details>

<details>
<summary>SFN diff</summary>

```diff
diff --color -U 5 -r sfn-old/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnAsyncClient.java sfn-new/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnAsyncClient.java
--- sfn-old/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnAsyncClient.java	2026-04-24 15:19:38
+++ sfn-new/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnAsyncClient.java	2026-04-24 15:22:09
@@ -3045,11 +3045,11 @@
                     operationMetadata, exceptionMetadataMapper);

             CompletableFuture<GetActivityTaskResponse> executeFuture = clientHandler
                     .execute(new ClientExecutionParams<GetActivityTaskRequest, GetActivityTaskResponse>()
                             .withOperationName("GetActivityTask").withProtocolMetadata(protocolMetadata)
-                            .withMarshaller(new GetActivityTaskRequestMarshaller(protocolFactory))
+                            .withMarshaller(new GetActivityTaskRequestMarshaller(protocolFactory)).withLongPolling(true)
                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                             .withRequestConfiguration(clientConfiguration).withMetricCollector(apiCallMetricCollector)
                             .withInput(getActivityTaskRequest));
             CompletableFuture<GetActivityTaskResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
diff --color -U 5 -r sfn-old/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnClient.java sfn-new/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnClient.java
--- sfn-old/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnClient.java	2026-04-24 15:19:38
+++ sfn-new/generated-sources/sdk/software/amazon/awssdk/services/sfn/DefaultSfnClient.java	2026-04-24 15:22:09
@@ -2959,11 +2959,11 @@
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "SFN");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "GetActivityTask");

             return clientHandler.execute(new ClientExecutionParams<GetActivityTaskRequest, GetActivityTaskResponse>()
                     .withOperationName("GetActivityTask").withProtocolMetadata(protocolMetadata)
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler).withLongPolling(true)
                     .withRequestConfiguration(clientConfiguration).withInput(getActivityTaskRequest)
                     .withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new GetActivityTaskRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
```

</details>


<details>
<summary>SWF diff</summary>

```diff
diff --color -U 5 -r swf-old/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfAsyncClient.java swf-new/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfAsyncClient.java
--- swf-old/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfAsyncClient.java	2026-04-24 15:19:45
+++ swf-new/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfAsyncClient.java	2026-04-24 15:22:13
@@ -3266,11 +3266,11 @@
                     operationMetadata, exceptionMetadataMapper);

             CompletableFuture<PollForActivityTaskResponse> executeFuture = clientHandler
                     .execute(new ClientExecutionParams<PollForActivityTaskRequest, PollForActivityTaskResponse>()
                             .withOperationName("PollForActivityTask").withProtocolMetadata(protocolMetadata)
-                            .withMarshaller(new PollForActivityTaskRequestMarshaller(protocolFactory))
+                            .withMarshaller(new PollForActivityTaskRequestMarshaller(protocolFactory)).withLongPolling(true)
                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                             .withRequestConfiguration(clientConfiguration).withMetricCollector(apiCallMetricCollector)
                             .withInput(pollForActivityTaskRequest));
             CompletableFuture<PollForActivityTaskResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
@@ -3427,11 +3427,11 @@
                     operationMetadata, exceptionMetadataMapper);

             CompletableFuture<PollForDecisionTaskResponse> executeFuture = clientHandler
                     .execute(new ClientExecutionParams<PollForDecisionTaskRequest, PollForDecisionTaskResponse>()
                             .withOperationName("PollForDecisionTask").withProtocolMetadata(protocolMetadata)
-                            .withMarshaller(new PollForDecisionTaskRequestMarshaller(protocolFactory))
+                            .withMarshaller(new PollForDecisionTaskRequestMarshaller(protocolFactory)).withLongPolling(true)
                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                             .withRequestConfiguration(clientConfiguration).withMetricCollector(apiCallMetricCollector)
                             .withInput(pollForDecisionTaskRequest));
             CompletableFuture<PollForDecisionTaskResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
diff --color -U 5 -r swf-old/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfClient.java swf-new/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfClient.java
--- swf-old/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfClient.java	2026-04-24 15:19:45
+++ swf-new/generated-sources/sdk/software/amazon/awssdk/services/swf/DefaultSwfClient.java	2026-04-24 15:22:13
@@ -3054,11 +3054,11 @@
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "SWF");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "PollForActivityTask");

             return clientHandler.execute(new ClientExecutionParams<PollForActivityTaskRequest, PollForActivityTaskResponse>()
                     .withOperationName("PollForActivityTask").withProtocolMetadata(protocolMetadata)
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler).withLongPolling(true)
                     .withRequestConfiguration(clientConfiguration).withInput(pollForActivityTaskRequest)
                     .withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new PollForActivityTaskRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
@@ -3205,11 +3205,11 @@
             apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "SWF");
             apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "PollForDecisionTask");

             return clientHandler.execute(new ClientExecutionParams<PollForDecisionTaskRequest, PollForDecisionTaskResponse>()
                     .withOperationName("PollForDecisionTask").withProtocolMetadata(protocolMetadata)
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler).withLongPolling(true)
                     .withRequestConfiguration(clientConfiguration).withInput(pollForDecisionTaskRequest)
                     .withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new PollForDecisionTaskRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));

```
</details>

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
