### PR TITLE
Support MRAP buckets in S3 TransferManager

### DIFF
--- a/.changes/next-release/feature-S3TransferManager-9973f30.json
+++ b/.changes/next-release/feature-S3TransferManager-9973f30.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "S3TransferManager",
+    "contributor": "",
+    "description": "Support MRAP buckets in S3 TransferManager."
+}

--- a/services-custom/s3-transfer-manager/pom.xml
+++ b/services-custom/s3-transfer-manager/pom.xml
@@ -84,11 +84,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>arns</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -29,7 +29,6 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
-import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.FileTransformerConfiguration;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -40,9 +39,6 @@ import software.amazon.awssdk.core.internal.async.FileAsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.internal.multipart.MultipartDownloadResumeContext;
 import software.amazon.awssdk.services.s3.internal.multipart.MultipartS3AsyncClient;
-import software.amazon.awssdk.services.s3.internal.resource.S3AccessPointResource;
-import software.amazon.awssdk.services.s3.internal.resource.S3ArnConverter;
-import software.amazon.awssdk.services.s3.internal.resource.S3Resource;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -622,27 +618,9 @@ class GenericS3TransferManager implements S3TransferManager {
             String error = String.format("%s does not support S3 Object Lambda resources", operation);
             throw new IllegalArgumentException(error);
         }
-
-        Arn arn = Arn.fromString(bucket);
-
-        if (isMrapArn(arn)) {
-            String error = String.format("%s does not support S3 multi-region access point ARN", operation);
-            throw new IllegalArgumentException(error);
-        }
     }
 
     private static boolean isObjectLambdaArn(String arn) {
         return arn.contains(":s3-object-lambda");
-    }
-
-    private static boolean isMrapArn(Arn arn) {
-        S3Resource s3Resource = S3ArnConverter.create().convertArn(arn);
-
-        S3AccessPointResource s3EndpointResource =
-            Validate.isInstanceOf(S3AccessPointResource.class, s3Resource,
-                                  "An ARN was passed as a bucket parameter to an S3 operation, however it does not "
-                                  + "appear to be a valid S3 access point ARN.");
-
-        return !s3EndpointResource.region().isPresent();
     }
 }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerTest.java
@@ -289,55 +289,63 @@ class S3TransferManagerTest {
     }
 
     @Test
-    void mrapArnProvided_shouldThrowException() {
+    void mrapArnProvided_shouldNotThrowException() {
         String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
 
-        assertThatThrownBy(() -> tm.uploadFile(b -> b.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
-                                                     .source(Paths.get(".")))
-                                   .completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
+        PutObjectResponse putResponse = PutObjectResponse.builder().build();
+        when(mockS3Crt.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(putResponse));
 
-        assertThatThrownBy(() -> tm.upload(b -> b.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
-                                                 .requestBody(AsyncRequestBody.fromString("foo")))
-                                   .completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
+        CompletedFileUpload completedFileUpload =
+            tm.uploadFile(b -> b.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
+                                .source(Paths.get(".")))
+               .completionFuture().join();
+        assertThat(completedFileUpload.response()).isEqualTo(putResponse);
 
-        assertThatThrownBy(() -> tm.downloadFile(b -> b.getObjectRequest(p -> p.bucket(mrapArn).key("key"))
-                                                       .destination(Paths.get(".")))
-                                   .completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
+        CompletedUpload completedUpload =
+            tm.upload(b -> b.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
+                            .requestBody(AsyncRequestBody.fromString("foo")))
+               .completionFuture().join();
+        assertThat(completedUpload.response()).isEqualTo(putResponse);
+
+        GetObjectResponse getResponse = GetObjectResponse.builder().build();
+        when(mockS3Crt.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class)))
+            .thenReturn(CompletableFuture.completedFuture(getResponse));
+
+        CompletedFileDownload completedFileDownload =
+            tm.downloadFile(b -> b.getObjectRequest(p -> p.bucket(mrapArn).key("key"))
+                                  .destination(Paths.get(".")))
+               .completionFuture().join();
+        assertThat(completedFileDownload.response()).isEqualTo(getResponse);
 
         DownloadRequest<ResponseBytes<GetObjectResponse>> downloadRequest =
             DownloadRequest.builder()
                            .getObjectRequest(g -> g.bucket(mrapArn).key("key"))
                            .responseTransformer(AsyncResponseTransformer.toBytes()).build();
 
-        assertThatThrownBy(() -> tm.download(downloadRequest).completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
+        CompletedDownload<ResponseBytes<GetObjectResponse>> completedDownload =
+            tm.download(downloadRequest).completionFuture().join();
+        assertThat(completedDownload).isNotNull();
 
-        assertThatThrownBy(() -> tm.uploadDirectory(b -> b.bucket(mrapArn)
-                                                          .source(Paths.get(".")))
-                                   .completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
+        CopyObjectResponse copyResponse = CopyObjectResponse.builder().build();
+        when(mockS3Crt.copyObject(any(CopyObjectRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(copyResponse));
 
-        assertThatThrownBy(() -> tm.downloadDirectory(b -> b.bucket(mrapArn)
-                                                            .destination(Paths.get(".")))
-                                   .completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
+        CompletedCopy completedCopy =
+            tm.copy(b -> b.copyObjectRequest(p -> p.sourceBucket(mrapArn)
+                                                    .sourceKey("sourceKey")
+                                                    .destinationBucket("bucket")
+                                                    .destinationKey("destKey")))
+               .completionFuture().join();
+        assertThat(completedCopy.response()).isEqualTo(copyResponse);
 
-        assertThatThrownBy(() -> tm.copy(b -> b.copyObjectRequest(p -> p.sourceBucket(mrapArn)
-                                                                        .sourceKey("sourceKey")
-                                                                        .destinationBucket("bucket")
-                                                                        .destinationKey("destKey")))
-                                   .completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> tm.copy(b -> b.copyObjectRequest(p -> p.sourceBucket("bucket")
-                                                                        .sourceKey("sourceKey")
-                                                                        .destinationBucket(mrapArn)
-                                                                        .destinationKey("destKey")))
-                                   .completionFuture().join())
-            .hasMessageContaining("multi-region access point ARN").hasCauseInstanceOf(IllegalArgumentException.class);
+        completedCopy =
+            tm.copy(b -> b.copyObjectRequest(p -> p.sourceBucket("bucket")
+                                                    .sourceKey("sourceKey")
+                                                    .destinationBucket(mrapArn)
+                                                    .destinationKey("destKey")))
+               .completionFuture().join();
+        assertThat(completedCopy.response()).isEqualTo(copyResponse);
     }
 
     @Test

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerTest.java
@@ -289,34 +289,53 @@ class S3TransferManagerTest {
     }
 
     @Test
-    void mrapArnProvided_shouldNotThrowException() {
+    void uploadFile_mrapArn_returnsResponse() {
         String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
-
-        PutObjectResponse putResponse = PutObjectResponse.builder().build();
+        PutObjectResponse response = PutObjectResponse.builder().build();
         when(mockS3Crt.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
-            .thenReturn(CompletableFuture.completedFuture(putResponse));
+            .thenReturn(CompletableFuture.completedFuture(response));
 
-        CompletedFileUpload completedFileUpload =
-            tm.uploadFile(b -> b.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
-                                .source(Paths.get(".")))
-               .completionFuture().join();
-        assertThat(completedFileUpload.response()).isEqualTo(putResponse);
+        CompletedFileUpload completedFileUpload = tm.uploadFile(u -> u.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
+                                                                      .source(Paths.get(".")))
+                                                    .completionFuture().join();
 
-        CompletedUpload completedUpload =
-            tm.upload(b -> b.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
-                            .requestBody(AsyncRequestBody.fromString("foo")))
-               .completionFuture().join();
-        assertThat(completedUpload.response()).isEqualTo(putResponse);
+        assertThat(completedFileUpload.response()).isEqualTo(response);
+    }
 
-        GetObjectResponse getResponse = GetObjectResponse.builder().build();
+    @Test
+    void upload_mrapArn_returnsResponse() {
+        String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
+        PutObjectResponse response = PutObjectResponse.builder().build();
+        when(mockS3Crt.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(response));
+
+        CompletedUpload completedUpload = tm.upload(u -> u.putObjectRequest(p -> p.bucket(mrapArn).key("key"))
+                                                          .requestBody(AsyncRequestBody.fromString("foo")))
+                                            .completionFuture().join();
+
+        assertThat(completedUpload.response()).isEqualTo(response);
+    }
+
+    @Test
+    void downloadFile_mrapArn_returnsResponse() {
+        String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
+        GetObjectResponse response = GetObjectResponse.builder().build();
         when(mockS3Crt.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class)))
-            .thenReturn(CompletableFuture.completedFuture(getResponse));
+            .thenReturn(CompletableFuture.completedFuture(response));
 
-        CompletedFileDownload completedFileDownload =
-            tm.downloadFile(b -> b.getObjectRequest(p -> p.bucket(mrapArn).key("key"))
-                                  .destination(Paths.get(".")))
-               .completionFuture().join();
-        assertThat(completedFileDownload.response()).isEqualTo(getResponse);
+        CompletedFileDownload completedFileDownload = tm.downloadFile(d -> d.getObjectRequest(g -> g.bucket(mrapArn).key("key"))
+                                                                            .destination(Paths.get(".")))
+                                                        .completionFuture().join();
+
+        assertThat(completedFileDownload.response()).isEqualTo(response);
+    }
+
+    @Test
+    void download_mrapArn_returnsResponse() {
+        String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
+        GetObjectResponse response = GetObjectResponse.builder().build();
+        when(mockS3Crt.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class)))
+            .thenReturn(CompletableFuture.completedFuture(response));
 
         DownloadRequest<ResponseBytes<GetObjectResponse>> downloadRequest =
             DownloadRequest.builder()
@@ -325,27 +344,50 @@ class S3TransferManagerTest {
 
         CompletedDownload<ResponseBytes<GetObjectResponse>> completedDownload =
             tm.download(downloadRequest).completionFuture().join();
+
         assertThat(completedDownload).isNotNull();
+    }
 
-        CopyObjectResponse copyResponse = CopyObjectResponse.builder().build();
+    @Test
+    void copy_mrapArn_returnsResponse() {
+        String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
+        CopyObjectResponse response = CopyObjectResponse.builder().build();
         when(mockS3Crt.copyObject(any(CopyObjectRequest.class)))
-            .thenReturn(CompletableFuture.completedFuture(copyResponse));
+            .thenReturn(CompletableFuture.completedFuture(response));
 
-        CompletedCopy completedCopy =
-            tm.copy(b -> b.copyObjectRequest(p -> p.sourceBucket(mrapArn)
-                                                    .sourceKey("sourceKey")
-                                                    .destinationBucket("bucket")
-                                                    .destinationKey("destKey")))
-               .completionFuture().join();
-        assertThat(completedCopy.response()).isEqualTo(copyResponse);
+        CompletedCopy completedCopy = tm.copy(u -> u.copyObjectRequest(p -> p.sourceBucket(mrapArn)
+                                                                             .sourceKey("sourceKey")
+                                                                             .destinationBucket("bucket")
+                                                                             .destinationKey("destKey")))
+                                        .completionFuture().join();
 
-        completedCopy =
-            tm.copy(b -> b.copyObjectRequest(p -> p.sourceBucket("bucket")
-                                                    .sourceKey("sourceKey")
-                                                    .destinationBucket(mrapArn)
-                                                    .destinationKey("destKey")))
-               .completionFuture().join();
-        assertThat(completedCopy.response()).isEqualTo(copyResponse);
+        assertThat(completedCopy.response()).isEqualTo(response);
+
+        completedCopy = tm.copy(u -> u.copyObjectRequest(p -> p.sourceBucket("bucket")
+                                                               .sourceKey("sourceKey")
+                                                               .destinationBucket(mrapArn)
+                                                               .destinationKey("destKey")))
+                          .completionFuture().join();
+
+        assertThat(completedCopy.response()).isEqualTo(response);
+    }
+
+    @Test
+    void uploadDirectory_mrapArn_returnsResponse() {
+        String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
+
+        tm.uploadDirectory(u -> u.source(Paths.get(".")).bucket(mrapArn));
+
+        verify(uploadDirectoryHelper).uploadDirectory(any(UploadDirectoryRequest.class));
+    }
+
+    @Test
+    void downloadDirectory_mrapArn_returnsResponse() {
+        String mrapArn = "arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap";
+
+        tm.downloadDirectory(d -> d.destination(Paths.get(".")).bucket(mrapArn));
+
+        verify(downloadDirectoryHelper).downloadDirectory(any(DownloadDirectoryRequest.class));
     }
 
     @Test

--- a/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/S3ChecksumsTestUtils.java
+++ b/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/S3ChecksumsTestUtils.java
@@ -203,11 +203,6 @@ public final class S3ChecksumsTestUtils {
                                 "Path style doesn't work with ARN type buckets");
     }
 
-    public static void assumeNotMRAP(UploadConfig config) {
-        Assumptions.assumeFalse(config.getBucketType().equals(BucketType.MRAP),
-                                "MRAP buckets are not supported by TransferManager.");
-    }
-
     public static String crc32(String s) {
         return crc32(s.getBytes(StandardCharsets.UTF_8));
     }

--- a/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadTransferManagerRegressionTesting.java
+++ b/test/s3-tests/src/it/java/software/amazon/awssdk/services/s3/regression/upload/UploadTransferManagerRegressionTesting.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.services.s3.regression.upload;
 
 import static software.amazon.awssdk.services.s3.regression.S3ChecksumsTestUtils.assumeNotAccessPointWithPathStyle;
-import static software.amazon.awssdk.services.s3.regression.S3ChecksumsTestUtils.assumeNotMRAP;
 import static software.amazon.awssdk.services.s3.regression.S3ClientFlavor.MULTIPART_ENABLED;
 
 import java.time.Duration;
@@ -49,7 +48,6 @@ public class UploadTransferManagerRegressionTesting extends UploadStreamingRegre
     void putObject(UploadConfig config) throws Exception {
 
         assumeNotAccessPointWithPathStyle(config);
-        assumeNotMRAP(config);
 
         // For testing purposes, ContentProvider is Publisher<ByteBuffer> for async clients
         // There is no way to create AsyncRequestBody with a Publisher<ByteBuffer> and also provide the content length


### PR DESCRIPTION
Support MRAP buckets in S3 TransferManager.

## Motivation and Context
Fixes: #3984

S3 MRAP now [supports all multi-part operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/MrapOperations.html#mrap-operations-support).


## Modifications
* Remove check for MRAP ARN.

## Testing
New unit tests.
Removed skip for MRAP buckets in existing TM regression tests (so no new tests needed to be added - existing tests will now run on an MRAP bucket).   Example log lines:
```
2026-04-28 13:40:38 [main] INFO  software.amazon.awssdk.services.s3.regression.upload.UploadTransferManagerRegressionTesting:43 - Running putObject with config: UploadConfig(bucketType=MRAP, forcePathStyle=false, requestChecksumValidation=WHEN_SUPPORTED, bodyType=BUFFERED_SPLITTABLE_UNKNOWN_CONTENT_LENGTH, contentSize=LARGE, payloadSigning=false)
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
