### PR TITLE
Fix presigned url multipart download for empty objects

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionMultipartIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionMultipartIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.services.s3.presignedurl;
+
+import org.junit.jupiter.api.BeforeAll;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+
+
+public class AsyncPresignedUrlExtensionMultipartIntegrationTest extends AsyncPresignedUrlExtensionTestSuite {
+
+    @BeforeAll
+    static void setUpIntegrationTest() {
+        S3AsyncClient s3AsyncClient = s3AsyncClientBuilder()
+            .multipartEnabled(true)
+            .build();
+        presignedUrlExtension = s3AsyncClient.presignedUrlExtension();
+    }
+
+    @Override
+    protected S3AsyncClient createS3AsyncClient() {
+        return s3AsyncClientBuilder().build();
+    }
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTestSuite.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTestSuite.java
@@ -16,6 +16,7 @@ package software.amazon.awssdk.services.s3.presignedurl;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAscii;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.net.URL;
@@ -47,6 +48,7 @@ import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
@@ -238,6 +240,44 @@ public abstract class AsyncPresignedUrlExtensionTestSuite extends S3IntegrationT
             assertThat(downloadFile.toFile().length()).isEqualTo(testLargeObjectContent.length);
             assertThat(collectedMetrics).isNotEmpty();
         }
+    }
+
+    @Test
+    void getObject_emptyObject_toBytes_shouldSucceed() throws Exception {
+        String emptyKey = uploadTestObject("empty-object-bytes", "");
+
+        PresignedUrlDownloadRequest request = createRequestForKey(emptyKey);
+        ResponseBytes<GetObjectResponse> response =
+            presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes())
+                                 .get(30, TimeUnit.SECONDS);
+
+        assertThat(response.asByteArray()).isEmpty();
+        assertThat(response.response().contentLength()).isEqualTo(0L);
+    }
+
+    @Test
+    void getObject_emptyObject_toFile_shouldSucceed() throws Exception {
+        String emptyKey = uploadTestObject("empty-object-file", "");
+
+        PresignedUrlDownloadRequest request = createRequestForKey(emptyKey);
+        Path downloadFile = temporaryFolder.resolve("empty-download-" + UUID.randomUUID() + ".bin");
+        GetObjectResponse response =
+            presignedUrlExtension.getObject(request, downloadFile)
+                                 .get(30, TimeUnit.SECONDS);
+
+        assertThat(downloadFile).exists();
+        assertThat(downloadFile.toFile().length()).isEqualTo(0L);
+    }
+
+    @Test
+    void getObject_emptyObject_withRange_shouldThrow416() throws Exception {
+        String emptyKey = uploadTestObject("empty-object-range", "");
+
+        PresignedUrlDownloadRequest request = createRequestForKey(emptyKey, "bytes=0-1024");
+
+        assertThatThrownBy(() -> presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes())
+                                                      .get(30, TimeUnit.SECONDS))
+            .hasCauseInstanceOf(S3Exception.class);
     }
 
     static Stream<Arguments> basicFunctionalityTestData() {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
@@ -133,11 +133,18 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
 
         inFlightRequests.put(0, response);
         inFlightRequestsNum.incrementAndGet();
-        CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
 
         response.whenComplete((res, error) -> {
-            if (error != null || isCompletedExceptionally.get()) {
-                handlePartError(error, 0);
+            if (error != null) {
+                if (PresignedUrlDownloadHelper.isRangeNotSatisfiable(error)) {
+                    resultFuture.completeExceptionally(
+                        new PresignedUrlDownloadHelper.EmptyObjectRangeNotSatisfiableException(error));
+                    synchronized (subscriptionLock) {
+                        subscription.cancel();
+                    }
+                } else {
+                    handlePartError(error, 0);
+                }
                 return;
             }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
@@ -16,12 +16,14 @@
 package software.amazon.awssdk.services.s3.internal.multipart;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SplittingTransformerConfiguration;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
 import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 import software.amazon.awssdk.utils.Logger;
@@ -59,6 +61,33 @@ public class PresignedUrlDownloadHelper {
                             + presignedRequest.range());
             return asyncPresignedUrlExtension.getObject(presignedRequest, asyncResponseTransformer);
         }
+
+        CompletableFuture<T> resultFuture = new CompletableFuture<>();
+        doMultipartDownload(presignedRequest, asyncResponseTransformer)
+            .whenComplete((result, error) -> {
+                Throwable cause = error instanceof CompletionException ? error.getCause() : error;
+                if (cause instanceof EmptyObjectRangeNotSatisfiableException) {
+                    log.debug(() -> "Received 416 on first request, falling back to non-range GET for empty object");
+                    asyncPresignedUrlExtension.getObject(presignedRequest, asyncResponseTransformer)
+                                              .whenComplete((r, e) -> {
+                                                  if (e != null) {
+                                                      resultFuture.completeExceptionally(e);
+                                                  } else {
+                                                      resultFuture.complete(r);
+                                                  }
+                                              });
+                } else if (error != null) {
+                    resultFuture.completeExceptionally(error);
+                } else {
+                    resultFuture.complete(result);
+                }
+            });
+        return resultFuture;
+    }
+
+    private <T> CompletableFuture<T> doMultipartDownload(
+        PresignedUrlDownloadRequest presignedRequest,
+        AsyncResponseTransformer<GetObjectResponse, T> asyncResponseTransformer) {
 
         SplittingTransformerConfiguration splittingConfig = SplittingTransformerConfiguration.builder()
                                                                                              .bufferSizeInBytes(bufferSizeInBytes)
@@ -111,5 +140,24 @@ public class PresignedUrlDownloadHelper {
 
     static SdkClientException invalidContentLength() {
         return SdkClientException.create("Invalid or missing Content-Length in response");
+    }
+
+    /**
+     * Returns true if the error is a 416 Range Not Satisfiable response from S3.
+     * Used by subscribers to detect empty object responses on the first range request.
+     */
+    static boolean isRangeNotSatisfiable(Throwable error) {
+        Throwable cause = error instanceof CompletionException ? error.getCause() : error;
+        return cause instanceof S3Exception && ((S3Exception) cause).statusCode() == 416;
+    }
+
+    /**
+     * Marker exception wrapping a 416 on the first range request, signaling an empty object.
+     * Used to distinguish from 416 errors on subsequent requests which should propagate as failures.
+     */
+    static class EmptyObjectRangeNotSatisfiableException extends RuntimeException {
+        EmptyObjectRangeNotSatisfiableException(Throwable cause) {
+            super("Object is empty (416 on first range request)", cause);
+        }
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
@@ -130,7 +130,16 @@ public class PresignedUrlMultipartDownloaderSubscriber
                      .getObject(partRequest, asyncResponseTransformer)
                      .whenComplete((response, error) -> {
                          if (error != null) {
-                             handleError(error);
+                             if (partIndex == 0 && PresignedUrlDownloadHelper.isRangeNotSatisfiable(error)) {
+                                 log.debug(() -> "Received 416 on first range request, object is empty");
+                                 resultFuture.completeExceptionally(
+                                     new PresignedUrlDownloadHelper.EmptyObjectRangeNotSatisfiableException(error));
+                                 synchronized (lock) {
+                                     subscription.cancel();
+                                 }
+                             } else {
+                                 handleError(error);
+                             }
                              return;
                          }
                          if (validatePart(response, partIndex, asyncResponseTransformer)) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
@@ -232,6 +233,68 @@ class ParallelPresignedUrlMultipartDownloaderSubscriberTest {
 
         assertThatThrownBy(() -> subscriber.onNext(null))
             .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void emptyObject_416OnFirstRequest_shouldFallbackToNonRangeGet() {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=.*"))
+                    .willReturn(aResponse()
+                                    .withStatus(416)
+                                    .withBody("<Error><Code>InvalidRange</Code>"
+                                              + "<Message>The requested range is not satisfiable</Message></Error>")));
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", absent())
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", "0")
+                                    .withHeader("ETag", "\"empty-etag\"")
+                                    .withBody(new byte[0])));
+
+        tempFile = createTempFileUnchecked();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+
+        s3AsyncClient.presignedUrlExtension()
+                     .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+                     .join();
+
+        assertThat(tempFile.toFile()).exists();
+        assertThat(tempFile.toFile().length()).isEqualTo(0L);
+    }
+
+    @Test
+    void multipartObject_416OnSecondRequest_shouldFailWithError() {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .inScenario("416-on-second")
+                    .whenScenarioStateIs("Started")
+                    .withHeader("Range", matching("bytes=0-15"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("Content-Range", "bytes 0-15/32")
+                                    .withHeader("ETag", "\"test-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 0, 16)))
+                    .willSetStateTo("first-done"));
+
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .inScenario("416-on-second")
+                    .whenScenarioStateIs("first-done")
+                    .willReturn(aResponse()
+                                    .withStatus(416)
+                                    .withBody("<Error><Code>InvalidRange</Code>"
+                                              + "<Message>The requested range is not satisfiable</Message></Error>")));
+
+        tempFile = createTempFileUnchecked();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+
+        assertThatThrownBy(() -> s3AsyncClient.presignedUrlExtension()
+                                              .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+                                              .join())
+            .isInstanceOf(CompletionException.class);
     }
 
     private static Path createTempFile() throws IOException {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriberWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriberWiremockTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -258,6 +259,84 @@ class PresignedUrlMultipartDownloaderSubscriberWiremockTest {
         assertThatThrownBy(() -> subscriber.onNext(null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("onNext must not be called with null asyncResponseTransformer");
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_emptyObject_shouldFallbackToNonRangeGet [{0}]")
+    @MethodSource("transformerTypes")
+    @SuppressWarnings("unchecked")
+    void presignedUrlDownload_emptyObject_shouldFallbackToNonRangeGet(String transformerType) throws IOException {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=.*"))
+                    .willReturn(aResponse()
+                                    .withStatus(416)
+                                    .withBody("<Error><Code>InvalidRange</Code>"
+                                              + "<Message>The requested range is not satisfiable</Message></Error>")));
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", absent())
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", "0")
+                                    .withHeader("ETag", "\"empty-etag\"")
+                                    .withBody(new byte[0])));
+
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        Object result = executeDownload(request, transformerType).join();
+        if ("toBytes".equals(transformerType)) {
+            ResponseBytes<GetObjectResponse> bytes = (ResponseBytes<GetObjectResponse>) result;
+            assertThat(bytes.asByteArray()).isEmpty();
+        } else {
+            assertThat(tempFile.toFile()).exists();
+            assertThat(Files.size(tempFile)).isEqualTo(0L);
+        }
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_416OnSecondRequest_shouldFailWithError [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_416OnSecondRequest_shouldFailWithError(String transformerType) {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .inScenario("416-on-second")
+                    .whenScenarioStateIs("Started")
+                    .withHeader("Range", matching("bytes=0-15"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "16")
+                                    .withHeader("Content-Range", "bytes 0-15/32")
+                                    .withHeader("ETag", "\"test-etag\"")
+                                    .withBody(Arrays.copyOfRange(TEST_DATA, 0, 16)))
+                    .willSetStateTo("first-done"));
+
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .inScenario("416-on-second")
+                    .whenScenarioStateIs("first-done")
+                    .willReturn(aResponse()
+                                    .withStatus(416)
+                                    .withBody("<Error><Code>InvalidRange</Code>"
+                                              + "<Message>The requested range is not satisfiable</Message></Error>")));
+
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
+            .hasRootCauseInstanceOf(S3Exception.class);
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_withRangeHeader_emptyObject_shouldThrow416 [{0}]")
+    @MethodSource("transformerTypes")
+    void presignedUrlDownload_withRangeHeader_emptyObject_shouldThrow416(String transformerType) {
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .willReturn(aResponse()
+                                    .withStatus(416)
+                                    .withBody("<Error><Code>InvalidRange</Code>"
+                                              + "<Message>The requested range is not satisfiable</Message></Error>")));
+
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .range("bytes=0-1024")
+                                                                         .build();
+        assertThatThrownBy(() -> executeDownload(request, transformerType).join())
+            .hasRootCauseInstanceOf(S3Exception.class);
     }
 
     @AfterEach


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Presigned URL multipart downloads fail with HTTP 416 (Range Not Satisfiable) when downloading zero-byte objects. The multipart subscriber sends Range: bytes=0-8388607 to request the first part, but for a zero-byte object there are no bytes in that range, so S3 returns 416 per the HTTP spec.
Normal (non-presigned) multipart downloads don't have this issue because they use partNumber=1 as a query parameter. S3 treats this differently — it returns 200 with Content-Length: 0 for empty objects, because "give me part 1" is valid even when the part is empty.
The difference is the mechanism: Range headers require the byte range to exist (fails for empty objects), while partNumber returns the part content regardless (succeeds with empty body).

## Modifications
When the first range request returns 416, the helper catches it and falls back to a non-range GET using the same presigned URL. The non-range GET succeeds for empty objects (returns 200 with Content-Length: 0), and the response flows through the normal transformer path — creating the file and returning full metadata.
A marker exception (`EmptyObjectRangeNotSatisfiableException`) distinguishes 416 on the first request (empty object, safe to fallback) from 416 on subsequent requests (real error that should propagate). Subscribers wrap the 416 in this marker only on the first request. The helper only triggers the fallback for this marker — all other errors propagate normally.

- `PresignedUrlDownloadHelper`: Added 416 fallback logic in downloadObject(), extracted doMultipartDownload(), added isRangeNotSatisfiable() and EmptyObjectRangeNotSatisfiableException marker class.
- `PresignedUrlMultipartDownloaderSubscriber`: Wraps 416 on partIndex == 0 with marker exception instead of calling handleError.
- `ParallelPresignedUrlMultipartDownloaderSubscriber`: Wraps 416 in sendFirstRequest with marker exception. Removed forwardExceptionTo from sendFirstRequest to prevent race with the wrapping logic.

## Testing

- `PresignedUrlMultipartDownloaderSubscriberWiremockTest`: Added tests for 416 fallback on first request, error propagation on subsequent request, and user-specified range on empty object.
- `ParallelPresignedUrlMultipartDownloaderSubscriberTest`: Added tests for 416 fallback on first request and error propagation on subsequent request for the parallel (toFile) path.
- `AsyncPresignedUrlExtensionTestSuite`: Added integration tests for zero-byte object download (toBytes and toFile) and user-specified range on empty object. Runs for both multipart and non-multipart clients.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
