### PR TITLE
Fix check-then-act race condition in parallel subscriber

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
@@ -21,6 +21,7 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.Subscriber;
@@ -64,7 +65,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
 
     private final AtomicInteger partNumber = new AtomicInteger(0);
     private final AtomicInteger completedParts = new AtomicInteger(0);
-    private final AtomicInteger inFlightRequestsNum = new AtomicInteger(0);
+    private final Semaphore inFlightPermits;
     private final AtomicBoolean isCompletedExceptionally = new AtomicBoolean(false);
     private final AtomicBoolean processingPending = new AtomicBoolean(false);
     private final Map<Integer, CompletableFuture<GetObjectResponse>> inFlightRequests = new ConcurrentHashMap<>();
@@ -90,6 +91,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
         this.configuredPartSizeInBytes = configuredPartSizeInBytes;
         this.resultFuture = resultFuture;
         this.maxInFlightParts = maxInFlightParts;
+        this.inFlightPermits = new Semaphore(maxInFlightParts);
     }
 
     @Override
@@ -132,17 +134,18 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             s3AsyncClient.presignedUrlExtension().getObject(partRequest, transformer);
 
         inFlightRequests.put(0, response);
-        inFlightRequestsNum.incrementAndGet();
+        inFlightPermits.tryAcquire();
         CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
 
         response.whenComplete((res, error) -> {
             if (error != null || isCompletedExceptionally.get()) {
+                inFlightPermits.release();
                 handlePartError(error, 0);
                 return;
             }
 
             inFlightRequests.remove(0);
-            inFlightRequestsNum.decrementAndGet();
+            inFlightPermits.release();
             completedParts.incrementAndGet();
 
             this.eTag = res.eTag();
@@ -188,7 +191,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             return;
         }
 
-        if (inFlightRequestsNum.get() >= maxInFlightParts) {
+        if (!inFlightPermits.tryAcquire()) {
             pendingTransformers.offer(Pair.of(currentPart, transformer));
             return;
         }
@@ -200,6 +203,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
     private void sendPartRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer,
                                  int partIndex) {
         if (isCompletedExceptionally.get()) {
+            inFlightPermits.release();
             return;
         }
 
@@ -210,24 +214,25 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             s3AsyncClient.presignedUrlExtension().getObject(partRequest, transformer);
 
         inFlightRequests.put(partIndex, response);
-        inFlightRequestsNum.incrementAndGet();
         CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
 
         response.whenComplete((res, error) -> {
             if (error != null || isCompletedExceptionally.get()) {
+                inFlightPermits.release();
                 handlePartError(error, partIndex);
                 return;
             }
 
             Optional<SdkClientException> validationError = validatePartResponse(res, partIndex);
             if (validationError.isPresent()) {
+                inFlightPermits.release();
                 handlePartError(validationError.get(), partIndex);
                 return;
             }
 
             log.debug(() -> "Completed part: " + partIndex);
             inFlightRequests.remove(partIndex);
-            inFlightRequestsNum.decrementAndGet();
+            inFlightPermits.release();
             int totalComplete = completedParts.incrementAndGet();
 
             if (totalComplete == totalParts) {
@@ -250,17 +255,19 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
                 return;
             }
             try {
-                while (!pendingTransformers.isEmpty() && inFlightRequestsNum.get() < maxInFlightParts) {
+                while (!pendingTransformers.isEmpty() && inFlightPermits.tryAcquire()) {
                     Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> pendingPart =
                         pendingTransformers.poll();
                     if (pendingPart != null && pendingPart.left() < totalParts) {
                         sendPartRequest(pendingPart.right(), pendingPart.left());
+                    } else {
+                        inFlightPermits.release();
                     }
                 }
             } finally {
                 processingPending.set(false);
             }
-        } while (!pendingTransformers.isEmpty() && inFlightRequestsNum.get() < maxInFlightParts);
+        } while (!pendingTransformers.isEmpty() && inFlightPermits.availablePermits() > 0);
     }
 
     private Optional<SdkClientException> validatePartResponse(GetObjectResponse response, int partIndex) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
@@ -130,22 +130,25 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
         PresignedUrlDownloadRequest partRequest = createRangedGetRequest(0);
         log.debug(() -> "Sending first range request with range=" + partRequest.range());
 
+        if (!inFlightPermits.tryAcquire()) {
+            throw new IllegalStateException("Failed to acquire permit for first request");
+        }
+
         CompletableFuture<GetObjectResponse> response =
             s3AsyncClient.presignedUrlExtension().getObject(partRequest, transformer);
 
         inFlightRequests.put(0, response);
-        inFlightPermits.tryAcquire();
         CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
 
         response.whenComplete((res, error) -> {
+            inFlightRequests.remove(0);
+            inFlightPermits.release();
+
             if (error != null || isCompletedExceptionally.get()) {
-                inFlightPermits.release();
                 handlePartError(error, 0);
                 return;
             }
 
-            inFlightRequests.remove(0);
-            inFlightPermits.release();
             completedParts.incrementAndGet();
 
             this.eTag = res.eTag();
@@ -217,22 +220,21 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
         CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
 
         response.whenComplete((res, error) -> {
+            inFlightRequests.remove(partIndex);
+            inFlightPermits.release();
+
             if (error != null || isCompletedExceptionally.get()) {
-                inFlightPermits.release();
                 handlePartError(error, partIndex);
                 return;
             }
 
             Optional<SdkClientException> validationError = validatePartResponse(res, partIndex);
             if (validationError.isPresent()) {
-                inFlightPermits.release();
                 handlePartError(validationError.get(), partIndex);
                 return;
             }
 
             log.debug(() -> "Completed part: " + partIndex);
-            inFlightRequests.remove(partIndex);
-            inFlightPermits.release();
             int totalComplete = completedParts.incrementAndGet();
 
             if (totalComplete == totalParts) {
@@ -250,11 +252,14 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
     }
 
     private void processPendingTransformers() {
+        // Re-check after releasing the gate to catch permits that arrived
+        // while exiting — prevents "missed signal" where no thread drains the queue.
         do {
             if (!processingPending.compareAndSet(false, true)) {
                 return;
             }
             try {
+                // Drain pending queue while permits are available
                 while (!pendingTransformers.isEmpty() && inFlightPermits.tryAcquire()) {
                     Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> pendingPart =
                         pendingTransformers.poll();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriberTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -35,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.AfterEach;
@@ -232,6 +235,45 @@ class ParallelPresignedUrlMultipartDownloaderSubscriberTest {
 
         assertThatThrownBy(() -> subscriber.onNext(null))
             .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void multiPartDownload_manyParts_shouldCompleteSuccessfully() throws Exception {
+        // 13 parts to exceed maxInFlightParts (10)
+        byte[] data = new byte[208]; // 13 × 16 bytes
+        Arrays.fill(data, (byte) 'X');
+
+        stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                    .withHeader("Range", matching("bytes=0-15"))
+                    .willReturn(aResponse().withStatus(206)
+                                           .withHeader("Content-Length", "16")
+                                           .withHeader("Content-Range", "bytes 0-15/208")
+                                           .withHeader("ETag", "\"etag\"")
+                                           .withBody(Arrays.copyOfRange(data, 0, 16))));
+
+        for (int i = 1; i < 13; i++) {
+            int start = i * 16;
+            int end = start + 15;
+            stubFor(get(urlEqualTo(PRESIGNED_URL_PATH))
+                        .withHeader("Range", matching("bytes=" + start + "-" + end))
+                        .willReturn(aResponse().withStatus(206)
+                                               .withHeader("Content-Length", "16")
+                                               .withHeader("Content-Range", "bytes " + start + "-" + end + "/208")
+                                               .withHeader("ETag", "\"etag\"")
+                                               .withBody(Arrays.copyOfRange(data, start, end + 1))));
+        }
+
+        tempFile = createTempFileUnchecked();
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+
+        s3AsyncClient.presignedUrlExtension()
+                     .getObject(request, AsyncResponseTransformer.toFile(tempFile))
+                     .join();
+
+        assertThat(Files.readAllBytes(tempFile)).isEqualTo(data);
+        verify(13, getRequestedFor(urlEqualTo(PRESIGNED_URL_PATH)));
     }
 
     private static Path createTempFile() throws IOException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The `ParallelPresignedUrlMultipartDownloaderSubscriber` has a check-then-act race condition when limiting concurrent in-flight requests. Two threads can simultaneously read `inFlightRequestsNum` as below the limit, both pass the check, and both send a request — exceeding `maxInFlightParts`.

The race occurs between:
- Thread A (onNext → processRequest): checks inFlightRequestsNum.get() < max, passes, then calls sendPartRequest which increments
- Thread B (whenComplete → processPendingTransformers): checks inFlightRequestsNum.get() < max, also passes (sees same value), then calls sendPartRequest which increments
- Both threads read the counter before either increments it — a classic check-then-act race. The overshoot is bounded to 1 (max 11 instead of 10) because only one onNext thread exists (Reactive Streams spec) and only one thread can hold the processingPending CAS at a time.

## Modifications
Replaced AtomicInteger `inFlightRequestsNum` with `java.util.concurrent.Semaphore`. `Semaphore.tryAcquire() `atomically checks availability and reserves a permit in a single operation — eliminating the gap between check and act. No two threads can both "pass the check" because the check IS the reservation.
- processRequest: `tryAcquire`() — atomic check+reserve, enqueue if unavailable
- sendPartRequest: `release`() on completion, error, or validation failure
- processPendingTransformers: `tryAcquire`() in the drain loop, `release`() if poll returns null
- sendFirstRequest: `tryAcquire`()/`release`() for the initial request

`ParallelPresignedUrlMultipartDownloaderSubscriber`: Replaced `AtomicInteger inFlightRequestsNum `with `Semaphore inFlightPermits.` All increment/decrement/check operations replaced with `tryAcquire()/release()`. Added permit release on all error paths to prevent permit leaks.

## Testing
- `ParallelPresignedUrlMultipartDownloaderSubscriberTest`: Added multiPartDownload_manyParts_shouldCompleteSuccessfully — downloads a 13-part object (exceeding maxInFlightParts=10) to verify the Semaphore correctly batches requests without deadlock or permit leaks.
- All existing tests pass (single-part, multi-part, error propagation, validation failures).
 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
