### PR TITLE
Port base changes from hackathon-2022-extension-methods branch

### DIFF
--- a/.changes/next-release/feature-AmazonS3-717127d.json
+++ b/.changes/next-release/feature-AmazonS3-717127d.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Added `doesObjectExist` and `doesBucketExist` convenience methods to S3Client and S3AsyncClient"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ClientExtensions.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ClientExtensions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+/**
+ * Whether the service has API extensions defined apart from the service model.
+ */
+public class ClientExtensions {
+
+    private boolean sync = false;
+    private boolean async = false;
+
+    public boolean getSync() {
+        return sync;
+    }
+
+    public void setSync(boolean sync) {
+        this.sync = sync;
+    }
+
+    public boolean getAsync() {
+        return async;
+    }
+
+    public void setAsync(boolean async) {
+        this.async = async;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -250,6 +250,11 @@ public class CustomizationConfig {
     private String asyncClientDecorator;
 
     /**
+     * If the client has API extensions to include.
+     */
+    private ClientExtensions clientExtensions;
+
+    /**
      * Only for s3. A set of customization to related to multipart operations.
      */
     private MultipartCustomization multipartCustomization;
@@ -744,6 +749,14 @@ public class CustomizationConfig {
 
     public void setAsyncClientDecorator(String asyncClientDecorator) {
         this.asyncClientDecorator = asyncClientDecorator;
+    }
+
+    public ClientExtensions getClientExtensions() {
+        return clientExtensions;
+    }
+
+    public void setClientExtensions(ClientExtensions clientExtensions) {
+        this.clientExtensions = clientExtensions;
     }
 
     public boolean isDelegateSyncClientClass() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetUtils.java
@@ -37,6 +37,9 @@ public final class PoetUtils {
                                                                   .addMember("value", "$S", "software.amazon.awssdk:codegen")
                                                                   .build();
 
+    private static final String EXTENSION_PACKAGE = ".extensions";
+    private static final String EXTENSION_INTERFACE_SUFFIX = "SdkExtension";
+
     private PoetUtils() {
     }
 
@@ -107,5 +110,11 @@ public final class PoetUtils {
         JavaFile.Builder builder = JavaFile.builder(spec.className().packageName(), spec.poetSpec()).skipJavaLangImports(true);
         spec.staticImports().forEach(i -> i.memberNames().forEach(m -> builder.addStaticImport(i.className(), m)));
         return builder.build();
+    }
+
+    public static ClassName extensionInterfaceClassName(ClassName clientInterfaceName) {
+        String packageName = clientInterfaceName.packageName() + EXTENSION_PACKAGE;
+        String className = clientInterfaceName.simpleName() + EXTENSION_INTERFACE_SUFFIX;
+        return ClassName.get(packageName, className);
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
@@ -21,6 +21,7 @@ import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.internal.Constant.ASYNC_STREAMING_INPUT_PARAM;
+import static software.amazon.awssdk.codegen.poet.PoetUtils.extensionInterfaceClassName;
 import static software.amazon.awssdk.codegen.internal.Constant.EVENT_PUBLISHER_PARAM_NAME;
 import static software.amazon.awssdk.codegen.internal.Constant.EVENT_RESPONSE_HANDLER_PARAM_NAME;
 
@@ -35,6 +36,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.reactivestreams.Publisher;
@@ -47,6 +49,8 @@ import software.amazon.awssdk.codegen.docs.DocConfiguration;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.docs.WaiterDocs;
 import software.amazon.awssdk.codegen.model.config.customization.AdditionalBuilderMethod;
+import software.amazon.awssdk.codegen.model.config.customization.ClientExtensions;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -111,6 +115,8 @@ public class AsyncClientInterface implements ClassSpec {
 
     protected void addInterfaceClass(TypeSpec.Builder type) {
         type.addSuperinterface(AwsClient.class);
+        Optional<ClassName> extensionInterface = findExtensionInterface(className, model.getCustomizationConfig());
+        extensionInterface.ifPresent(type::addSuperinterface);
     }
 
     protected void addAnnotations(TypeSpec.Builder type) {
@@ -549,6 +555,15 @@ public class AsyncClientInterface implements ClassSpec {
     protected MethodSpec.Builder batchManagerOperationBody(MethodSpec.Builder builder) {
         return builder.addModifiers(DEFAULT, PUBLIC)
                       .addStatement("throw new $T()", UnsupportedOperationException.class);
+    }
+
+    private static Optional<ClassName> findExtensionInterface(ClassName clientInterfaceName,
+                                                              CustomizationConfig customizationConfig) {
+        ClientExtensions clientExtensions = customizationConfig.getClientExtensions();
+        if (clientExtensions != null && clientExtensions.getAsync()) {
+            return Optional.of(extensionInterfaceClassName(clientInterfaceName));
+        }
+        return Optional.empty();
     }
 
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -25,6 +25,7 @@ import static software.amazon.awssdk.codegen.internal.Constant.SYNC_CLIENT_DESTI
 import static software.amazon.awssdk.codegen.internal.Constant.SYNC_CLIENT_SOURCE_PATH_PARAM_NAME;
 import static software.amazon.awssdk.codegen.internal.Constant.SYNC_STREAMING_INPUT_PARAM;
 import static software.amazon.awssdk.codegen.internal.Constant.SYNC_STREAMING_OUTPUT_PARAM;
+import static software.amazon.awssdk.codegen.poet.PoetUtils.extensionInterfaceClassName;
 import static software.amazon.awssdk.codegen.poet.client.AsyncClientInterface.STREAMING_TYPE_VARIABLE;
 
 import com.squareup.javapoet.ClassName;
@@ -38,6 +39,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -49,6 +51,8 @@ import software.amazon.awssdk.codegen.docs.ClientType;
 import software.amazon.awssdk.codegen.docs.DocConfiguration;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.docs.WaiterDocs;
+import software.amazon.awssdk.codegen.model.config.customization.ClientExtensions;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -102,6 +106,8 @@ public class SyncClientInterface implements ClassSpec {
 
     protected void addInterfaceClass(TypeSpec.Builder type) {
         type.addSuperinterface(AwsClient.class);
+        Optional<ClassName> extensionInterface = findExtensionInterface(className, model.getCustomizationConfig());
+        extensionInterface.ifPresent(type::addSuperinterface);
     }
 
     protected TypeSpec.Builder createTypeSpec() {
@@ -558,5 +564,14 @@ public class SyncClientInterface implements ClassSpec {
     protected MethodSpec.Builder waiterOperationBody(MethodSpec.Builder builder) {
         return builder.addModifiers(DEFAULT, PUBLIC)
                       .addStatement("throw new $T()", UnsupportedOperationException.class);
+    }
+
+    private static Optional<ClassName> findExtensionInterface(ClassName clientInterfaceName,
+                                                              CustomizationConfig customizationConfig) {
+        ClientExtensions clientExtensions = customizationConfig.getClientExtensions();
+        if (clientExtensions != null && clientExtensions.getSync()) {
+            return Optional.of(extensionInterfaceClassName(clientInterfaceName));
+        }
+        return Optional.empty();
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -606,6 +606,18 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel clientExtensionModels() {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/clientextensions/service-2.json").getFile());
+        File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/clientextensions/customization.config").getFile());
+
+        C2jModels models = C2jModels.builder()
+                                    .serviceModel(getServiceModel(serviceModel))
+                                    .customizationConfig(getCustomizationConfig(customizationModel))
+                                    .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     private static ServiceModel getServiceModel(File file) {
         return ModelLoaderUtils.loadModel(ServiceModel.class, file);
     }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterfaceTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterfaceTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.codegen.poet.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.batchManagerModels;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.clientExtensionModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.restJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
@@ -34,5 +35,11 @@ public class AsyncClientInterfaceTest {
     public void asyncClientInterfaceWithBatchManager() {
         ClassSpec asyncClientInterface = new AsyncClientInterface(batchManagerModels());
         assertThat(asyncClientInterface, generatesTo("test-json-async-client-interface-batchmanager.java"));
+    }
+
+    @Test
+    public void asyncClientInterfaceClientExtensions() {
+        ClassSpec asyncClientInterface = new AsyncClientInterface(clientExtensionModels());
+        assertThat(asyncClientInterface, generatesTo("test-clientextensions-async-interface.java"));
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterfaceTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterfaceTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.codegen.poet.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.clientExtensionModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.restJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
@@ -27,5 +28,11 @@ public class SyncClientInterfaceTest {
     public void syncClientInterface() {
         ClassSpec syncClientInterface = new SyncClientInterface(restJsonServiceModels());
         assertThat(syncClientInterface, generatesTo("test-json-client-interface.java"));
+    }
+
+    @Test
+    public void syncClientInterfaceClientExtensions() {
+        ClassSpec syncClientInterface = new SyncClientInterface(clientExtensionModels());
+        assertThat(syncClientInterface, generatesTo("test-clientextensions-sync-interface.java"));
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/utils/PoetUtilsTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/utils/PoetUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+
+/**
+ * Validate functionality of {@link PoetUtils} methods.
+ */
+public class PoetUtilsTest {
+
+    @Test
+    public void findExtensionInterface_whenNotExists_returnEmpty() {
+        ClassName clientName = ClassName.get("software.amazon.awssdk.sdkservice", "SdkServiceClient");
+        ClassName extensionClass = PoetUtils.extensionInterfaceClassName(clientName);
+        assertThat(extensionClass).isNotNull();
+        assertThat(extensionClass.canonicalName())
+            .isEqualTo("software.amazon.awssdk.sdkservice.extensions.SdkServiceClientSdkExtension");
+    }
+
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/clientextensions/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/clientextensions/customization.config
@@ -1,0 +1,6 @@
+{
+    "clientExtensions": {
+      "sync": true,
+      "async": true
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/clientextensions/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/clientextensions/service-2.json
@@ -1,0 +1,36 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"clientextensions",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "serviceAbbreviation":"AmazonSdkExtensions",
+    "serviceFullName":"Amazon Sdk Extensions",
+    "serviceId":"AmazonSdkExtensions",
+    "signatureVersion":"v4",
+    "targetPrefix":"ProtocolTestsService",
+    "uid":"restjson-2016-03-11"
+  },
+  "operations":{
+    "OneOperation":{
+      "name":"OneOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/oneoperation"
+      },
+      "input":{"shape":"OneShape"}
+    }
+  },
+  "shapes": {
+    "OneShape": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "String":{"type":"string"}
+  }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-clientextensions-async-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-clientextensions-async-interface.java
@@ -1,0 +1,85 @@
+package software.amazon.awssdk.services.sdkextensions;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.services.sdkextensions.extensions.SdkExtensionsAsyncClientSdkExtension;
+import software.amazon.awssdk.services.sdkextensions.model.OneOperationRequest;
+import software.amazon.awssdk.services.sdkextensions.model.OneOperationResponse;
+
+/**
+ * Service client for accessing AmazonSdkExtensions asynchronously. This can be created using the static {@link #builder()} method.The asynchronous client performs non-blocking I/O when configured with any {@code SdkAsyncHttpClient} supported in the SDK. However, full non-blocking is not guaranteed as the async client may perform blocking calls in some cases such as credentials retrieval and endpoint discovery as part of the async API call.
+ *
+ * null
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+@ThreadSafe
+public interface SdkExtensionsAsyncClient extends AwsClient, SdkExtensionsAsyncClientSdkExtension {
+  String SERVICE_NAME = "clientextensions";
+
+  /**
+   * Value for looking up the service's metadata from the {@link software.amazon.awssdk.regions.ServiceMetadataProvider}.
+   */
+  String SERVICE_METADATA_ID = "clientextensions";
+
+  /**
+   * Invokes the OneOperation operation asynchronously.
+   *
+   * @param oneOperationRequest
+   * @return A Java Future containing the result of the OneOperation operation returned by the service.<br/>
+   * The CompletableFuture returned by this method can be completed exceptionally with the following exceptions. The exception returned is wrapped with CompletionException, so you need to invoke {@link Throwable#getCause} to retrieve the underlying exception.
+   * <ul>
+   * <li>SdkException  Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for catch all scenarios.</li>
+   * <li>SdkClientException  If any client side error occurs such as an IO related failure, failure to get credentials, etc.</li>
+   * <li>SdkExtensionsException Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.</li>
+   * </ul>
+   * @sample SdkExtensionsAsyncClient.OneOperation
+   * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/restjson-2016-03-11/OneOperation" target="_top">AWS API Documentation</a>
+   */
+  default CompletableFuture<OneOperationResponse> oneOperation(
+      OneOperationRequest oneOperationRequest) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Invokes the OneOperation operation asynchronously.<br/><p>This is a convenience which creates an instance of the {@link OneOperationRequest.Builder} avoiding the need to create one manually via {@link OneOperationRequest#builder()}</p>
+   *
+   * @param oneOperationRequest A {@link Consumer} that will call methods on {@link software.amazon.awssdk.services.sdkextensions.model.OneOperationRequest.Builder} to create a request.
+   * @return A Java Future containing the result of the OneOperation operation returned by the service.<br/>
+   * The CompletableFuture returned by this method can be completed exceptionally with the following exceptions. The exception returned is wrapped with CompletionException, so you need to invoke {@link Throwable#getCause} to retrieve the underlying exception.
+   * <ul>
+   * <li>SdkException  Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for catch all scenarios.</li>
+   * <li>SdkClientException  If any client side error occurs such as an IO related failure, failure to get credentials, etc.</li>
+   * <li>SdkExtensionsException Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.</li>
+   * </ul>
+   * @sample SdkExtensionsAsyncClient.OneOperation
+   * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/restjson-2016-03-11/OneOperation" target="_top">AWS API Documentation</a>
+   */
+  default CompletableFuture<OneOperationResponse> oneOperation(
+      Consumer<OneOperationRequest.Builder> oneOperationRequest) {
+    return oneOperation(OneOperationRequest.builder().applyMutation(oneOperationRequest).build());
+  }
+
+  @Override
+  default SdkExtensionsServiceClientConfiguration serviceClientConfiguration() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Create a {@link SdkExtensionsAsyncClient} with the region loaded from the {@link software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain} and credentials loaded from the {@link software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider}.
+   */
+  static SdkExtensionsAsyncClient create() {
+    return builder().build();
+  }
+
+  /**
+   * Create a builder that can be used to configure and create a {@link SdkExtensionsAsyncClient}.
+   */
+  static SdkExtensionsAsyncClientBuilder builder() {
+    return new DefaultSdkExtensionsAsyncClientBuilder();
+  }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-clientextensions-sync-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-clientextensions-sync-interface.java
@@ -1,0 +1,87 @@
+package software.amazon.awssdk.services.sdkextensions;
+
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.ServiceMetadata;
+import software.amazon.awssdk.services.sdkextensions.extensions.SdkExtensionsClientSdkExtension;
+import software.amazon.awssdk.services.sdkextensions.model.OneOperationRequest;
+import software.amazon.awssdk.services.sdkextensions.model.OneOperationResponse;
+import software.amazon.awssdk.services.sdkextensions.model.SdkExtensionsException;
+
+/**
+ * Service client for accessing AmazonSdkExtensions. This can be created using the static {@link #builder()} method.
+ *
+ * null
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+@ThreadSafe
+public interface SdkExtensionsClient extends AwsClient, SdkExtensionsClientSdkExtension {
+  String SERVICE_NAME = "clientextensions";
+
+  /**
+   * Value for looking up the service's metadata from the {@link software.amazon.awssdk.regions.ServiceMetadataProvider}.
+   */
+  String SERVICE_METADATA_ID = "clientextensions";
+
+  /**
+   * Invokes the OneOperation operation.
+   *
+   * @param oneOperationRequest
+   * @return Result of the OneOperation operation returned by the service.
+   * @throws SdkException  Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for catch all scenarios.
+   * @throws SdkClientException  If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+   * @throws SdkExtensionsException Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+   * @sample SdkExtensionsClient.OneOperation
+   * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/restjson-2016-03-11/OneOperation" target="_top">AWS API Documentation</a>
+   */
+  default OneOperationResponse oneOperation(OneOperationRequest oneOperationRequest) throws
+      AwsServiceException, SdkClientException, SdkExtensionsException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Invokes the OneOperation operation.<br/><p>This is a convenience which creates an instance of the {@link OneOperationRequest.Builder} avoiding the need to create one manually via {@link OneOperationRequest#builder()}</p>
+   *
+   * @param oneOperationRequest A {@link Consumer} that will call methods on {@link software.amazon.awssdk.services.sdkextensions.model.OneOperationRequest.Builder} to create a request.
+   * @return Result of the OneOperation operation returned by the service.
+   * @throws SdkException  Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for catch all scenarios.
+   * @throws SdkClientException  If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+   * @throws SdkExtensionsException Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+   * @sample SdkExtensionsClient.OneOperation
+   * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/restjson-2016-03-11/OneOperation" target="_top">AWS API Documentation</a>
+   */
+  default OneOperationResponse oneOperation(
+      Consumer<OneOperationRequest.Builder> oneOperationRequest) throws AwsServiceException,
+      SdkClientException, SdkExtensionsException {
+    return oneOperation(OneOperationRequest.builder().applyMutation(oneOperationRequest).build());
+  }
+
+  /**
+   * Create a {@link SdkExtensionsClient} with the region loaded from the {@link software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain} and credentials loaded from the {@link software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider}.
+   */
+  static SdkExtensionsClient create() {
+    return builder().build();
+  }
+
+  /**
+   * Create a builder that can be used to configure and create a {@link SdkExtensionsClient}.
+   */
+  static SdkExtensionsClientBuilder builder() {
+    return new DefaultSdkExtensionsClientBuilder();
+  }
+
+  static ServiceMetadata serviceMetadata() {
+    return ServiceMetadata.of(SERVICE_METADATA_ID);
+  }
+
+  @Override
+  default SdkExtensionsServiceClientConfiguration serviceClientConfiguration() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/core/annotations/src/main/java/software/amazon/awssdk/annotations/SdkExtensionMethod.java
+++ b/core/annotations/src/main/java/software/amazon/awssdk/annotations/SdkExtensionMethod.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * {@link SdkExtensionMethod} indicates a method that has been explicitly added to a service client interface on behalf of the
+ * SDK. While most service clients are automatically and fully generated from the corresponding service's API model, the SDK may
+ * sometimes choose to extend a service's logical API in order to provide improved abstractions or convenience functions. {@link
+ * SdkExtensionMethod} implementations may invoke one or more service requests to fulfil their behavior.
+ */
+@Target(ElementType.METHOD)
+@SdkProtectedApi
+public @interface SdkExtensionMethod {
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/extensions/DefaultS3ExtensionIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/extensions/DefaultS3ExtensionIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.testutils.RandomTempFile;
+
+public class DefaultS3ExtensionIntegrationTest extends S3IntegrationTestBase {
+
+    private static final String BUCKET = temporaryBucketName(DefaultS3ExtensionIntegrationTest.class);
+    private static final String KEY = "some-key";
+
+    private static File file;
+
+    @BeforeClass
+    public static void setupFixture() throws IOException {
+        createBucket(BUCKET);
+        file = new RandomTempFile(10_000);
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET).key(KEY).build(), file.toPath());
+    }
+
+    @AfterClass
+    public static void tearDownFixture() {
+        deleteBucketAndAllContents(BUCKET);
+        file.delete();
+    }
+
+    @Test
+    public void bucketExistsSync() {
+        assertThat(s3.doesBucketExist(BUCKET)).isTrue();
+    }
+
+    @Test
+    public void bucketExistsAsync() {
+        assertThat(s3Async.doesBucketExist(BUCKET).join()).isTrue();
+    }
+
+    @Test
+    public void bucketDoesNotExistSync() {
+        assertThat(s3.doesBucketExist(temporaryBucketName("noexist"))).isFalse();
+    }
+
+    @Test
+    public void bucketDoesNotExistAsync() {
+        assertThat(s3Async.doesBucketExist(temporaryBucketName("noexist")).join()).isFalse();
+    }
+
+    @Test
+    public void objectExistsSync() {
+        assertThat(s3.doesObjectExist(BUCKET, KEY)).isTrue();
+    }
+
+    @Test
+    public void objectExistsAsync() {
+        assertThat(s3Async.doesObjectExist(BUCKET, KEY).join()).isTrue();
+    }
+
+    @Test
+    public void objectDoesNotExistSync() {
+        assertThat(s3.doesObjectExist(BUCKET, "noexist")).isFalse();
+    }
+
+    @Test
+    public void objectDoesNotExistAsync() {
+        assertThat(s3Async.doesObjectExist(BUCKET, "noexist").join()).isFalse();
+    }
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/s3express/S3ExpressExtensionMethodsTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/s3express/S3ExpressExtensionMethodsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.s3express;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Verify that doesObjectExist/doesBucketExist extension methods work with S3 Express (directory buckets).
+ */
+class S3ExpressExtensionMethodsTest extends S3ExpressIntegrationTestBase {
+
+    private static final Region TEST_REGION = Region.US_EAST_1;
+    private static final String AZ = "use1-az4";
+    private static final String BUCKET = String.format(
+        temporaryBucketName(S3ExpressExtensionMethodsTest.class) + "--%s--x-s3", AZ);
+    private static final String KEY = "test-key";
+
+    private static S3Client s3;
+
+    @BeforeAll
+    static void setup() {
+        s3 = s3ClientBuilder(TEST_REGION).build();
+        createBucketS3Express(s3, BUCKET, AZ);
+        s3.putObject(r -> r.bucket(BUCKET).key(KEY), RequestBody.fromString("hello"));
+    }
+
+    @AfterAll
+    static void teardown() {
+        deleteBucketAndAllContents(s3, BUCKET);
+        s3.close();
+    }
+
+    @Test
+    void doesObjectExist_existingObject_returnsTrue() {
+        assertThat(s3.doesObjectExist(BUCKET, KEY)).isTrue();
+    }
+
+    @Test
+    void doesObjectExist_nonExistentObject_returnsFalse() {
+        assertThat(s3.doesObjectExist(BUCKET, "fake-key")).isFalse();
+    }
+
+    @Test
+    void doesBucketExist_existingBucket_returnsTrue() {
+        assertThat(s3.doesBucketExist(BUCKET)).isTrue();
+    }
+
+    @Test
+    void doesBucketExist_nonExistentBucket_returnsFalse() {
+        String fakeBucket = String.format(
+            temporaryBucketName("nonexistent") + "--%s--x-s3", AZ);
+        assertThat(s3.doesBucketExist(fakeBucket)).isFalse();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/extensions/S3AsyncClientSdkExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/extensions/S3AsyncClientSdkExtension.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.extensions;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkExtensionMethod;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.internal.extensions.DefaultS3AsyncClientSdkExtension;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Extension methods for the {@link S3AsyncClient} interface.
+ *
+ * <p>These are convenience methods that provide higher-level abstractions over S3 service API calls.
+ * They are available directly on the {@link S3AsyncClient} interface.
+ */
+@SdkPublicApi
+public interface S3AsyncClientSdkExtension {
+
+    /**
+     * Check whether the specified bucket exists in Amazon S3 and is accessible to the caller.
+     *
+     * <p>This method calls {@code HeadBucket} and interprets the response:
+     * <ul>
+     *   <li>200 — the bucket exists and is accessible, completes with {@code true}</li>
+     *   <li>404 — the bucket does not exist, completes with {@code false}</li>
+     *   <li>403 — the bucket may exist but the caller does not have access, completes exceptionally
+     *       with {@link S3Exception}</li>
+     * </ul>
+     *
+     * @param bucket the bucket name
+     * @return a {@link CompletableFuture} that completes with {@code true} if the bucket exists and is accessible;
+     *         {@code false} if it does not exist
+     * @throws S3Exception if S3 returns an error other than 404 (e.g., 403 Access Denied)
+     */
+    @SdkExtensionMethod
+    default CompletableFuture<Boolean> doesBucketExist(String bucket) {
+        return new DefaultS3AsyncClientSdkExtension((S3AsyncClient) this).doesBucketExist(bucket);
+    }
+
+    /**
+     * Check whether the specified object exists in Amazon S3 and is accessible to the caller.
+     *
+     * <p>This method calls {@code HeadObject} and interprets the response:
+     * <ul>
+     *   <li>200 — the object exists, completes with {@code true}</li>
+     *   <li>404 — the object does not exist, completes with {@code false}</li>
+     *   <li>403 — access is denied, completes exceptionally with {@link S3Exception}. Note that S3 returns 403
+     *       instead of 404 when the caller lacks {@code s3:ListBucket} permission on the bucket.</li>
+     * </ul>
+     *
+     * @param bucket the bucket containing the object
+     * @param key the object key
+     * @return a {@link CompletableFuture} that completes with {@code true} if the object exists and is accessible;
+     *         {@code false} if it does not exist
+     * @throws S3Exception if S3 returns an error other than 404 (e.g., 403 Access Denied)
+     */
+    @SdkExtensionMethod
+    default CompletableFuture<Boolean> doesObjectExist(String bucket, String key) {
+        return new DefaultS3AsyncClientSdkExtension((S3AsyncClient) this).doesObjectExist(bucket, key);
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/extensions/S3ClientSdkExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/extensions/S3ClientSdkExtension.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.extensions;
+
+import software.amazon.awssdk.annotations.SdkExtensionMethod;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.internal.extensions.DefaultS3ClientSdkExtension;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Extension methods for the {@link S3Client} interface.
+ *
+ * <p>These are convenience methods that provide higher-level abstractions over S3 service API calls.
+ * They are available directly on the {@link S3Client} interface.
+ */
+@SdkPublicApi
+public interface S3ClientSdkExtension {
+
+    /**
+     * Check whether the specified bucket exists in Amazon S3 and is accessible to the caller.
+     *
+     * <p>This method calls {@code HeadBucket} and interprets the response:
+     * <ul>
+     *   <li>200 — the bucket exists and is accessible, returns {@code true}</li>
+     *   <li>404 — the bucket does not exist, returns {@code false}</li>
+     *   <li>403 — the bucket may exist but the caller does not have access, throws {@link S3Exception}</li>
+     * </ul>
+     *
+     * @param bucket the bucket name
+     * @return {@code true} if the bucket exists and is accessible; {@code false} if it does not exist
+     * @throws S3Exception if S3 returns an error other than 404 (e.g., 403 Access Denied)
+     */
+    @SdkExtensionMethod
+    default boolean doesBucketExist(String bucket) {
+        return new DefaultS3ClientSdkExtension((S3Client) this).doesBucketExist(bucket);
+    }
+
+    /**
+     * Check whether the specified object exists in Amazon S3 and is accessible to the caller.
+     *
+     * <p>This method calls {@code HeadObject} and interprets the response:
+     * <ul>
+     *   <li>200 — the object exists, returns {@code true}</li>
+     *   <li>404 — the object does not exist, returns {@code false}</li>
+     *   <li>403 — access is denied, throws {@link S3Exception}. Note that S3 returns 403 instead of 404
+     *       when the caller lacks {@code s3:ListBucket} permission on the bucket.</li>
+     * </ul>
+     *
+     * @param bucket the bucket containing the object
+     * @param key the object key
+     * @return {@code true} if the object exists and is accessible; {@code false} if it does not exist
+     * @throws S3Exception if S3 returns an error other than 404 (e.g., 403 Access Denied)
+     */
+    @SdkExtensionMethod
+    default boolean doesObjectExist(String bucket, String key) {
+        return new DefaultS3ClientSdkExtension((S3Client) this).doesObjectExist(bucket, key);
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3AsyncClientSdkExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3AsyncClientSdkExtension.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.extensions;
+
+import static software.amazon.awssdk.utils.CompletableFutureUtils.failedFuture;
+import static software.amazon.awssdk.utils.CompletableFutureUtils.forwardExceptionTo;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.extensions.S3AsyncClientSdkExtension;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public class DefaultS3AsyncClientSdkExtension implements S3AsyncClientSdkExtension {
+
+    private final S3AsyncClient s3;
+
+    public DefaultS3AsyncClientSdkExtension(S3AsyncClient s3) {
+        this.s3 = Validate.notNull(s3, "s3");
+    }
+
+    @Override
+    public CompletableFuture<Boolean> doesBucketExist(String bucket) {
+        try {
+            Validate.notEmpty(bucket, "bucket must not be null or empty");
+            CompletableFuture<Boolean> returnFuture = new CompletableFuture<>();
+            CompletableFuture<HeadBucketResponse> responseFuture = s3.headBucket(r -> r.bucket(bucket));
+            forwardExceptionTo(returnFuture, responseFuture);
+            responseFuture.whenComplete((r, t) -> {
+                Throwable cause = t instanceof CompletionException ? t.getCause() : t;
+                if (cause == null) {
+                    returnFuture.complete(true);
+                } else if (cause instanceof NoSuchBucketException) {
+                    returnFuture.complete(false);
+                } else {
+                    returnFuture.completeExceptionally(cause);
+                }
+            });
+            return returnFuture;
+        } catch (Throwable t) {
+            return failedFuture(t);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> doesObjectExist(String bucket, String key) {
+        try {
+            Validate.notEmpty(bucket, "bucket must not be null or empty");
+            Validate.notEmpty(key, "key must not be null or empty");
+            CompletableFuture<Boolean> returnFuture = new CompletableFuture<>();
+            CompletableFuture<HeadObjectResponse> responseFuture = s3.headObject(r -> r.bucket(bucket).key(key));
+            forwardExceptionTo(returnFuture, responseFuture);
+            responseFuture.whenComplete((r, t) -> {
+                Throwable cause = t instanceof CompletionException ? t.getCause() : t;
+                if (cause == null) {
+                    returnFuture.complete(true);
+                } else if (cause instanceof NoSuchKeyException) {
+                    returnFuture.complete(false);
+                } else {
+                    returnFuture.completeExceptionally(cause);
+                }
+            });
+            return returnFuture;
+        } catch (Throwable t) {
+            return failedFuture(t);
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtension.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.extensions;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.extensions.S3ClientSdkExtension;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public class DefaultS3ClientSdkExtension implements S3ClientSdkExtension {
+
+    private final S3Client s3;
+
+    public DefaultS3ClientSdkExtension(S3Client s3) {
+        this.s3 = Validate.notNull(s3, "s3");
+    }
+
+    @Override
+    public boolean doesBucketExist(String bucket) {
+        Validate.notEmpty(bucket, "bucket must not be null or empty");
+        try {
+            s3.headBucket(r -> r.bucket(bucket));
+            return true;
+        } catch (NoSuchBucketException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean doesObjectExist(String bucket, String key) {
+        Validate.notEmpty(bucket, "bucket must not be null or empty");
+        Validate.notEmpty(key, "key must not be null or empty");
+        try {
+            s3.headObject(r -> r.bucket(bucket).key(key));
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+}

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -285,6 +285,10 @@
   "delegateSyncClientClass": true,
   "syncClientDecorator": "software.amazon.awssdk.services.s3.internal.client.S3SyncClientDecorator",
   "asyncClientDecorator": "software.amazon.awssdk.services.s3.internal.client.S3AsyncClientDecorator",
+  "clientExtensions": {
+    "sync": true,
+    "async": true
+  },
   "useGlobalEndpoint": true,
   "useS3ExpressSessionAuth": true,
   "multipartCustomization": {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3AsyncClientSdkExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3AsyncClientSdkExtensionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+class DefaultS3AsyncClientSdkExtensionTest {
+
+    private S3AsyncClient s3;
+    private DefaultS3AsyncClientSdkExtension extension;
+
+    @BeforeEach
+    void setUp() {
+        s3 = mock(S3AsyncClient.class);
+        extension = new DefaultS3AsyncClientSdkExtension(s3);
+    }
+
+    @Test
+    void doesObjectExist_objectExists_returnsTrue() {
+        when(s3.headObject(any(Consumer.class)))
+            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().build()));
+        assertThat(extension.doesObjectExist("bucket", "key").join()).isTrue();
+    }
+
+    @Test
+    void doesObjectExist_noSuchKey_returnsFalse() {
+        CompletableFuture<HeadObjectResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(NoSuchKeyException.builder().build());
+        when(s3.headObject(any(Consumer.class))).thenReturn(future);
+        assertThat(extension.doesObjectExist("bucket", "key").join()).isFalse();
+    }
+
+    @Test
+    void doesObjectExist_otherException_propagates() {
+        S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
+        CompletableFuture<HeadObjectResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(forbidden);
+        when(s3.headObject(any(Consumer.class))).thenReturn(future);
+        assertThatThrownBy(() -> extension.doesObjectExist("bucket", "key").join())
+            .isInstanceOf(CompletionException.class)
+            .hasCause(forbidden);
+    }
+
+    @Test
+    void doesBucketExist_bucketExists_returnsTrue() {
+        when(s3.headBucket(any(Consumer.class)))
+            .thenReturn(CompletableFuture.completedFuture(HeadBucketResponse.builder().build()));
+        assertThat(extension.doesBucketExist("bucket").join()).isTrue();
+    }
+
+    @Test
+    void doesBucketExist_noSuchBucket_returnsFalse() {
+        CompletableFuture<HeadBucketResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(NoSuchBucketException.builder().build());
+        when(s3.headBucket(any(Consumer.class))).thenReturn(future);
+        assertThat(extension.doesBucketExist("bucket").join()).isFalse();
+    }
+
+    @Test
+    void doesBucketExist_otherException_propagates() {
+        S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
+        CompletableFuture<HeadBucketResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(forbidden);
+        when(s3.headBucket(any(Consumer.class))).thenReturn(future);
+        assertThatThrownBy(() -> extension.doesBucketExist("bucket").join())
+            .isInstanceOf(CompletionException.class)
+            .hasCause(forbidden);
+    }
+
+    @Test
+    void doesBucketExist_nullBucket_failsFuture() {
+        CompletableFuture<Boolean> result = extension.doesBucketExist(null);
+        assertThatThrownBy(result::join).hasCauseInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void doesObjectExist_nullBucket_failsFuture() {
+        CompletableFuture<Boolean> result = extension.doesObjectExist(null, "key");
+        assertThatThrownBy(result::join).hasCauseInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void doesObjectExist_nullKey_failsFuture() {
+        CompletableFuture<Boolean> result = extension.doesObjectExist("bucket", null);
+        assertThatThrownBy(result::join).hasCauseInstanceOf(NullPointerException.class);
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3AsyncClientSdkExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3AsyncClientSdkExtensionTest.java
@@ -18,8 +18,8 @@ package software.amazon.awssdk.services.s3.internal.extensions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -35,82 +35,106 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 
 class DefaultS3AsyncClientSdkExtensionTest {
 
-    private S3AsyncClient s3;
-    private DefaultS3AsyncClientSdkExtension extension;
+    S3AsyncClient s3;
 
     @BeforeEach
     void setUp() {
-        s3 = mock(S3AsyncClient.class);
-        extension = new DefaultS3AsyncClientSdkExtension(s3);
+        s3 = spy(S3AsyncClient.class);
     }
 
     @Test
-    void doesObjectExist_objectExists_returnsTrue() {
-        when(s3.headObject(any(Consumer.class)))
-            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().build()));
-        assertThat(extension.doesObjectExist("bucket", "key").join()).isTrue();
+    void doesObjectExist_200_returnsTrue() {
+        stubHeadObject(CompletableFuture.completedFuture(HeadObjectResponse.builder().build()));
+        assertThat(s3.doesObjectExist("foo", "bar").join()).isTrue();
     }
 
     @Test
-    void doesObjectExist_noSuchKey_returnsFalse() {
+    void doesObjectExist_404_returnsFalse() {
         CompletableFuture<HeadObjectResponse> future = new CompletableFuture<>();
         future.completeExceptionally(NoSuchKeyException.builder().build());
-        when(s3.headObject(any(Consumer.class))).thenReturn(future);
-        assertThat(extension.doesObjectExist("bucket", "key").join()).isFalse();
+        stubHeadObject(future);
+        assertThat(s3.doesObjectExist("foo", "bar").join()).isFalse();
     }
 
     @Test
-    void doesObjectExist_otherException_propagates() {
+    void doesObjectExist_403_propagatesException() {
         S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
         CompletableFuture<HeadObjectResponse> future = new CompletableFuture<>();
         future.completeExceptionally(forbidden);
-        when(s3.headObject(any(Consumer.class))).thenReturn(future);
-        assertThatThrownBy(() -> extension.doesObjectExist("bucket", "key").join())
+        stubHeadObject(future);
+        assertThatThrownBy(() -> s3.doesObjectExist("foo", "bar").join())
             .isInstanceOf(CompletionException.class)
             .hasCause(forbidden);
     }
 
     @Test
-    void doesBucketExist_bucketExists_returnsTrue() {
-        when(s3.headBucket(any(Consumer.class)))
-            .thenReturn(CompletableFuture.completedFuture(HeadBucketResponse.builder().build()));
-        assertThat(extension.doesBucketExist("bucket").join()).isTrue();
+    void doesBucketExist_200_returnsTrue() {
+        stubHeadBucket(CompletableFuture.completedFuture(HeadBucketResponse.builder().build()));
+        assertThat(s3.doesBucketExist("foo").join()).isTrue();
     }
 
     @Test
-    void doesBucketExist_noSuchBucket_returnsFalse() {
+    void doesBucketExist_404_returnsFalse() {
         CompletableFuture<HeadBucketResponse> future = new CompletableFuture<>();
         future.completeExceptionally(NoSuchBucketException.builder().build());
-        when(s3.headBucket(any(Consumer.class))).thenReturn(future);
-        assertThat(extension.doesBucketExist("bucket").join()).isFalse();
+        stubHeadBucket(future);
+        assertThat(s3.doesBucketExist("foo").join()).isFalse();
     }
 
     @Test
-    void doesBucketExist_otherException_propagates() {
+    void doesBucketExist_403_propagatesException() {
         S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
         CompletableFuture<HeadBucketResponse> future = new CompletableFuture<>();
         future.completeExceptionally(forbidden);
-        when(s3.headBucket(any(Consumer.class))).thenReturn(future);
-        assertThatThrownBy(() -> extension.doesBucketExist("bucket").join())
+        stubHeadBucket(future);
+        assertThatThrownBy(() -> s3.doesBucketExist("foo").join())
             .isInstanceOf(CompletionException.class)
             .hasCause(forbidden);
     }
 
+    // Validation tests
+
     @Test
-    void doesBucketExist_nullBucket_failsFuture() {
-        CompletableFuture<Boolean> result = extension.doesBucketExist(null);
-        assertThatThrownBy(result::join).hasCauseInstanceOf(NullPointerException.class);
+    void doesBucketExist_nullBucket_fails() {
+        assertThatThrownBy(() -> s3.doesBucketExist(null).join())
+            .hasCauseInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void doesObjectExist_nullBucket_failsFuture() {
-        CompletableFuture<Boolean> result = extension.doesObjectExist(null, "key");
-        assertThatThrownBy(result::join).hasCauseInstanceOf(NullPointerException.class);
+    void doesBucketExist_emptyBucket_fails() {
+        assertThatThrownBy(() -> s3.doesBucketExist("").join())
+            .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void doesObjectExist_nullKey_failsFuture() {
-        CompletableFuture<Boolean> result = extension.doesObjectExist("bucket", null);
-        assertThatThrownBy(result::join).hasCauseInstanceOf(NullPointerException.class);
+    void doesObjectExist_nullBucket_fails() {
+        assertThatThrownBy(() -> s3.doesObjectExist(null, "key").join())
+            .hasCauseInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void doesObjectExist_emptyBucket_fails() {
+        assertThatThrownBy(() -> s3.doesObjectExist("", "key").join())
+            .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void doesObjectExist_nullKey_fails() {
+        assertThatThrownBy(() -> s3.doesObjectExist("bucket", null).join())
+            .hasCauseInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void doesObjectExist_emptyKey_fails() {
+        assertThatThrownBy(() -> s3.doesObjectExist("bucket", "").join())
+            .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void stubHeadBucket(CompletableFuture<HeadBucketResponse> result) {
+        doReturn(result).when(s3).headBucket(any(Consumer.class));
+    }
+
+    private void stubHeadObject(CompletableFuture<HeadObjectResponse> result) {
+        doReturn(result).when(s3).headObject(any(Consumer.class));
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtensionTest.java
@@ -86,8 +86,6 @@ class DefaultS3ClientSdkExtensionTest {
         assertThatThrownBy(() -> s3.doesObjectExist("foo", "bar")).isInstanceOf(S3Exception.class);
     }
 
-    // Validation tests (not in prototype)
-
     @Test
     void doesBucketExist_nullBucket_throws() {
         assertThatThrownBy(() -> s3.doesBucketExist(null)).isInstanceOf(NullPointerException.class);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtensionTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+class DefaultS3ClientSdkExtensionTest {
+
+    private S3Client s3;
+    private DefaultS3ClientSdkExtension extension;
+
+    @BeforeEach
+    void setUp() {
+        s3 = mock(S3Client.class);
+        extension = new DefaultS3ClientSdkExtension(s3);
+    }
+
+    @Test
+    void doesObjectExist_objectExists_returnsTrue() {
+        when(s3.headObject(any(Consumer.class))).thenReturn(HeadObjectResponse.builder().build());
+        assertThat(extension.doesObjectExist("bucket", "key")).isTrue();
+    }
+
+    @Test
+    void doesObjectExist_noSuchKey_returnsFalse() {
+        when(s3.headObject(any(Consumer.class))).thenThrow(NoSuchKeyException.builder().build());
+        assertThat(extension.doesObjectExist("bucket", "key")).isFalse();
+    }
+
+    @Test
+    void doesObjectExist_otherS3Exception_propagates() {
+        S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
+        when(s3.headObject(any(Consumer.class))).thenThrow(forbidden);
+        assertThatThrownBy(() -> extension.doesObjectExist("bucket", "key")).isSameAs(forbidden);
+    }
+
+    @Test
+    void doesBucketExist_bucketExists_returnsTrue() {
+        when(s3.headBucket(any(Consumer.class))).thenReturn(HeadBucketResponse.builder().build());
+        assertThat(extension.doesBucketExist("bucket")).isTrue();
+    }
+
+    @Test
+    void doesBucketExist_noSuchBucket_returnsFalse() {
+        when(s3.headBucket(any(Consumer.class))).thenThrow(NoSuchBucketException.builder().build());
+        assertThat(extension.doesBucketExist("bucket")).isFalse();
+    }
+
+    @Test
+    void doesBucketExist_otherS3Exception_propagates() {
+        S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
+        when(s3.headBucket(any(Consumer.class))).thenThrow(forbidden);
+        assertThatThrownBy(() -> extension.doesBucketExist("bucket")).isSameAs(forbidden);
+    }
+
+    @Test
+    void doesBucketExist_nullBucket_throws() {
+        assertThatThrownBy(() -> extension.doesBucketExist(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void doesBucketExist_emptyBucket_throws() {
+        assertThatThrownBy(() -> extension.doesBucketExist("")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void doesObjectExist_nullBucket_throws() {
+        assertThatThrownBy(() -> extension.doesObjectExist(null, "key")).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void doesObjectExist_emptyBucket_throws() {
+        assertThatThrownBy(() -> extension.doesObjectExist("", "key")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void doesObjectExist_nullKey_throws() {
+        assertThatThrownBy(() -> extension.doesObjectExist("bucket", null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void doesObjectExist_emptyKey_throws() {
+        assertThatThrownBy(() -> extension.doesObjectExist("bucket", "")).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/extensions/DefaultS3ClientSdkExtensionTest.java
@@ -18,10 +18,10 @@ package software.amazon.awssdk.services.s3.internal.extensions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
-import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -35,80 +35,94 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 
 class DefaultS3ClientSdkExtensionTest {
 
-    private S3Client s3;
-    private DefaultS3ClientSdkExtension extension;
+    S3Client s3;
 
     @BeforeEach
     void setUp() {
-        s3 = mock(S3Client.class);
-        extension = new DefaultS3ClientSdkExtension(s3);
+        s3 = spy(S3Client.class);
     }
 
     @Test
-    void doesObjectExist_objectExists_returnsTrue() {
-        when(s3.headObject(any(Consumer.class))).thenReturn(HeadObjectResponse.builder().build());
-        assertThat(extension.doesObjectExist("bucket", "key")).isTrue();
+    void doesBucketExist_200_returnsTrue() {
+        stubHeadBucket(() -> HeadBucketResponse.builder().build());
+        assertThat(s3.doesBucketExist("foo")).isEqualTo(true);
     }
 
     @Test
-    void doesObjectExist_noSuchKey_returnsFalse() {
-        when(s3.headObject(any(Consumer.class))).thenThrow(NoSuchKeyException.builder().build());
-        assertThat(extension.doesObjectExist("bucket", "key")).isFalse();
+    void doesBucketExist_404_returnsFalse() {
+        stubHeadBucket(() -> {
+            throw NoSuchBucketException.builder().build();
+        });
+        assertThat(s3.doesBucketExist("foo")).isEqualTo(false);
     }
 
     @Test
-    void doesObjectExist_otherS3Exception_propagates() {
-        S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
-        when(s3.headObject(any(Consumer.class))).thenThrow(forbidden);
-        assertThatThrownBy(() -> extension.doesObjectExist("bucket", "key")).isSameAs(forbidden);
+    void doesBucketExist_403_propagatesException() {
+        stubHeadBucket(() -> {
+            throw S3Exception.builder().build();
+        });
+        assertThatThrownBy(() -> s3.doesBucketExist("foo")).isInstanceOf(S3Exception.class);
     }
 
     @Test
-    void doesBucketExist_bucketExists_returnsTrue() {
-        when(s3.headBucket(any(Consumer.class))).thenReturn(HeadBucketResponse.builder().build());
-        assertThat(extension.doesBucketExist("bucket")).isTrue();
+    void doesObjectExist_200_returnsTrue() {
+        stubHeadObject(() -> HeadObjectResponse.builder().build());
+        assertThat(s3.doesObjectExist("foo", "bar")).isEqualTo(true);
     }
 
     @Test
-    void doesBucketExist_noSuchBucket_returnsFalse() {
-        when(s3.headBucket(any(Consumer.class))).thenThrow(NoSuchBucketException.builder().build());
-        assertThat(extension.doesBucketExist("bucket")).isFalse();
+    void doesObjectExist_404_returnsFalse() {
+        stubHeadObject(() -> {
+            throw NoSuchKeyException.builder().build();
+        });
+        assertThat(s3.doesObjectExist("foo", "bar")).isEqualTo(false);
     }
 
     @Test
-    void doesBucketExist_otherS3Exception_propagates() {
-        S3Exception forbidden = (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
-        when(s3.headBucket(any(Consumer.class))).thenThrow(forbidden);
-        assertThatThrownBy(() -> extension.doesBucketExist("bucket")).isSameAs(forbidden);
+    void doesObjectExist_403_propagatesException() {
+        stubHeadObject(() -> {
+            throw S3Exception.builder().build();
+        });
+        assertThatThrownBy(() -> s3.doesObjectExist("foo", "bar")).isInstanceOf(S3Exception.class);
     }
+
+    // Validation tests (not in prototype)
 
     @Test
     void doesBucketExist_nullBucket_throws() {
-        assertThatThrownBy(() -> extension.doesBucketExist(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> s3.doesBucketExist(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void doesBucketExist_emptyBucket_throws() {
-        assertThatThrownBy(() -> extension.doesBucketExist("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> s3.doesBucketExist("")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void doesObjectExist_nullBucket_throws() {
-        assertThatThrownBy(() -> extension.doesObjectExist(null, "key")).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> s3.doesObjectExist(null, "key")).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void doesObjectExist_emptyBucket_throws() {
-        assertThatThrownBy(() -> extension.doesObjectExist("", "key")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> s3.doesObjectExist("", "key")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void doesObjectExist_nullKey_throws() {
-        assertThatThrownBy(() -> extension.doesObjectExist("bucket", null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> s3.doesObjectExist("bucket", null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void doesObjectExist_emptyKey_throws() {
-        assertThatThrownBy(() -> extension.doesObjectExist("bucket", "")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> s3.doesObjectExist("bucket", "")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void stubHeadBucket(Supplier<HeadBucketResponse> behavior) {
+        doAnswer(i -> behavior.get()).when(s3).headBucket(any(HeadBucketRequest.class));
+    }
+
+    private void stubHeadObject(Supplier<HeadObjectResponse> behavior) {
+        doAnswer(i -> behavior.get()).when(s3).headObject(any(HeadObjectRequest.class));
     }
 }


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-java-v2/issues/392

---

This PR is aimed at reviving https://github.com/aws/aws-sdk-java-v2/tree/hackathon-2022-extension-methods

The hackathon branch couldn't be easily rebased (3 years of drift), so this is a fresh implementation on current master following the same design.

Scoped to `doesObjectExist` / `doesBucketExist` only. The prototype included `deleteBucketAndAllContents`, `getUrl`, `presigner`, and `verifyBucketOwnership`. Those are excluded from this PR to keep the review surface minimal. They can be added as followups.

Added test coverage:
- async unit tests
- input validation tests 
- Codegen test golden files regenerated for current master's codegen output.
- `PoetClientFunctionalTests.java` no longer exists on master.  Codegen tests moved to `SyncClientInterfaceTest` / `AsyncClientInterfaceTest`.

