### PR TITLE
Retries 2.1 std suggested delay computation

### DIFF
--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/BaseRetryStrategy.java
@@ -380,6 +380,13 @@ public abstract class BaseRetryStrategy implements DefaultAwareRetryStrategy {
         return right;
     }
 
+    static Duration minOf(Duration left, Duration right) {
+        if (left.compareTo(right) <= 0) {
+            return left;
+        }
+        return right;
+    }
+
     static DefaultRetryToken asDefaultRetryToken(RetryToken token) {
         return Validate.isInstanceOf(DefaultRetryToken.class, token,
                                      "RetryToken is of unexpected class (%s), "

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/internal/DefaultStandardRetryStrategy.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/internal/DefaultStandardRetryStrategy.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.retries.internal;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.function.Predicate;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.retries.StandardRetryStrategy;
@@ -28,6 +29,7 @@ import software.amazon.awssdk.utils.Logger;
 public final class DefaultStandardRetryStrategy
     extends BaseRetryStrategy implements StandardRetryStrategy {
     private static final Logger LOG = Logger.loggerFor(DefaultStandardRetryStrategy.class);
+    private static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
     private final boolean retries2026Enabled;
 
     DefaultStandardRetryStrategy(Builder builder) {
@@ -54,6 +56,38 @@ public final class DefaultStandardRetryStrategy
                                                                                    .increaseAttempt()
                                                                                    .build();
         return computeBackoff(request, attemptIncremented);
+    }
+
+    @Override
+    protected Duration computeBackoff(RefreshRetryTokenRequest request, DefaultRetryToken token) {
+        if (!retries2026Enabled) {
+            return super.computeBackoff(request, token);
+        }
+
+        Duration strategyBackoff;
+        if (treatAsThrottling.test(request.failure())) {
+            strategyBackoff = throttlingBackoffStrategy.computeDelay(token.attempt());
+        } else {
+            strategyBackoff = backoffStrategy.computeDelay(token.attempt());
+        }
+
+        Optional<Duration> optionalSuggested = request.suggestedDelay();
+
+        if (!optionalSuggested.isPresent()) {
+            return strategyBackoff;
+        }
+
+        // the suggested delay needs to be at least what the strategy computed, OR
+        // not greater than 5s more than what the strat computed
+        Duration minBackoff = strategyBackoff;
+        Duration maxBackoff = strategyBackoff.plus(FIVE_SECONDS);
+
+        Duration backoff = optionalSuggested.get();
+
+        backoff = maxOf(minBackoff, backoff);
+        backoff = minOf(maxBackoff, backoff);
+
+        return backoff;
     }
 
     public static class Builder extends BaseRetryStrategy.Builder implements StandardRetryStrategy.Builder {

--- a/core/retries/src/test/java/software/amazon/awssdk/retries/internal/StandardRetryStrategyTest.java
+++ b/core/retries/src/test/java/software/amazon/awssdk/retries/internal/StandardRetryStrategyTest.java
@@ -104,12 +104,17 @@ public class StandardRetryStrategyTest {
                 case RETRY_REQUEST: {
                     ScenarioTestException scenarioTestException = new ScenarioTestException(response.statusCode,
                                                                                             response.throttling);
-                    RefreshRetryTokenRequest refreshRequest = RefreshRetryTokenRequest.builder()
-                                                                                      .failure(scenarioTestException)
-                                                                                      .isLongPolling(given.isLongPolling)
-                                                                                      .token(token.get())
-                                                                                      .build();
-                    RefreshRetryTokenResponse refreshResponse = strategy.refreshRetryToken(refreshRequest);
+                    RefreshRetryTokenRequest.Builder refreshRequest = RefreshRetryTokenRequest.builder();
+
+                    if (response.xAmzRetryAfter != null) {
+                        refreshRequest.suggestedDelay(response.xAmzRetryAfter);
+                    }
+
+                    refreshRequest.failure(scenarioTestException)
+                                  .isLongPolling(given.isLongPolling)
+                                  .token(token.get())
+                                  .build();
+                    RefreshRetryTokenResponse refreshResponse = strategy.refreshRetryToken(refreshRequest.build());
                     DefaultRetryToken refreshedToken = (DefaultRetryToken) refreshResponse.token();
                     token.set(refreshedToken);
 
@@ -120,14 +125,18 @@ public class StandardRetryStrategyTest {
                 case RETRY_QUOTA_EXCEEDED: {
                     ScenarioTestException scenarioTestException = new ScenarioTestException(response.statusCode,
                                                                                             response.throttling);
-                    RefreshRetryTokenRequest refreshRequest = RefreshRetryTokenRequest.builder()
-                                                                                      .failure(scenarioTestException)
-                                                                                      .isLongPolling(given.isLongPolling)
-                                                                                      .token(token.get())
-                                                                                      .build();
+                    RefreshRetryTokenRequest.Builder refreshRequest = RefreshRetryTokenRequest.builder();
 
+                    if (response.xAmzRetryAfter != null) {
+                        refreshRequest.suggestedDelay(response.xAmzRetryAfter);
+                    }
 
-                    assertThatThrownBy(() -> strategy.refreshRetryToken(refreshRequest))
+                    refreshRequest.failure(scenarioTestException)
+                                  .isLongPolling(given.isLongPolling)
+                                  .token(token.get())
+                                  .build();
+
+                    assertThatThrownBy(() -> strategy.refreshRetryToken(refreshRequest.build()))
                         .isInstanceOf(TokenAcquisitionFailedException.class)
                         .matches(e -> {
                                      TokenAcquisitionFailedException acquireException = (TokenAcquisitionFailedException) e;
@@ -149,12 +158,18 @@ public class StandardRetryStrategyTest {
                 case MAX_ATTEMPTS_EXCEEDED: {
                     ScenarioTestException scenarioTestException = new ScenarioTestException(response.statusCode,
                                                                                             response.throttling);
-                    RefreshRetryTokenRequest refreshRequest = RefreshRetryTokenRequest.builder()
-                                                                                      .failure(scenarioTestException)
-                                                                                      .isLongPolling(given.isLongPolling)
-                                                                                      .token(token.get())
-                                                                                      .build();
-                    assertThatThrownBy(() -> strategy.refreshRetryToken(refreshRequest))
+                    RefreshRetryTokenRequest.Builder refreshRequest = RefreshRetryTokenRequest.builder();
+
+                    if (response.xAmzRetryAfter != null) {
+                        refreshRequest.suggestedDelay(response.xAmzRetryAfter);
+                    }
+
+                    refreshRequest.failure(scenarioTestException)
+                                  .isLongPolling(given.isLongPolling)
+                                  .token(token.get())
+                                  .build();
+
+                    assertThatThrownBy(() -> strategy.refreshRetryToken(refreshRequest.build()))
                         .isInstanceOf(TokenAcquisitionFailedException.class)
                         .matches(e -> {
                             TokenAcquisitionFailedException acquireException = (TokenAcquisitionFailedException) e;
@@ -673,7 +688,52 @@ public class StandardRetryStrategyTest {
                                   .expected(e ->
                                                 e.outcome(Outcome.MAX_ATTEMPTS_EXCEEDED)
                                                  .delay(Duration.ZERO)
+                                                 .retryQuota(486))),
+
+            aScenario("Honor x-amz-retry-after Header")
+                .newRetries2026(true)
+                .addResponse(r ->
+                                 r.statusCode(500)
+                                  .xAmzRetryAfter(Duration.ofMillis(1500))
+                                  .expected(e ->
+                                                e.outcome(Outcome.RETRY_REQUEST)
+                                                 .delay(Duration.ofMillis(1500))
                                                  .retryQuota(486)))
+                .addResponse(r ->
+                                 r.statusCode(200)
+                                  .expected(e ->
+                                                e.outcome(Outcome.SUCCESS)
+                                                 .retryQuota(500))),
+
+            aScenario("x-amz-retry-after minimum is exponential backoff duration")
+                .newRetries2026(true)
+                .addResponse(r ->
+                                 r.statusCode(500)
+                                  .xAmzRetryAfter(Duration.ofMillis(0))
+                                  .expected(e ->
+                                                e.outcome(Outcome.RETRY_REQUEST)
+                                                 .delay(Duration.ofMillis(50))
+                                                 .retryQuota(486)))
+                .addResponse(r ->
+                                 r.statusCode(200)
+                                  .expected(e ->
+                                                e.outcome(Outcome.SUCCESS)
+                                                 .retryQuota(500))),
+
+            aScenario("x-amz-retry-after maximum is 5+exponential backoff duration")
+                .newRetries2026(true)
+                .addResponse(r ->
+                                 r.statusCode(500)
+                                  .xAmzRetryAfter(Duration.ofMillis(10000))
+                                  .expected(e ->
+                                                e.outcome(Outcome.RETRY_REQUEST)
+                                                 .delay(Duration.ofMillis(5050))
+                                                 .retryQuota(486)))
+                .addResponse(r ->
+                                 r.statusCode(200)
+                                  .expected(e ->
+                                                e.outcome(Outcome.SUCCESS)
+                                                 .retryQuota(500)))
         );
     }
 
@@ -721,6 +781,7 @@ public class StandardRetryStrategyTest {
     private static class Response {
         private int statusCode;
         private boolean throttling;
+        private Duration xAmzRetryAfter;
         private Expected expected;
 
         public Response statusCode(int statusCode) {
@@ -730,6 +791,11 @@ public class StandardRetryStrategyTest {
 
         public Response isThrottling(boolean throttling) {
             this.throttling = throttling;
+            return this;
+        }
+
+        public Response xAmzRetryAfter(Duration xAmzRetryAfter) {
+            this.xAmzRetryAfter = xAmzRetryAfter;
             return this;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
For standard 2.1, there is additional treatment of the service suggested
backoff so it's at least as long as the strategy computed value, and not
longer than 5s more than the strategy computed value.

## Modifications
- Override `computeBackoff()` for standard retry strategy to implement 2.1 behavior.

## Testing
- New unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
