### PR TITLE
Add presigned URL download support to S3 Transfer Manager

### DIFF
--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
@@ -54,12 +54,14 @@ public class S3IntegrationTestBase extends AwsTestBase {
      */
     protected static S3Client s3;
 
-    protected static S3AsyncClient s3Async;
+    protected static S3AsyncClient s3Async;;
+    protected static S3AsyncClient s3NonMultipartAsync;
 
     protected static S3AsyncClient s3CrtAsync;
 
     protected static S3TransferManager tmCrt;
     protected static S3TransferManager tmJava;
+    protected static S3TransferManager tmNonMultipartJava;
 
     /**
      * Loads the AWS account info for the integration tests and creates an S3
@@ -71,6 +73,11 @@ public class S3IntegrationTestBase extends AwsTestBase {
         System.setProperty("aws.crt.debugnative", "true");
         s3 = s3ClientBuilder().build();
         s3Async = s3AsyncClientBuilder().build();
+        s3NonMultipartAsync = S3AsyncClient.builder()
+                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                           .region(DEFAULT_REGION)
+                                           .build();
+
         s3CrtAsync = S3CrtAsyncClient.builder()
                                      .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                      .region(DEFAULT_REGION)
@@ -82,6 +89,9 @@ public class S3IntegrationTestBase extends AwsTestBase {
         tmJava = S3TransferManager.builder()
                                   .s3Client(s3Async)
                                   .build();
+        tmNonMultipartJava = S3TransferManager.builder()
+                                              .s3Client(s3NonMultipartAsync)
+                                              .build();
 
     }
 
@@ -89,8 +99,11 @@ public class S3IntegrationTestBase extends AwsTestBase {
     public static void cleanUpForAllIntegTests() {
         s3.close();
         s3Async.close();
+        s3NonMultipartAsync.close();
         s3CrtAsync.close();
         tmCrt.close();
+        tmJava.close();
+        tmNonMultipartJava.close();
         CrtResource.waitForNoResources();
     }
 
@@ -182,4 +195,11 @@ public class S3IntegrationTestBase extends AwsTestBase {
             Arguments.of(tmJava));
     }
 
+    static Stream<Arguments> presignedUrlTransferManagers() {
+        return Stream.of(
+            // TODO: uncomment when CRT for presigned URL is supported
+            // Arguments.of(tmCrt),
+            Arguments.of(tmNonMultipartJava),
+            Arguments.of(tmJava));
+    }
 }

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
@@ -54,7 +54,7 @@ public class S3IntegrationTestBase extends AwsTestBase {
      */
     protected static S3Client s3;
 
-    protected static S3AsyncClient s3Async;;
+    protected static S3AsyncClient s3Async;
     protected static S3AsyncClient s3NonMultipartAsync;
 
     protected static S3AsyncClient s3CrtAsync;

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.transfer.s3.model.CompletedDownload;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.FileDownload;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
+import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
+import software.amazon.awssdk.utils.Md5Utils;
+
+public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3IntegrationTestBase {
+    private static final String BUCKET = temporaryBucketName(S3TransferManagerPresignedUrlDownloadIntegrationTest.class);
+    private static final String SMALL_KEY = "small-key";
+    private static final String LARGE_KEY = "large-key";
+    private static final int SMALL_OBJ_SIZE = 5 * 1024 * 1024;
+    private static final int LARGE_OBJ_SIZE = 16 * 1024 * 1024;
+
+    private static File smallFile;
+    private static File largeFile;
+    private static S3Presigner presigner;
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        createBucket(BUCKET);
+        smallFile = new RandomTempFile(SMALL_OBJ_SIZE);
+        largeFile = new RandomTempFile(LARGE_OBJ_SIZE);
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET).key(SMALL_KEY).build(), smallFile.toPath());
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET).key(LARGE_KEY).build(), largeFile.toPath());
+        presigner = S3Presigner.builder()
+                              .region(DEFAULT_REGION)
+                              .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                              .build();
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        if (presigner != null) {
+            presigner.close();
+        }
+        deleteBucketAndAllContents(BUCKET);
+    }
+
+    static Stream<Arguments> testCases() {
+        return Stream.of(
+            Arguments.of(tmNonMultipartJava, "nonMultipart", SMALL_KEY, smallFile, SMALL_OBJ_SIZE),
+            Arguments.of(tmNonMultipartJava, "nonMultipart", LARGE_KEY, largeFile, LARGE_OBJ_SIZE),
+            Arguments.of(tmJava, "multipart", SMALL_KEY, smallFile, SMALL_OBJ_SIZE),
+            Arguments.of(tmJava, "multipart", LARGE_KEY, largeFile, LARGE_OBJ_SIZE)
+        );
+    }
+
+    @ParameterizedTest(name = "downloadFileWithPresignedUrl_{1}_{2}")
+    @MethodSource("testCases")
+    void downloadFileWithPresignedUrl_shouldDownloadCorrectly(S3TransferManager tm, String tmType, String key,
+                                                              File sourceFile, int objSize) throws Exception {
+        Path downloadPath = RandomTempFile.randomUncreatedFile().toPath();
+        FileDownload download = tm.downloadFileWithPresignedUrl(createFileDownloadRequest(key, downloadPath));
+        CompletedFileDownload completed = download.completionFuture().join();
+
+        assertThat(Files.exists(downloadPath)).isTrue();
+        assertThat(Md5Utils.md5AsBase64(downloadPath.toFile())).isEqualTo(Md5Utils.md5AsBase64(sourceFile));
+        assertThat(completed.response().responseMetadata().requestId()).isNotNull();
+    }
+
+    @ParameterizedTest(name = "downloadWithPresignedUrl_toBytes_{1}_{2}")
+    @MethodSource("testCases")
+    void downloadWithPresignedUrl_toBytes_shouldReturnCorrectData(S3TransferManager tm, String tmType, String key,
+                                                                   File sourceFile, int objSize) {
+        CompletedDownload<ResponseBytes<GetObjectResponse>> completed =
+            tm.downloadWithPresignedUrl(createBytesDownloadRequest(key)).completionFuture().join();
+
+        assertThat(completed.result().asByteArray()).hasSize(objSize);
+    }
+
+    private static PresignedDownloadFileRequest createFileDownloadRequest(String key, Path destination) {
+        return PresignedDownloadFileRequest.builder()
+            .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                .presignedUrl(createPresignedRequest(key).url())
+                .build())
+            .destination(destination)
+            .addTransferListener(LoggingTransferListener.create())
+            .build();
+    }
+
+    private static PresignedDownloadRequest<ResponseBytes<GetObjectResponse>> createBytesDownloadRequest(String key) {
+        return PresignedDownloadRequest.builder()
+            .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                .presignedUrl(createPresignedRequest(key).url())
+                .build())
+            .responseTransformer(AsyncResponseTransformer.toBytes())
+            .addTransferListener(LoggingTransferListener.create())
+            .build();
+    }
+
+    private static PresignedGetObjectRequest createPresignedRequest(String key) {
+        return presigner.presignGetObject(GetObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofMinutes(10))
+            .getObjectRequest(GetObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(key)
+                .build())
+            .build());
+    }
+}

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
@@ -80,17 +80,15 @@ public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3Inte
     }
 
     static Stream<Arguments> testCases() {
-        return Stream.of(
-            Arguments.of(tmNonMultipartJava, "nonMultipart", SMALL_KEY, smallFile, SMALL_OBJ_SIZE),
-            Arguments.of(tmNonMultipartJava, "nonMultipart", LARGE_KEY, largeFile, LARGE_OBJ_SIZE),
-            Arguments.of(tmJava, "multipart", SMALL_KEY, smallFile, SMALL_OBJ_SIZE),
-            Arguments.of(tmJava, "multipart", LARGE_KEY, largeFile, LARGE_OBJ_SIZE)
-        );
+        return presignedUrlTransferManagers().flatMap(tmArg -> Stream.of(
+            Arguments.of(tmArg.get()[0], SMALL_KEY, smallFile, SMALL_OBJ_SIZE),
+            Arguments.of(tmArg.get()[0], LARGE_KEY, largeFile, LARGE_OBJ_SIZE)
+        ));
     }
 
-    @ParameterizedTest(name = "downloadFileWithPresignedUrl_{1}_{2}")
+    @ParameterizedTest(name = "downloadFileWithPresignedUrl_{1}")
     @MethodSource("testCases")
-    void downloadFileWithPresignedUrl_shouldDownloadCorrectly(S3TransferManager tm, String tmType, String key,
+    void downloadFileWithPresignedUrl_shouldDownloadCorrectly(S3TransferManager tm, String key,
                                                               File sourceFile, int objSize) throws Exception {
         Path downloadPath = RandomTempFile.randomUncreatedFile().toPath();
         FileDownload download = tm.downloadFileWithPresignedUrl(createFileDownloadRequest(key, downloadPath));
@@ -101,9 +99,9 @@ public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3Inte
         assertThat(completed.response().responseMetadata().requestId()).isNotNull();
     }
 
-    @ParameterizedTest(name = "downloadWithPresignedUrl_toBytes_{1}_{2}")
+    @ParameterizedTest(name = "downloadWithPresignedUrl_toBytes_{1}")
     @MethodSource("testCases")
-    void downloadWithPresignedUrl_toBytes_shouldReturnCorrectData(S3TransferManager tm, String tmType, String key,
+    void downloadWithPresignedUrl_toBytes_shouldReturnCorrectData(S3TransferManager tm, String key,
                                                                    File sourceFile, int objSize) {
         CompletedDownload<ResponseBytes<GetObjectResponse>> completed =
             tm.downloadWithPresignedUrl(createBytesDownloadRequest(key)).completionFuture().join();

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DelegatingS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DelegatingS3TransferManager.java
@@ -27,6 +27,8 @@ import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 import software.amazon.awssdk.transfer.s3.model.UploadDirectoryRequest;
@@ -83,6 +85,16 @@ abstract class DelegatingS3TransferManager implements S3TransferManager {
     @Override
     public Copy copy(CopyRequest copyRequest) {
         return delegate.copy(copyRequest);
+    }
+
+    @Override
+    public FileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
+        return delegate.downloadFileWithPresignedUrl(presignedDownloadFileRequest);
+    }
+
+    @Override
+    public <ResultT> Download<ResultT> downloadWithPresignedUrl(PresignedDownloadRequest<ResultT> presignedDownloadRequest) {
+        return delegate.downloadWithPresignedUrl(presignedDownloadRequest);
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -75,6 +75,8 @@ import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
@@ -595,6 +597,76 @@ class GenericS3TransferManager implements S3TransferManager {
         }
 
         return new DefaultCopy(returnFuture, progressUpdater.progress());
+    }
+
+    @Override
+    public final FileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
+        Validate.paramNotNull(presignedDownloadFileRequest, "presignedDownloadFileRequest");
+
+        AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> responseTransformer =
+            AsyncResponseTransformer.toFile(presignedDownloadFileRequest.destination(),
+                                            FileTransformerConfiguration.defaultCreateOrReplaceExisting());
+
+        CompletableFuture<CompletedFileDownload> returnFuture = new CompletableFuture<>();
+
+        TransferProgressUpdater progressUpdater = new TransferProgressUpdater(presignedDownloadFileRequest, null);
+        progressUpdater.transferInitiated();
+
+        responseTransformer = isS3ClientMultipartEnabled()
+                              ? progressUpdater.wrapForNonSerialFileDownload(
+            responseTransformer, GetObjectRequest.builder().build())
+                              : progressUpdater.wrapResponseTransformer(responseTransformer);
+        progressUpdater.registerCompletion(returnFuture);
+
+        try {
+            CompletableFuture<GetObjectResponse> future = s3AsyncClient.presignedUrlExtension().getObject(
+                presignedDownloadFileRequest.presignedUrlDownloadRequest(), responseTransformer);
+
+            CompletableFutureUtils.forwardExceptionTo(returnFuture, future);
+            CompletableFutureUtils.forwardTransformedResultTo(future, returnFuture,
+                                                              res -> CompletedFileDownload.builder()
+                                                                                          .response(res)
+                                                                                          .build());
+        } catch (Throwable throwable) {
+            returnFuture.completeExceptionally(throwable);
+        }
+
+        return new DefaultFileDownload(returnFuture, progressUpdater.progress(), () -> null, null);
+    }
+
+    @Override
+    public final <ResultT> Download<ResultT> downloadWithPresignedUrl(
+        PresignedDownloadRequest<ResultT> presignedDownloadRequest) {
+        Validate.paramNotNull(presignedDownloadRequest, "presignedDownloadRequest");
+
+        AsyncResponseTransformer<GetObjectResponse, ResultT> responseTransformer =
+            presignedDownloadRequest.responseTransformer();
+
+        CompletableFuture<CompletedDownload<ResultT>> returnFuture = new CompletableFuture<>();
+
+        TransferProgressUpdater progressUpdater = new TransferProgressUpdater(presignedDownloadRequest, null);
+        progressUpdater.transferInitiated();
+
+        responseTransformer = isS3ClientMultipartEnabled()
+                              ? progressUpdater.wrapForNonSerialFileDownload(
+            responseTransformer, GetObjectRequest.builder().build())
+                              : progressUpdater.wrapResponseTransformer(responseTransformer);
+        progressUpdater.registerCompletion(returnFuture);
+
+        try {
+            CompletableFuture<ResultT> future = s3AsyncClient.presignedUrlExtension().getObject(
+                presignedDownloadRequest.presignedUrlDownloadRequest(), responseTransformer);
+
+            CompletableFutureUtils.forwardExceptionTo(returnFuture, future);
+            CompletableFutureUtils.forwardTransformedResultTo(future, returnFuture,
+                                                              r -> CompletedDownload.builder()
+                                                                                    .result(r)
+                                                                                    .build());
+        } catch (Throwable throwable) {
+            returnFuture.completeExceptionally(throwable);
+        }
+
+        return new DefaultDownload<>(returnFuture, progressUpdater.progress());
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -631,7 +631,11 @@ class GenericS3TransferManager implements S3TransferManager {
             returnFuture.completeExceptionally(throwable);
         }
 
-        return new DefaultFileDownload(returnFuture, progressUpdater.progress(), () -> null, null);
+        return new DefaultFileDownload(returnFuture, progressUpdater.progress(),
+                                       () -> {
+                                           throw new UnsupportedOperationException(
+                                               "Pause is not supported for presigned URL downloads");
+                                       }, null);
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlDownloadTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlDownloadTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+import software.amazon.awssdk.transfer.s3.model.CompletedDownload;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
+
+/**
+ * Unit tests for S3TransferManager presigned URL download functionality.
+ */
+class S3TransferManagerPresignedUrlDownloadTest {
+    private static final String PRESIGNED_URL = "https://test-bucket.s3.amazonaws.com/test-key"
+                                                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKID"
+                                                + "&X-Amz-Date=20260101T000000Z&X-Amz-Expires=600"
+                                                + "&X-Amz-SignedHeaders=host&X-Amz-Signature=abc123";
+
+    private S3AsyncClient mockS3AsyncClient;
+    private AsyncPresignedUrlExtension mockPresignedUrlExtension;
+    private GenericS3TransferManager tm;
+    private URL presignedUrl;
+
+    @BeforeEach
+    public void methodSetup() throws Exception {
+        mockS3AsyncClient = mock(S3AsyncClient.class);
+        mockPresignedUrlExtension = mock(AsyncPresignedUrlExtension.class);
+        presignedUrl = new URL(PRESIGNED_URL);
+
+        when(mockS3AsyncClient.presignedUrlExtension()).thenReturn(mockPresignedUrlExtension);
+
+        tm = new GenericS3TransferManager(mockS3AsyncClient,
+                                         mock(UploadDirectoryHelper.class),
+                                         mock(TransferManagerConfiguration.class),
+                                         mock(DownloadDirectoryHelper.class));
+    }
+
+    @AfterEach
+    public void methodTeardown() {
+        tm.close();
+    }
+
+    @Test
+    void downloadFileWithPresignedUrl_withValidRequest_returnsResponse() {
+        GetObjectResponse response = GetObjectResponse.builder().build();
+        stubGetObject(CompletableFuture.completedFuture(response));
+
+        CompletedFileDownload completed = tm.downloadFileWithPresignedUrl(fileDownloadRequest())
+            .completionFuture().join();
+
+        assertThat(completed.response()).isEqualTo(response);
+    }
+
+    @Test
+    void downloadWithPresignedUrl_withValidRequest_returnsResponse() {
+        ResponseBytes<GetObjectResponse> responseBytes = ResponseBytes.fromByteArray(
+            GetObjectResponse.builder().build(), "test".getBytes());
+        stubGetObject(CompletableFuture.completedFuture(responseBytes));
+
+        CompletedDownload<ResponseBytes<GetObjectResponse>> completed =
+            tm.downloadWithPresignedUrl(bytesDownloadRequest()).completionFuture().join();
+
+        assertThat(completed.result()).isEqualTo(responseBytes);
+    }
+
+    @Test
+    void downloadFileWithPresignedUrl_withConsumerBuilder_returnsResponse() {
+        GetObjectResponse response = GetObjectResponse.builder().build();
+        stubGetObject(CompletableFuture.completedFuture(response));
+
+        CompletedFileDownload completed = tm.downloadFileWithPresignedUrl(
+            request -> request.presignedUrlDownloadRequest(p -> p.presignedUrl(presignedUrl))
+                              .destination(Paths.get("/tmp/test")))
+            .completionFuture().join();
+
+        assertThat(completed.response()).isEqualTo(response);
+    }
+
+    @Test
+    void downloadFileWithPresignedUrl_whenCancelled_shouldForwardCancellation() {
+        CompletableFuture<GetObjectResponse> s3Future = new CompletableFuture<>();
+        stubGetObject(s3Future);
+
+        CompletableFuture<CompletedFileDownload> future =
+            tm.downloadFileWithPresignedUrl(fileDownloadRequest()).completionFuture();
+
+        future.cancel(true);
+        assertThat(s3Future).isCancelled();
+    }
+
+    @Test
+    void downloadFileWithPresignedUrl_whenRequestFails_shouldCompleteExceptionally() {
+        CompletableFuture<GetObjectResponse> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RuntimeException("download failed"));
+        stubGetObject(failedFuture);
+
+        assertThatThrownBy(() -> tm.downloadFileWithPresignedUrl(fileDownloadRequest()).completionFuture().join())
+            .hasCauseInstanceOf(RuntimeException.class)
+            .hasMessageContaining("download failed");
+    }
+
+    @Test
+    void downloadWithPresignedUrl_whenCancelled_shouldForwardCancellation() {
+        CompletableFuture s3Future = new CompletableFuture<>();
+        stubGetObject(s3Future);
+
+        CompletableFuture<CompletedDownload<ResponseBytes<GetObjectResponse>>> future =
+            tm.downloadWithPresignedUrl(bytesDownloadRequest()).completionFuture();
+
+        future.cancel(true);
+        assertThat(s3Future).isCancelled();
+    }
+
+    @Test
+    void downloadFileWithPresignedUrl_withNullRequest_shouldThrowNullPointerException() {
+        assertThatThrownBy(() -> tm.downloadFileWithPresignedUrl((PresignedDownloadFileRequest) null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void downloadWithPresignedUrl_withNullRequest_shouldThrowNullPointerException() {
+        assertThatThrownBy(() -> tm.downloadWithPresignedUrl(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    private PresignedDownloadFileRequest fileDownloadRequest() {
+        return PresignedDownloadFileRequest.builder()
+            .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                .presignedUrl(presignedUrl)
+                .build())
+            .destination(Paths.get("/tmp/test"))
+            .build();
+    }
+
+    private PresignedDownloadRequest<ResponseBytes<GetObjectResponse>> bytesDownloadRequest() {
+        return PresignedDownloadRequest.builder()
+            .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                .presignedUrl(presignedUrl)
+                .build())
+            .responseTransformer(AsyncResponseTransformer.toBytes())
+            .build();
+    }
+
+    private void stubGetObject(CompletableFuture<?> future) {
+        when(mockPresignedUrlExtension.getObject(any(PresignedUrlDownloadRequest.class), any(AsyncResponseTransformer.class)))
+            .thenReturn(future);
+    }
+}

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlDownloadTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlDownloadTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtensio
 import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.CompletedDownload;
 import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 
@@ -152,6 +153,18 @@ class S3TransferManagerPresignedUrlDownloadTest {
     void downloadWithPresignedUrl_withNullRequest_shouldThrowNullPointerException() {
         assertThatThrownBy(() -> tm.downloadWithPresignedUrl(null))
             .isInstanceOf(NullPointerException.class);
+    }
+    @Test
+    void downloadFileWithPresignedUrl_pause_shouldThrowUnsupportedOperationException() {
+        GetObjectResponse response = GetObjectResponse.builder().build();
+        stubGetObject(CompletableFuture.completedFuture(response));
+
+        FileDownload download = tm.downloadFileWithPresignedUrl(fileDownloadRequest());
+        download.completionFuture().join();
+
+        assertThatThrownBy(download::pause)
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("Pause is not supported for presigned URL downloads");
     }
 
     private PresignedDownloadFileRequest fileDownloadRequest() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Adds presigned URL download support to S3 Transfer Manager with `downloadFileWithPresignedUrl` and `downloadWithPresignedUrl` methods. This enables customers to download objects using pre-signed URLs through the Transfer Manager with multipart download support and progress tracking.

## Modifications

- `S3TransferManager`: Added `downloadFileWithPresignedUrl` (with consumer builder variant) and `downloadWithPresignedUrl` public API methods with javadoc and code snippets.
- `GenericS3TransferManager`: Implemented presigned URL download logic with multipart support and progress tracking using wrapForNonSerialFileDownload.
- `S3IntegrationTestBase`: Added `tmNonMultipartJava` (non-multipart transfer manager) and `presignedUrlTransferManagers`() method source for presigned URL integration tests. CRT client is commented out with a TODO to enable when CRT presigned URL support is available.

## Testing

- `S3TransferManagerPresignedUrlDownloadTest`: Unit tests covering happy path (toFile/toBytes), consumer builder, cancellation forwarding, error propagation, and null validation.
- `S3TransferManagerPresignedUrlDownloadIntegrationTest`: Integration tests parameterized by transfer manager type (nonMultipart/multipart) and file size (5MB/16MB), verifying data integrity with checksums for both downloadFileWithPresignedUrl and downloadWithPresignedUrl.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
