### PR TITLE
Add Parallel Multipart Download support for Pre-signed URL GetObject

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-stringarray.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-stringarray.java
@@ -84,7 +84,7 @@ public final class SampleSvcResolveEndpointInterceptor implements ExecutionInter
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         Endpoint resolvedEndpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
-        if (resolvedEndpoint.headers().isEmpty()) {
+        if (resolvedEndpoint == null || CollectionUtils.isNullOrEmpty(resolvedEndpoint.headers())) {
             return context.httpRequest();
         }
         SdkHttpRequest.Builder httpRequestBuilder = context.httpRequest().toBuilder();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.multipart;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Pair;
+
+/**
+ * A parallel subscriber for multipart presigned URL downloads that writes parts concurrently.
+ * Used with {@link software.amazon.awssdk.core.internal.async.FileAsyncResponseTransformerPublisher}
+ * when {@code parallelSplitSupported() == true} (i.e., toFile() downloads).
+ *
+ * <p>Unlike {@link PresignedUrlMultipartDownloaderSubscriber} which requests one part at a time,
+ * this subscriber requests up to {@code maxInFlightParts} concurrently, similar to
+ * {@link ParallelMultipartDownloaderSubscriber} for regular multipart downloads.</p>
+ */
+@SdkInternalApi
+public class ParallelPresignedUrlMultipartDownloaderSubscriber
+    implements Subscriber<AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> {
+
+    private static final Logger log = Logger.loggerFor(ParallelPresignedUrlMultipartDownloaderSubscriber.class);
+    private static final String BYTES_RANGE_PREFIX = "bytes=";
+
+    private final S3AsyncClient s3AsyncClient;
+    private final PresignedUrlDownloadRequest presignedUrlDownloadRequest;
+    private final long configuredPartSizeInBytes;
+    private final CompletableFuture<GetObjectResponse> resultFuture;
+    private final int maxInFlightParts;
+
+    private final AtomicInteger partNumber = new AtomicInteger(0);
+    private final AtomicInteger completedParts = new AtomicInteger(0);
+    private final AtomicInteger inFlightRequestsNum = new AtomicInteger(0);
+    private final AtomicBoolean isCompletedExceptionally = new AtomicBoolean(false);
+    private final AtomicBoolean processingPending = new AtomicBoolean(false);
+    private final Map<Integer, CompletableFuture<GetObjectResponse>> inFlightRequests = new ConcurrentHashMap<>();
+    private final Queue<Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>>> pendingTransformers =
+        new ConcurrentLinkedQueue<>();
+
+    private final Object subscriptionLock = new Object();
+    private Subscription subscription;
+
+    private volatile Long totalContentLength;
+    private volatile Integer totalParts;
+    private volatile String eTag;
+    private volatile GetObjectResponse firstResponse;
+
+    public ParallelPresignedUrlMultipartDownloaderSubscriber(
+        S3AsyncClient s3AsyncClient,
+        PresignedUrlDownloadRequest presignedUrlDownloadRequest,
+        long configuredPartSizeInBytes,
+        CompletableFuture<GetObjectResponse> resultFuture,
+        int maxInFlightParts) {
+        this.s3AsyncClient = s3AsyncClient;
+        this.presignedUrlDownloadRequest = presignedUrlDownloadRequest;
+        this.configuredPartSizeInBytes = configuredPartSizeInBytes;
+        this.resultFuture = resultFuture;
+        this.maxInFlightParts = maxInFlightParts;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (this.subscription != null) {
+            s.cancel();
+            return;
+        }
+        this.subscription = s;
+        s.request(1);
+    }
+
+    @Override
+    public void onNext(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> asyncResponseTransformer) {
+        if (asyncResponseTransformer == null) {
+            throw new NullPointerException("onNext must not be called with null asyncResponseTransformer");
+        }
+
+        int currentPart = partNumber.getAndIncrement();
+
+        if (currentPart == 0) {
+            sendFirstRequest(asyncResponseTransformer);
+        } else {
+            if (totalParts != null && currentPart >= totalParts) {
+                return;
+            }
+            if (totalParts != null) {
+                processRequest(asyncResponseTransformer, currentPart);
+            } else {
+                pendingTransformers.offer(Pair.of(currentPart, asyncResponseTransformer));
+            }
+        }
+    }
+
+    private void sendFirstRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer) {
+        PresignedUrlDownloadRequest partRequest = createRangedGetRequest(0);
+        log.debug(() -> "Sending first range request with range=" + partRequest.range());
+
+        CompletableFuture<GetObjectResponse> response =
+            s3AsyncClient.presignedUrlExtension().getObject(partRequest, transformer);
+
+        inFlightRequests.put(0, response);
+        inFlightRequestsNum.incrementAndGet();
+        CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
+
+        response.whenComplete((res, error) -> {
+            if (error != null || isCompletedExceptionally.get()) {
+                handlePartError(error, 0);
+                return;
+            }
+
+            inFlightRequests.remove(0);
+            inFlightRequestsNum.decrementAndGet();
+            completedParts.incrementAndGet();
+
+            // Discover size and ETag from first response
+            this.eTag = res.eTag();
+            this.firstResponse = res;
+
+            String contentRange = res.contentRange();
+            if (contentRange == null) {
+                handlePartError(PresignedUrlDownloadHelper.missingContentRangeHeader(), 0);
+                return;
+            }
+
+            Optional<Long> parsedTotal = MultipartDownloadUtils.parseContentRangeForTotalSize(contentRange);
+            if (!parsedTotal.isPresent()) {
+                handlePartError(PresignedUrlDownloadHelper.invalidContentRangeHeader(contentRange), 0);
+                return;
+            }
+
+            this.totalContentLength = parsedTotal.get();
+            this.totalParts = calculateTotalParts(totalContentLength, configuredPartSizeInBytes);
+            log.debug(() -> String.format("Total content length: %d, Total parts: %d", totalContentLength, totalParts));
+
+            if (totalParts <= 1) {
+                synchronized (subscriptionLock) {
+                    subscription.cancel();
+                }
+                resultFuture.complete(firstResponse);
+                return;
+            }
+
+            processPendingTransformers();
+
+            int remainingParts = totalParts - 1;
+            int toRequest = Math.min(remainingParts, maxInFlightParts);
+            synchronized (subscriptionLock) {
+                subscription.request(toRequest);
+            }
+        });
+    }
+
+    private void processRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer,
+                                int currentPart) {
+        if (currentPart >= totalParts) {
+            return;
+        }
+
+        if (inFlightRequestsNum.get() >= maxInFlightParts) {
+            pendingTransformers.offer(Pair.of(currentPart, transformer));
+            return;
+        }
+
+        sendPartRequest(transformer, currentPart);
+        processPendingTransformers();
+    }
+
+    private void sendPartRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer,
+                                 int partIndex) {
+        if (isCompletedExceptionally.get()) {
+            return;
+        }
+
+        PresignedUrlDownloadRequest partRequest = createRangedGetRequest(partIndex);
+        log.debug(() -> "Sending range request for part " + partIndex + " with range=" + partRequest.range());
+
+        CompletableFuture<GetObjectResponse> response =
+            s3AsyncClient.presignedUrlExtension().getObject(partRequest, transformer);
+
+        inFlightRequests.put(partIndex, response);
+        inFlightRequestsNum.incrementAndGet();
+        CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
+
+        response.whenComplete((res, error) -> {
+            if (error != null || isCompletedExceptionally.get()) {
+                handlePartError(error, partIndex);
+                return;
+            }
+
+            Optional<SdkClientException> validationError = validatePartResponse(res, partIndex);
+            if (validationError.isPresent()) {
+                handlePartError(validationError.get(), partIndex);
+                return;
+            }
+
+            log.debug(() -> "Completed part: " + partIndex);
+            inFlightRequests.remove(partIndex);
+            inFlightRequestsNum.decrementAndGet();
+            int totalComplete = completedParts.incrementAndGet();
+
+            if (totalComplete >= totalParts) {
+                synchronized (subscriptionLock) {
+                    subscription.cancel();
+                }
+                resultFuture.complete(firstResponse);
+            } else {
+                processPendingTransformers();
+                synchronized (subscriptionLock) {
+                    subscription.request(1);
+                }
+            }
+        });
+    }
+
+    private void processPendingTransformers() {
+        do {
+            if (!processingPending.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                while (!pendingTransformers.isEmpty() && inFlightRequestsNum.get() < maxInFlightParts) {
+                    Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> pair =
+                        pendingTransformers.poll();
+                    if (pair != null && pair.left() < totalParts) {
+                        sendPartRequest(pair.right(), pair.left());
+                    }
+                }
+            } finally {
+                processingPending.set(false);
+            }
+        } while (!pendingTransformers.isEmpty() && inFlightRequestsNum.get() < maxInFlightParts);
+    }
+
+    private Optional<SdkClientException> validatePartResponse(GetObjectResponse response, int partIndex) {
+        String contentRange = response.contentRange();
+        if (contentRange == null) {
+            return Optional.of(PresignedUrlDownloadHelper.missingContentRangeHeader());
+        }
+        Long contentLength = response.contentLength();
+        if (contentLength == null || contentLength < 0) {
+            return Optional.of(PresignedUrlDownloadHelper.invalidContentLength());
+        }
+        long expectedStartByte = partIndex * configuredPartSizeInBytes;
+        long expectedEndByte = Math.min(expectedStartByte + configuredPartSizeInBytes - 1, totalContentLength - 1);
+        String expectedRange = "bytes " + expectedStartByte + "-" + expectedEndByte + "/";
+        if (!contentRange.startsWith(expectedRange)) {
+            return Optional.of(SdkClientException.create(
+                "Content-Range mismatch. Expected range starting with: " + expectedRange +
+                ", but got: " + contentRange));
+        }
+        long expectedPartSize = (partIndex == totalParts - 1)
+                                ? totalContentLength - (partIndex * configuredPartSizeInBytes)
+                                : configuredPartSizeInBytes;
+        if (!contentLength.equals(expectedPartSize)) {
+            return Optional.of(SdkClientException.create(
+                String.format("Part content length validation failed for part %d. Expected: %d, but got: %d",
+                              partIndex, expectedPartSize, contentLength)));
+        }
+        return Optional.empty();
+    }
+
+    private void handlePartError(Throwable error, int partIndex) {
+        if (isCompletedExceptionally.compareAndSet(false, true)) {
+            log.debug(() -> "Error on part " + partIndex, error);
+            resultFuture.completeExceptionally(error);
+            inFlightRequests.values().forEach(future -> future.cancel(true));
+            synchronized (subscriptionLock) {
+                if (subscription != null) {
+                    subscription.cancel();
+                }
+            }
+        }
+    }
+
+    private PresignedUrlDownloadRequest createRangedGetRequest(int partIndex) {
+        long startByte = partIndex * configuredPartSizeInBytes;
+        long endByte;
+        if (totalContentLength != null) {
+            endByte = Math.min(startByte + configuredPartSizeInBytes - 1, totalContentLength - 1);
+        } else {
+            endByte = startByte + configuredPartSizeInBytes - 1;
+        }
+        String rangeHeader = BYTES_RANGE_PREFIX + startByte + "-" + endByte;
+        PresignedUrlDownloadRequest.Builder builder = presignedUrlDownloadRequest.toBuilder()
+                                                                                 .range(rangeHeader);
+        if (partIndex > 0 && eTag != null) {
+            builder.ifMatch(eTag);
+        }
+        return builder.build();
+    }
+
+    private int calculateTotalParts(long contentLength, long partSize) {
+        return (int) Math.ceil((double) contentLength / partSize);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        log.debug(() -> "Error in parallel multipart download", t);
+        resultFuture.completeExceptionally(t);
+        inFlightRequests.values().forEach(future -> future.cancel(true));
+    }
+
+    @Override
+    public void onComplete() {
+        // Completion is handled by resultFuture
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
@@ -54,6 +54,11 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
     private final S3AsyncClient s3AsyncClient;
     private final PresignedUrlDownloadRequest presignedUrlDownloadRequest;
     private final long configuredPartSizeInBytes;
+    /**
+     * The future returned by the SplitResult, representing the overall download completion.
+     * Completed exceptionally on error (before cancel) to prevent ByteArraySplittingTransformer
+     * from assembling invalid data.
+     */
     private final CompletableFuture<GetObjectResponse> resultFuture;
     private final int maxInFlightParts;
 
@@ -140,7 +145,6 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             inFlightRequestsNum.decrementAndGet();
             completedParts.incrementAndGet();
 
-            // Discover size and ETag from first response
             this.eTag = res.eTag();
             this.firstResponse = res;
 
@@ -161,10 +165,10 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             log.debug(() -> String.format("Total content length: %d, Total parts: %d", totalContentLength, totalParts));
 
             if (totalParts <= 1) {
+                resultFuture.complete(firstResponse);
                 synchronized (subscriptionLock) {
                     subscription.cancel();
                 }
-                resultFuture.complete(firstResponse);
                 return;
             }
 
@@ -226,11 +230,11 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             inFlightRequestsNum.decrementAndGet();
             int totalComplete = completedParts.incrementAndGet();
 
-            if (totalComplete >= totalParts) {
+            if (totalComplete == totalParts) {
+                resultFuture.complete(firstResponse);
                 synchronized (subscriptionLock) {
                     subscription.cancel();
                 }
-                resultFuture.complete(firstResponse);
             } else {
                 processPendingTransformers();
                 synchronized (subscriptionLock) {
@@ -247,10 +251,10 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             }
             try {
                 while (!pendingTransformers.isEmpty() && inFlightRequestsNum.get() < maxInFlightParts) {
-                    Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> pair =
+                    Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> pendingPart =
                         pendingTransformers.poll();
-                    if (pair != null && pair.left() < totalParts) {
-                        sendPartRequest(pair.right(), pair.left());
+                    if (pendingPart != null && pendingPart.left() < totalParts) {
+                        sendPartRequest(pendingPart.right(), pendingPart.left());
                     }
                 }
             } finally {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class PresignedUrlDownloadHelper {
     private static final Logger log = Logger.loggerFor(PresignedUrlDownloadHelper.class);
+    private static final int DEFAULT_MAX_IN_FLIGHT_PARTS = 10;
 
     private final S3AsyncClient s3AsyncClient;
     private final AsyncPresignedUrlExtension asyncPresignedUrlExtension;
@@ -64,12 +65,38 @@ public class PresignedUrlDownloadHelper {
                                                                                              .build();
         AsyncResponseTransformer.SplitResult<GetObjectResponse, T> split =
             asyncResponseTransformer.split(splittingConfig);
+
+        if (split.parallelSplitSupported()) {
+            return downloadPartsInParallel(presignedRequest, split);
+        }
+        return downloadPartsSerially(presignedRequest, split);
+    }
+
+    private <T> CompletableFuture<T> downloadPartsInParallel(
+        PresignedUrlDownloadRequest presignedRequest,
+        AsyncResponseTransformer.SplitResult<GetObjectResponse, T> split) {
+        log.debug(() -> "Using parallel multipart download for presigned URL");
+        ParallelPresignedUrlMultipartDownloaderSubscriber subscriber =
+            new ParallelPresignedUrlMultipartDownloaderSubscriber(
+                s3AsyncClient,
+                presignedRequest,
+                configuredPartSizeInBytes,
+                (CompletableFuture<GetObjectResponse>) split.resultFuture(),
+                DEFAULT_MAX_IN_FLIGHT_PARTS);
+        split.publisher().subscribe(subscriber);
+        return split.resultFuture();
+    }
+
+    private <T> CompletableFuture<T> downloadPartsSerially(
+        PresignedUrlDownloadRequest presignedRequest,
+        AsyncResponseTransformer.SplitResult<GetObjectResponse, T> split) {
+        log.debug(() -> "Using serial multipart download for presigned URL");
         PresignedUrlMultipartDownloaderSubscriber subscriber =
             new PresignedUrlMultipartDownloaderSubscriber(
                 s3AsyncClient,
                 presignedRequest,
-                configuredPartSizeInBytes);
-
+                configuredPartSizeInBytes,
+                split.resultFuture());
         split.publisher().subscribe(subscriber);
         return split.resultFuture();
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
@@ -54,6 +54,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
     private final PresignedUrlDownloadRequest presignedUrlDownloadRequest;
     private final Long configuredPartSizeInBytes;
     private final CompletableFuture<Void> future;
+    private final CompletableFuture<?> resultFuture;
     private final Object lock = new Object();
     private final AtomicInteger completedParts;
     private final AtomicInteger requestsSent;
@@ -66,13 +67,15 @@ public class PresignedUrlMultipartDownloaderSubscriber
     public PresignedUrlMultipartDownloaderSubscriber(
         S3AsyncClient s3AsyncClient,
         PresignedUrlDownloadRequest presignedUrlDownloadRequest,
-        long configuredPartSizeInBytes) {
+        long configuredPartSizeInBytes,
+        CompletableFuture<?> resultFuture) {
         this.s3AsyncClient = s3AsyncClient;
         this.presignedUrlDownloadRequest = presignedUrlDownloadRequest;
         this.configuredPartSizeInBytes = configuredPartSizeInBytes;
         this.completedParts = new AtomicInteger(0);
         this.requestsSent = new AtomicInteger(0);
         this.future = new CompletableFuture<>();
+        this.resultFuture = resultFuture;
     }
 
     @Override
@@ -109,20 +112,20 @@ public class PresignedUrlMultipartDownloaderSubscriber
                                       GetObjectResponse> asyncResponseTransformer) {
         PresignedUrlDownloadRequest partRequest = createRangedGetRequest(partIndex);
         log.debug(() -> "Sending range request for part " + partIndex + " with range=" + partRequest.range());
-        
+
         requestsSent.incrementAndGet();
         s3AsyncClient.presignedUrlExtension()
-            .getObject(partRequest, asyncResponseTransformer)
-            .whenComplete((response, error) -> {
-                if (error != null) {
-                    log.debug(() -> "Error encountered during part request for part " + partIndex);
-                    handleError(error);
-                    return;
-                }
-                if (validatePart(response, partIndex, asyncResponseTransformer)) {
-                    requestMoreIfNeeded(completedParts.get());
-                }
-            });
+                     .getObject(partRequest, asyncResponseTransformer)
+                     .whenComplete((response, error) -> {
+                         if (error != null) {
+                             log.debug(() -> "Error encountered during part request for part " + partIndex);
+                             handleError(error);
+                             return;
+                         }
+                         if (validatePart(response, partIndex, asyncResponseTransformer)) {
+                             requestMoreIfNeeded(completedParts.get());
+                         }
+                     });
     }
 
     private boolean validatePart(GetObjectResponse response, int partIndex,
@@ -137,14 +140,6 @@ public class PresignedUrlMultipartDownloaderSubscriber
             log.debug(() -> String.format("Multipart object ETag: %s", this.eTag));
         }
 
-        Optional<SdkClientException> validationError = validateResponse(response, partIndex);
-        if (validationError.isPresent()) {
-            log.debug(() -> "Response validation failed", validationError.get());
-            asyncResponseTransformer.exceptionOccurred(validationError.get());
-            handleError(validationError.get());
-            return false;
-        }
-        
         if (totalContentLength == null && responseContentRange != null) {
             Optional<Long> parsedContentLength = MultipartDownloadUtils.parseContentRangeForTotalSize(responseContentRange);
             if (!parsedContentLength.isPresent()) {
@@ -159,6 +154,15 @@ public class PresignedUrlMultipartDownloaderSubscriber
             this.totalParts = calculateTotalParts(totalContentLength, configuredPartSizeInBytes);
             log.debug(() -> String.format("Total content length: %d, Total parts: %d", totalContentLength, totalParts));
         }
+
+        Optional<SdkClientException> validationError = validateResponse(response, partIndex);
+        if (validationError.isPresent()) {
+            log.debug(() -> "Response validation failed", validationError.get());
+            asyncResponseTransformer.exceptionOccurred(validationError.get());
+            handleError(validationError.get());
+            return false;
+        }
+
         return true;
     }
 
@@ -186,7 +190,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
         if (contentRange == null) {
             return Optional.of(PresignedUrlDownloadHelper.missingContentRangeHeader());
         }
-        
+
         Long contentLength = response.contentLength();
         if (contentLength == null || contentLength < 0) {
             return Optional.of(PresignedUrlDownloadHelper.invalidContentLength());
@@ -202,7 +206,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
         String expectedRange = "bytes " + expectedStartByte + "-" + expectedEndByte + "/";
         if (!contentRange.startsWith(expectedRange)) {
             return Optional.of(SdkClientException.create(
-                "Content-Range mismatch. Expected range starting with: " + expectedRange + 
+                "Content-Range mismatch. Expected range starting with: " + expectedRange +
                 ", but got: " + contentRange));
         }
 
@@ -215,19 +219,19 @@ public class PresignedUrlMultipartDownloaderSubscriber
         if (!contentLength.equals(expectedPartSize)) {
             return Optional.of(SdkClientException.create(
                 String.format("Part content length validation failed for part %d. Expected: %d, but got: %d",
-                             partIndex, expectedPartSize, contentLength)));
+                              partIndex, expectedPartSize, contentLength)));
         }
 
         long actualStartByte = MultipartDownloadUtils.parseStartByteFromContentRange(contentRange);
         if (actualStartByte != expectedStartByte) {
             return Optional.of(SdkClientException.create(
-                "Content range offset mismatch for part " + partIndex + 
+                "Content range offset mismatch for part " + partIndex +
                 ". Expected start: " + expectedStartByte + ", but got: " + actualStartByte));
         }
-        
+
         return Optional.empty();
     }
-    
+
     private int calculateTotalParts(long contentLength, long partSize) {
         return (int) Math.ceil((double) contentLength / partSize);
     }
@@ -246,7 +250,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
         }
         String rangeHeader = BYTES_RANGE_PREFIX + startByte + "-" + endByte;
         PresignedUrlDownloadRequest.Builder builder = presignedUrlDownloadRequest.toBuilder()
-                                                                                  .range(rangeHeader);
+                                                                                 .range(rangeHeader);
         if (partIndex > 0 && eTag != null) {
             builder.ifMatch(eTag);
         }
@@ -254,18 +258,24 @@ public class PresignedUrlMultipartDownloaderSubscriber
     }
 
     private void handleError(Throwable t) {
+        future.completeExceptionally(t);
+        if (resultFuture != null) {
+            resultFuture.completeExceptionally(t);
+        }
         synchronized (lock) {
             if (subscription != null) {
                 subscription.cancel();
             }
         }
-        onError(t);
     }
 
     @Override
     public void onError(Throwable t) {
         log.debug(() -> "Error in multipart download", t);
         future.completeExceptionally(t);
+        if (resultFuture != null) {
+            resultFuture.completeExceptionally(t);
+        }
     }
 
     @Override

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
@@ -53,7 +53,19 @@ public class PresignedUrlMultipartDownloaderSubscriber
     private final S3AsyncClient s3AsyncClient;
     private final PresignedUrlDownloadRequest presignedUrlDownloadRequest;
     private final Long configuredPartSizeInBytes;
+
+    /**
+     * Internal lifecycle future for this subscriber. Completed when all parts are downloaded
+     * or when an error occurs.
+     */
     private final CompletableFuture<Void> future;
+
+    /**
+     * The split transformer's completion future (from {@code SplitResult.resultFuture()}).
+     * Completing this signals the download result to the caller. Must be completed exceptionally
+     * before cancelling the subscription to prevent ByteArraySplittingTransformer from assembling
+     * invalid data.
+     */
     private final CompletableFuture<?> resultFuture;
     private final Object lock = new Object();
     private final AtomicInteger completedParts;
@@ -118,7 +130,6 @@ public class PresignedUrlMultipartDownloaderSubscriber
                      .getObject(partRequest, asyncResponseTransformer)
                      .whenComplete((response, error) -> {
                          if (error != null) {
-                             log.debug(() -> "Error encountered during part request for part " + partIndex);
                              handleError(error);
                              return;
                          }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTckTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTckTest.java
@@ -33,68 +33,49 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
 import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 
-public class PresignedUrlMultipartDownloaderSubscriberTckTest
+public class ParallelPresignedUrlMultipartDownloaderSubscriberTckTest
     extends SubscriberWhiteboxVerification<AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> {
-    
-    private S3AsyncClient s3mock;
 
-    public PresignedUrlMultipartDownloaderSubscriberTckTest() {
+    private final S3AsyncClient s3mock;
+
+    public ParallelPresignedUrlMultipartDownloaderSubscriberTckTest() {
         super(new TestEnvironment());
         this.s3mock = Mockito.mock(S3AsyncClient.class);
-    }
-
-    @Override
-    public Subscriber<AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>>
-    createSubscriber(WhiteboxSubscriberProbe<AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> probe) {
         AsyncPresignedUrlExtension presignedUrlExtension = Mockito.mock(AsyncPresignedUrlExtension.class);
         when(s3mock.presignedUrlExtension()).thenReturn(presignedUrlExtension);
 
-        CompletableFuture<GetObjectResponse> firstPartResponse = CompletableFuture.completedFuture(
-            GetObjectResponse.builder()
-                .contentRange("bytes 0-8388607/33554432")
-                .contentLength(8388608L) // 8MB
-                .eTag("\"test-etag-12345\"")
-                .build()
-        );
-
-        CompletableFuture<GetObjectResponse> subsequentPartResponse = CompletableFuture.completedFuture(
-            GetObjectResponse.builder()
-                .contentRange("bytes 8388608-16777215/33554432")
-                .contentLength(8388608L) // 8MB
-                .eTag("\"test-etag-12345\"")
-                .build()
-        );
-        
         when(presignedUrlExtension.getObject(any(PresignedUrlDownloadRequest.class), any(AsyncResponseTransformer.class)))
-            .thenReturn(firstPartResponse)
-            .thenReturn(subsequentPartResponse)
-            .thenReturn(subsequentPartResponse)
-            .thenReturn(subsequentPartResponse);
-        
-        return new PresignedUrlMultipartDownloaderSubscriber(
+            .thenReturn(CompletableFuture.completedFuture(
+                GetObjectResponse.builder()
+                                 .contentRange("bytes 0-8388607/33554432")
+                                 .contentLength(8388608L)
+                                 .eTag("\"test-etag\"")
+                                 .build()));
+    }
+
+    @Override
+    public Subscriber<AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> createSubscriber(
+        WhiteboxSubscriberProbe<AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> probe) {
+
+        return new ParallelPresignedUrlMultipartDownloaderSubscriber(
             s3mock,
             createTestPresignedUrlRequest(),
             8 * 1024 * 1024L,
-            new CompletableFuture<>()
+            new CompletableFuture<>(),
+            10
         ) {
             @Override
-            public void onError(Throwable throwable) {
-                super.onError(throwable);
-                probe.registerOnError(throwable);
-            }
-
-            @Override
-            public void onSubscribe(Subscription subscription) {
-                super.onSubscribe(subscription);
+            public void onSubscribe(Subscription s) {
+                super.onSubscribe(s);
                 probe.registerOnSubscribe(new SubscriberPuppet() {
                     @Override
                     public void triggerRequest(long elements) {
-                        subscription.request(elements);
+                        s.request(elements);
                     }
 
                     @Override
                     public void signalCancel() {
-                        subscription.cancel();
+                        s.cancel();
                     }
                 });
             }
@@ -103,6 +84,12 @@ public class PresignedUrlMultipartDownloaderSubscriberTckTest
             public void onNext(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> item) {
                 super.onNext(item);
                 probe.registerOnNext(item);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                super.onError(t);
+                probe.registerOnError(t);
             }
 
             @Override
@@ -115,7 +102,24 @@ public class PresignedUrlMultipartDownloaderSubscriberTckTest
 
     @Override
     public AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> createElement(int element) {
-        return new TestAsyncResponseTransformer();
+        return new AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>() {
+            @Override
+            public CompletableFuture<GetObjectResponse> prepare() {
+                return new CompletableFuture<>();
+            }
+
+            @Override
+            public void onResponse(GetObjectResponse response) {
+            }
+
+            @Override
+            public void onStream(SdkPublisher<ByteBuffer> publisher) {
+            }
+
+            @Override
+            public void exceptionOccurred(Throwable error) {
+            }
+        };
     }
 
     private PresignedUrlDownloadRequest createTestPresignedUrlRequest() {
@@ -124,31 +128,7 @@ public class PresignedUrlMultipartDownloaderSubscriberTckTest
                 .presignedUrl(java.net.URI.create("https://test-bucket.s3.amazonaws.com/test-key").toURL())
                 .build();
         } catch (MalformedURLException e) {
-            throw new RuntimeException("Failed to create test URL", e);
-        }
-    }
-
-    private static class TestAsyncResponseTransformer implements AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> {
-        private CompletableFuture<GetObjectResponse> future;
-
-        @Override
-        public CompletableFuture<GetObjectResponse> prepare() {
-            this.future = new CompletableFuture<>();
-            return this.future;
-        }
-
-        @Override
-        public void onResponse(GetObjectResponse response) {
-            this.future.complete(response);
-        }
-
-        @Override
-        public void onStream(SdkPublisher<ByteBuffer> publisher) {
-        }
-
-        @Override
-        public void exceptionOccurred(Throwable error) {
-            future.completeExceptionally(error);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.multipart;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+
+/**
+ * Unit tests for {@link ParallelPresignedUrlMultipartDownloaderSubscriber}.
+ * Tests parallel-specific behavior: single-part detection, concurrent requests,
+ * and error propagation with in-flight cancellation.
+ */
+@WireMockTest
+class ParallelPresignedUrlMultipartDownloaderSubscriberTest {
+
+    private static final String PRESIGNED_URL_PATH = "/parallel-test";
+    private static final byte[] TEST_DATA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456".getBytes(StandardCharsets.UTF_8); // 32 bytes
+
+    private S3AsyncClient s3AsyncClient;
+    private URL presignedUrl;
+    private Path tempFile;
+
+    @BeforeEach
+    void setup(WireMockRuntimeInfo wiremock) throws MalformedURLException {
+        MultipartConfiguration multipartConfig = MultipartConfiguration.builder()
+                                                                       .minimumPartSizeInBytes(16L)
+                                                                       .build();
+        s3AsyncClient = S3AsyncClient.builder()
+                                     .endpointOverride(URI.create("http://localhost:" + wiremock.getHttpPort()))
+                                     .multipartEnabled(true)
+                                     .multipartConfiguration(multipartConfig)
+                                     .build();
+        presignedUrl = new URL("http://localhost:" + wiremock.getHttpPort() + PRESIGNED_URL_PATH);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        if (tempFile != null && Files.exists(tempFile)) {
+            Files.delete(tempFile);
+        }
+    }
+
+    @Test
+    void singlePartObject_shouldCompleteWithoutAdditionalRequests() throws IOException {
+        byte[] smallData = "0123456789".getBytes(StandardCharsets.UTF_8);
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=0-15"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", String.valueOf(smallData.length))
+                                    .withHeader("Content-Range", "bytes 0-9/10")
+                                    .withHeader("ETag", "\"single-part-etag\"")
+                                    .withBody(smallData)));
+
+        tempFile = createTempFile();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                        .presignedUrl(presignedUrl)
+                                                                        .build();
+        GetObjectResponse response = (GetObjectResponse) s3AsyncClient.presignedUrlExtension()
+            .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+            .join();
+
+        assertThat(response.eTag()).isEqualTo("\"single-part-etag\"");
+        assertThat(Files.readAllBytes(tempFile)).isEqualTo(smallData);
+        verify(1, getRequestedFor(urlEqualTo(PRESIGNED_URL_PATH)));
+    }
+
+    @Test
+    void multiPartObject_shouldDownloadAllPartsConcurrently() throws IOException {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=0-15"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("Content-Range", "bytes 0-15/32")
+                                    .withHeader("ETag", "\"multi-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 0, 16))));
+
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=16-31"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("Content-Range", "bytes 16-31/32")
+                                    .withHeader("ETag", "\"multi-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 16, 32))));
+
+        tempFile = createTempFile();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                        .presignedUrl(presignedUrl)
+                                                                        .build();
+        s3AsyncClient.presignedUrlExtension()
+            .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+            .join();
+
+        assertThat(Files.readAllBytes(tempFile)).isEqualTo(TEST_DATA);
+    }
+
+    @Test
+    void errorOnSecondPart_shouldCompleteExceptionallyAndNotSendMoreRequests() {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=0-15"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("Content-Range", "bytes 0-15/48")
+                                    .withHeader("ETag", "\"error-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 0, 16))));
+
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=16-31"))
+                    .willReturn(aResponse()
+                                    .withStatus(500)
+                                    .withBody("<Error><Code>InternalError</Code>"
+                                              + "<Message>Simulated failure</Message></Error>")));
+
+        tempFile = createTempFileUnchecked();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                        .presignedUrl(presignedUrl)
+                                                                        .build();
+
+        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
+            .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+            .join())
+            .isInstanceOf(CompletionException.class);
+    }
+
+    @Test
+    void missingContentRangeOnFirstPart_shouldFail() {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("ETag", "\"no-range-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 0, 16))));
+
+        tempFile = createTempFileUnchecked();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                        .presignedUrl(presignedUrl)
+                                                                        .build();
+
+        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
+            .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+            .join())
+            .hasRootCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("No Content-Range header");
+    }
+
+    @Test
+    void contentRangeMismatchOnSecondPart_shouldFail() {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=0-15"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("Content-Range", "bytes 0-15/32")
+                                    .withHeader("ETag", "\"mismatch-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 0, 16))));
+
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=16-31"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("Content-Range", "bytes 9999-10014/32")
+                                    .withHeader("ETag", "\"mismatch-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 16, 32))));
+
+        tempFile = createTempFileUnchecked();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                        .presignedUrl(presignedUrl)
+                                                                        .build();
+
+        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
+            .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+            .join())
+            .hasRootCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("Content-Range mismatch");
+    }
+
+    @Test
+    void onNext_withNullTransformer_shouldThrowNPE() {
+        ParallelPresignedUrlMultipartDownloaderSubscriber subscriber =
+            new ParallelPresignedUrlMultipartDownloaderSubscriber(
+                s3AsyncClient,
+                PresignedUrlDownloadRequest.builder().presignedUrl(presignedUrl).build(),
+                16L,
+                new java.util.concurrent.CompletableFuture<>(),
+                10);
+
+        assertThatThrownBy(() -> subscriber.onNext(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    private static Path createTempFile() throws IOException {
+        Path path = Files.createTempFile("parallel-test-" + UUID.randomUUID(), ".tmp");
+        Files.deleteIfExists(path);
+        return path;
+    }
+
+    private static Path createTempFileUnchecked() {
+        try {
+            return createTempFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriberWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriberWiremockTest.java
@@ -35,12 +35,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
 import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
@@ -70,96 +77,179 @@ class PresignedUrlMultipartDownloaderSubscriberWiremockTest {
         presignedUrl = createPresignedUrl();
     }
 
-    @Test
-    void presignedUrlDownload_withMultipartData_shouldReceiveCompleteBody() {
-        stubSuccessfulPresignedUrlResponse();
-        byte[] result = s3AsyncClient.presignedUrlExtension()
-                                     .getObject(PresignedUrlDownloadRequest.builder()
-                                                                           .presignedUrl(presignedUrl)
-                                                                           .build(),
-                                                AsyncResponseTransformer.toBytes())
-                                     .join()
-                                     .asByteArray();
-        assertArrayEquals(TEST_DATA, result);
+    static Stream<Arguments> transformerTypes() {
+        return Stream.of(
+            Arguments.of("toBytes"),
+            Arguments.of("toFile")
+        );
     }
 
-    @Test
-    void presignedUrlDownload_withRangeHeader_shouldReceivePartialContent() {
+    private CompletableFuture<?> executeDownload(PresignedUrlDownloadRequest request, String transformerType)
+        throws IOException {
+        if ("toFile".equals(transformerType)) {
+            tempFile = createUniqueTempFile();
+            return s3AsyncClient.presignedUrlExtension().getObject(request, AsyncResponseTransformer.toFile(tempFile));
+        }
+        return s3AsyncClient.presignedUrlExtension().getObject(request, AsyncResponseTransformer.toBytes());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertSuccessfulDownload(String type, Object result) throws IOException {
+        if ("toBytes".equals(type)) {
+            assertArrayEquals(TEST_DATA, ((ResponseBytes<GetObjectResponse>) result).asByteArray());
+        } else {
+            assertThat(tempFile.toFile()).exists();
+            byte[] fileContent = Files.readAllBytes(tempFile);
+            assertArrayEquals(TEST_DATA, fileContent);
+        }
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_withMultipartData_shouldReceiveCompleteBody [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_withMultipartData_shouldReceiveCompleteBody(String transformerType) throws IOException {
+        stubSuccessfulPresignedUrlResponse();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        Object result = executeDownload(request, transformerType).join();
+        assertSuccessfulDownload(transformerType, result);
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_smallObjectSmallerThanPartSize_shouldSucceed [{0}]")
+    @MethodSource("transformerTypes")
+    @SuppressWarnings("unchecked")
+    void presignedUrlDownload_smallObjectSmallerThanPartSize_shouldSucceed(String transformerType) throws IOException {
+        byte[] smallData = "0123456789".getBytes(StandardCharsets.UTF_8);
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Type", "application/octet-stream")
+                                    .withHeader("Content-Length", "10")
+                                    .withHeader("Content-Range", "bytes 0-9/10")
+                                    .withHeader("ETag", "\"small-etag\"")
+                                    .withBody(smallData)));
+
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        Object result = executeDownload(request, transformerType).join();
+        if ("toBytes".equals(transformerType)) {
+            assertArrayEquals(smallData, ((ResponseBytes<GetObjectResponse>) result).asByteArray());
+        } else {
+            assertThat(tempFile.toFile()).exists();
+            assertArrayEquals(smallData, Files.readAllBytes(tempFile));
+        }
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_withRangeHeader_shouldReceivePartialContent [{0}]")
+    @MethodSource("transformerTypes")
+    @SuppressWarnings("unchecked")
+    void presignedUrlDownload_withRangeHeader_shouldReceivePartialContent(String transformerType) throws IOException {
         stubSuccessfulRangeResponse();
-        byte[] result = s3AsyncClient.presignedUrlExtension()
-                                     .getObject(PresignedUrlDownloadRequest.builder()
-                                                                           .presignedUrl(presignedUrl)
-                                                                           .range("bytes=0-10")
-                                                                           .build(),
-                                                AsyncResponseTransformer.toBytes())
-                                     .join()
-                                     .asByteArray();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .range("bytes=0-10")
+                                                                         .build();
+        Object result = executeDownload(request, transformerType).join();
         byte[] expectedPartial = Arrays.copyOfRange(TEST_DATA, 0, 11);
-        assertArrayEquals(expectedPartial, result);
+        if ("toBytes".equals(transformerType)) {
+            assertArrayEquals(expectedPartial, ((ResponseBytes<GetObjectResponse>) result).asByteArray());
+        } else {
+            byte[] fileContent = Files.readAllBytes(tempFile);
+            assertArrayEquals(expectedPartial, fileContent);
+        }
     }
 
-    @Test
-    void presignedUrlDownload_whenRequestFails_shouldThrowException() {
+    @ParameterizedTest(name = "presignedUrlDownload_whenRequestFails_shouldThrowException [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_whenRequestFails_shouldThrowException(String transformerType) {
         stubFailedPresignedUrlResponse();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                         AsyncResponseTransformer.toBytes())
-                                              .join())
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
             .hasRootCauseInstanceOf(S3Exception.class);
     }
 
-    @Test
-    void presignedUrlDownload_withFileTransformer_shouldWork() throws IOException {
-        stubSuccessfulPresignedUrlResponse();
-        tempFile = createUniqueTempFile();
-        s3AsyncClient.presignedUrlExtension()
-                     .getObject(PresignedUrlDownloadRequest.builder()
-                                                           .presignedUrl(presignedUrl)
-                                                           .build(),
-                                AsyncResponseTransformer.toFile(tempFile))
-                     .join();
-        assertThat(tempFile.toFile()).exists();
-        assertThat(tempFile.toFile().length()).isGreaterThan(0);
-    }
-
-    @Test
-    void presignedUrlDownload_whenFirstRequestFails_shouldThrowException() {
+    @ParameterizedTest(name = "presignedUrlDownload_whenFirstRequestFails_shouldThrowException [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_whenFirstRequestFails_shouldThrowException(String transformerType) {
         stubInternalServerError();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                         AsyncResponseTransformer.toBytes())
-                                              .join())
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
             .hasRootCauseInstanceOf(S3Exception.class);
     }
 
-    @Test
-    void presignedUrlDownload_whenSecondRequestFails_shouldThrowException() {
+    @ParameterizedTest(name = "presignedUrlDownload_whenSecondRequestFails_shouldThrowException [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_whenSecondRequestFails_shouldThrowException(String transformerType) {
         stubPartialFailureScenario();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                         AsyncResponseTransformer.toBytes())
-                                              .join())
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
             .hasRootCauseInstanceOf(S3Exception.class);
     }
 
-    @Test
-    void presignedUrlDownload_whenIOErrorOccurs_shouldThrowException() {
+    @ParameterizedTest(name = "presignedUrlDownload_whenIOErrorOccurs_shouldThrowException [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_whenIOErrorOccurs_shouldThrowException(String transformerType) {
         stubConnectionReset();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                         AsyncResponseTransformer.toBytes())
-                                              .join())
-            .hasCauseInstanceOf(IOException.class);
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
+            .hasCauseInstanceOf(SdkClientException.class);
     }
 
+    @ParameterizedTest(name = "presignedUrlDownload_withMissingContentRange_shouldFailRequest [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_withMissingContentRange_shouldFailRequest(String transformerType) {
+        stubResponseWithMissingContentRange();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
+            .hasRootCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("No Content-Range header in response");
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_withInvalidContentLength_shouldFailRequest [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_withInvalidContentLength_shouldFailRequest(String transformerType) {
+        stubResponseWithInvalidContentLength();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
+            .hasRootCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("Invalid or missing Content-Length in response");
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_withContentRangeMismatch_shouldFailRequest [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_withContentRangeMismatch_shouldFailRequest(String transformerType) {
+        stubResponseWithContentRangeMismatch();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
+            .hasRootCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("Content-Range mismatch");
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_withContentLengthMismatch_shouldFailRequest [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_withContentLengthMismatch_shouldFailRequest(String transformerType) {
+        stubResponseWithContentLengthMismatch();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
+            .hasRootCauseInstanceOf(SdkClientException.class);
+    }
 
     @Test
     void onNext_withNullTransformer_shouldThrowException() {
@@ -168,58 +258,6 @@ class PresignedUrlMultipartDownloaderSubscriberWiremockTest {
         assertThatThrownBy(() -> subscriber.onNext(null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("onNext must not be called with null asyncResponseTransformer");
-    }
-
-    @Test
-    void presignedUrlDownload_withMissingContentRange_shouldFailRequest() {
-        stubResponseWithMissingContentRange();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                         AsyncResponseTransformer.toBytes())
-                                              .join())
-            .hasRootCauseInstanceOf(SdkClientException.class)
-            .hasMessageContaining("No Content-Range header in response");
-    }
-
-    @Test
-    void presignedUrlDownload_withInvalidContentLength_shouldFailRequest() {
-        stubResponseWithInvalidContentLength();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                         AsyncResponseTransformer.toBytes())
-                                              .join())
-            .hasRootCauseInstanceOf(SdkClientException.class)
-            .hasMessageContaining("Invalid or missing Content-Length in response");
-    }
-
-    @Test
-    void presignedUrlDownload_withContentRangeMismatch_shouldFailRequest() {
-        stubResponseWithContentRangeMismatch();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                         AsyncResponseTransformer.toBytes())
-                                              .join())
-            .hasRootCauseInstanceOf(SdkClientException.class)
-            .hasMessageContaining("Content-Range mismatch");
-    }
-
-    @Test
-    void presignedUrlDownload_withContentLengthMismatch_shouldFailRequest() {
-        stubResponseWithContentLengthMismatch();
-        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
-                                              .getObject(PresignedUrlDownloadRequest.builder()
-                                                                                    .presignedUrl(presignedUrl)
-                                                                                    .build(),
-                                                        AsyncResponseTransformer.toBytes())
-                                              .join())
-            .hasRootCauseInstanceOf(SdkClientException.class)
-            .hasMessageContaining("Part content length validation failed");
     }
 
     @AfterEach
@@ -250,7 +288,7 @@ class PresignedUrlMultipartDownloaderSubscriberWiremockTest {
                                     .withHeader("Content-Range", "bytes 0-15/32")
                                     .withHeader("ETag", "\"test-etag\"")
                                     .withBody(Arrays.copyOfRange(TEST_DATA, 0, 16))));
-        
+
         // Stub for second part (bytes 16-31)
         stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
                     .withHeader("Range", matching("bytes=16-31"))
@@ -324,7 +362,8 @@ class PresignedUrlMultipartDownloaderSubscriberWiremockTest {
         return new PresignedUrlMultipartDownloaderSubscriber(
             s3AsyncClient,
             PresignedUrlDownloadRequest.builder().presignedUrl(presignedUrl).build(),
-            1024L);
+            1024L,
+            new CompletableFuture<>());
     }
 
     private void stubResponseWithMissingContentRange() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Adding support for `FileAsyncResponseTransformerPublisher` (toFile path) in pre-signed URL multipart downloads. 
This introduces a parallel subscriber `ParallelPresignedUrlMultipartDownloaderSubscriber` that handles concurrent range requests and explicit resultFuture completion, similar to `ParallelMultipartDownloaderSubscriber` for regular multipart downloads.

Also fixes error propagation in the serial subscriber (toBytes path) where resultFuture
was being completed after subscription cancel, allowing `ByteArraySplittingTransformer` to
race and assemble invalid data.

Also fixes small object downloads in the serial subscriber (toBytes path) by reordering
Content-Range parsing before validation, so S3's actual object range is correctly validated
instead of being compared against the larger requested range. 

## Modifications
- `ParallelPresignedUrlMultipartDownloaderSubscriber` (NEW): Parallel subscriber for toFile().
 Discovers object size from first part, fires remaining parts concurrently (up to
 maxInFlightParts=10). Completes resultFuture explicitly when all parts finish. Handles
 single-part objects by completing immediately after first response.

- `PresignedUrlDownloadHelper`: Routes based on split.parallelSplitSupported() — parallel
 subscriber for toFile, serial subscriber for toBytes.

- `PresignedUrlMultipartDownloaderSubscriber`: Added resultFuture field. 
Reordered validatePart to parse Content-Range before validation, fixing small object downloads where S3 returns the actual object range instead of the requested range.  
handleError() completes resultFuture before cancel to prevent data corruption in toBytes() path.

## Testing
- `PresignedUrlMultipartDownloaderSubscriberWiremockTest`: Parameterized for toBytes/toFile,
 added small object test case
- `ParallelPresignedUrlMultipartDownloaderSubscriberTest` (NEW): Single-part detection,
 multi-part download, error propagation, Content-Range validation failures
- `ParallelPresignedUrlMultipartDownloaderSubscriberTckTest` (NEW): Reactive Streams TCK
 compliance
- `PresignedUrlMultipartDownloaderSubscriberTckTest`: Updated constructor

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
