### PR TITLE
Improve error message for ResponseTransformer.toFile() and AsyncRespo…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-8da4e26.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-8da4e26.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Improved error message when `ResponseTransformer.toFile()` or `AsyncResponseTransformer.toFile()` fails because the parent directory does not exist. The error now indicates that the parent directory must be created before calling the method."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
@@ -105,7 +105,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
      * <p>
      * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown.
      * In the event of an error, the SDK will attempt to delete the file (whatever has been written to it so far).
-     * The parent directory must already exist; the SDK will not auto-create it.
+     * The file's parent directories must already exist; the SDK will not auto-create them.
      */
     public static FileTransformerConfiguration defaultCreateNew() {
         return builder().fileWriteOption(FileWriteOption.CREATE_NEW)
@@ -118,7 +118,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
      * <p>
      * Create a new file if it doesn't exist, otherwise replace the existing file.
      * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is.
-     * The parent directory must already exist; the SDK will not auto-create it.
+     * The file's parent directories must already exist; the SDK will not auto-create them.
      */
     public static FileTransformerConfiguration defaultCreateOrReplaceExisting() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_REPLACE_EXISTING)
@@ -131,7 +131,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
      * <p>
      * Create a new file if it doesn't exist, otherwise append to the existing file.
      * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is.
-     * The parent directory must already exist; the SDK will not auto-create it.
+     * The file's parent directories must already exist; the SDK will not auto-create them.
      */
     public static FileTransformerConfiguration defaultCreateOrAppend() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_APPEND_TO_EXISTING)
@@ -182,19 +182,19 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     public enum FileWriteOption {
         /**
          * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown.
-         * The parent directory must already exist; the SDK will not auto-create it.
+         * The file's parent directories must already exist; the SDK will not auto-create them.
          */
         CREATE_NEW,
 
         /**
          * Create a new file if it doesn't exist, otherwise replace the existing file.
-         * The parent directory must already exist; the SDK will not auto-create it.
+         * The file's parent directories must already exist; the SDK will not auto-create them.
          */
         CREATE_OR_REPLACE_EXISTING,
 
         /**
          * Create a new file if it doesn't exist, otherwise append to the existing file.
-         * The parent directory must already exist; the SDK will not auto-create it.
+         * The file's parent directories must already exist; the SDK will not auto-create them.
          */
         CREATE_OR_APPEND_TO_EXISTING,
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/FileTransformerConfiguration.java
@@ -105,6 +105,7 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
      * <p>
      * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown.
      * In the event of an error, the SDK will attempt to delete the file (whatever has been written to it so far).
+     * The parent directory must already exist; the SDK will not auto-create it.
      */
     public static FileTransformerConfiguration defaultCreateNew() {
         return builder().fileWriteOption(FileWriteOption.CREATE_NEW)
@@ -116,7 +117,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_OR_REPLACE_EXISTING}
      * <p>
      * Create a new file if it doesn't exist, otherwise replace the existing file.
-     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is
+     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is.
+     * The parent directory must already exist; the SDK will not auto-create it.
      */
     public static FileTransformerConfiguration defaultCreateOrReplaceExisting() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_REPLACE_EXISTING)
@@ -128,7 +130,8 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
      * Returns the default {@link FileTransformerConfiguration} for {@link FileWriteOption#CREATE_OR_APPEND_TO_EXISTING}
      * <p>
      * Create a new file if it doesn't exist, otherwise append to the existing file.
-     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is
+     * In the event of an error, the SDK will NOT attempt to delete the file, leaving it as-is.
+     * The parent directory must already exist; the SDK will not auto-create it.
      */
     public static FileTransformerConfiguration defaultCreateOrAppend() {
         return builder().fileWriteOption(FileWriteOption.CREATE_OR_APPEND_TO_EXISTING)
@@ -179,16 +182,19 @@ public final class FileTransformerConfiguration implements ToCopyableBuilder<Fil
     public enum FileWriteOption {
         /**
          * Always create a new file. If the file already exists, {@link FileAlreadyExistsException} will be thrown.
+         * The parent directory must already exist; the SDK will not auto-create it.
          */
         CREATE_NEW,
 
         /**
          * Create a new file if it doesn't exist, otherwise replace the existing file.
+         * The parent directory must already exist; the SDK will not auto-create it.
          */
         CREATE_OR_REPLACE_EXISTING,
 
         /**
          * Create a new file if it doesn't exist, otherwise append to the existing file.
+         * The parent directory must already exist; the SDK will not auto-create it.
          */
         CREATE_OR_APPEND_TO_EXISTING,
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
@@ -177,6 +177,9 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
      * SDK will attempt to delete the file (whatever has been written to it so far). If the file already exists, an exception will
      * be thrown.
      *
+     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * {@link java.nio.file.NoSuchFileException} will be thrown if they are missing.
+     *
      * @param path        Path to file to write to.
      * @param <ResponseT> Pojo Response type.
      * @return AsyncResponseTransformer instance.
@@ -189,6 +192,9 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
     /**
      * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file with the specified
      * {@link FileTransformerConfiguration}.
+     *
+     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * {@link java.nio.file.NoSuchFileException} will be thrown if they are missing.
      *
      * @param path        Path to file to write to.
      * @param config      configuration for the transformer
@@ -216,6 +222,9 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
      * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file. In the event of an error, the
      * SDK will attempt to delete the file (whatever has been written to it so far). If the file already exists, an exception will
      * be thrown.
+     *
+     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * {@link java.nio.file.NoSuchFileException} will be thrown if they are missing.
      *
      * @param file        File to write to.
      * @param <ResponseT> Pojo Response type.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
@@ -177,7 +177,7 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
      * SDK will attempt to delete the file (whatever has been written to it so far). If the file already exists, an exception will
      * be thrown.
      *
-     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * <p>The file's parent directories must already exist. The SDK will not auto-create directories, and a
      * {@link java.nio.file.NoSuchFileException} will be thrown if they are missing.
      *
      * @param path        Path to file to write to.
@@ -193,7 +193,7 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
      * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file with the specified
      * {@link FileTransformerConfiguration}.
      *
-     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * <p>The file's parent directories must already exist. The SDK will not auto-create directories, and a
      * {@link java.nio.file.NoSuchFileException} will be thrown if they are missing.
      *
      * @param path        Path to file to write to.
@@ -223,7 +223,7 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
      * SDK will attempt to delete the file (whatever has been written to it so far). If the file already exists, an exception will
      * be thrown.
      *
-     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * <p>The file's parent directories must already exist. The SDK will not auto-create directories, and a
      * {@link java.nio.file.NoSuchFileException} will be thrown if they are missing.
      *
      * @param file        File to write to.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
@@ -126,7 +126,15 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
         }
 
         ExecutorService executorService = configuration.executorService().orElse(null);
-        return AsynchronousFileChannel.open(path, options, executorService);
+        try {
+            return AsynchronousFileChannel.open(path, options, executorService);
+        } catch (NoSuchFileException e) {
+            if (configuration.fileWriteOption() == WRITE_TO_POSITION) {
+                throw e;
+            }
+            throw new NoSuchFileException(e.getFile(), e.getOtherFile(),
+                                          "Verify that the parent directory exists. The SDK will not auto-create it.");
+        }
     }
 
     @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
@@ -133,7 +133,7 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
                 throw e;
             }
             throw new NoSuchFileException(e.getFile(), e.getOtherFile(),
-                                          "Verify that the parent directory exists. The SDK will not auto-create it.");
+                                          "Verify that the file's parent directories exist. The SDK will not auto-create them.");
         }
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
@@ -111,7 +111,7 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
      * Creates a response transformer that writes all response content to the specified file. If the file already exists
      * then a {@link FileAlreadyExistsException} will be thrown.
      *
-     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * <p>The file's parent directories must already exist. The SDK will not auto-create directories, and a
      * {@link NoSuchFileException} will be thrown if they are missing.
      *
      * @param path        Path to file to write to.
@@ -173,8 +173,8 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
     static String copyErrorMessage(Path path, IOException copyException) {
         String baseMessage = "Failed to read response into file: " + path;
         if (copyException instanceof NoSuchFileException) {
-            return baseMessage + ". Verify that the parent directory exists."
-                   + " The SDK will not auto-create it.";
+            return baseMessage + ". Verify that the file's parent directories exist."
+                   + " The SDK will not auto-create them.";
         }
         return baseMessage;
     }
@@ -183,7 +183,7 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
      * Creates a response transformer that writes all response content to the specified file. If the file already exists
      * then a {@link FileAlreadyExistsException} will be thrown.
      *
-     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * <p>The file's parent directories must already exist. The SDK will not auto-create directories, and a
      * {@link NoSuchFileException} will be thrown if they are missing.
      *
      * @param file        File to write to.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
@@ -109,7 +109,10 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
 
     /**
      * Creates a response transformer that writes all response content to the specified file. If the file already exists
-     * then a {@link java.nio.file.FileAlreadyExistsException} will be thrown.
+     * then a {@link FileAlreadyExistsException} will be thrown.
+     *
+     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * {@link NoSuchFileException} will be thrown if they are missing.
      *
      * @param path        Path to file to write to.
      * @param <ResponseT> Type of unmarshalled response POJO.
@@ -124,7 +127,7 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
                     Files.copy(inputStream, path);
                     return response;
                 } catch (IOException copyException) {
-                    String copyError = "Failed to read response into file: " + path;
+                    String copyError = copyErrorMessage(path, copyException);
 
                     if (shouldThrowIOException(copyException)) {
                         throw new IOException(copyError, copyException);
@@ -167,9 +170,21 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
                copyException instanceof AccessDeniedException;
     }
 
+    static String copyErrorMessage(Path path, IOException copyException) {
+        String baseMessage = "Failed to read response into file: " + path;
+        if (copyException instanceof NoSuchFileException) {
+            return baseMessage + ". Verify that the parent directory exists."
+                   + " The SDK will not auto-create it.";
+        }
+        return baseMessage;
+    }
+
     /**
      * Creates a response transformer that writes all response content to the specified file. If the file already exists
-     * then a {@link java.nio.file.FileAlreadyExistsException} will be thrown.
+     * then a {@link FileAlreadyExistsException} will be thrown.
+     *
+     * <p>The parent directory must already exist. The SDK will not auto-create parent directories, and a
+     * {@link NoSuchFileException} will be thrown if they are missing.
      *
      * @param file        File to write to.
      * @param <ResponseT> Type of unmarshalled response POJO.

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -339,8 +339,8 @@ class FileAsyncResponseTransformerTest {
         assertThat(future).failsWithin(1, TimeUnit.SECONDS)
                           .withThrowableOfType(ExecutionException.class)
                           .withCauseInstanceOf(NoSuchFileException.class)
-                          .withMessageContaining("Verify that the parent directory exists")
-                          .withMessageContaining("The SDK will not auto-create it");
+                          .withMessageContaining("Verify that the file's parent directories exist")
+                          .withMessageContaining("The SDK will not auto-create them");
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -318,6 +318,49 @@ class FileAsyncResponseTransformerTest {
         assertThat(future).isCompletedExceptionally();
     }
 
+    private static List<FileTransformerConfiguration> parentDirConfigurations() {
+        return java.util.Arrays.asList(
+            FileTransformerConfiguration.defaultCreateNew(),
+            FileTransformerConfiguration.defaultCreateOrReplaceExisting(),
+            FileTransformerConfiguration.defaultCreateOrAppend()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parentDirConfigurations")
+    void parentDirectoryDoesNotExist_throwsWithHelpfulMessage(FileTransformerConfiguration config) {
+        Path testPath = testFs.getPath("nonexistent-parent", "test_file.txt");
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath, config);
+
+        CompletableFuture<String> future = transformer.prepare();
+        transformer.onResponse("foobar");
+        transformer.onStream(testPublisher("content"));
+
+        assertThat(future).failsWithin(1, TimeUnit.SECONDS)
+                          .withThrowableOfType(ExecutionException.class)
+                          .withCauseInstanceOf(NoSuchFileException.class)
+                          .withMessageContaining("Verify that the parent directory exists")
+                          .withMessageContaining("The SDK will not auto-create it");
+    }
+
+    @Test
+    void writeToPosition_fileDoesNotExist_throwsWithHelpfulMessage() {
+        Path testPath = testFs.getPath("nonexistent_file.txt");
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath,
+            FileTransformerConfiguration.builder()
+                                        .failureBehavior(DELETE)
+                                        .fileWriteOption(FileWriteOption.WRITE_TO_POSITION)
+                                        .build());
+
+        CompletableFuture<String> future = transformer.prepare();
+        transformer.onResponse("foobar");
+        transformer.onStream(testPublisher("content"));
+
+        assertThat(future).failsWithin(1, TimeUnit.SECONDS)
+                          .withThrowableOfType(ExecutionException.class)
+                          .withCauseInstanceOf(NoSuchFileException.class);
+    }
+
     private static void stubSuccessfulStreaming(String newContent, FileAsyncResponseTransformer<String> transformer) throws Exception {
         CompletableFuture<String> future = transformer.prepare();
         transformer.onResponse("foobar");

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/ResponseTransformerToFileTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/ResponseTransformerToFileTest.java
@@ -43,8 +43,8 @@ class ResponseTransformerToFileTest {
 
         assertThatThrownBy(() -> transformer.transform("response", inputStream))
             .isInstanceOf(IOException.class)
-            .hasMessageContaining("Verify that the parent directory exists")
-            .hasMessageContaining("The SDK will not auto-create it")
+            .hasMessageContaining("Verify that the file's parent directories exist")
+            .hasMessageContaining("The SDK will not auto-create them")
             .hasCauseInstanceOf(NoSuchFileException.class);
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/ResponseTransformerToFileTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/ResponseTransformerToFileTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.sync;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.http.AbortableInputStream;
+
+
+class ResponseTransformerToFileTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void toFile_parentDirectoryDoesNotExist_throwsWithHelpfulMessage() throws Exception {
+        Path fileWithMissingParent = tempDir.resolve("nonexistent-parent/subdir/output.wav");
+        ResponseTransformer<String, String> transformer = ResponseTransformer.toFile(fileWithMissingParent);
+
+        AbortableInputStream inputStream = AbortableInputStream.create(
+            new ByteArrayInputStream("test-content".getBytes(StandardCharsets.UTF_8))
+        );
+
+        assertThatThrownBy(() -> transformer.transform("response", inputStream))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("Verify that the parent directory exists")
+            .hasMessageContaining("The SDK will not auto-create it")
+            .hasCauseInstanceOf(NoSuchFileException.class);
+    }
+}


### PR DESCRIPTION
  ## Motivation and Context

   When `ResponseTransformer.toFile()` or `AsyncResponseTransformer.toFile()` is called with a path whose parent directory does not exist, the SDK throws a `NoSuchFileException` wrapped in a generic "Failed to read response into file" message. This is confusing because the error doesn't indicate *why* the file couldn't be written. This is a common issue for customers migrating from SDK v1, where `getObject(request, File)` auto-created parent directories via `mkdirs()`.

   ## Modifications

   - Improve error messages
   - Updated documentations
  
   ## Testing

   - Added `ResponseTransformerToFileTest` for the sync path.
   - Added parameterized tests in `FileAsyncResponseTransformerTest` covering `CREATE_NEW`, `CREATE_OR_REPLACE_EXISTING`,
   `CREATE_OR_APPEND_TO_EXISTING` (missing parent dir) and `WRITE_TO_POSITION` (missing file).

   ## Types of changes
   - [x] Bug fix (non-breaking change which fixes an issue)

   ## Checklist
   - [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
   - [ ] Local run of `mvn install` succeeds
   - [x] My code follows the code style of this project
   - [x] My change requires a change to the Javadoc documentation
   - [x] I have updated the Javadoc documentation accordingly
   - [x] I have added tests to cover my changes
   - [ ] All new and existing tests passed
   - [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following
   the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

   ## License
   - [x] I confirm that this pull request can be released under the Apache 2 license