### PR TITLE
Preserve AWS_CREDENTIALS during auth scheme resolution

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/identity/AwsIdentityProviderUpdater.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/identity/AwsIdentityProviderUpdater.java
@@ -16,14 +16,18 @@
 package software.amazon.awssdk.awscore.internal.identity;
 
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.spi.identity.IdentityProviderUpdater;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 
 /**
  * AWS implementation of {@link IdentityProviderUpdater} that reads credential overrides
- * from {@link AwsRequestOverrideConfiguration}.
+ * from {@link AwsRequestOverrideConfiguration} and deprecated {@link AwsSignerExecutionAttribute#AWS_CREDENTIALS}.
  */
 @SdkInternalApi
 public final class AwsIdentityProviderUpdater implements IdentityProviderUpdater {
@@ -38,17 +42,32 @@ public final class AwsIdentityProviderUpdater implements IdentityProviderUpdater
     }
 
     @Override
-    public IdentityProviders update(SdkRequest request, IdentityProviders base) {
+    public IdentityProviders update(SdkRequest request, IdentityProviders base, ExecutionAttributes executionAttributes) {
         if (base == null) {
             return null;
         }
-        return request.overrideConfiguration()
+
+        IdentityProviders updated = request.overrideConfiguration()
             .filter(c -> c instanceof AwsRequestOverrideConfiguration)
             .map(c -> (AwsRequestOverrideConfiguration) c)
             .map(c -> base.copy(b -> {
                 c.credentialsIdentityProvider().ifPresent(b::putIdentityProvider);
                 c.tokenIdentityProvider().ifPresent(b::putIdentityProvider);
             }))
-            .orElse(base);
+            .orElse(null);
+
+        if (updated != null) {
+            return updated;
+        }
+
+        // Support deprecated AWS_CREDENTIALS execution attribute for backwards compatibility
+        // with interceptors that set credentials via AwsSignerExecutionAttribute.AWS_CREDENTIALS
+        AwsCredentials credentials = executionAttributes.getOptionalAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS)
+                                                        .orElse(null);
+        if (credentials != null) {
+            return base.copy(b -> b.putIdentityProvider(StaticCredentialsProvider.create(credentials)));
+        }
+
+        return base;
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
@@ -108,7 +108,7 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
         IdentityProviderUpdater updater =
             executionAttributes.getAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDER_UPDATER);
         if (updater != null) {
-            identityProviders = updater.update(request, identityProviders);
+            identityProviders = updater.update(request, identityProviders, executionAttributes);
         }
         return identityProviders;
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
@@ -104,10 +104,11 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
             return false;
         }
         String requestHost = request.host();
+        Integer requestPort = request.port();
         return requestHost != null
             && (!requestHost.equals(preModifyUri.getHost())
                 || !String.valueOf(request.protocol()).equals(preModifyUri.getScheme())
-                || request.port() != preModifyUri.getPort());
+                || (requestPort != null && requestPort != preModifyUri.getPort()));
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/spi/identity/IdentityProviderUpdater.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/spi/identity/IdentityProviderUpdater.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.spi.identity;
 
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 
 /**
@@ -29,11 +30,13 @@ import software.amazon.awssdk.identity.spi.IdentityProviders;
 @SdkProtectedApi
 public interface IdentityProviderUpdater {
     /**
-     * Updates identity providers based on request-level overrides.
+     * Updates identity providers by applying request-level credential overrides or
+     * credentials set via {@code AwsSignerExecutionAttribute.AWS_CREDENTIALS} by interceptors.
      *
      * @param request The request (after interceptors have modified it)
      * @param base The base identity providers from client configuration
-     * @return Updated identity providers, or base if no overrides
+     * @param executionAttributes The execution attributes, checked for interceptor-set AWS_CREDENTIALS
+     * @return Updated identity providers, or base if no overrides apply
      */
-    IdentityProviders update(SdkRequest request, IdentityProviders base);
+    IdentityProviders update(SdkRequest request, IdentityProviders base, ExecutionAttributes executionAttributes);
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStageTest.java
@@ -147,7 +147,7 @@ class AuthSchemeResolutionStageTest {
         IdentityProviders updatedProviders = mock(IdentityProviders.class);
 
         IdentityProviderUpdater updater = mock(IdentityProviderUpdater.class);
-        doReturn(updatedProviders).when(updater).update(sdkRequest, baseProviders);
+        doReturn(updatedProviders).when(updater).update(sdkRequest, baseProviders, executionAttributes);
 
         // Setup so that auth scheme uses the updated providers
         @SuppressWarnings("unchecked")
@@ -162,7 +162,7 @@ class AuthSchemeResolutionStageTest {
 
         stage.execute(httpRequestBuilder, context);
 
-        verify(updater).update(sdkRequest, baseProviders);
+        verify(updater).update(sdkRequest, baseProviders, executionAttributes);
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context

Previously some customers override AWS credentials for specific requests by setting AwsSignerExecutionAttribute.AWS_CREDENTIALS in their execution interceptors. After moving auth scheme resolution from interceptors to a dedicated pipeline stage (#6755), these interceptor-set credentials were being ignored.

 This happened because after moving auth scheme resolution to a pipeline stage, credentials are now freshly resolved in AuthSchemeResolutionStage. Since this stage runs after all interceptors, the freshly resolved credentials replace whatever the interceptor had set via AWS_CREDENTIALS.

## Modifications

**Fix 1:**

Updated IdentityProviderUpdater to accept ExecutionAttributes and check for interceptor-set AWS_CREDENTIALS before resolving credentials. If an interceptor has set credentials, they are wrapped in a StaticCredentialsProvider and used instead of the default provider.

Credentials are resolved in this priority order:

   1. Request-level override via AwsRequestOverrideConfiguration.credentialsProvider()(Not respected before, this refactoring fixes it)
   2. Interceptor-set AwsSignerExecutionAttribute.AWS_CREDENTIALS (deprecated, preserved for backwards compatibility)
   3. Client-configured credentials provider (default)

 This matches the behavior before the migration.
 
 Changes:

   - IdentityProviderUpdater — added executionAttributes parameter to the update method
   - AwsIdentityProviderUpdater — added check for deprecated AWS_CREDENTIALS execution attribute
   - AuthSchemeResolutionStage — passes execution attributes to the updater
   - EndpointResolutionStage — null-safe port comparison in interceptorModifiedEndpoint
   
   **Fix 2 : Fixed NPE in EndpointResolutionStage on null port**
   
   Fixed a NullPointerException in EndpointResolutionStage when comparing request ports. The port can be null when   no explicit port is set, and the comparison was not null-safe.

## Testing
Verified with existing unit test in IdentityResolutionOverrideTest which covers credential override scenarios including interceptor-set AWS_CREDENTIALS, request-level overrides, and default credentials provider fallback.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
