### PR TITLE
Support backoff on refresh failure

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Either;
 
 /**
  * Wrapper around the pipeline for a single request to provide retry, clockskew and request throttling functionality.
@@ -134,9 +135,20 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
         }
 
         public void maybeAttemptExecute(CompletableFuture<Response<OutputT>> future) {
-            Optional<Duration> delay = retryableStageHelper.tryRefreshToken(Duration.ZERO);
-            if (!delay.isPresent()) {
-                future.completeExceptionally(retryableStageHelper.retryPolicyDisallowedRetryException());
+            Either<Duration, Duration> backoffDelay = retryableStageHelper.tryRefreshToken(Duration.ZERO);
+
+            Optional<Duration> acquireFailureDelay = backoffDelay.right();
+            if (acquireFailureDelay.isPresent()) {
+                Duration delay = acquireFailureDelay.get();
+                retryableStageHelper.logAcquireFailureBackingOff(delay);
+                SdkException disallowedException = retryableStageHelper.retryPolicyDisallowedRetryException();
+                // Avoid needless scheduling if we won't wait
+                if (delay.isZero()) {
+                    future.completeExceptionally(disallowedException);
+                } else {
+                    scheduledExecutor.schedule(() -> future.completeExceptionally(disallowedException),
+                                               delay.toMillis(), MILLISECONDS);
+                }
                 return;
             }
             // We failed the last attempt, but will retry. The response handler wants to know when that happens.
@@ -145,9 +157,10 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
             // Reset the request provider to the original one before retries, in case it was modified downstream.
             context.requestProvider(originalRequestBody);
 
-            Duration backoffDelay = delay.get();
-            retryableStageHelper.logBackingOff(backoffDelay);
-            long totalDelayMillis = backoffDelay.toMillis();
+            // get() is safe, Either requires left OR right to be present
+            Duration successDelay = backoffDelay.left().get();
+            retryableStageHelper.logBackingOff(successDelay);
+            long totalDelayMillis = successDelay.toMillis();
             scheduledExecutor.schedule(() -> attemptExecute(future), totalDelayMillis, MILLISECONDS);
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.core.internal.http.pipeline.RequestToResponsePipel
 import software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.utils.Either;
 
 /**
  * Wrapper around the pipeline for a single request to provide retry, clock-skew and request throttling functionality.
@@ -64,12 +65,19 @@ public final class RetryableStage<OutputT> implements RequestToResponsePipeline<
                 }
                 retryableStageHelper.setLastException(throwable);
                 Duration suggestedDelay = suggestedDelay(e);
-                Optional<Duration> backoffDelay = retryableStageHelper.tryRefreshToken(suggestedDelay);
-                if (backoffDelay.isPresent()) {
-                    Duration delay = backoffDelay.get();
+                Either<Duration, Duration> backoffDelay = retryableStageHelper.tryRefreshToken(suggestedDelay);
+                Optional<Duration> successDelay = backoffDelay.left();
+                if (successDelay.isPresent()) {
+                    Duration delay = successDelay.get();
                     retryableStageHelper.logBackingOff(delay);
                     TimeUnit.MILLISECONDS.sleep(delay.toMillis());
                 } else {
+                    Optional<Duration> failureDelay = backoffDelay.right();
+                    if (failureDelay.isPresent()) {
+                        Duration delay = failureDelay.get();
+                        retryableStageHelper.logAcquireFailureBackingOff(delay);
+                        TimeUnit.MILLISECONDS.sleep(delay.toMillis());
+                    }
                     throw retryableStageHelper.retryPolicyDisallowedRetryException();
                 }
             }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelper.java
@@ -49,6 +49,7 @@ import software.amazon.awssdk.retries.api.RefreshRetryTokenResponse;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.retries.api.RetryToken;
 import software.amazon.awssdk.retries.api.TokenAcquisitionFailedException;
+import software.amazon.awssdk.utils.Either;
 
 /**
  * Contains the logic shared by {@link RetryableStage} and {@link AsyncRetryableStage} when querying and interacting with a
@@ -126,16 +127,17 @@ public final class RetryableStageHelper {
     }
 
     /**
-     * Invoked after a failed attempt and before retrying. The returned optional will be non-empty if the client can retry or
-     * empty if the retry-strategy disallows the retry. The calling code is expected to wait the delay represented in the duration
-     * if present before retrying the request.
+     * Invoked after a failed attempt and before retrying. The returned {@link Either} will have its <b>left</b> be populated
+     * if the refresh is successful. The <b>right</b> is populated if the refresh is unsuccessful. In either case, the calling
+     * code is expected to wait the delay represented in the duration before retrying the request or exiting the retry loop.
      *
      * @param suggestedDelay A suggested delay, presumably coming from the server response. The response when present will be at
      *                       least this amount.
-     * @return An optional time to wait. If the value is not present the retry strategy disallowed the retry and the calling code
-     * should not retry.
+     * @return An optional time to wait, regardless of whether the refresh is successful. If the left value is present, the
+     * retry strategy allowed the retry. If the right value is present the retry strategy disallowed the retry and the calling
+     * code should not retry.
      */
-    public Optional<Duration> tryRefreshToken(Duration suggestedDelay) {
+    public Either<Duration, Duration> tryRefreshToken(Duration suggestedDelay) {
         RetryToken retryToken = context.executionAttributes().getAttribute(RETRY_TOKEN);
         RefreshRetryTokenResponse refreshResponse;
         try {
@@ -148,12 +150,18 @@ public final class RetryableStageHelper {
             refreshResponse = retryStrategy().refreshRetryToken(refreshRequest);
         } catch (TokenAcquisitionFailedException e) {
             context.executionAttributes().putAttribute(RETRY_TOKEN, e.token());
-            return Optional.empty();
+            Optional<Duration> acquireFailureDelay = e.delay();
+            if (acquireFailureDelay.isPresent()) {
+                Duration acquireDelay = acquireFailureDelay.get();
+                context.executionAttributes().putAttribute(LAST_BACKOFF_DELAY_DURATION, acquireDelay);
+                return Either.right(acquireDelay);
+            }
+            return Either.right(Duration.ZERO);
         }
-        Duration delay = refreshResponse.delay();
+        Duration acquireSuccessDelay = refreshResponse.delay();
         context.executionAttributes().putAttribute(RETRY_TOKEN, refreshResponse.token());
-        context.executionAttributes().putAttribute(LAST_BACKOFF_DELAY_DURATION, delay);
-        return Optional.of(delay);
+        context.executionAttributes().putAttribute(LAST_BACKOFF_DELAY_DURATION, acquireSuccessDelay);
+        return Either.left(acquireSuccessDelay);
     }
 
     /**
@@ -182,6 +190,12 @@ public final class RetryableStageHelper {
     public void logBackingOff(Duration backoffDelay) {
         SdkStandardLogger.REQUEST_LOGGER.debug(() -> "Retryable error detected. Will retry in " +
                                                      backoffDelay.toMillis() + "ms. Request attempt number " +
+                                                     attemptNumber, lastException);
+    }
+
+    public void logAcquireFailureBackingOff(Duration acquireFailureBackoffDelay) {
+        SdkStandardLogger.REQUEST_LOGGER.debug(() -> "Unable to acquire sufficient retry quota to retry. Will cease retrying in "
+                                                     + acquireFailureBackoffDelay.toMillis() + "ms. Request attempt number " +
                                                      attemptNumber, lastException);
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStageTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.Response;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.TransformingAsyncResponseHandler;
+import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenResponse;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenResponse;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.retries.api.RetryToken;
+import software.amazon.awssdk.retries.api.TokenAcquisitionFailedException;
+
+public class AsyncRetryableStageTest {
+    private RetryStrategy mockRetryStrategy;
+    private AcquireInitialTokenResponse mockAcquireInitialTokenResponse;
+    private RetryToken mockRetryToken;
+
+    private RequestPipeline<SdkHttpFullRequest, CompletableFuture<Response<SdkResponse>>> mockDelegatePipeline;
+
+    private static ScheduledExecutorService executorService;
+
+    @BeforeAll
+    static void setup() {
+        executorService = Executors.newScheduledThreadPool(1);
+    }
+
+    @AfterAll
+    static void teardown() {
+        executorService.shutdownNow();
+    }
+
+    @BeforeEach
+    void methodSetup() {
+        mockRetryStrategy = mock(RetryStrategy.class);
+        mockAcquireInitialTokenResponse = mock(AcquireInitialTokenResponse.class);
+        mockRetryToken = mock(RetryToken.class);
+
+        when(mockAcquireInitialTokenResponse.token()).thenReturn(mockRetryToken);
+        when(mockAcquireInitialTokenResponse.delay()).thenReturn(Duration.ZERO);
+
+        when(mockRetryStrategy.acquireInitialToken(any())).thenReturn(mockAcquireInitialTokenResponse);
+
+        mockDelegatePipeline = mock(RequestPipeline.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("acquireDelayTestCases")
+    void execute_acquireDelay_behavesCorrectly(AcquireDelayTestCase testCase) throws Exception {
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                                                                    .option(SdkClientOption.RETRY_STRATEGY, mockRetryStrategy)
+                                                                    .option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE,
+                                                                            executorService)
+                                                                    .build();
+
+        HttpClientDependencies deps = HttpClientDependencies.builder()
+                                                            .clientConfiguration(clientConfig)
+                                                            .build();
+
+        AsyncRetryableStage<SdkResponse> retryableStage = new AsyncRetryableStage<>(mock(TransformingAsyncResponseHandler.class),
+                                                                                    deps, mockDelegatePipeline);
+
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .uri(URI.create("https://my-service.amazonaws.com"))
+                                                           .build();
+
+        ExecutionAttributes execAttrs = ExecutionAttributes.builder()
+                                                           .build();
+
+        ExecutionContext execCtx = ExecutionContext.builder()
+                                                   .metricCollector(NoOpMetricCollector.create())
+                                                   .executionAttributes(execAttrs)
+                                                   .build();
+
+        RequestExecutionContext ctx = RequestExecutionContext.builder()
+                                                             .originalRequest(mock(SdkRequest.class))
+                                                             .executionContext(execCtx)
+                                                             .build();
+
+        SdkHttpFullResponse.Builder httpResponse = SdkHttpFullResponse.builder()
+                                                                      .statusCode(502);
+
+        Response<SdkResponse> response = Response.<SdkResponse>builder()
+                                                 .httpResponse(httpResponse.build())
+                                                 .isSuccess(false)
+                                                 .exception(SdkException.builder().build())
+                                                 .build();
+
+        when(mockDelegatePipeline.execute(any(), any())).thenReturn(CompletableFuture.completedFuture(response));
+
+        if (testCase.failure) {
+            when(mockRetryStrategy.refreshRetryToken(any())).thenThrow(
+                new TokenAcquisitionFailedException("Acquire failed", mockRetryToken, null, testCase.failureDelay)
+            );
+        } else {
+            // only retry once, otherwise we'll get into an infinite loop
+            AtomicBoolean first = new AtomicBoolean();
+            when(mockRetryStrategy.refreshRetryToken(any())).thenAnswer(i -> {
+                if (first.compareAndSet(false, true)) {
+                    return RefreshRetryTokenResponse.create(mockRetryToken, testCase.successDelay);
+                }
+                throw new TokenAcquisitionFailedException("Acquire failed", mockRetryToken, null, Duration.ZERO);
+            });
+        }
+
+        long start = System.nanoTime();
+        CompletableFuture<Response<SdkResponse>> execute = retryableStage.execute(httpRequest, ctx);
+        // exception thrown doesn't matter, just results in exception because we mock just enough...
+        assertThatThrownBy(execute::join);
+        long end = System.nanoTime();
+
+        Duration lowerBound = testCase.expectedDelay();
+        assertThat(Duration.ofNanos(end - start)).isBetween(lowerBound, lowerBound.plusMillis(250));
+    }
+
+    private static Stream<AcquireDelayTestCase> acquireDelayTestCases() {
+        return Stream.of(
+            new AcquireDelayTestCase(true, Duration.ofDays(1), Duration.ZERO),
+            new AcquireDelayTestCase(true, Duration.ofDays(1), Duration.ofMillis(100)),
+
+
+            new AcquireDelayTestCase(false, Duration.ZERO, Duration.ofDays(1)),
+            new AcquireDelayTestCase(false, Duration.ofMillis(100), Duration.ofDays(1))
+        );
+    }
+
+    private static class AcquireDelayTestCase {
+        private boolean failure;
+        private Duration successDelay;
+        private Duration failureDelay;
+
+        public AcquireDelayTestCase(boolean failure, Duration successDelay, Duration failureDelay) {
+            this.failure = failure;
+            this.successDelay = successDelay;
+            this.failureDelay = failureDelay;
+        }
+
+        public Duration expectedDelay() {
+            if (failure) {
+                return failureDelay;
+            }
+            return successDelay;
+        }
+
+        @Override
+        public String toString() {
+            return (failure ? "Failure" : "Success") + " with delay " + expectedDelay();
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStageTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.Response;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.retries.api.AcquireInitialTokenResponse;
+import software.amazon.awssdk.retries.api.RefreshRetryTokenResponse;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+import software.amazon.awssdk.retries.api.RetryToken;
+import software.amazon.awssdk.retries.api.TokenAcquisitionFailedException;
+
+public class RetryableStageTest {
+    private RetryStrategy mockRetryStrategy;
+    private AcquireInitialTokenResponse mockAcquireInitialTokenResponse;
+    private RetryToken mockRetryToken;
+
+    private RequestPipeline<SdkHttpFullRequest, Response<SdkResponse>> mockDelegatePipeline;
+
+    @BeforeEach
+    void setup() {
+        mockRetryStrategy = mock(RetryStrategy.class);
+        mockAcquireInitialTokenResponse = mock(AcquireInitialTokenResponse.class);
+        mockRetryToken = mock(RetryToken.class);
+
+        when(mockAcquireInitialTokenResponse.token()).thenReturn(mockRetryToken);
+        when(mockAcquireInitialTokenResponse.delay()).thenReturn(Duration.ZERO);
+
+        when(mockRetryStrategy.acquireInitialToken(any())).thenReturn(mockAcquireInitialTokenResponse);
+
+        mockDelegatePipeline = mock(RequestPipeline.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("acquireDelayTestCases")
+    void execute_acquireDelay_behavesCorrectly(AcquireDelayTestCase testCase) throws Exception {
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                                                                    .option(SdkClientOption.RETRY_STRATEGY, mockRetryStrategy)
+                                                                    .build();
+
+        HttpClientDependencies deps = HttpClientDependencies.builder()
+                                                            .clientConfiguration(clientConfig)
+                                                            .build();
+
+        RetryableStage<SdkResponse> retryableStage = new RetryableStage<>(deps, mockDelegatePipeline);
+
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .uri(URI.create("https://my-service.amazonaws.com"))
+                                                           .build();
+
+        ExecutionAttributes execAttrs = ExecutionAttributes.builder()
+                                                           .build();
+
+        ExecutionContext execCtx = ExecutionContext.builder()
+                                                   .executionAttributes(execAttrs)
+                                                   .build();
+
+        RequestExecutionContext ctx = RequestExecutionContext.builder()
+                                                             .originalRequest(mock(SdkRequest.class))
+                                                             .executionContext(execCtx)
+                                                             .build();
+
+        SdkHttpFullResponse.Builder httpResponse = SdkHttpFullResponse.builder()
+                                                                      .statusCode(502);
+
+        Response<SdkResponse> response = Response.<SdkResponse>builder()
+                                                 .httpResponse(httpResponse.build())
+                                                 .isSuccess(false)
+                                                 .exception(SdkException.builder().build())
+                                                 .build();
+
+        when(mockDelegatePipeline.execute(any(), any())).thenReturn(response);
+
+        if (testCase.failure) {
+            when(mockRetryStrategy.refreshRetryToken(any())).thenThrow(
+                new TokenAcquisitionFailedException("Acquire failed", mockRetryToken, null, testCase.failureDelay));
+        } else {
+            // only retry once, otherwise we'll get into an infinite loop
+            AtomicBoolean first = new AtomicBoolean();
+            when(mockRetryStrategy.refreshRetryToken(any())).thenAnswer(i -> {
+                if (first.compareAndSet(false, true)) {
+                    return RefreshRetryTokenResponse.create(mockRetryToken, testCase.successDelay);
+                }
+                throw new TokenAcquisitionFailedException("Acquire failed", mockRetryToken, null, Duration.ZERO);
+            });
+        }
+
+        long start = System.nanoTime();
+        // exception thrown doesn't matter, just results in exception because we mock just enough...
+        assertThatThrownBy(() -> retryableStage.execute(httpRequest, ctx));
+        long end = System.nanoTime();
+
+        Duration lowerBound = testCase.expectedDelay();
+        assertThat(Duration.ofNanos(end - start)).isBetween(lowerBound, lowerBound.plusMillis(250));
+    }
+
+    private static Stream<AcquireDelayTestCase> acquireDelayTestCases() {
+        return Stream.of(
+            new AcquireDelayTestCase(true, Duration.ofDays(1), Duration.ZERO),
+            new AcquireDelayTestCase(true, Duration.ofDays(1), Duration.ofMillis(100)),
+
+
+            new AcquireDelayTestCase(false, Duration.ZERO, Duration.ofDays(1)),
+            new AcquireDelayTestCase(false, Duration.ofMillis(100), Duration.ofDays(1))
+        );
+    }
+
+    private static class AcquireDelayTestCase {
+        private boolean failure;
+        private Duration successDelay;
+        private Duration failureDelay;
+
+        public AcquireDelayTestCase(boolean failure, Duration successDelay, Duration failureDelay) {
+            this.failure = failure;
+            this.successDelay = successDelay;
+            this.failureDelay = failureDelay;
+        }
+
+        public Duration expectedDelay() {
+            if (failure) {
+                return failureDelay;
+            }
+            return successDelay;
+        }
+
+        @Override
+        public String toString() {
+            return (failure ? "Failure" : "Success") + " with delay " + expectedDelay();
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelperTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/RetryableStageHelperTest.java
@@ -43,6 +43,8 @@ import software.amazon.awssdk.retries.api.RefreshRetryTokenRequest;
 import software.amazon.awssdk.retries.api.RefreshRetryTokenResponse;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.retries.api.RetryToken;
+import software.amazon.awssdk.retries.api.TokenAcquisitionFailedException;
+import software.amazon.awssdk.utils.Either;
 
 public class RetryableStageHelperTest {
 
@@ -101,12 +103,77 @@ public class RetryableStageHelperTest {
         assertThat(refreshRequestCaptor.getValue().isLongPolling()).isEqualTo(expected);
     }
 
+    @ParameterizedTest(name = "delay on successful refresh = {0}, delay on failed refresh = {1}")
+    @MethodSource("refreshBackoffTestParams")
+    void tryRefreshToken_returnsCorrectBackoff(Duration successDelay, Duration failureDelay) {
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .uri(URI.create("https://my-service.amazonaws.com"))
+                                                           .build();
+
+        ExecutionAttributes.Builder attributes = ExecutionAttributes.builder();
+
+        ExecutionContext executionContext = ExecutionContext.builder().executionAttributes(attributes.build()).build();
+
+        RequestExecutionContext requestExecutionContext = RequestExecutionContext.builder()
+                                                                                 .originalRequest(mock(SdkRequest.class))
+                                                                                 .executionContext(executionContext)
+                                                                                 .build();
+
+        RetryStrategy retryStrategy = mock(RetryStrategy.class);
+
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                                                                    .option(SdkClientOption.RETRY_STRATEGY, retryStrategy)
+                                                                    .build();
+
+        HttpClientDependencies dependencies = HttpClientDependencies.builder()
+                                                                    .clientConfiguration(clientConfig)
+                                                                    .build();
+
+        RetryableStageHelper helper = new RetryableStageHelper(httpRequest,
+                                                               requestExecutionContext,
+                                                               dependencies);
+
+        AcquireInitialTokenResponse mockAcquireResponse = mock(AcquireInitialTokenResponse.class);
+        RetryToken token = mock(RetryToken.class);
+        when(mockAcquireResponse.token()).thenReturn(token);
+        when(retryStrategy.acquireInitialToken(any())).thenReturn(mockAcquireResponse);
+
+        if (successDelay != null) {
+            RefreshRetryTokenResponse mockRefreshResponse = mock(RefreshRetryTokenResponse.class);
+            when(mockRefreshResponse.delay()).thenReturn(successDelay);
+            when(retryStrategy.refreshRetryToken(any())).thenReturn(mockRefreshResponse);
+        } else {
+            when(retryStrategy.refreshRetryToken(any())).thenThrow(
+                new TokenAcquisitionFailedException("failed", token, null, failureDelay)
+            );
+        }
+
+        helper.acquireInitialToken();
+
+        helper.setLastException(new RuntimeException());
+        Either<Duration, Duration> backoff = helper.tryRefreshToken(Duration.ZERO);
+
+        if (successDelay != null) {
+            assertThat(backoff.left().get()).isEqualTo(successDelay);
+        } else {
+            assertThat(backoff.right().get()).isEqualTo(failureDelay);
+        }
+    }
+
     private static Stream<Arguments> longPollingValueTestParams() {
         return Stream.of(
             // Absent should default to false
             Arguments.of(null, false),
             Arguments.of(true, true),
             Arguments.of(false, false)
+        );
+    }
+
+    private static Stream<Arguments> refreshBackoffTestParams() {
+        return Stream.of(
+            Arguments.of(null, Duration.ofSeconds(1)),
+            Arguments.of(Duration.ofSeconds(1), null)
         );
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Retry strategies can optionally return a backoff even when token refresh fails. Add support for this in the sync and async retry stages.

## Modifications
In RetryableStage and AsyncRetryableStage, check the value of TokenAcquisitionFailedException#delay() backoff if given.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
