### PR TITLE
Update DDB retry policy with v2.1 constants

### DIFF
--- a/core/retries/src/test/java/software/amazon/awssdk/retries/StandardRetryStrategyV21ConstantsTest.java
+++ b/core/retries/src/test/java/software/amazon/awssdk/retries/StandardRetryStrategyV21ConstantsTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.retries;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.retries.api.AcquireInitialTokenResponse;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
@@ -82,24 +83,33 @@ class StandardRetryStrategyV21ConstantsTest {
 
     @Test
     void v21Enabled_backoffUses50msBaseDelay() {
-        RetryStrategy strategy = StandardRetryStrategy.builder(true)
-            .retryOnException(t -> true)
-            .build();
 
-        RefreshRetryTokenResponse response = refreshToken(strategy, new RuntimeException("err"));
-        // First retry delay should be in [0, 50ms] (jittered)
-        assertThat(response.delay()).isBetween(Duration.ZERO, Duration.ofMillis(50));
+        Supplier<RetryStrategy> stratSupplier = () -> StandardRetryStrategy.builder(true)
+                                                                              .retryOnException(t -> true)
+                                                                              .build();
+
+        probabilisticAssertDelayBetween(stratSupplier, new RuntimeException("err"), Duration.ZERO, Duration.ofMillis(50));
+    }
+
+    @Test
+    void v21Enabled_throttlingBackoffUses1000msBaseDelay() {
+
+        Supplier<RetryStrategy> stratSupplier = () -> StandardRetryStrategy.builder(true)
+                                                                           .retryOnException(t -> true)
+                                                                           .treatAsThrottling(t -> true)
+                                                                           .build();
+
+        probabilisticAssertDelayBetween(stratSupplier, new RuntimeException("err"), Duration.ZERO, Duration.ofMillis(1000));
     }
 
     @Test
     void v20_backoffUses100msBaseDelay() {
-        RetryStrategy strategy = StandardRetryStrategy.builder(false)
-            .retryOnException(t -> true)
-            .build();
+        Supplier<RetryStrategy> stratSupplier = () -> StandardRetryStrategy.builder(false)
+                                                                              .retryOnException(t -> true)
+                                                                              .build();
 
-        RefreshRetryTokenResponse response = refreshToken(strategy, new RuntimeException("err"));
-        // First retry delay should be in [0, 100ms] (jittered)
-        assertThat(response.delay()).isBetween(Duration.ZERO, Duration.ofMillis(100));
+        probabilisticAssertDelayBetween(stratSupplier, new RuntimeException("err"), Duration.ZERO, Duration.ofMillis(100));
+
     }
 
     @Test
@@ -134,5 +144,16 @@ class StandardRetryStrategyV21ConstantsTest {
         AcquireInitialTokenResponse initial = strategy.acquireInitialToken(AcquireInitialTokenRequestImpl.create("test"));
         return strategy.refreshRetryToken(
             RefreshRetryTokenRequest.builder().token(initial.token()).failure(failure).build());
+    }
+
+    // Backoffs are jittered, so verify it by testing it many times
+    private void probabilisticAssertDelayBetween(Supplier<RetryStrategy> strategy,
+                                                 Exception failure,
+                                                 Duration min,
+                                                 Duration max) {
+        for (int i = 0; i < 128; ++i) {
+            RefreshRetryTokenResponse response = refreshToken(strategy.get(), failure);
+            assertThat(response.delay()).isBetween(min, max);
+        }
     }
 }

--- a/services/dynamodb/pom.xml
+++ b/services/dynamodb/pom.xml
@@ -78,5 +78,11 @@
             <artifactId>http-auth-aws</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicy.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicy.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.internal.retry.RetryPolicyAdapter;
 import software.amazon.awssdk.core.internal.retry.SdkDefaultRetrySetting;
+import software.amazon.awssdk.core.retry.NewRetries2026Resolver;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
@@ -41,12 +42,17 @@ final class DynamoDbRetryPolicy {
     /**
      * Default max retry count for DynamoDB client, regardless of retry mode.
      **/
-    private static final int MAX_ERROR_RETRY = 8;
+    private static final int MAX_ERROR_RETRY_V20 = 8;
 
     /**
      * Default attempts count for DynamoDB client, regardless of retry mode.
      **/
-    private static final int MAX_ATTEMPTS = MAX_ERROR_RETRY + 1;
+    private static final int MAX_ATTEMPTS_V20 = MAX_ERROR_RETRY_V20 + 1;
+
+    /**
+     * Default attempts count for DynamoDB client, regardless of retry mode. (v2.1)
+     **/
+    private static final int MAX_ATTEMPTS_V21 = 4;
 
     /**
      * Default base sleep time for DynamoDB, regardless of retry mode.
@@ -95,9 +101,12 @@ final class DynamoDbRetryPolicy {
                                      .build();
         }
 
-        return AwsRetryStrategy.forRetryMode(retryMode)
+        boolean newRetries2026Enabled = isNewRetries2026Enabled(config);
+        int maxAttempts = newRetries2026Enabled ? MAX_ATTEMPTS_V21 : MAX_ATTEMPTS_V20;
+
+        return AwsRetryStrategy.forRetryMode(retryMode, newRetries2026Enabled)
             .toBuilder()
-            .maxAttempts(MAX_ATTEMPTS)
+            .maxAttempts(maxAttempts)
             .backoffStrategy(exponentialDelay(BASE_DELAY, SdkDefaultRetrySetting.MAX_BACKOFF))
             .build();
     }
@@ -106,7 +115,7 @@ final class DynamoDbRetryPolicy {
         return AwsRetryPolicy.forRetryMode(retryMode)
                              .toBuilder()
                              .additionalRetryConditionsAllowed(false)
-                             .numRetries(MAX_ERROR_RETRY)
+                             .numRetries(MAX_ERROR_RETRY_V20)
                              .backoffStrategy(BACKOFF_STRATEGY)
                              .build();
     }
@@ -116,6 +125,12 @@ final class DynamoDbRetryPolicy {
                         .profileFile(config.option(SdkClientOption.PROFILE_FILE_SUPPLIER))
                         .profileName(config.option(SdkClientOption.PROFILE_NAME))
                         .defaultRetryMode(config.option(SdkClientOption.DEFAULT_RETRY_MODE))
+                        .defaultNewRetries2026(config.option(SdkClientOption.DEFAULT_NEW_RETRIES_2026))
                         .resolve();
+    }
+
+    private static boolean isNewRetries2026Enabled(SdkClientConfiguration config) {
+        Boolean defaultNewRetries2026 = config.option(SdkClientOption.DEFAULT_NEW_RETRIES_2026);
+        return new NewRetries2026Resolver().defaultNewRetries2026(defaultNewRetries2026).resolve();
     }
 }

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
@@ -5,12 +5,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.retries.LegacyRetryStrategy;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.StringInputStream;
@@ -126,4 +130,20 @@ class DynamoDbRetryPolicyTest {
         assertThat(retryMode).isEqualTo(RetryMode.LEGACY);
     }
 
+    @ParameterizedTest(name = "V2.1 retries = {0}, max attempts = {1}")
+    @CsvSource({
+        "false,9",
+        "true,4"
+    })
+    void resolve_maxAttemptsAndStrategyCompliantWithRetriesVersion(boolean retries21, int expectedMaxAttempts) {
+        SdkClientConfiguration cfg = SdkClientConfiguration.builder()
+                                                           .option(SdkClientOption.DEFAULT_NEW_RETRIES_2026, retries21)
+                                                           .build();
+        RetryStrategy strategy = DynamoDbRetryPolicy.resolveRetryStrategy(cfg);
+
+        Class<?> expectedStrategy = retries21 ? StandardRetryStrategy.class : LegacyRetryStrategy.class;
+
+        assertThat(strategy).isInstanceOf(expectedStrategy);
+        assertThat(strategy.maxAttempts()).isEqualTo(expectedMaxAttempts);
+    }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In 2.1:
 - base delay : 25ms (existing)
 - max attempts: 4 (down from 9)

## Modifications
Use constants based on whether 2.1 is enabled.

## Testing
New unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
