### PR TITLE
Increase Jackson maxNameLength to support DynamoDB attribute names up…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1f2b503.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1f2b503.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed deserialization failure for JSON responses containing field names longer than 50,000 characters. Services like DynamoDB allow attribute names up to 65,535 bytes, which exceeded Jackson's default `maxNameLength` limit."
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/AwsStructuredPlainJsonFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/AwsStructuredPlainJsonFactory.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.protocols.json.BaseAwsStructuredJsonFactory;
 import software.amazon.awssdk.protocols.json.SdkJsonGenerator;
 import software.amazon.awssdk.protocols.json.StructuredJsonGenerator;
 import software.amazon.awssdk.thirdparty.jackson.core.JsonFactory;
+import software.amazon.awssdk.thirdparty.jackson.core.StreamReadConstraints;
 import software.amazon.awssdk.thirdparty.jackson.core.StreamReadFeature;
 import software.amazon.awssdk.thirdparty.jackson.core.StreamWriteFeature;
 
@@ -37,6 +38,13 @@ public final class AwsStructuredPlainJsonFactory {
                                                                .enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)
                                                                .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
                                                                .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+                                                               // Override Jackson's default maxNameLength of 50,000 to support
+                                                               // DynamoDB attribute names, which can be up to 65,535 bytes.
+                                                               // See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html
+                                                               .streamReadConstraints(
+                                                                   StreamReadConstraints.builder()
+                                                                                        .maxNameLength(65_535)
+                                                                                        .build())
                                                                .build();
 
     public static final BaseAwsStructuredJsonFactory SDK_JSON_FACTORY = new BaseAwsStructuredJsonFactory(JSON_FACTORY) {

--- a/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/internal/AwsStructuredPlainJsonFactoryTest.java
+++ b/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/internal/AwsStructuredPlainJsonFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.json.internal;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
+import software.amazon.awssdk.thirdparty.jackson.core.JsonFactory;
+
+class AwsStructuredPlainJsonFactoryTest {
+
+    private static final JsonFactory JSON_FACTORY = AwsStructuredPlainJsonFactory.SDK_JSON_FACTORY.getJsonFactory();
+
+    @Test
+    void parse_fieldNameAtMaxDynamoDbLength_succeeds() {
+        char[] chars = new char[65_535];
+        Arrays.fill(chars, 'a');
+        String name = new String(chars);
+        String json = "{\"" + name + "\": \"value\"}";
+
+        assertThatNoException().isThrownBy(() ->
+            JsonNodeParser.builder().jsonFactory(JSON_FACTORY).build().parse(json));
+    }
+}

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/LongAttributeNameTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/LongAttributeNameTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+
+/**
+ * Regression test for long DynamoDB attribute names. DynamoDB allows attribute names up to 65,535 bytes,
+ * but Jackson's default maxNameLength of 50,000 caused deserialization failures for names exceeding that limit.
+ *
+ * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html">
+ *     DynamoDB Naming Rules</a>
+ */
+@WireMockTest
+class LongAttributeNameTest {
+
+    private static final StaticCredentialsProvider CREDENTIALS =
+        StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test"));
+
+    private static final String LONG_ATTR_NAME;
+    private static final String RESPONSE_BODY;
+
+    static {
+        char[] chars = new char[65_535];
+        Arrays.fill(chars, 'a');
+        LONG_ATTR_NAME = new String(chars);
+        RESPONSE_BODY = "{\"Item\": {\"pk\": {\"S\": \"test1\"}, \"" + LONG_ATTR_NAME + "\": {\"S\": \"value\"}}}";
+    }
+
+    private void stubResponse(WireMockRuntimeInfo wmInfo) {
+        wmInfo.getWireMock().register(any(urlEqualTo("/"))
+            .willReturn(aResponse().withStatus(200).withBody(RESPONSE_BODY)));
+    }
+
+    @Test
+    void syncClient_getItem_withLongAttributeName_succeeds(WireMockRuntimeInfo wmInfo) {
+        stubResponse(wmInfo);
+
+        DynamoDbClient client = DynamoDbClient.builder()
+                                              .endpointOverride(URI.create(wmInfo.getHttpBaseUrl()))
+                                              .region(Region.US_EAST_1)
+                                              .credentialsProvider(CREDENTIALS)
+                                              .build();
+
+        GetItemResponse response = client.getItem(r -> r.tableName("test")
+                                                         .key(Collections.singletonMap("pk",
+                                                             AttributeValue.fromS("test1"))));
+
+        assertThat(response.item()).containsKey(LONG_ATTR_NAME);
+        assertThat(response.item().get(LONG_ATTR_NAME).s()).isEqualTo("value");
+    }
+
+    @Test
+    void asyncClient_getItem_withLongAttributeName_succeeds(WireMockRuntimeInfo wmInfo) {
+        stubResponse(wmInfo);
+
+        DynamoDbAsyncClient client = DynamoDbAsyncClient.builder()
+                                                        .endpointOverride(URI.create(wmInfo.getHttpBaseUrl()))
+                                                        .region(Region.US_EAST_1)
+                                                        .credentialsProvider(CREDENTIALS)
+                                                        .build();
+
+        GetItemResponse response = client.getItem(r -> r.tableName("test")
+                                                         .key(Collections.singletonMap("pk",
+                                                             AttributeValue.fromS("test1")))).join();
+
+        assertThat(response.item()).containsKey(LONG_ATTR_NAME);
+        assertThat(response.item().get(LONG_ATTR_NAME).s()).isEqualTo("value");
+    }
+}


### PR DESCRIPTION
   ## Motivation and Context

   DynamoDB allows attribute names up to 65,535 bytes([docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html)), but Jackson's default `StreamReadConstraints.maxNameLength` of 50,000 causes `StreamConstraintsException` when the SDK deserializes responses containing attribute names longer than 50K characters. Since Jackson is shaded inside the SDK, customers cannot override this setting.

   ## Modifications

   - Override `maxNameLength` to 65,535 in `AwsStructuredPlainJsonFactory.JSON_FACTORY` to match the DynamoDB service limit. This is the `JsonFactory` used by all JSON-protocol service clients.

   ## Testing

   - Added unit test in `AwsStructuredPlainJsonFactoryTest` verifying the `JsonFactory` can parse a 65,535-char
   field name.
   - Added WireMock integration test in `LongAttributeNameTest` (sync + async clients) that stubs a DynamoDB
   GetItem response with a 65,535-char attribute name and verifies end-to-end deserialization succeeds.
   - Ran one-off integration test against real DynamoDB with attribute names of 50,001 and 65,535 characters.

   ## Types of changes
   - [x] Bug fix (non-breaking change which fixes an issue)

   ## Checklist
   - [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md)
   document
   - [x] Local run of `mvn install` succeeds
   - [x] My code follows the code style of this project
   - [ ] My change requires a change to the Javadoc documentation
   - [ ] I have updated the Javadoc documentation accordingly
   - [x] I have added tests to cover my changes
   - [x] All new and existing tests passed
   - [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the
   `scripts/new-change` script and following the instructions. Commit the new file created by the script in
   `.changes/next-release` with your changes.

   ## License
  - [x] I confirm that this pull request can be released under the Apache 2 license