### PR TITLE
SdkFilterInputStream: do not abort in close()

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-17646a4.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-17646a4.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "benjaminp",
+    "description": "Do not check for thread interruption in `SdkFilterInputStream.close()`."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/io/SdkFilterInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/io/SdkFilterInputStream.java
@@ -79,12 +79,6 @@ public class SdkFilterInputStream extends FilterInputStream implements Releasabl
     }
 
     @Override
-    public void close() throws IOException {
-        in.close();
-        abortIfNeeded();
-    }
-
-    @Override
     public synchronized void mark(int readlimit) {
         abortIfNeeded();
         in.mark(readlimit);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixes https://github.com/aws/aws-sdk-java-v2/issues/6906.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications

Remove `SdkFilterInputStream.close` override, so that the superclass implementation that does not check for thread interruption is used.
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
