### PR TITLE
Support prefix headers in RestJson

### DIFF
--- a/.changes/next-release/feature-AWSDataExchange-043946b.json
+++ b/.changes/next-release/feature-AWSDataExchange-043946b.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS Data Exchange",
+    "contributor": "",
+    "description": "Add support for SendApiAsset operation."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-3acca9b.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-3acca9b.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Support prefix headers (header maps) in Rest-Json"
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMarshaller.java
@@ -20,6 +20,7 @@ import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
@@ -36,7 +37,7 @@ import software.amazon.awssdk.utils.StringUtils;
 public final class HeaderMarshaller {
 
     public static final JsonMarshaller<String> STRING = new SimpleHeaderMarshaller<>(
-        (val, field) -> field.containsTrait(JsonValueTrait.class, TraitType.JSON_VALUE_TRAIT) ?
+        (val, field) -> field != null && field.containsTrait(JsonValueTrait.class, TraitType.JSON_VALUE_TRAIT) ?
                         BinaryUtils.toBase64(val.getBytes(StandardCharsets.UTF_8)) : val);
 
     public static final JsonMarshaller<Integer> INTEGER = new SimpleHeaderMarshaller<>(ValueToStringConverter.FROM_INTEGER);
@@ -69,6 +70,19 @@ public final class HeaderMarshaller {
             }
             JsonMarshaller marshaller = context.marshallerRegistry().getMarshaller(MarshallLocation.HEADER, listValue);
             marshaller.marshall(listValue, context, paramName, memberFieldInfo);
+        }
+    };
+
+    @SuppressWarnings("unchecked")
+    public static final JsonMarshaller<Map<String, ?>> MAP = (map, context, paramName, sdkField) -> {
+        if (isNullOrEmpty(map)) {
+            return;
+        }
+        for (Map.Entry<String, ?> entry : map.entrySet()) {
+            String key = entry.getKey().startsWith(paramName) ? entry.getKey()
+                                                              : paramName + entry.getKey();
+            JsonMarshaller marshaller = context.marshallerRegistry().getMarshaller(MarshallLocation.HEADER, entry.getValue());
+            marshaller.marshall(entry.getValue(), context, key, null);
         }
     };
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -143,6 +143,7 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
             .headerMarshaller(MarshallingType.BOOLEAN, HeaderMarshaller.BOOLEAN)
             .headerMarshaller(MarshallingType.INSTANT, HeaderMarshaller.INSTANT)
             .headerMarshaller(MarshallingType.LIST, HeaderMarshaller.LIST)
+            .headerMarshaller(MarshallingType.MAP, HeaderMarshaller.MAP)
             .headerMarshaller(MarshallingType.NULL, HeaderMarshaller.NULL)
 
             .queryParamMarshaller(MarshallingType.STRING, QueryParamMarshaller.STRING)

--- a/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMapMarshallingTest.java
+++ b/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMapMarshallingTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.json.internal.marshall;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.protocols.core.OperationInfo;
+import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolMetadata;
+import software.amazon.awssdk.protocols.json.internal.AwsStructuredPlainJsonFactory;
+
+/**
+ * Tests that Map fields with {@link MarshallLocation#HEADER} (prefix headers) are marshalled
+ * correctly in the JSON protocol. This covers the bug where the JSON protocol was missing a
+ * headerMarshaller for {@link MarshallingType#MAP}, causing a NullPointerException in
+ * {@link JsonProtocolMarshaller#marshallFieldViaRegistry}.
+ */
+class HeaderMapMarshallingTest {
+
+    private static final URI ENDPOINT = URI.create("http://localhost");
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final OperationInfo OP_INFO = OperationInfo.builder()
+        .httpMethod(SdkHttpMethod.PUT)
+        .hasImplicitPayloadMembers(false)
+        .build();
+    private static final AwsJsonProtocolMetadata METADATA =
+        AwsJsonProtocolMetadata.builder()
+            .protocol(AwsJsonProtocol.REST_JSON)
+            .contentType(CONTENT_TYPE)
+            .build();
+
+    @Test
+    void mapInHeader_withEntries_producesCorrectPrefixHeaders() {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("key1", "value1");
+        metadata.put("key2", "value2");
+
+        SdkField<Map<String, String>> field = mapHeaderField("x-amz-meta-", obj -> metadata);
+        SdkPojo pojo = new SimplePojo(field);
+
+        SdkHttpFullRequest result = createMarshaller().marshall(pojo);
+
+        assertThat(result.firstMatchingHeader("x-amz-meta-key1")).hasValue("value1");
+        assertThat(result.firstMatchingHeader("x-amz-meta-key2")).hasValue("value2");
+    }
+
+    @Test
+    void mapInHeader_withEmptyMap_producesNoHeaders() {
+        Map<String, String> metadata = new HashMap<>();
+
+        SdkField<Map<String, String>> field = mapHeaderField("x-amz-meta-", obj -> metadata);
+        SdkPojo pojo = new SimplePojo(field);
+
+        SdkHttpFullRequest result = createMarshaller().marshall(pojo);
+
+        assertThat(result.firstMatchingHeader("x-amz-meta-")).isNotPresent();
+    }
+
+    @Test
+    void mapInHeader_withNullMap_producesNoHeaders() {
+        SdkField<Map<String, String>> field = mapHeaderField("x-amz-meta-", obj -> null);
+        SdkPojo pojo = new SimplePojo(field);
+
+        SdkHttpFullRequest result = createMarshaller().marshall(pojo);
+
+        assertThat(result.firstMatchingHeader("x-amz-meta-")).isNotPresent();
+    }
+
+    @Test
+    void mapInHeader_keyAlreadyHasPrefix_doesNotDoublePrefix() {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("x-amz-meta-already-prefixed", "value1");
+
+        SdkField<Map<String, String>> field = mapHeaderField("x-amz-meta-", obj -> metadata);
+        SdkPojo pojo = new SimplePojo(field);
+
+        SdkHttpFullRequest result = createMarshaller().marshall(pojo);
+
+        assertThat(result.firstMatchingHeader("x-amz-meta-already-prefixed")).hasValue("value1");
+    }
+
+    @Test
+    void mapInHeader_withEmptyStringValue_producesHeaderWithEmptyValue() {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("key1", "");
+
+        SdkField<Map<String, String>> field = mapHeaderField("x-amz-meta-", obj -> metadata);
+        SdkPojo pojo = new SimplePojo(field);
+
+        SdkHttpFullRequest result = createMarshaller().marshall(pojo);
+
+        // The SDK's firstMatchingHeader returns Optional.empty() for empty-value headers,
+        // but the header IS present in the raw headers map
+        assertThat(result.headers().get("x-amz-meta-key1")).containsExactly("");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private static SdkField<Map<String, String>> mapHeaderField(
+            String prefix, java.util.function.Function<Object, Map<String, String>> getter) {
+
+        SdkField<String> valueField = SdkField.<String>builder(MarshallingType.STRING)
+            .memberName("value")
+            .getter(obj -> null)
+            .setter((obj, val) -> { })
+            .traits(LocationTrait.builder()
+                        .location(MarshallLocation.HEADER)
+                        .locationName("value")
+                        .build())
+            .build();
+
+        return (SdkField<Map<String, String>>) (SdkField) SdkField.builder(MarshallingType.MAP)
+            .memberName("Metadata")
+            .getter((java.util.function.Function) getter)
+            .setter((obj, val) -> { })
+            .traits(LocationTrait.builder()
+                        .location(MarshallLocation.HEADER)
+                        .locationName(prefix)
+                        .build(),
+                    MapTrait.builder()
+                        .valueFieldInfo(valueField)
+                        .build())
+            .build();
+    }
+
+    private static ProtocolMarshaller<SdkHttpFullRequest> createMarshaller() {
+        return JsonProtocolMarshallerBuilder.create()
+            .endpoint(ENDPOINT)
+            .jsonGenerator(AwsStructuredPlainJsonFactory
+                .SDK_JSON_FACTORY.createWriter(CONTENT_TYPE))
+            .contentType(CONTENT_TYPE)
+            .operationInfo(OP_INFO)
+            .sendExplicitNullForPayload(false)
+            .protocolMetadata(METADATA)
+            .build();
+    }
+
+    private static final class SimplePojo implements SdkPojo {
+        private final List<SdkField<?>> fields;
+
+        SimplePojo(SdkField<?>... fields) {
+            this.fields = Arrays.asList(fields);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return fields;
+        }
+
+        @Override
+        public boolean equalsBySdkFields(Object other) {
+            return other instanceof SimplePojo;
+        }
+
+        @Override
+        public Map<String, SdkField<?>> sdkFieldNameToField() {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMapMarshallingTest.java
+++ b/core/protocols/aws-json-protocol/src/test/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMapMarshallingTest.java
@@ -39,12 +39,7 @@ import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
 import software.amazon.awssdk.protocols.json.AwsJsonProtocolMetadata;
 import software.amazon.awssdk.protocols.json.internal.AwsStructuredPlainJsonFactory;
 
-/**
- * Tests that Map fields with {@link MarshallLocation#HEADER} (prefix headers) are marshalled
- * correctly in the JSON protocol. This covers the bug where the JSON protocol was missing a
- * headerMarshaller for {@link MarshallingType#MAP}, causing a NullPointerException in
- * {@link JsonProtocolMarshaller#marshallFieldViaRegistry}.
- */
+
 class HeaderMapMarshallingTest {
 
     private static final URI ENDPOINT = URI.create("http://localhost");

--- a/services/dataexchange/src/main/resources/codegen-resources/customization.config
+++ b/services/dataexchange/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,8 @@
 {
     "operationModifiers": {
+        "SendApiAsset": {
+            "exclude": true
+        }
     },
     "generateEndpointClientTests": true,
     "enableGenerateCompiledEndpointRules": true

--- a/services/dataexchange/src/main/resources/codegen-resources/customization.config
+++ b/services/dataexchange/src/main/resources/codegen-resources/customization.config
@@ -1,8 +1,5 @@
 {
     "operationModifiers": {
-        "SendApiAsset": {
-            "exclude": true
-        }
     },
     "generateEndpointClientTests": true,
     "enableGenerateCompiledEndpointRules": true

--- a/services/dataexchange/src/main/resources/codegen-resources/customization.config
+++ b/services/dataexchange/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,4 @@
 {
-    "operationModifiers": {
-    },
     "generateEndpointClientTests": true,
     "enableGenerateCompiledEndpointRules": true
 }

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-core-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-core-input.json
@@ -3,8 +3,7 @@
   {
     "description": "Operation with no path params, sets URI and HTTP method correctly",
     "given": {
-      "input": {
-      }
+      "input": {}
     },
     "when": {
       "action": "marshall",
@@ -26,7 +25,9 @@
     "then": {
       "serializedAs": {
         "headers": {
-          "doesNotContain": [ "X-Amz-Target" ]
+          "doesNotContain": [
+            "X-Amz-Target"
+          ]
         }
       }
     }
@@ -92,7 +93,9 @@
     "then": {
       "serializedAs": {
         "headers": {
-          "doesNotContain": ["StringMember"]
+          "doesNotContain": [
+            "StringMember"
+          ]
         }
       }
     }
@@ -256,7 +259,9 @@
     "then": {
       "serializedAs": {
         "params": {
-          "doesNotContain": ["item"]
+          "doesNotContain": [
+            "item"
+          ]
         }
       }
     }
@@ -265,7 +270,9 @@
     "description": "Singleton list with empty string in query params, adds param with empty value",
     "given": {
       "input": {
-        "ListOfStrings": [""]
+        "ListOfStrings": [
+          ""
+        ]
       }
     },
     "when": {
@@ -456,8 +463,7 @@
   {
     "description": "Operation that has a static query parameter with no value.",
     "given": {
-      "input": {
-      }
+      "input": {}
     },
     "when": {
       "action": "marshall",
@@ -468,7 +474,9 @@
         "uri": "/2016-03-11/queryParamWithoutValue",
         "params": {
           "contains": {
-            "param": [null]
+            "param": [
+              null
+            ]
           }
         }
       }
@@ -477,8 +485,7 @@
   {
     "description": "GET operation does not have content-type header",
     "given": {
-      "input": {
-      }
+      "input": {}
     },
     "when": {
       "action": "marshall",
@@ -487,28 +494,30 @@
     "then": {
       "serializedAs": {
         "headers": {
-          "doesNotContain": [ "content-type" ]
+          "doesNotContain": [
+            "content-type"
+          ]
         }
       }
     }
   },
   {
-      "description": "Input with greedy label in path",
-      "given": {
-	  "input": {
-	      "NonGreedyPathParam": "pathParamValue",
-	      "GreedyPathParam": "foo/bar/baz"
-	  }
-      },
-      "when": {
-	  "action": "marshall",
-	  "operation": "OperationWithGreedyLabel"
-      },
-      "then": {
-	  "serializedAs": {
-	      "uri": "/2016-03-11/operationWithGreedyLabel/pathParamValue/foo/bar/baz"
-	  }
+    "description": "Input with greedy label in path",
+    "given": {
+      "input": {
+        "NonGreedyPathParam": "pathParamValue",
+        "GreedyPathParam": "foo/bar/baz"
       }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "OperationWithGreedyLabel"
+    },
+    "then": {
+      "serializedAs": {
+        "uri": "/2016-03-11/operationWithGreedyLabel/pathParamValue/foo/bar/baz"
+      }
+    }
   },
   {
     "description": "Operation with null members that have the idempotent trait are autofilled.",
@@ -536,9 +545,9 @@
     "description": "Operation with non-null members that have the idempotent trait are not autofilled.",
     "given": {
       "input": {
-          "PathIdempotentToken": "foo",
-          "QueryIdempotentToken": "bar",
-          "HeaderIdempotentToken": "baz"
+        "PathIdempotentToken": "foo",
+        "QueryIdempotentToken": "bar",
+        "HeaderIdempotentToken": "baz"
       }
     },
     "when": {
@@ -565,7 +574,7 @@
     "description": "Operation with modeled content-type, respects modeled content-type over protocol default.",
     "given": {
       "input": {
-          "ContentType": "application/foo"
+        "ContentType": "application/foo"
       }
     },
     "when": {
@@ -578,6 +587,52 @@
           "contains": {
             "Content-Type": "application/foo"
           }
+        }
+      }
+    }
+  },
+  {
+    "description": "Map bound to headers with prefix produces prefixed headers for each entry",
+    "given": {
+      "input": {
+        "MetadataMember": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "MapInHeaders"
+    },
+    "then": {
+      "serializedAs": {
+        "headers": {
+          "contains": {
+            "x-amz-meta-key1": "value1",
+            "x-amz-meta-key2": "value2"
+          }
+        }
+      }
+    }
+  },
+  {
+    "description": "Empty map bound to headers with prefix does not produce any prefixed headers",
+    "given": {
+      "input": {
+        "MetadataMember": {}
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "MapInHeaders"
+    },
+    "then": {
+      "serializedAs": {
+        "headers": {
+          "doesNotContain": [
+            "x-amz-meta-"
+          ]
         }
       }
     }

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-core-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-core-input.json
@@ -3,7 +3,8 @@
   {
     "description": "Operation with no path params, sets URI and HTTP method correctly",
     "given": {
-      "input": {}
+      "input": {
+      }
     },
     "when": {
       "action": "marshall",
@@ -25,9 +26,7 @@
     "then": {
       "serializedAs": {
         "headers": {
-          "doesNotContain": [
-            "X-Amz-Target"
-          ]
+          "doesNotContain": [ "X-Amz-Target" ]
         }
       }
     }
@@ -93,9 +92,7 @@
     "then": {
       "serializedAs": {
         "headers": {
-          "doesNotContain": [
-            "StringMember"
-          ]
+          "doesNotContain": ["StringMember"]
         }
       }
     }
@@ -259,9 +256,7 @@
     "then": {
       "serializedAs": {
         "params": {
-          "doesNotContain": [
-            "item"
-          ]
+          "doesNotContain": ["item"]
         }
       }
     }
@@ -270,9 +265,7 @@
     "description": "Singleton list with empty string in query params, adds param with empty value",
     "given": {
       "input": {
-        "ListOfStrings": [
-          ""
-        ]
+        "ListOfStrings": [""]
       }
     },
     "when": {
@@ -463,7 +456,8 @@
   {
     "description": "Operation that has a static query parameter with no value.",
     "given": {
-      "input": {}
+      "input": {
+      }
     },
     "when": {
       "action": "marshall",
@@ -474,9 +468,7 @@
         "uri": "/2016-03-11/queryParamWithoutValue",
         "params": {
           "contains": {
-            "param": [
-              null
-            ]
+            "param": [null]
           }
         }
       }
@@ -485,7 +477,8 @@
   {
     "description": "GET operation does not have content-type header",
     "given": {
-      "input": {}
+      "input": {
+      }
     },
     "when": {
       "action": "marshall",
@@ -494,30 +487,28 @@
     "then": {
       "serializedAs": {
         "headers": {
-          "doesNotContain": [
-            "content-type"
-          ]
+          "doesNotContain": [ "content-type" ]
         }
       }
     }
   },
   {
-    "description": "Input with greedy label in path",
-    "given": {
-      "input": {
-        "NonGreedyPathParam": "pathParamValue",
-        "GreedyPathParam": "foo/bar/baz"
+      "description": "Input with greedy label in path",
+      "given": {
+	  "input": {
+	      "NonGreedyPathParam": "pathParamValue",
+	      "GreedyPathParam": "foo/bar/baz"
+	  }
+      },
+      "when": {
+	  "action": "marshall",
+	  "operation": "OperationWithGreedyLabel"
+      },
+      "then": {
+	  "serializedAs": {
+	      "uri": "/2016-03-11/operationWithGreedyLabel/pathParamValue/foo/bar/baz"
+	  }
       }
-    },
-    "when": {
-      "action": "marshall",
-      "operation": "OperationWithGreedyLabel"
-    },
-    "then": {
-      "serializedAs": {
-        "uri": "/2016-03-11/operationWithGreedyLabel/pathParamValue/foo/bar/baz"
-      }
-    }
   },
   {
     "description": "Operation with null members that have the idempotent trait are autofilled.",
@@ -545,9 +536,9 @@
     "description": "Operation with non-null members that have the idempotent trait are not autofilled.",
     "given": {
       "input": {
-        "PathIdempotentToken": "foo",
-        "QueryIdempotentToken": "bar",
-        "HeaderIdempotentToken": "baz"
+          "PathIdempotentToken": "foo",
+          "QueryIdempotentToken": "bar",
+          "HeaderIdempotentToken": "baz"
       }
     },
     "when": {
@@ -574,7 +565,7 @@
     "description": "Operation with modeled content-type, respects modeled content-type over protocol default.",
     "given": {
       "input": {
-        "ContentType": "application/foo"
+          "ContentType": "application/foo"
       }
     },
     "when": {
@@ -630,9 +621,7 @@
     "then": {
       "serializedAs": {
         "headers": {
-          "doesNotContain": [
-            "x-amz-meta-"
-          ]
+          "doesNotContain": ["x-amz-meta-"]
         }
       }
     }

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
@@ -1,226 +1,308 @@
 {
-  "version":"2.0",
-  "metadata":{
-    "apiVersion":"2016-03-11",
-    "endpointPrefix":"restjson",
-    "jsonVersion":"1.1",
-    "protocol":"rest-json",
-    "serviceAbbreviation":"RestJsonProtocolTests",
-    "serviceFullName":"AWS DR Tools Rest JSON Protocol Tests",
-    "serviceId":"ProtocolRestJson",
-    "signatureVersion":"v4",
-    "targetPrefix":"ProtocolTestsService",
-    "uid":"restjson-2016-03-11"
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2016-03-11",
+    "endpointPrefix": "restjson",
+    "jsonVersion": "1.1",
+    "protocol": "rest-json",
+    "serviceAbbreviation": "RestJsonProtocolTests",
+    "serviceFullName": "AWS DR Tools Rest JSON Protocol Tests",
+    "serviceId": "ProtocolRestJson",
+    "signatureVersion": "v4",
+    "targetPrefix": "ProtocolTestsService",
+    "uid": "restjson-2016-03-11"
   },
-  "operations":{
-    "AllTypes":{
-      "name":"AllTypes",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/allTypes"
+  "operations": {
+    "AllTypes": {
+      "name": "AllTypes",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/allTypes"
       },
-      "input":{"shape":"AllTypesStructure"},
-      "output":{"shape":"AllTypesStructure"},
-      "errors":[
-        {"shape":"EmptyModeledException"},
-        {"shape":"ExplicitPayloadAndHeadersException"},
-        {"shape":"ImplicitPayloadException"}
+      "input": {
+        "shape": "AllTypesStructure"
+      },
+      "output": {
+        "shape": "AllTypesStructure"
+      },
+      "errors": [
+        {
+          "shape": "EmptyModeledException"
+        },
+        {
+          "shape": "ExplicitPayloadAndHeadersException"
+        },
+        {
+          "shape": "ImplicitPayloadException"
+        }
       ]
     },
-    "DeleteOperation":{
-      "name":"DeleteOperation",
-      "http":{
-        "method":"DELETE",
-        "requestUri":"/2016-03-11/deleteOperation"
+    "DeleteOperation": {
+      "name": "DeleteOperation",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/2016-03-11/deleteOperation"
       }
     },
-    "FurtherNestedContainers":{
-      "name":"FurtherNestedContainers",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/furtherNestedContainers"
+    "FurtherNestedContainers": {
+      "name": "FurtherNestedContainers",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/furtherNestedContainers"
       },
-      "input":{"shape":"FurtherNestedContainersStructure"},
-      "output":{"shape":"FurtherNestedContainersStructure"}
-    },
-    "GetOperationWithBody":{
-      "name":"GetOperationWithBody",
-      "http":{
-        "method":"GET",
-        "requestUri":"/2016-03-11/getOperationWithBody"
+      "input": {
+        "shape": "FurtherNestedContainersStructure"
       },
-      "input":{"shape":"GetOperationWithBodyInput"}
-    },
-    "HeadOperation":{
-      "name":"HeadOperation",
-      "http":{
-        "method":"HEAD",
-        "requestUri":"/2016-03-11/headOperation"
+      "output": {
+        "shape": "FurtherNestedContainersStructure"
       }
     },
-    "IdempotentOperation":{
-      "name":"IdempotentOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/idempotentOperation/{PathParam}"
+    "GetOperationWithBody": {
+      "name": "GetOperationWithBody",
+      "http": {
+        "method": "GET",
+        "requestUri": "/2016-03-11/getOperationWithBody"
       },
-      "input":{"shape":"IdempotentOperationStructure"}
+      "input": {
+        "shape": "GetOperationWithBodyInput"
+      }
     },
-    "JsonValuesOperation":{
-      "name":"JsonValuesOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/JsonValuesStructure"
+    "HeadOperation": {
+      "name": "HeadOperation",
+      "http": {
+        "method": "HEAD",
+        "requestUri": "/2016-03-11/headOperation"
+      }
+    },
+    "IdempotentOperation": {
+      "name": "IdempotentOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/idempotentOperation/{PathParam}"
       },
-      "input":{"shape":"JsonValuesStructure"},
-      "output":{"shape":"JsonValuesStructure"},
-      "errors":[
-        {"shape":"EmptyModeledException"}
+      "input": {
+        "shape": "IdempotentOperationStructure"
+      }
+    },
+    "JsonValuesOperation": {
+      "name": "JsonValuesOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/JsonValuesStructure"
+      },
+      "input": {
+        "shape": "JsonValuesStructure"
+      },
+      "output": {
+        "shape": "JsonValuesStructure"
+      },
+      "errors": [
+        {
+          "shape": "EmptyModeledException"
+        }
       ]
     },
-    "MapOfStringToListOfStringInQueryParams":{
-      "name":"MapOfStringToListOfStringInQueryParams",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/mapOfStringToListOfStringInQueryParams"
+    "MapOfStringToListOfStringInQueryParams": {
+      "name": "MapOfStringToListOfStringInQueryParams",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/mapOfStringToListOfStringInQueryParams"
       },
-      "input":{"shape":"MapOfStringToListOfStringInQueryParamsInput"}
-    },
-    "MembersInHeaders":{
-      "name":"MembersInHeaders",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/membersInHeaders"
-      },
-      "input":{"shape":"MembersInHeadersStructure"},
-      "output":{"shape":"MembersInHeadersStructure"}
-    },
-    "MembersInQueryParams":{
-      "name":"MembersInQueryParams",
-      "http":{
-        "method":"GET",
-        "requestUri":"/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
-      },
-      "input":{"shape":"MembersInQueryParamsInput"},
-      "output":{"shape":"MembersInQueryParamsInput"}
-    },
-    "MultiLocationOperation":{
-      "name":"MultiLocationOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/multiLocationOperation/{PathParam}"
-      },
-      "input":{"shape":"MultiLocationOperationInput"},
-      "output":{"shape":"MultiLocationOperationInput"}
-    },
-    "NestedContainers":{
-      "name":"NestedContainers",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/nestedContainers"
-      },
-      "input":{"shape":"NestedContainersStructure"},
-      "output":{"shape":"NestedContainersStructure"}
-    },
-    "OperationWithExplicitPayloadBlob":{
-      "name":"OperationWithExplicitPayloadBlob",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithExplicitPayloadBlob"
-      },
-      "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
-      "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
-    },
-    "OperationWithExplicitPayloadString":{
-      "name":"OperationWithExplicitPayloadString",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
-      },
-      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
-      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
-    },
-    "OperationWithExplicitPayloadStructure":{
-      "name":"OperationWithExplicitPayloadStructure",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithExplicitPayloadStructure"
-      },
-      "input":{"shape":"OperationWithExplicitPayloadStructureInput"},
-      "output":{"shape":"OperationWithExplicitPayloadStructureInput"}
-    },
-    "OperationWithGreedyLabel":{
-      "name":"OperationWithGreedyLabel",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
-      },
-      "input":{"shape":"OperationWithGreedyLabelInput"}
-    },
-    "OperationWithModeledContentType":{
-      "name":"OperationWithModeledContentType",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithModeledContentType"
-      },
-      "input":{"shape":"OperationWithModeledContentTypeInput"}
-    },
-    "OperationWithNoInputOrOutput":{
-      "name":"OperationWithNoInputOrOutput",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithNoInputOrOutput"
+      "input": {
+        "shape": "MapOfStringToListOfStringInQueryParamsInput"
       }
     },
-    "QueryParamWithoutValue":{
-      "name":"QueryParamWithoutValue",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/queryParamWithoutValue?param"
+    "MembersInHeaders": {
+      "name": "MembersInHeaders",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/membersInHeaders"
       },
-      "input":{"shape":"QueryParamWithoutValueInput"}
+      "input": {
+        "shape": "MembersInHeadersStructure"
+      },
+      "output": {
+        "shape": "MembersInHeadersStructure"
+      }
     },
-    "StatusCodeInOutputOperation":{
-      "name":"StatusCodeInOutputOperation",
-      "http":{
-        "method":"GET",
-        "requestUri":"/2016-03-11/statusCodeInOutput"
+    "MapInHeaders": {
+      "name": "MapInHeaders",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/mapInHeaders"
       },
-      "output":{"shape":"StatusCodeInOutputStructure"}
+      "input": {
+        "shape": "MapInHeadersInput"
+      }
     },
-    "MixedLocationOperation":{
-      "name":"MixedLocationOperation",
-      "http":{
-        "method":"GET",
-        "requestUri":"/2016-03-11/mixedLocationOperation"
+    "MembersInQueryParams": {
+      "name": "MembersInQueryParams",
+      "http": {
+        "method": "GET",
+        "requestUri": "/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
       },
-      "output":{"shape":"MixedLocationOperationOutput"},
-      "input":{"shape":"MixedLocationOperationInput"}
+      "input": {
+        "shape": "MembersInQueryParamsInput"
+      },
+      "output": {
+        "shape": "MembersInQueryParamsInput"
+      }
     },
-    "StreamingInputOperation":{
-      "name":"StreamingInputOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/streamingInputOperation"
+    "MultiLocationOperation": {
+      "name": "MultiLocationOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/multiLocationOperation/{PathParam}"
       },
-      "input":{"shape":"StructureWithStreamingMember"}
+      "input": {
+        "shape": "MultiLocationOperationInput"
+      },
+      "output": {
+        "shape": "MultiLocationOperationInput"
+      }
     },
-    "StreamingInputOperationChunkedEncoding":{
-      "name":"StreamingInputOperationChunkedEncoding",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/streamingInputOperationChunkedEncoding"
+    "NestedContainers": {
+      "name": "NestedContainers",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/nestedContainers"
       },
-      "input":{"shape":"StructureWithStreamingMemberChunkedEncoding"},
-      "authtype":"v4-unsigned-body"
+      "input": {
+        "shape": "NestedContainersStructure"
+      },
+      "output": {
+        "shape": "NestedContainersStructure"
+      }
     },
-    "StreamingOutputOperation":{
-      "name":"StreamingOutputOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/streamingOutputOperation"
+    "OperationWithExplicitPayloadBlob": {
+      "name": "OperationWithExplicitPayloadBlob",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithExplicitPayloadBlob"
       },
-      "output":{"shape":"StructureWithStreamingMember"}
+      "input": {
+        "shape": "OperationWithExplicitPayloadBlobInput"
+      },
+      "output": {
+        "shape": "OperationWithExplicitPayloadBlobInput"
+      }
+    },
+    "OperationWithExplicitPayloadString": {
+      "name": "OperationWithExplicitPayloadString",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithExplicitPayloadString"
+      },
+      "input": {
+        "shape": "OperationWithExplicitPayloadStringInput"
+      },
+      "output": {
+        "shape": "OperationWithExplicitPayloadStringInput"
+      }
+    },
+    "OperationWithExplicitPayloadStructure": {
+      "name": "OperationWithExplicitPayloadStructure",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithExplicitPayloadStructure"
+      },
+      "input": {
+        "shape": "OperationWithExplicitPayloadStructureInput"
+      },
+      "output": {
+        "shape": "OperationWithExplicitPayloadStructureInput"
+      }
+    },
+    "OperationWithGreedyLabel": {
+      "name": "OperationWithGreedyLabel",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
+      },
+      "input": {
+        "shape": "OperationWithGreedyLabelInput"
+      }
+    },
+    "OperationWithModeledContentType": {
+      "name": "OperationWithModeledContentType",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithModeledContentType"
+      },
+      "input": {
+        "shape": "OperationWithModeledContentTypeInput"
+      }
+    },
+    "OperationWithNoInputOrOutput": {
+      "name": "OperationWithNoInputOrOutput",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithNoInputOrOutput"
+      }
+    },
+    "QueryParamWithoutValue": {
+      "name": "QueryParamWithoutValue",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/queryParamWithoutValue?param"
+      },
+      "input": {
+        "shape": "QueryParamWithoutValueInput"
+      }
+    },
+    "StatusCodeInOutputOperation": {
+      "name": "StatusCodeInOutputOperation",
+      "http": {
+        "method": "GET",
+        "requestUri": "/2016-03-11/statusCodeInOutput"
+      },
+      "output": {
+        "shape": "StatusCodeInOutputStructure"
+      }
+    },
+    "MixedLocationOperation": {
+      "name": "MixedLocationOperation",
+      "http": {
+        "method": "GET",
+        "requestUri": "/2016-03-11/mixedLocationOperation"
+      },
+      "output": {
+        "shape": "MixedLocationOperationOutput"
+      },
+      "input": {
+        "shape": "MixedLocationOperationInput"
+      }
+    },
+    "StreamingInputOperation": {
+      "name": "StreamingInputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingInputOperation"
+      },
+      "input": {
+        "shape": "StructureWithStreamingMember"
+      }
+    },
+    "StreamingInputOperationChunkedEncoding": {
+      "name": "StreamingInputOperationChunkedEncoding",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingInputOperationChunkedEncoding"
+      },
+      "input": {
+        "shape": "StructureWithStreamingMemberChunkedEncoding"
+      },
+      "authtype": "v4-unsigned-body"
+    },
+    "StreamingOutputOperation": {
+      "name": "StreamingOutputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingOutputOperation"
+      },
+      "output": {
+        "shape": "StructureWithStreamingMember"
+      }
     },
     "EventStreamOperation": {
       "name": "EventStreamOperation",
@@ -248,685 +330,950 @@
         "shape": "EventStreamOutput"
       }
     },
-    "DocumentInputOperation":{
-      "name":"DocumentInputOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/documentInputOperation"
+    "DocumentInputOperation": {
+      "name": "DocumentInputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/documentInputOperation"
       },
-      "input":{"shape":"StructureWithDocumentMember"}
+      "input": {
+        "shape": "StructureWithDocumentMember"
+      }
     },
-    "NestedLocationOperation":{
-      "name":"NestedLocationOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/nestedLocationOperation"
+    "NestedLocationOperation": {
+      "name": "NestedLocationOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/nestedLocationOperation"
       },
-      "input":{"shape":"NestedLocationOperationInput"},
-      "output":{"shape":"NestedLocationOperationOutput"}
+      "input": {
+        "shape": "NestedLocationOperationInput"
+      },
+      "output": {
+        "shape": "NestedLocationOperationOutput"
+      }
     }
   },
-  "shapes":{
-    "AllTypesStructure":{
-      "type":"structure",
-      "members":{
-        "StringMember":{"shape":"String"},
-        "IntegerMember":{"shape":"Integer"},
-        "BooleanMember":{"shape":"Boolean"},
-        "FloatMember":{"shape":"Float"},
-        "DoubleMember":{"shape":"Double"},
-        "LongMember":{"shape":"Long"},
-        "ShortMember":{"shape":"Short"},
-        "ByteMember":{"shape":"Byte"},
-        "BigDecimalMember":{"shape":"NumericValue"},
-        "SimpleList":{"shape":"ListOfStrings"},
-        "ListOfMaps":{"shape":"ListOfMapStringToString"},
-        "ListOfStructs":{"shape":"ListOfSimpleStructs"},
-        "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
-        "MapOfStringToString":{"shape":"MapOfStringToString"},
-        "MapOfStringToStruct":{"shape":"MapOfStringToSimpleStruct"},
-        "TimestampMember":{"shape":"Timestamp"},
-        "StructWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
-        "TimestampFormatMember":{"shape":"IsoTimestamp"},
-        "BlobArg":{"shape":"BlobType"},
-        "StructWithNestedBlob":{"shape":"StructWithNestedBlobType"},
-        "BlobMap":{"shape":"BlobMapType"},
-        "ListOfBlobs":{"shape":"ListOfBlobsType"},
-        "RecursiveStruct":{"shape":"RecursiveStructType"},
-        "PolymorphicTypeWithSubTypes":{"shape":"BaseType"},
-        "PolymorphicTypeWithoutSubTypes":{"shape":"SubTypeOne"},
-        "EnumMember":{"shape":"EnumType"},
-        "ListOfEnums":{"shape":"ListOfEnums"},
-        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
-        "ListOfTimeStamp":{"shape":"ListOfTimeStamp"},
-        "MapOfTimeStamp":{"shape":"MapOfTimeStamp"},
-        "MyDocument":{"shape":"MyDocument"},
-        "UnionMember":{"shape":"AllTypesUnionStructure"}
+  "shapes": {
+    "AllTypesStructure": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        },
+        "IntegerMember": {
+          "shape": "Integer"
+        },
+        "BooleanMember": {
+          "shape": "Boolean"
+        },
+        "FloatMember": {
+          "shape": "Float"
+        },
+        "DoubleMember": {
+          "shape": "Double"
+        },
+        "LongMember": {
+          "shape": "Long"
+        },
+        "ShortMember": {
+          "shape": "Short"
+        },
+        "ByteMember": {
+          "shape": "Byte"
+        },
+        "BigDecimalMember": {
+          "shape": "NumericValue"
+        },
+        "SimpleList": {
+          "shape": "ListOfStrings"
+        },
+        "ListOfMaps": {
+          "shape": "ListOfMapStringToString"
+        },
+        "ListOfStructs": {
+          "shape": "ListOfSimpleStructs"
+        },
+        "MapOfStringToIntegerList": {
+          "shape": "MapOfStringToIntegerList"
+        },
+        "MapOfStringToString": {
+          "shape": "MapOfStringToString"
+        },
+        "MapOfStringToStruct": {
+          "shape": "MapOfStringToSimpleStruct"
+        },
+        "TimestampMember": {
+          "shape": "Timestamp"
+        },
+        "StructWithNestedTimestampMember": {
+          "shape": "StructWithTimestamp"
+        },
+        "TimestampFormatMember": {
+          "shape": "IsoTimestamp"
+        },
+        "BlobArg": {
+          "shape": "BlobType"
+        },
+        "StructWithNestedBlob": {
+          "shape": "StructWithNestedBlobType"
+        },
+        "BlobMap": {
+          "shape": "BlobMapType"
+        },
+        "ListOfBlobs": {
+          "shape": "ListOfBlobsType"
+        },
+        "RecursiveStruct": {
+          "shape": "RecursiveStructType"
+        },
+        "PolymorphicTypeWithSubTypes": {
+          "shape": "BaseType"
+        },
+        "PolymorphicTypeWithoutSubTypes": {
+          "shape": "SubTypeOne"
+        },
+        "EnumMember": {
+          "shape": "EnumType"
+        },
+        "ListOfEnums": {
+          "shape": "ListOfEnums"
+        },
+        "MapOfEnumToEnum": {
+          "shape": "MapOfEnumToEnum"
+        },
+        "ListOfTimeStamp": {
+          "shape": "ListOfTimeStamp"
+        },
+        "MapOfTimeStamp": {
+          "shape": "MapOfTimeStamp"
+        },
+        "MyDocument": {
+          "shape": "MyDocument"
+        },
+        "UnionMember": {
+          "shape": "AllTypesUnionStructure"
+        }
       }
     },
-    "BaseType":{
-      "type":"structure",
-      "members":{
-        "BaseMember":{"shape":"String"}
+    "BaseType": {
+      "type": "structure",
+      "members": {
+        "BaseMember": {
+          "shape": "String"
+        }
       }
     },
-    "BlobMapType":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"BlobType"}
-    },
-    "BlobType":{"type":"blob"},
-    "Boolean":{"type":"boolean"},
-    "Double":{"type":"double"},
-    "EmptyModeledException":{
-      "type":"structure",
-      "members":{
+    "BlobMapType": {
+      "type": "map",
+      "key": {
+        "shape": "String"
       },
-      "exception":true
+      "value": {
+        "shape": "BlobType"
+      }
     },
-    "EnumType":{
-      "type":"string",
-      "enum":[
+    "BlobType": {
+      "type": "blob"
+    },
+    "Boolean": {
+      "type": "boolean"
+    },
+    "Double": {
+      "type": "double"
+    },
+    "EmptyModeledException": {
+      "type": "structure",
+      "members": {},
+      "exception": true
+    },
+    "EnumType": {
+      "type": "string",
+      "enum": [
         "EnumValue1",
         "EnumValue2"
       ]
     },
-    "ExplicitPayloadAndHeadersException":{
-      "type":"structure",
-      "members":{
-        "StringHeader":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-string"
+    "ExplicitPayloadAndHeadersException": {
+      "type": "structure",
+      "members": {
+        "StringHeader": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-string"
         },
-        "IntegerHeader":{
-          "shape":"Integer",
-          "location":"header",
-          "locationName":"x-amz-integer"
+        "IntegerHeader": {
+          "shape": "Integer",
+          "location": "header",
+          "locationName": "x-amz-integer"
         },
-        "LongHeader":{
-          "shape":"Long",
-          "location":"header",
-          "locationName":"x-amz-long"
+        "LongHeader": {
+          "shape": "Long",
+          "location": "header",
+          "locationName": "x-amz-long"
         },
-        "ShortHeader":{
-          "shape":"Short",
-          "location":"header",
-          "locationName":"x-amz-short"
+        "ShortHeader": {
+          "shape": "Short",
+          "location": "header",
+          "locationName": "x-amz-short"
         },
-        "DoubleHeader":{
-          "shape":"Double",
-          "location":"header",
-          "locationName":"x-amz-double"
+        "DoubleHeader": {
+          "shape": "Double",
+          "location": "header",
+          "locationName": "x-amz-double"
         },
-        "FloatHeader":{
-          "shape":"Float",
-          "location":"header",
-          "locationName":"x-amz-float"
+        "FloatHeader": {
+          "shape": "Float",
+          "location": "header",
+          "locationName": "x-amz-float"
         },
-        "TimestampHeader":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timestamp"
+        "TimestampHeader": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timestamp"
         },
-        "BooleanHeader":{
-          "shape":"Boolean",
-          "location":"header",
-          "locationName":"x-amz-boolean"
+        "BooleanHeader": {
+          "shape": "Boolean",
+          "location": "header",
+          "locationName": "x-amz-boolean"
         },
-        "PayloadMember":{"shape":"SimpleStruct"}
+        "PayloadMember": {
+          "shape": "SimpleStruct"
+        }
       },
-      "exception":true,
-      "payload":"PayloadMember"
+      "exception": true,
+      "payload": "PayloadMember"
     },
-    "Float":{"type":"float"},
-    "FurtherNestedContainersStructure":{
-      "type":"structure",
-      "members":{
-        "ListOfNested":{"shape":"ListOfNested"}
-      }
+    "Float": {
+      "type": "float"
     },
-    "GetOperationWithBodyInput":{
-      "type":"structure",
-      "members":{
-        "StringMember":{"shape":"String"}
-      }
-    },
-    "IdempotentOperationStructure":{
-      "type":"structure",
-      "required":["PathIdempotentToken"],
-      "members":{
-        "PathIdempotentToken":{
-          "shape":"String",
-          "idempotencyToken":true,
-          "location":"uri",
-          "locationName":"PathParam"
-        },
-        "QueryIdempotentToken":{
-          "shape":"String",
-          "idempotencyToken":true,
-          "location":"querystring",
-          "locationName":"QueryParam"
-        },
-        "HeaderIdempotentToken":{
-          "shape":"String",
-          "idempotencyToken":true,
-          "location":"header",
-          "locationName":"x-amz-idempotent-header"
+    "FurtherNestedContainersStructure": {
+      "type": "structure",
+      "members": {
+        "ListOfNested": {
+          "shape": "ListOfNested"
         }
       }
     },
-    "ImplicitPayloadException":{
-      "type":"structure",
-      "members":{
-        "StringMember":{"shape":"String"},
-        "IntegerMember":{"shape":"Integer"},
-        "LongMember":{"shape":"Long"},
-        "ShortMember":{"shape":"Short"},
-        "DoubleMember":{"shape":"Double"},
-        "FloatMember":{"shape":"Float"},
-        "TimestampMember":{"shape":"Timestamp"},
-        "BooleanMember":{"shape":"Boolean"},
-        "BlobMember":{"shape":"BlobType"},
-        "ListMember":{"shape":"ListOfStrings"},
-        "MapMember":{"shape":"MapOfStringToString"},
-        "SimpleStructMember":{"shape":"SimpleStruct"}
-      },
-      "exception":true
+    "GetOperationWithBodyInput": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        }
+      }
     },
-    "Integer":{"type":"integer"},
+    "IdempotentOperationStructure": {
+      "type": "structure",
+      "required": [
+        "PathIdempotentToken"
+      ],
+      "members": {
+        "PathIdempotentToken": {
+          "shape": "String",
+          "idempotencyToken": true,
+          "location": "uri",
+          "locationName": "PathParam"
+        },
+        "QueryIdempotentToken": {
+          "shape": "String",
+          "idempotencyToken": true,
+          "location": "querystring",
+          "locationName": "QueryParam"
+        },
+        "HeaderIdempotentToken": {
+          "shape": "String",
+          "idempotencyToken": true,
+          "location": "header",
+          "locationName": "x-amz-idempotent-header"
+        }
+      }
+    },
+    "ImplicitPayloadException": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        },
+        "IntegerMember": {
+          "shape": "Integer"
+        },
+        "LongMember": {
+          "shape": "Long"
+        },
+        "ShortMember": {
+          "shape": "Short"
+        },
+        "DoubleMember": {
+          "shape": "Double"
+        },
+        "FloatMember": {
+          "shape": "Float"
+        },
+        "TimestampMember": {
+          "shape": "Timestamp"
+        },
+        "BooleanMember": {
+          "shape": "Boolean"
+        },
+        "BlobMember": {
+          "shape": "BlobType"
+        },
+        "ListMember": {
+          "shape": "ListOfStrings"
+        },
+        "MapMember": {
+          "shape": "MapOfStringToString"
+        },
+        "SimpleStructMember": {
+          "shape": "SimpleStruct"
+        }
+      },
+      "exception": true
+    },
+    "Integer": {
+      "type": "integer"
+    },
     // Shape is customized to BigDecimal in customization.config
     "NumericValue": {
       "type": "string",
-      "pattern":"([0-9]*\\.)?[0-9]+"
+      "pattern": "([0-9]*\\.)?[0-9]+"
     },
-    "IsoTimestamp":{
-      "type":"timestamp",
-      "timestampFormat":"iso8601"
+    "IsoTimestamp": {
+      "type": "timestamp",
+      "timestampFormat": "iso8601"
     },
-    "UnixTimestamp":{
-      "type":"timestamp",
-      "timestampFormat":"unixTimestamp"
+    "UnixTimestamp": {
+      "type": "timestamp",
+      "timestampFormat": "unixTimestamp"
     },
-    "JsonValuesStructure":{
-      "type":"structure",
-      "members":{
-        "JsonValueHeaderMember":{
-          "shape":"String",
-          "jsonvalue":true,
-          "location":"header",
-          "locationName":"Encoded-Header"
+    "JsonValuesStructure": {
+      "type": "structure",
+      "members": {
+        "JsonValueHeaderMember": {
+          "shape": "String",
+          "jsonvalue": true,
+          "location": "header",
+          "locationName": "Encoded-Header"
         },
-        "JsonValueMember":{
-          "shape":"String",
-          "jsonvalue":true
+        "JsonValueMember": {
+          "shape": "String",
+          "jsonvalue": true
         }
       }
     },
-    "ListOfAllTypesStructs":{
-      "type":"list",
-      "member":{"shape":"AllTypesStructure"}
-    },
-    "ListOfBlobsType":{
-      "type":"list",
-      "member":{"shape":"BlobType"}
-    },
-    "ListOfEnums":{
-      "type":"list",
-      "member":{"shape":"EnumType"}
-    },
-    "ListOfIntegers":{
-      "type":"list",
-      "member":{"shape":"Integer"}
-    },
-    "ListOfListOfListsOfStrings":{
-      "type":"list",
-      "member":{"shape":"ListOfListsOfStrings"}
-    },
-    "ListOfListsOfAllTypesStructs":{
-      "type":"list",
-      "member":{"shape":"ListOfAllTypesStructs"}
-    },
-    "ListOfListsOfStrings":{
-      "type":"list",
-      "member":{"shape":"ListOfStrings"}
-    },
-    "ListOfListsOfStructs":{
-      "type":"list",
-      "member":{"shape":"ListOfSimpleStructs"}
-    },
-    "ListOfMapStringToString":{
-      "type":"list",
-      "member":{"shape":"MapOfStringToString"}
-    },
-    "ListOfNested":{
-      "type":"list",
-      "member":{"shape":"NestedContainersStructure"}
-    },
-    "ListOfSimpleStructs":{
-      "type":"list",
-      "member":{"shape":"SimpleStruct"}
-    },
-    "ListOfStrings":{
-      "type":"list",
-      "member":{"shape":"String"}
-    },
-    "Long":{"type":"long"},
-    "Short":{"type":"short"},
-    "Byte":{"type":"byte"},
-    "MapOfEnumToEnum":{
-      "type":"map",
-      "key":{"shape":"EnumType"},
-      "value":{"shape":"EnumType"}
-    },
-    "MapOfStringToIntegerList":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"ListOfIntegers"}
-    },
-    "MapOfStringToListOfListsOfStrings":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"ListOfListsOfStrings"}
-    },
-    "MapOfStringToListOfStringInQueryParamsInput":{
-      "type":"structure",
-      "members":{
-        "MapOfStringToListOfStrings":{
-          "shape":"MapOfStringToListOfStrings",
-          "location":"querystring"
-        }
+    "ListOfAllTypesStructs": {
+      "type": "list",
+      "member": {
+        "shape": "AllTypesStructure"
       }
     },
-    "MapOfStringToListOfStrings":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"ListOfStrings"}
-    },
-    "MapOfStringToSimpleStruct":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"SimpleStruct"}
-    },
-    "MapOfStringToString":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"String"}
-    },
-    "MembersInHeadersStructure":{
-      "type":"structure",
-      "members":{
-        "StringMember":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-string"
-        },
-        "ListOfStringsMember":{
-          "shape":"ListOfStrings",
-          "location":"header",
-          "locationName":"x-amz-string-list"
-        },
-        "BooleanMember":{
-          "shape":"Boolean",
-          "location":"header",
-          "locationName":"x-amz-boolean"
-        },
-        "IntegerMember":{
-          "shape":"Integer",
-          "location":"header",
-          "locationName":"x-amz-integer"
-        },
-        "LongMember":{
-          "shape":"Long",
-          "location":"header",
-          "locationName":"x-amz-long"
-        },
-        "ShortMember":{
-          "shape":"Short",
-          "location":"header",
-          "locationName":"x-amz-short"
-        },
-        "FloatMember":{
-          "shape":"Float",
-          "location":"header",
-          "locationName":"x-amz-float"
-        },
-        "DoubleMember":{
-          "shape":"Double",
-          "location":"header",
-          "locationName":"x-amz-double"
-        },
-        "TimestampMember":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timestamp"
-        },
-        "IsoTimestampMember":{
-          "shape":"IsoTimestamp",
-          "location":"header",
-          "locationName":"x-amz-iso-timestamp"
-        }
+    "ListOfBlobsType": {
+      "type": "list",
+      "member": {
+        "shape": "BlobType"
       }
     },
-    "MembersInQueryParamsInput":{
-      "type":"structure",
-      "members":{
-        "StringQueryParam":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"String"
-        },
-        "BooleanQueryParam":{
-          "shape":"Boolean",
-          "location":"querystring",
-          "locationName":"Boolean"
-        },
-        "IntegerQueryParam":{
-          "shape":"Integer",
-          "location":"querystring",
-          "locationName":"Integer"
-        },
-        "LongQueryParam":{
-          "shape":"Long",
-          "location":"querystring",
-          "locationName":"Long"
-        },
-        "ShortQueryParam":{
-          "shape":"Short",
-          "location":"querystring",
-          "locationName":"Short"
-        },
-        "FloatQueryParam":{
-          "shape":"Float",
-          "location":"querystring",
-          "locationName":"Float"
-        },
-        "DoubleQueryParam":{
-          "shape":"Double",
-          "location":"querystring",
-          "locationName":"Double"
-        },
-        "TimestampQueryParam":{
-          "shape":"Timestamp",
-          "location":"querystring",
-          "locationName":"Timestamp"
-        },
-        "ListOfStrings":{
-          "shape":"ListOfStrings",
-          "location":"querystring",
-          "locationName":"item"
-        },
-        "MapOfStringToString":{
-          "shape":"MapOfStringToString",
-          "location":"querystring"
-        }
+    "ListOfEnums": {
+      "type": "list",
+      "member": {
+        "shape": "EnumType"
       }
     },
-    "MultiLocationOperationInput":{
-      "type":"structure",
-      "required":["PathParam"],
-      "members":{
-        "PathParam":{
-          "shape":"String",
-          "location":"uri",
-          "locationName":"PathParam"
-        },
-        "QueryParamOne":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"QueryParamOne"
-        },
-        "QueryParamTwo":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"QueryParamTwo"
-        },
-        "StringHeaderMember":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-header-string"
-        },
-        "TimestampHeaderMember":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timearg"
-        },
-        "PayloadStructParam":{"shape":"PayloadStructType"}
+    "ListOfIntegers": {
+      "type": "list",
+      "member": {
+        "shape": "Integer"
       }
     },
-    "NestedContainersStructure":{
-      "type":"structure",
-      "members":{
-        "ListOfListsOfStrings":{"shape":"ListOfListsOfStrings"},
-        "ListOfListsOfStructs":{"shape":"ListOfListsOfStructs"},
-        "ListOfListsOfAllTypesStructs":{"shape":"ListOfListsOfAllTypesStructs"},
-        "ListOfListOfListsOfStrings":{"shape":"ListOfListOfListsOfStrings"},
-        "MapOfStringToListOfListsOfStrings":{"shape":"MapOfStringToListOfListsOfStrings"},
-        "StringMember":{"shape":"String"}
+    "ListOfListOfListsOfStrings": {
+      "type": "list",
+      "member": {
+        "shape": "ListOfListsOfStrings"
       }
     },
-    "OperationWithExplicitPayloadBlobInput":{
-      "type":"structure",
-      "members":{
-        "PayloadMember":{"shape":"BlobType"}
+    "ListOfListsOfAllTypesStructs": {
+      "type": "list",
+      "member": {
+        "shape": "ListOfAllTypesStructs"
+      }
+    },
+    "ListOfListsOfStrings": {
+      "type": "list",
+      "member": {
+        "shape": "ListOfStrings"
+      }
+    },
+    "ListOfListsOfStructs": {
+      "type": "list",
+      "member": {
+        "shape": "ListOfSimpleStructs"
+      }
+    },
+    "ListOfMapStringToString": {
+      "type": "list",
+      "member": {
+        "shape": "MapOfStringToString"
+      }
+    },
+    "ListOfNested": {
+      "type": "list",
+      "member": {
+        "shape": "NestedContainersStructure"
+      }
+    },
+    "ListOfSimpleStructs": {
+      "type": "list",
+      "member": {
+        "shape": "SimpleStruct"
+      }
+    },
+    "ListOfStrings": {
+      "type": "list",
+      "member": {
+        "shape": "String"
+      }
+    },
+    "Long": {
+      "type": "long"
+    },
+    "Short": {
+      "type": "short"
+    },
+    "Byte": {
+      "type": "byte"
+    },
+    "MapOfEnumToEnum": {
+      "type": "map",
+      "key": {
+        "shape": "EnumType"
       },
-      "payload":"PayloadMember"
+      "value": {
+        "shape": "EnumType"
+      }
     },
-    "OperationWithExplicitPayloadStringInput":{
-      "type":"structure",
-      "members":{
-        "PayloadMember":{"shape":"String"}
+    "MapOfStringToIntegerList": {
+      "type": "map",
+      "key": {
+        "shape": "String"
       },
-      "payload":"PayloadMember"
+      "value": {
+        "shape": "ListOfIntegers"
+      }
     },
-    "OperationWithExplicitPayloadStructureInput":{
-      "type":"structure",
-      "members":{
-        "PayloadMember":{"shape":"SimpleStruct"}
+    "MapOfStringToListOfListsOfStrings": {
+      "type": "map",
+      "key": {
+        "shape": "String"
       },
-      "payload":"PayloadMember"
+      "value": {
+        "shape": "ListOfListsOfStrings"
+      }
     },
-    "OperationWithGreedyLabelInput":{
-      "type":"structure",
-      "required":[
+    "MapOfStringToListOfStringInQueryParamsInput": {
+      "type": "structure",
+      "members": {
+        "MapOfStringToListOfStrings": {
+          "shape": "MapOfStringToListOfStrings",
+          "location": "querystring"
+        }
+      }
+    },
+    "MapOfStringToListOfStrings": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "ListOfStrings"
+      }
+    },
+    "MapOfStringToSimpleStruct": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "SimpleStruct"
+      }
+    },
+    "MapOfStringToString": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "String"
+      }
+    },
+    "Metadata": {
+      "type": "map",
+      "key": {
+        "shape": "MetadataKey"
+      },
+      "value": {
+        "shape": "MetadataValue"
+      }
+    },
+    "MetadataKey": {
+      "type": "string"
+    },
+    "MetadataValue": {
+      "type": "string"
+    },
+    "MapInHeadersInput": {
+      "type": "structure",
+      "members": {
+        "MetadataMember": {
+          "shape": "Metadata",
+          "location": "header",
+          "locationName": "x-amz-meta-"
+        }
+      }
+    },
+    "MembersInHeadersStructure": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-string"
+        },
+        "ListOfStringsMember": {
+          "shape": "ListOfStrings",
+          "location": "header",
+          "locationName": "x-amz-string-list"
+        },
+        "BooleanMember": {
+          "shape": "Boolean",
+          "location": "header",
+          "locationName": "x-amz-boolean"
+        },
+        "IntegerMember": {
+          "shape": "Integer",
+          "location": "header",
+          "locationName": "x-amz-integer"
+        },
+        "LongMember": {
+          "shape": "Long",
+          "location": "header",
+          "locationName": "x-amz-long"
+        },
+        "ShortMember": {
+          "shape": "Short",
+          "location": "header",
+          "locationName": "x-amz-short"
+        },
+        "FloatMember": {
+          "shape": "Float",
+          "location": "header",
+          "locationName": "x-amz-float"
+        },
+        "DoubleMember": {
+          "shape": "Double",
+          "location": "header",
+          "locationName": "x-amz-double"
+        },
+        "TimestampMember": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timestamp"
+        },
+        "IsoTimestampMember": {
+          "shape": "IsoTimestamp",
+          "location": "header",
+          "locationName": "x-amz-iso-timestamp"
+        }
+      }
+    },
+    "MembersInQueryParamsInput": {
+      "type": "structure",
+      "members": {
+        "StringQueryParam": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "String"
+        },
+        "BooleanQueryParam": {
+          "shape": "Boolean",
+          "location": "querystring",
+          "locationName": "Boolean"
+        },
+        "IntegerQueryParam": {
+          "shape": "Integer",
+          "location": "querystring",
+          "locationName": "Integer"
+        },
+        "LongQueryParam": {
+          "shape": "Long",
+          "location": "querystring",
+          "locationName": "Long"
+        },
+        "ShortQueryParam": {
+          "shape": "Short",
+          "location": "querystring",
+          "locationName": "Short"
+        },
+        "FloatQueryParam": {
+          "shape": "Float",
+          "location": "querystring",
+          "locationName": "Float"
+        },
+        "DoubleQueryParam": {
+          "shape": "Double",
+          "location": "querystring",
+          "locationName": "Double"
+        },
+        "TimestampQueryParam": {
+          "shape": "Timestamp",
+          "location": "querystring",
+          "locationName": "Timestamp"
+        },
+        "ListOfStrings": {
+          "shape": "ListOfStrings",
+          "location": "querystring",
+          "locationName": "item"
+        },
+        "MapOfStringToString": {
+          "shape": "MapOfStringToString",
+          "location": "querystring"
+        }
+      }
+    },
+    "MultiLocationOperationInput": {
+      "type": "structure",
+      "required": [
+        "PathParam"
+      ],
+      "members": {
+        "PathParam": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "PathParam"
+        },
+        "QueryParamOne": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "QueryParamOne"
+        },
+        "QueryParamTwo": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "QueryParamTwo"
+        },
+        "StringHeaderMember": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-header-string"
+        },
+        "TimestampHeaderMember": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timearg"
+        },
+        "PayloadStructParam": {
+          "shape": "PayloadStructType"
+        }
+      }
+    },
+    "NestedContainersStructure": {
+      "type": "structure",
+      "members": {
+        "ListOfListsOfStrings": {
+          "shape": "ListOfListsOfStrings"
+        },
+        "ListOfListsOfStructs": {
+          "shape": "ListOfListsOfStructs"
+        },
+        "ListOfListsOfAllTypesStructs": {
+          "shape": "ListOfListsOfAllTypesStructs"
+        },
+        "ListOfListOfListsOfStrings": {
+          "shape": "ListOfListOfListsOfStrings"
+        },
+        "MapOfStringToListOfListsOfStrings": {
+          "shape": "MapOfStringToListOfListsOfStrings"
+        },
+        "StringMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "OperationWithExplicitPayloadBlobInput": {
+      "type": "structure",
+      "members": {
+        "PayloadMember": {
+          "shape": "BlobType"
+        }
+      },
+      "payload": "PayloadMember"
+    },
+    "OperationWithExplicitPayloadStringInput": {
+      "type": "structure",
+      "members": {
+        "PayloadMember": {
+          "shape": "String"
+        }
+      },
+      "payload": "PayloadMember"
+    },
+    "OperationWithExplicitPayloadStructureInput": {
+      "type": "structure",
+      "members": {
+        "PayloadMember": {
+          "shape": "SimpleStruct"
+        }
+      },
+      "payload": "PayloadMember"
+    },
+    "OperationWithGreedyLabelInput": {
+      "type": "structure",
+      "required": [
         "NonGreedyPathParam",
         "GreedyPathParam"
       ],
-      "members":{
-        "NonGreedyPathParam":{
-          "shape":"String",
-          "location":"uri",
-          "locationName":"NonGreedyPathParam"
+      "members": {
+        "NonGreedyPathParam": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "NonGreedyPathParam"
         },
-        "GreedyPathParam":{
-          "shape":"String",
-          "location":"uri",
-          "locationName":"GreedyPathParam"
+        "GreedyPathParam": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "GreedyPathParam"
         }
       }
     },
-    "OperationWithModeledContentTypeInput":{
-      "type":"structure",
-      "members":{
-        "ContentType":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"Content-Type"
+    "OperationWithModeledContentTypeInput": {
+      "type": "structure",
+      "members": {
+        "ContentType": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "Content-Type"
         }
       }
     },
-    "PayloadStructType":{
-      "type":"structure",
-      "members":{
-        "PayloadMemberOne":{"shape":"String"},
-        "PayloadMemberTwo":{"shape":"String"}
-      }
-    },
-    "QueryParamWithoutValueInput":{
-      "type":"structure",
-      "members":{
-      }
-    },
-    "RecursiveListType":{
-      "type":"list",
-      "member":{"shape":"RecursiveStructType"}
-    },
-    "RecursiveMapType":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"RecursiveStructType"}
-    },
-    "RecursiveStructType":{
-      "type":"structure",
-      "members":{
-        "NoRecurse":{"shape":"String"},
-        "RecursiveStruct":{"shape":"RecursiveStructType"},
-        "RecursiveList":{"shape":"RecursiveListType"},
-        "RecursiveMap":{"shape":"RecursiveMapType"}
-      }
-    },
-    "SimpleStruct":{
-      "type":"structure",
-      "members":{
-        "StringMember":{"shape":"String"}
-      }
-    },
-    "NestedLocationOperationInput":{
-      "type":"structure",
-      "members":{
-        "TopLevelQueryParam":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"topLevel"
+    "PayloadStructType": {
+      "type": "structure",
+      "members": {
+        "PayloadMemberOne": {
+          "shape": "String"
         },
-        "Nested":{"shape":"NestedShapeWithLocations"}
-      }
-    },
-    "NestedShapeWithLocations":{
-      "type":"structure",
-      "members":{
-        "NestedQueryParam":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"shouldBeIgnored"
-        },
-        "StringMember":{"shape":"String"}
-      }
-    },
-    "NestedLocationOperationOutput":{
-      "type":"structure",
-      "members":{
-        "TopLevelHeader":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-top-level"
-        },
-        "NestedResult":{"shape":"NestedResponseData"}
-      }
-    },
-    "NestedResponseData":{
-      "type":"structure",
-      "members":{
-        "NestedHeader":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-should-be-ignored"
-        },
-        "Value":{"shape":"String"}
-      }
-    },
-    "StatusCodeInOutputStructure":{
-      "type":"structure",
-      "members":{
-        "StatusCodeMember":{
-          "shape":"Integer",
-          "location":"statusCode"
+        "PayloadMemberTwo": {
+          "shape": "String"
         }
       }
     },
-    "MixedLocationOperationInput":{
-      "type":"structure",
-      "members":{
-        "StringMember":{
-          "shape":"String"
-        },
-        "IntegerMember":{
-          "shape":"Integer"
-        }
+    "QueryParamWithoutValueInput": {
+      "type": "structure",
+      "members": {}
+    },
+    "RecursiveListType": {
+      "type": "list",
+      "member": {
+        "shape": "RecursiveStructType"
       }
     },
-    "MixedLocationOperationOutput":{
-      "type":"structure",
-      "members":{
-        "StringMember":{
-          "shape":"String"
-        },
-        "IntegerMember":{
-          "shape":"Integer"
-        },
-        "StatusCodeMember":{
-          "shape":"Integer",
-          "location":"statusCode"
-        },
-        "StringHeaderMember":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-string"
-        }
-      }
-    },
-    "StreamType":{
-      "type":"blob",
-      "streaming":true,
-      "requiresLength":true
-    },
-    "StreamTypeChunkedEncoding":{
-      "type":"blob",
-      "streaming":true,
-      "requiresLength":false
-    },
-    "String":{"type":"string"},
-    "StructWithNestedBlobType":{
-      "type":"structure",
-      "members":{
-        "NestedBlob":{"shape":"BlobType"}
-      }
-    },
-    "StructWithTimestamp":{
-      "type":"structure",
-      "members":{
-        "NestedTimestamp":{"shape":"Timestamp"}
-      }
-    },
-    "StructureWithStreamingMember":{
-      "type":"structure",
-      "members":{
-        "StreamingMember":{"shape":"StreamType"}
+    "RecursiveMapType": {
+      "type": "map",
+      "key": {
+        "shape": "String"
       },
-      "payload":"StreamingMember"
-    },
-    "StructureWithStreamingMemberChunkedEncoding":{
-      "type":"structure",
-      "members":{
-        "StreamingMember":{"shape":"StreamTypeChunkedEncoding"}
-      },
-      "payload":"StreamingMember"
-    },
-    "SubTypeOne":{
-      "type":"structure",
-      "members":{
-        "SubTypeOneMember":{"shape":"String"}
+      "value": {
+        "shape": "RecursiveStructType"
       }
     },
-    "Timestamp":{"type":"timestamp"},
-    "ListOfTimeStamp":{
-      "type":"list",
-      "member":{"shape":"UnixTimestamp"}
+    "RecursiveStructType": {
+      "type": "structure",
+      "members": {
+        "NoRecurse": {
+          "shape": "String"
+        },
+        "RecursiveStruct": {
+          "shape": "RecursiveStructType"
+        },
+        "RecursiveList": {
+          "shape": "RecursiveListType"
+        },
+        "RecursiveMap": {
+          "shape": "RecursiveMapType"
+        }
+      }
     },
-    "MapOfTimeStamp":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"UnixTimestamp"}
+    "SimpleStruct": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "NestedLocationOperationInput": {
+      "type": "structure",
+      "members": {
+        "TopLevelQueryParam": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "topLevel"
+        },
+        "Nested": {
+          "shape": "NestedShapeWithLocations"
+        }
+      }
+    },
+    "NestedShapeWithLocations": {
+      "type": "structure",
+      "members": {
+        "NestedQueryParam": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "shouldBeIgnored"
+        },
+        "StringMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "NestedLocationOperationOutput": {
+      "type": "structure",
+      "members": {
+        "TopLevelHeader": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-top-level"
+        },
+        "NestedResult": {
+          "shape": "NestedResponseData"
+        }
+      }
+    },
+    "NestedResponseData": {
+      "type": "structure",
+      "members": {
+        "NestedHeader": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-should-be-ignored"
+        },
+        "Value": {
+          "shape": "String"
+        }
+      }
+    },
+    "StatusCodeInOutputStructure": {
+      "type": "structure",
+      "members": {
+        "StatusCodeMember": {
+          "shape": "Integer",
+          "location": "statusCode"
+        }
+      }
+    },
+    "MixedLocationOperationInput": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        },
+        "IntegerMember": {
+          "shape": "Integer"
+        }
+      }
+    },
+    "MixedLocationOperationOutput": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        },
+        "IntegerMember": {
+          "shape": "Integer"
+        },
+        "StatusCodeMember": {
+          "shape": "Integer",
+          "location": "statusCode"
+        },
+        "StringHeaderMember": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-string"
+        }
+      }
+    },
+    "StreamType": {
+      "type": "blob",
+      "streaming": true,
+      "requiresLength": true
+    },
+    "StreamTypeChunkedEncoding": {
+      "type": "blob",
+      "streaming": true,
+      "requiresLength": false
+    },
+    "String": {
+      "type": "string"
+    },
+    "StructWithNestedBlobType": {
+      "type": "structure",
+      "members": {
+        "NestedBlob": {
+          "shape": "BlobType"
+        }
+      }
+    },
+    "StructWithTimestamp": {
+      "type": "structure",
+      "members": {
+        "NestedTimestamp": {
+          "shape": "Timestamp"
+        }
+      }
+    },
+    "StructureWithStreamingMember": {
+      "type": "structure",
+      "members": {
+        "StreamingMember": {
+          "shape": "StreamType"
+        }
+      },
+      "payload": "StreamingMember"
+    },
+    "StructureWithStreamingMemberChunkedEncoding": {
+      "type": "structure",
+      "members": {
+        "StreamingMember": {
+          "shape": "StreamTypeChunkedEncoding"
+        }
+      },
+      "payload": "StreamingMember"
+    },
+    "SubTypeOne": {
+      "type": "structure",
+      "members": {
+        "SubTypeOneMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "Timestamp": {
+      "type": "timestamp"
+    },
+    "ListOfTimeStamp": {
+      "type": "list",
+      "member": {
+        "shape": "UnixTimestamp"
+      }
+    },
+    "MapOfTimeStamp": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "UnixTimestamp"
+      }
     },
     "EventStreamOperationRequest": {
       "type": "structure",
@@ -938,7 +1285,7 @@
           "shape": "InputEventStream"
         }
       },
-      "payload":"InputEventStream"
+      "payload": "InputEventStream"
     },
     "EventStreamStringPayloadOperationRequest": {
       "type": "structure",
@@ -950,7 +1297,7 @@
           "shape": "InputEventStreamStringPayload"
         }
       },
-      "payload":"InputEventStreamStringPayload"
+      "payload": "InputEventStreamStringPayload"
     },
     "EventStreamOutput": {
       "type": "structure",
@@ -985,8 +1332,8 @@
       "type": "structure",
       "members": {
         "ExplicitPayloadMember": {
-          "shape":"ExplicitPayloadMember",
-          "eventpayload":true
+          "shape": "ExplicitPayloadMember",
+          "eventpayload": true
         },
         "HeaderMember": {
           "shape": "String",
@@ -999,8 +1346,8 @@
       "type": "structure",
       "members": {
         "ExplicitPayloadStringMember": {
-          "shape":"String",
-          "eventpayload":true
+          "shape": "String",
+          "eventpayload": true
         },
         "HeaderMember": {
           "shape": "String",
@@ -1009,7 +1356,9 @@
       },
       "event": true
     },
-    "ExplicitPayloadMember":{"type":"blob"},
+    "ExplicitPayloadMember": {
+      "type": "blob"
+    },
     "EventStream": {
       "type": "structure",
       "members": {
@@ -1047,10 +1396,12 @@
       "type": "structure",
       "document": true
     },
-    "StructureWithDocumentMember":{
-      "type":"structure",
-      "members":{
-        "DocumentMember":{"shape":"MyDocument"}
+    "StructureWithDocumentMember": {
+      "type": "structure",
+      "members": {
+        "DocumentMember": {
+          "shape": "MyDocument"
+        }
       }
     },
     "AllTypesUnionStructure": {

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
@@ -1,308 +1,234 @@
 {
-  "version": "2.0",
-  "metadata": {
-    "apiVersion": "2016-03-11",
-    "endpointPrefix": "restjson",
-    "jsonVersion": "1.1",
-    "protocol": "rest-json",
-    "serviceAbbreviation": "RestJsonProtocolTests",
-    "serviceFullName": "AWS DR Tools Rest JSON Protocol Tests",
-    "serviceId": "ProtocolRestJson",
-    "signatureVersion": "v4",
-    "targetPrefix": "ProtocolTestsService",
-    "uid": "restjson-2016-03-11"
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"restjson",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "serviceAbbreviation":"RestJsonProtocolTests",
+    "serviceFullName":"AWS DR Tools Rest JSON Protocol Tests",
+    "serviceId":"ProtocolRestJson",
+    "signatureVersion":"v4",
+    "targetPrefix":"ProtocolTestsService",
+    "uid":"restjson-2016-03-11"
   },
-  "operations": {
-    "AllTypes": {
-      "name": "AllTypes",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/allTypes"
+  "operations":{
+    "AllTypes":{
+      "name":"AllTypes",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypes"
       },
-      "input": {
-        "shape": "AllTypesStructure"
-      },
-      "output": {
-        "shape": "AllTypesStructure"
-      },
-      "errors": [
-        {
-          "shape": "EmptyModeledException"
-        },
-        {
-          "shape": "ExplicitPayloadAndHeadersException"
-        },
-        {
-          "shape": "ImplicitPayloadException"
-        }
+      "input":{"shape":"AllTypesStructure"},
+      "output":{"shape":"AllTypesStructure"},
+      "errors":[
+        {"shape":"EmptyModeledException"},
+        {"shape":"ExplicitPayloadAndHeadersException"},
+        {"shape":"ImplicitPayloadException"}
       ]
     },
-    "DeleteOperation": {
-      "name": "DeleteOperation",
-      "http": {
-        "method": "DELETE",
-        "requestUri": "/2016-03-11/deleteOperation"
+    "DeleteOperation":{
+      "name":"DeleteOperation",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/2016-03-11/deleteOperation"
       }
     },
-    "FurtherNestedContainers": {
-      "name": "FurtherNestedContainers",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/furtherNestedContainers"
+    "FurtherNestedContainers":{
+      "name":"FurtherNestedContainers",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/furtherNestedContainers"
       },
-      "input": {
-        "shape": "FurtherNestedContainersStructure"
+      "input":{"shape":"FurtherNestedContainersStructure"},
+      "output":{"shape":"FurtherNestedContainersStructure"}
+    },
+    "GetOperationWithBody":{
+      "name":"GetOperationWithBody",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2016-03-11/getOperationWithBody"
       },
-      "output": {
-        "shape": "FurtherNestedContainersStructure"
+      "input":{"shape":"GetOperationWithBodyInput"}
+    },
+    "HeadOperation":{
+      "name":"HeadOperation",
+      "http":{
+        "method":"HEAD",
+        "requestUri":"/2016-03-11/headOperation"
       }
     },
-    "GetOperationWithBody": {
-      "name": "GetOperationWithBody",
-      "http": {
-        "method": "GET",
-        "requestUri": "/2016-03-11/getOperationWithBody"
+    "IdempotentOperation":{
+      "name":"IdempotentOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/idempotentOperation/{PathParam}"
       },
-      "input": {
-        "shape": "GetOperationWithBodyInput"
-      }
+      "input":{"shape":"IdempotentOperationStructure"}
     },
-    "HeadOperation": {
-      "name": "HeadOperation",
-      "http": {
-        "method": "HEAD",
-        "requestUri": "/2016-03-11/headOperation"
-      }
-    },
-    "IdempotentOperation": {
-      "name": "IdempotentOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/idempotentOperation/{PathParam}"
+    "JsonValuesOperation":{
+      "name":"JsonValuesOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/JsonValuesStructure"
       },
-      "input": {
-        "shape": "IdempotentOperationStructure"
-      }
-    },
-    "JsonValuesOperation": {
-      "name": "JsonValuesOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/JsonValuesStructure"
-      },
-      "input": {
-        "shape": "JsonValuesStructure"
-      },
-      "output": {
-        "shape": "JsonValuesStructure"
-      },
-      "errors": [
-        {
-          "shape": "EmptyModeledException"
-        }
+      "input":{"shape":"JsonValuesStructure"},
+      "output":{"shape":"JsonValuesStructure"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
       ]
     },
-    "MapOfStringToListOfStringInQueryParams": {
-      "name": "MapOfStringToListOfStringInQueryParams",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/mapOfStringToListOfStringInQueryParams"
+    "MapOfStringToListOfStringInQueryParams":{
+      "name":"MapOfStringToListOfStringInQueryParams",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/mapOfStringToListOfStringInQueryParams"
       },
-      "input": {
-        "shape": "MapOfStringToListOfStringInQueryParamsInput"
+      "input":{"shape":"MapOfStringToListOfStringInQueryParamsInput"}
+    },
+    "MembersInHeaders":{
+      "name":"MembersInHeaders",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/membersInHeaders"
+      },
+      "input":{"shape":"MembersInHeadersStructure"},
+      "output":{"shape":"MembersInHeadersStructure"}
+    },
+    "MapInHeaders":{
+      "name":"MapInHeaders",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/mapInHeaders"
+      },
+      "input":{"shape":"MapInHeadersInput"}
+    },
+    "MembersInQueryParams":{
+      "name":"MembersInQueryParams",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
+      },
+      "input":{"shape":"MembersInQueryParamsInput"},
+      "output":{"shape":"MembersInQueryParamsInput"}
+    },
+    "MultiLocationOperation":{
+      "name":"MultiLocationOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/multiLocationOperation/{PathParam}"
+      },
+      "input":{"shape":"MultiLocationOperationInput"},
+      "output":{"shape":"MultiLocationOperationInput"}
+    },
+    "NestedContainers":{
+      "name":"NestedContainers",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/nestedContainers"
+      },
+      "input":{"shape":"NestedContainersStructure"},
+      "output":{"shape":"NestedContainersStructure"}
+    },
+    "OperationWithExplicitPayloadBlob":{
+      "name":"OperationWithExplicitPayloadBlob",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadBlob"
+      },
+      "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
+      "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
+    },
+    "OperationWithExplicitPayloadString":{
+      "name":"OperationWithExplicitPayloadString",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
+      },
+      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
+      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
+    },
+    "OperationWithExplicitPayloadStructure":{
+      "name":"OperationWithExplicitPayloadStructure",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadStructure"
+      },
+      "input":{"shape":"OperationWithExplicitPayloadStructureInput"},
+      "output":{"shape":"OperationWithExplicitPayloadStructureInput"}
+    },
+    "OperationWithGreedyLabel":{
+      "name":"OperationWithGreedyLabel",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
+      },
+      "input":{"shape":"OperationWithGreedyLabelInput"}
+    },
+    "OperationWithModeledContentType":{
+      "name":"OperationWithModeledContentType",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithModeledContentType"
+      },
+      "input":{"shape":"OperationWithModeledContentTypeInput"}
+    },
+    "OperationWithNoInputOrOutput":{
+      "name":"OperationWithNoInputOrOutput",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithNoInputOrOutput"
       }
     },
-    "MembersInHeaders": {
-      "name": "MembersInHeaders",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/membersInHeaders"
+    "QueryParamWithoutValue":{
+      "name":"QueryParamWithoutValue",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/queryParamWithoutValue?param"
       },
-      "input": {
-        "shape": "MembersInHeadersStructure"
-      },
-      "output": {
-        "shape": "MembersInHeadersStructure"
-      }
+      "input":{"shape":"QueryParamWithoutValueInput"}
     },
-    "MapInHeaders": {
-      "name": "MapInHeaders",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/mapInHeaders"
+    "StatusCodeInOutputOperation":{
+      "name":"StatusCodeInOutputOperation",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2016-03-11/statusCodeInOutput"
       },
-      "input": {
-        "shape": "MapInHeadersInput"
-      }
+      "output":{"shape":"StatusCodeInOutputStructure"}
     },
-    "MembersInQueryParams": {
-      "name": "MembersInQueryParams",
-      "http": {
-        "method": "GET",
-        "requestUri": "/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
+    "MixedLocationOperation":{
+      "name":"MixedLocationOperation",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2016-03-11/mixedLocationOperation"
       },
-      "input": {
-        "shape": "MembersInQueryParamsInput"
-      },
-      "output": {
-        "shape": "MembersInQueryParamsInput"
-      }
+      "output":{"shape":"MixedLocationOperationOutput"},
+      "input":{"shape":"MixedLocationOperationInput"}
     },
-    "MultiLocationOperation": {
-      "name": "MultiLocationOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/multiLocationOperation/{PathParam}"
+    "StreamingInputOperation":{
+      "name":"StreamingInputOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/streamingInputOperation"
       },
-      "input": {
-        "shape": "MultiLocationOperationInput"
-      },
-      "output": {
-        "shape": "MultiLocationOperationInput"
-      }
+      "input":{"shape":"StructureWithStreamingMember"}
     },
-    "NestedContainers": {
-      "name": "NestedContainers",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/nestedContainers"
+    "StreamingInputOperationChunkedEncoding":{
+      "name":"StreamingInputOperationChunkedEncoding",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/streamingInputOperationChunkedEncoding"
       },
-      "input": {
-        "shape": "NestedContainersStructure"
-      },
-      "output": {
-        "shape": "NestedContainersStructure"
-      }
+      "input":{"shape":"StructureWithStreamingMemberChunkedEncoding"},
+      "authtype":"v4-unsigned-body"
     },
-    "OperationWithExplicitPayloadBlob": {
-      "name": "OperationWithExplicitPayloadBlob",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithExplicitPayloadBlob"
+    "StreamingOutputOperation":{
+      "name":"StreamingOutputOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/streamingOutputOperation"
       },
-      "input": {
-        "shape": "OperationWithExplicitPayloadBlobInput"
-      },
-      "output": {
-        "shape": "OperationWithExplicitPayloadBlobInput"
-      }
-    },
-    "OperationWithExplicitPayloadString": {
-      "name": "OperationWithExplicitPayloadString",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithExplicitPayloadString"
-      },
-      "input": {
-        "shape": "OperationWithExplicitPayloadStringInput"
-      },
-      "output": {
-        "shape": "OperationWithExplicitPayloadStringInput"
-      }
-    },
-    "OperationWithExplicitPayloadStructure": {
-      "name": "OperationWithExplicitPayloadStructure",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithExplicitPayloadStructure"
-      },
-      "input": {
-        "shape": "OperationWithExplicitPayloadStructureInput"
-      },
-      "output": {
-        "shape": "OperationWithExplicitPayloadStructureInput"
-      }
-    },
-    "OperationWithGreedyLabel": {
-      "name": "OperationWithGreedyLabel",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
-      },
-      "input": {
-        "shape": "OperationWithGreedyLabelInput"
-      }
-    },
-    "OperationWithModeledContentType": {
-      "name": "OperationWithModeledContentType",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithModeledContentType"
-      },
-      "input": {
-        "shape": "OperationWithModeledContentTypeInput"
-      }
-    },
-    "OperationWithNoInputOrOutput": {
-      "name": "OperationWithNoInputOrOutput",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithNoInputOrOutput"
-      }
-    },
-    "QueryParamWithoutValue": {
-      "name": "QueryParamWithoutValue",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/queryParamWithoutValue?param"
-      },
-      "input": {
-        "shape": "QueryParamWithoutValueInput"
-      }
-    },
-    "StatusCodeInOutputOperation": {
-      "name": "StatusCodeInOutputOperation",
-      "http": {
-        "method": "GET",
-        "requestUri": "/2016-03-11/statusCodeInOutput"
-      },
-      "output": {
-        "shape": "StatusCodeInOutputStructure"
-      }
-    },
-    "MixedLocationOperation": {
-      "name": "MixedLocationOperation",
-      "http": {
-        "method": "GET",
-        "requestUri": "/2016-03-11/mixedLocationOperation"
-      },
-      "output": {
-        "shape": "MixedLocationOperationOutput"
-      },
-      "input": {
-        "shape": "MixedLocationOperationInput"
-      }
-    },
-    "StreamingInputOperation": {
-      "name": "StreamingInputOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/streamingInputOperation"
-      },
-      "input": {
-        "shape": "StructureWithStreamingMember"
-      }
-    },
-    "StreamingInputOperationChunkedEncoding": {
-      "name": "StreamingInputOperationChunkedEncoding",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/streamingInputOperationChunkedEncoding"
-      },
-      "input": {
-        "shape": "StructureWithStreamingMemberChunkedEncoding"
-      },
-      "authtype": "v4-unsigned-body"
-    },
-    "StreamingOutputOperation": {
-      "name": "StreamingOutputOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/streamingOutputOperation"
-      },
-      "output": {
-        "shape": "StructureWithStreamingMember"
-      }
+      "output":{"shape":"StructureWithStreamingMember"}
     },
     "EventStreamOperation": {
       "name": "EventStreamOperation",
@@ -330,950 +256,702 @@
         "shape": "EventStreamOutput"
       }
     },
-    "DocumentInputOperation": {
-      "name": "DocumentInputOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/documentInputOperation"
+    "DocumentInputOperation":{
+      "name":"DocumentInputOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/documentInputOperation"
       },
-      "input": {
-        "shape": "StructureWithDocumentMember"
-      }
+      "input":{"shape":"StructureWithDocumentMember"}
     },
-    "NestedLocationOperation": {
-      "name": "NestedLocationOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/nestedLocationOperation"
+    "NestedLocationOperation":{
+      "name":"NestedLocationOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/nestedLocationOperation"
       },
-      "input": {
-        "shape": "NestedLocationOperationInput"
-      },
-      "output": {
-        "shape": "NestedLocationOperationOutput"
-      }
+      "input":{"shape":"NestedLocationOperationInput"},
+      "output":{"shape":"NestedLocationOperationOutput"}
     }
   },
-  "shapes": {
-    "AllTypesStructure": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        },
-        "IntegerMember": {
-          "shape": "Integer"
-        },
-        "BooleanMember": {
-          "shape": "Boolean"
-        },
-        "FloatMember": {
-          "shape": "Float"
-        },
-        "DoubleMember": {
-          "shape": "Double"
-        },
-        "LongMember": {
-          "shape": "Long"
-        },
-        "ShortMember": {
-          "shape": "Short"
-        },
-        "ByteMember": {
-          "shape": "Byte"
-        },
-        "BigDecimalMember": {
-          "shape": "NumericValue"
-        },
-        "SimpleList": {
-          "shape": "ListOfStrings"
-        },
-        "ListOfMaps": {
-          "shape": "ListOfMapStringToString"
-        },
-        "ListOfStructs": {
-          "shape": "ListOfSimpleStructs"
-        },
-        "MapOfStringToIntegerList": {
-          "shape": "MapOfStringToIntegerList"
-        },
-        "MapOfStringToString": {
-          "shape": "MapOfStringToString"
-        },
-        "MapOfStringToStruct": {
-          "shape": "MapOfStringToSimpleStruct"
-        },
-        "TimestampMember": {
-          "shape": "Timestamp"
-        },
-        "StructWithNestedTimestampMember": {
-          "shape": "StructWithTimestamp"
-        },
-        "TimestampFormatMember": {
-          "shape": "IsoTimestamp"
-        },
-        "BlobArg": {
-          "shape": "BlobType"
-        },
-        "StructWithNestedBlob": {
-          "shape": "StructWithNestedBlobType"
-        },
-        "BlobMap": {
-          "shape": "BlobMapType"
-        },
-        "ListOfBlobs": {
-          "shape": "ListOfBlobsType"
-        },
-        "RecursiveStruct": {
-          "shape": "RecursiveStructType"
-        },
-        "PolymorphicTypeWithSubTypes": {
-          "shape": "BaseType"
-        },
-        "PolymorphicTypeWithoutSubTypes": {
-          "shape": "SubTypeOne"
-        },
-        "EnumMember": {
-          "shape": "EnumType"
-        },
-        "ListOfEnums": {
-          "shape": "ListOfEnums"
-        },
-        "MapOfEnumToEnum": {
-          "shape": "MapOfEnumToEnum"
-        },
-        "ListOfTimeStamp": {
-          "shape": "ListOfTimeStamp"
-        },
-        "MapOfTimeStamp": {
-          "shape": "MapOfTimeStamp"
-        },
-        "MyDocument": {
-          "shape": "MyDocument"
-        },
-        "UnionMember": {
-          "shape": "AllTypesUnionStructure"
-        }
+  "shapes":{
+    "AllTypesStructure":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"},
+        "IntegerMember":{"shape":"Integer"},
+        "BooleanMember":{"shape":"Boolean"},
+        "FloatMember":{"shape":"Float"},
+        "DoubleMember":{"shape":"Double"},
+        "LongMember":{"shape":"Long"},
+        "ShortMember":{"shape":"Short"},
+        "ByteMember":{"shape":"Byte"},
+        "BigDecimalMember":{"shape":"NumericValue"},
+        "SimpleList":{"shape":"ListOfStrings"},
+        "ListOfMaps":{"shape":"ListOfMapStringToString"},
+        "ListOfStructs":{"shape":"ListOfSimpleStructs"},
+        "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
+        "MapOfStringToString":{"shape":"MapOfStringToString"},
+        "MapOfStringToStruct":{"shape":"MapOfStringToSimpleStruct"},
+        "TimestampMember":{"shape":"Timestamp"},
+        "StructWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
+        "TimestampFormatMember":{"shape":"IsoTimestamp"},
+        "BlobArg":{"shape":"BlobType"},
+        "StructWithNestedBlob":{"shape":"StructWithNestedBlobType"},
+        "BlobMap":{"shape":"BlobMapType"},
+        "ListOfBlobs":{"shape":"ListOfBlobsType"},
+        "RecursiveStruct":{"shape":"RecursiveStructType"},
+        "PolymorphicTypeWithSubTypes":{"shape":"BaseType"},
+        "PolymorphicTypeWithoutSubTypes":{"shape":"SubTypeOne"},
+        "EnumMember":{"shape":"EnumType"},
+        "ListOfEnums":{"shape":"ListOfEnums"},
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
+        "ListOfTimeStamp":{"shape":"ListOfTimeStamp"},
+        "MapOfTimeStamp":{"shape":"MapOfTimeStamp"},
+        "MyDocument":{"shape":"MyDocument"},
+        "UnionMember":{"shape":"AllTypesUnionStructure"}
       }
     },
-    "BaseType": {
-      "type": "structure",
-      "members": {
-        "BaseMember": {
-          "shape": "String"
-        }
+    "BaseType":{
+      "type":"structure",
+      "members":{
+        "BaseMember":{"shape":"String"}
       }
     },
-    "BlobMapType": {
-      "type": "map",
-      "key": {
-        "shape": "String"
+    "BlobMapType":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"BlobType"}
+    },
+    "BlobType":{"type":"blob"},
+    "Boolean":{"type":"boolean"},
+    "Double":{"type":"double"},
+    "EmptyModeledException":{
+      "type":"structure",
+      "members":{
       },
-      "value": {
-        "shape": "BlobType"
-      }
+      "exception":true
     },
-    "BlobType": {
-      "type": "blob"
-    },
-    "Boolean": {
-      "type": "boolean"
-    },
-    "Double": {
-      "type": "double"
-    },
-    "EmptyModeledException": {
-      "type": "structure",
-      "members": {},
-      "exception": true
-    },
-    "EnumType": {
-      "type": "string",
-      "enum": [
+    "EnumType":{
+      "type":"string",
+      "enum":[
         "EnumValue1",
         "EnumValue2"
       ]
     },
-    "ExplicitPayloadAndHeadersException": {
-      "type": "structure",
-      "members": {
-        "StringHeader": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-string"
+    "ExplicitPayloadAndHeadersException":{
+      "type":"structure",
+      "members":{
+        "StringHeader":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-string"
         },
-        "IntegerHeader": {
-          "shape": "Integer",
-          "location": "header",
-          "locationName": "x-amz-integer"
+        "IntegerHeader":{
+          "shape":"Integer",
+          "location":"header",
+          "locationName":"x-amz-integer"
         },
-        "LongHeader": {
-          "shape": "Long",
-          "location": "header",
-          "locationName": "x-amz-long"
+        "LongHeader":{
+          "shape":"Long",
+          "location":"header",
+          "locationName":"x-amz-long"
         },
-        "ShortHeader": {
-          "shape": "Short",
-          "location": "header",
-          "locationName": "x-amz-short"
+        "ShortHeader":{
+          "shape":"Short",
+          "location":"header",
+          "locationName":"x-amz-short"
         },
-        "DoubleHeader": {
-          "shape": "Double",
-          "location": "header",
-          "locationName": "x-amz-double"
+        "DoubleHeader":{
+          "shape":"Double",
+          "location":"header",
+          "locationName":"x-amz-double"
         },
-        "FloatHeader": {
-          "shape": "Float",
-          "location": "header",
-          "locationName": "x-amz-float"
+        "FloatHeader":{
+          "shape":"Float",
+          "location":"header",
+          "locationName":"x-amz-float"
         },
-        "TimestampHeader": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timestamp"
+        "TimestampHeader":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timestamp"
         },
-        "BooleanHeader": {
-          "shape": "Boolean",
-          "location": "header",
-          "locationName": "x-amz-boolean"
+        "BooleanHeader":{
+          "shape":"Boolean",
+          "location":"header",
+          "locationName":"x-amz-boolean"
         },
-        "PayloadMember": {
-          "shape": "SimpleStruct"
-        }
+        "PayloadMember":{"shape":"SimpleStruct"}
       },
-      "exception": true,
-      "payload": "PayloadMember"
+      "exception":true,
+      "payload":"PayloadMember"
     },
-    "Float": {
-      "type": "float"
+    "Float":{"type":"float"},
+    "FurtherNestedContainersStructure":{
+      "type":"structure",
+      "members":{
+        "ListOfNested":{"shape":"ListOfNested"}
+      }
     },
-    "FurtherNestedContainersStructure": {
-      "type": "structure",
-      "members": {
-        "ListOfNested": {
-          "shape": "ListOfNested"
+    "GetOperationWithBodyInput":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "IdempotentOperationStructure":{
+      "type":"structure",
+      "required":["PathIdempotentToken"],
+      "members":{
+        "PathIdempotentToken":{
+          "shape":"String",
+          "idempotencyToken":true,
+          "location":"uri",
+          "locationName":"PathParam"
+        },
+        "QueryIdempotentToken":{
+          "shape":"String",
+          "idempotencyToken":true,
+          "location":"querystring",
+          "locationName":"QueryParam"
+        },
+        "HeaderIdempotentToken":{
+          "shape":"String",
+          "idempotencyToken":true,
+          "location":"header",
+          "locationName":"x-amz-idempotent-header"
         }
       }
     },
-    "GetOperationWithBodyInput": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        }
-      }
-    },
-    "IdempotentOperationStructure": {
-      "type": "structure",
-      "required": [
-        "PathIdempotentToken"
-      ],
-      "members": {
-        "PathIdempotentToken": {
-          "shape": "String",
-          "idempotencyToken": true,
-          "location": "uri",
-          "locationName": "PathParam"
-        },
-        "QueryIdempotentToken": {
-          "shape": "String",
-          "idempotencyToken": true,
-          "location": "querystring",
-          "locationName": "QueryParam"
-        },
-        "HeaderIdempotentToken": {
-          "shape": "String",
-          "idempotencyToken": true,
-          "location": "header",
-          "locationName": "x-amz-idempotent-header"
-        }
-      }
-    },
-    "ImplicitPayloadException": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        },
-        "IntegerMember": {
-          "shape": "Integer"
-        },
-        "LongMember": {
-          "shape": "Long"
-        },
-        "ShortMember": {
-          "shape": "Short"
-        },
-        "DoubleMember": {
-          "shape": "Double"
-        },
-        "FloatMember": {
-          "shape": "Float"
-        },
-        "TimestampMember": {
-          "shape": "Timestamp"
-        },
-        "BooleanMember": {
-          "shape": "Boolean"
-        },
-        "BlobMember": {
-          "shape": "BlobType"
-        },
-        "ListMember": {
-          "shape": "ListOfStrings"
-        },
-        "MapMember": {
-          "shape": "MapOfStringToString"
-        },
-        "SimpleStructMember": {
-          "shape": "SimpleStruct"
-        }
+    "ImplicitPayloadException":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"},
+        "IntegerMember":{"shape":"Integer"},
+        "LongMember":{"shape":"Long"},
+        "ShortMember":{"shape":"Short"},
+        "DoubleMember":{"shape":"Double"},
+        "FloatMember":{"shape":"Float"},
+        "TimestampMember":{"shape":"Timestamp"},
+        "BooleanMember":{"shape":"Boolean"},
+        "BlobMember":{"shape":"BlobType"},
+        "ListMember":{"shape":"ListOfStrings"},
+        "MapMember":{"shape":"MapOfStringToString"},
+        "SimpleStructMember":{"shape":"SimpleStruct"}
       },
-      "exception": true
+      "exception":true
     },
-    "Integer": {
-      "type": "integer"
-    },
+    "Integer":{"type":"integer"},
     // Shape is customized to BigDecimal in customization.config
     "NumericValue": {
       "type": "string",
-      "pattern": "([0-9]*\\.)?[0-9]+"
+      "pattern":"([0-9]*\\.)?[0-9]+"
     },
-    "IsoTimestamp": {
-      "type": "timestamp",
-      "timestampFormat": "iso8601"
+    "IsoTimestamp":{
+      "type":"timestamp",
+      "timestampFormat":"iso8601"
     },
-    "UnixTimestamp": {
-      "type": "timestamp",
-      "timestampFormat": "unixTimestamp"
+    "UnixTimestamp":{
+      "type":"timestamp",
+      "timestampFormat":"unixTimestamp"
     },
-    "JsonValuesStructure": {
-      "type": "structure",
-      "members": {
-        "JsonValueHeaderMember": {
-          "shape": "String",
-          "jsonvalue": true,
-          "location": "header",
-          "locationName": "Encoded-Header"
+    "JsonValuesStructure":{
+      "type":"structure",
+      "members":{
+        "JsonValueHeaderMember":{
+          "shape":"String",
+          "jsonvalue":true,
+          "location":"header",
+          "locationName":"Encoded-Header"
         },
-        "JsonValueMember": {
-          "shape": "String",
-          "jsonvalue": true
+        "JsonValueMember":{
+          "shape":"String",
+          "jsonvalue":true
         }
       }
     },
-    "ListOfAllTypesStructs": {
-      "type": "list",
-      "member": {
-        "shape": "AllTypesStructure"
-      }
+    "ListOfAllTypesStructs":{
+      "type":"list",
+      "member":{"shape":"AllTypesStructure"}
     },
-    "ListOfBlobsType": {
-      "type": "list",
-      "member": {
-        "shape": "BlobType"
-      }
+    "ListOfBlobsType":{
+      "type":"list",
+      "member":{"shape":"BlobType"}
     },
-    "ListOfEnums": {
-      "type": "list",
-      "member": {
-        "shape": "EnumType"
-      }
+    "ListOfEnums":{
+      "type":"list",
+      "member":{"shape":"EnumType"}
     },
-    "ListOfIntegers": {
-      "type": "list",
-      "member": {
-        "shape": "Integer"
-      }
+    "ListOfIntegers":{
+      "type":"list",
+      "member":{"shape":"Integer"}
     },
-    "ListOfListOfListsOfStrings": {
-      "type": "list",
-      "member": {
-        "shape": "ListOfListsOfStrings"
-      }
+    "ListOfListOfListsOfStrings":{
+      "type":"list",
+      "member":{"shape":"ListOfListsOfStrings"}
     },
-    "ListOfListsOfAllTypesStructs": {
-      "type": "list",
-      "member": {
-        "shape": "ListOfAllTypesStructs"
-      }
+    "ListOfListsOfAllTypesStructs":{
+      "type":"list",
+      "member":{"shape":"ListOfAllTypesStructs"}
     },
-    "ListOfListsOfStrings": {
-      "type": "list",
-      "member": {
-        "shape": "ListOfStrings"
-      }
+    "ListOfListsOfStrings":{
+      "type":"list",
+      "member":{"shape":"ListOfStrings"}
     },
-    "ListOfListsOfStructs": {
-      "type": "list",
-      "member": {
-        "shape": "ListOfSimpleStructs"
-      }
+    "ListOfListsOfStructs":{
+      "type":"list",
+      "member":{"shape":"ListOfSimpleStructs"}
     },
-    "ListOfMapStringToString": {
-      "type": "list",
-      "member": {
-        "shape": "MapOfStringToString"
-      }
+    "ListOfMapStringToString":{
+      "type":"list",
+      "member":{"shape":"MapOfStringToString"}
     },
-    "ListOfNested": {
-      "type": "list",
-      "member": {
-        "shape": "NestedContainersStructure"
-      }
+    "ListOfNested":{
+      "type":"list",
+      "member":{"shape":"NestedContainersStructure"}
     },
-    "ListOfSimpleStructs": {
-      "type": "list",
-      "member": {
-        "shape": "SimpleStruct"
-      }
+    "ListOfSimpleStructs":{
+      "type":"list",
+      "member":{"shape":"SimpleStruct"}
     },
-    "ListOfStrings": {
-      "type": "list",
-      "member": {
-        "shape": "String"
-      }
+    "ListOfStrings":{
+      "type":"list",
+      "member":{"shape":"String"}
     },
-    "Long": {
-      "type": "long"
+    "Long":{"type":"long"},
+    "Short":{"type":"short"},
+    "Byte":{"type":"byte"},
+    "MapOfEnumToEnum":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"EnumType"}
     },
-    "Short": {
-      "type": "short"
+    "MapOfStringToIntegerList":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfIntegers"}
     },
-    "Byte": {
-      "type": "byte"
+    "MapOfStringToListOfListsOfStrings":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfListsOfStrings"}
     },
-    "MapOfEnumToEnum": {
-      "type": "map",
-      "key": {
-        "shape": "EnumType"
-      },
-      "value": {
-        "shape": "EnumType"
-      }
-    },
-    "MapOfStringToIntegerList": {
-      "type": "map",
-      "key": {
-        "shape": "String"
-      },
-      "value": {
-        "shape": "ListOfIntegers"
-      }
-    },
-    "MapOfStringToListOfListsOfStrings": {
-      "type": "map",
-      "key": {
-        "shape": "String"
-      },
-      "value": {
-        "shape": "ListOfListsOfStrings"
-      }
-    },
-    "MapOfStringToListOfStringInQueryParamsInput": {
-      "type": "structure",
-      "members": {
-        "MapOfStringToListOfStrings": {
-          "shape": "MapOfStringToListOfStrings",
-          "location": "querystring"
+    "MapOfStringToListOfStringInQueryParamsInput":{
+      "type":"structure",
+      "members":{
+        "MapOfStringToListOfStrings":{
+          "shape":"MapOfStringToListOfStrings",
+          "location":"querystring"
         }
       }
     },
-    "MapOfStringToListOfStrings": {
-      "type": "map",
-      "key": {
-        "shape": "String"
+    "MapOfStringToListOfStrings":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfStrings"}
+    },
+    "MapOfStringToSimpleStruct":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"SimpleStruct"}
+    },
+    "MapOfStringToString":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
+    },
+    "Metadata":{
+      "type":"map",
+      "key":{"shape":"MetadataKey"},
+      "value":{"shape":"MetadataValue"}
+    },
+    "MetadataKey":{"type":"string"},
+    "MetadataValue":{"type":"string"},
+    "MapInHeadersInput":{
+      "type":"structure",
+      "members":{
+        "MetadataMember":{
+          "shape":"Metadata",
+          "location":"header",
+          "locationName":"x-amz-meta-"
+        }
+      }
+    },
+    "MembersInHeadersStructure":{
+      "type":"structure",
+      "members":{
+        "StringMember":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-string"
+        },
+        "ListOfStringsMember":{
+          "shape":"ListOfStrings",
+          "location":"header",
+          "locationName":"x-amz-string-list"
+        },
+        "BooleanMember":{
+          "shape":"Boolean",
+          "location":"header",
+          "locationName":"x-amz-boolean"
+        },
+        "IntegerMember":{
+          "shape":"Integer",
+          "location":"header",
+          "locationName":"x-amz-integer"
+        },
+        "LongMember":{
+          "shape":"Long",
+          "location":"header",
+          "locationName":"x-amz-long"
+        },
+        "ShortMember":{
+          "shape":"Short",
+          "location":"header",
+          "locationName":"x-amz-short"
+        },
+        "FloatMember":{
+          "shape":"Float",
+          "location":"header",
+          "locationName":"x-amz-float"
+        },
+        "DoubleMember":{
+          "shape":"Double",
+          "location":"header",
+          "locationName":"x-amz-double"
+        },
+        "TimestampMember":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timestamp"
+        },
+        "IsoTimestampMember":{
+          "shape":"IsoTimestamp",
+          "location":"header",
+          "locationName":"x-amz-iso-timestamp"
+        }
+      }
+    },
+    "MembersInQueryParamsInput":{
+      "type":"structure",
+      "members":{
+        "StringQueryParam":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"String"
+        },
+        "BooleanQueryParam":{
+          "shape":"Boolean",
+          "location":"querystring",
+          "locationName":"Boolean"
+        },
+        "IntegerQueryParam":{
+          "shape":"Integer",
+          "location":"querystring",
+          "locationName":"Integer"
+        },
+        "LongQueryParam":{
+          "shape":"Long",
+          "location":"querystring",
+          "locationName":"Long"
+        },
+        "ShortQueryParam":{
+          "shape":"Short",
+          "location":"querystring",
+          "locationName":"Short"
+        },
+        "FloatQueryParam":{
+          "shape":"Float",
+          "location":"querystring",
+          "locationName":"Float"
+        },
+        "DoubleQueryParam":{
+          "shape":"Double",
+          "location":"querystring",
+          "locationName":"Double"
+        },
+        "TimestampQueryParam":{
+          "shape":"Timestamp",
+          "location":"querystring",
+          "locationName":"Timestamp"
+        },
+        "ListOfStrings":{
+          "shape":"ListOfStrings",
+          "location":"querystring",
+          "locationName":"item"
+        },
+        "MapOfStringToString":{
+          "shape":"MapOfStringToString",
+          "location":"querystring"
+        }
+      }
+    },
+    "MultiLocationOperationInput":{
+      "type":"structure",
+      "required":["PathParam"],
+      "members":{
+        "PathParam":{
+          "shape":"String",
+          "location":"uri",
+          "locationName":"PathParam"
+        },
+        "QueryParamOne":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"QueryParamOne"
+        },
+        "QueryParamTwo":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"QueryParamTwo"
+        },
+        "StringHeaderMember":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-header-string"
+        },
+        "TimestampHeaderMember":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timearg"
+        },
+        "PayloadStructParam":{"shape":"PayloadStructType"}
+      }
+    },
+    "NestedContainersStructure":{
+      "type":"structure",
+      "members":{
+        "ListOfListsOfStrings":{"shape":"ListOfListsOfStrings"},
+        "ListOfListsOfStructs":{"shape":"ListOfListsOfStructs"},
+        "ListOfListsOfAllTypesStructs":{"shape":"ListOfListsOfAllTypesStructs"},
+        "ListOfListOfListsOfStrings":{"shape":"ListOfListOfListsOfStrings"},
+        "MapOfStringToListOfListsOfStrings":{"shape":"MapOfStringToListOfListsOfStrings"},
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "OperationWithExplicitPayloadBlobInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"BlobType"}
       },
-      "value": {
-        "shape": "ListOfStrings"
-      }
+      "payload":"PayloadMember"
     },
-    "MapOfStringToSimpleStruct": {
-      "type": "map",
-      "key": {
-        "shape": "String"
+    "OperationWithExplicitPayloadStringInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"String"}
       },
-      "value": {
-        "shape": "SimpleStruct"
-      }
+      "payload":"PayloadMember"
     },
-    "MapOfStringToString": {
-      "type": "map",
-      "key": {
-        "shape": "String"
+    "OperationWithExplicitPayloadStructureInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"SimpleStruct"}
       },
-      "value": {
-        "shape": "String"
-      }
+      "payload":"PayloadMember"
     },
-    "Metadata": {
-      "type": "map",
-      "key": {
-        "shape": "MetadataKey"
-      },
-      "value": {
-        "shape": "MetadataValue"
-      }
-    },
-    "MetadataKey": {
-      "type": "string"
-    },
-    "MetadataValue": {
-      "type": "string"
-    },
-    "MapInHeadersInput": {
-      "type": "structure",
-      "members": {
-        "MetadataMember": {
-          "shape": "Metadata",
-          "location": "header",
-          "locationName": "x-amz-meta-"
-        }
-      }
-    },
-    "MembersInHeadersStructure": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-string"
-        },
-        "ListOfStringsMember": {
-          "shape": "ListOfStrings",
-          "location": "header",
-          "locationName": "x-amz-string-list"
-        },
-        "BooleanMember": {
-          "shape": "Boolean",
-          "location": "header",
-          "locationName": "x-amz-boolean"
-        },
-        "IntegerMember": {
-          "shape": "Integer",
-          "location": "header",
-          "locationName": "x-amz-integer"
-        },
-        "LongMember": {
-          "shape": "Long",
-          "location": "header",
-          "locationName": "x-amz-long"
-        },
-        "ShortMember": {
-          "shape": "Short",
-          "location": "header",
-          "locationName": "x-amz-short"
-        },
-        "FloatMember": {
-          "shape": "Float",
-          "location": "header",
-          "locationName": "x-amz-float"
-        },
-        "DoubleMember": {
-          "shape": "Double",
-          "location": "header",
-          "locationName": "x-amz-double"
-        },
-        "TimestampMember": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timestamp"
-        },
-        "IsoTimestampMember": {
-          "shape": "IsoTimestamp",
-          "location": "header",
-          "locationName": "x-amz-iso-timestamp"
-        }
-      }
-    },
-    "MembersInQueryParamsInput": {
-      "type": "structure",
-      "members": {
-        "StringQueryParam": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "String"
-        },
-        "BooleanQueryParam": {
-          "shape": "Boolean",
-          "location": "querystring",
-          "locationName": "Boolean"
-        },
-        "IntegerQueryParam": {
-          "shape": "Integer",
-          "location": "querystring",
-          "locationName": "Integer"
-        },
-        "LongQueryParam": {
-          "shape": "Long",
-          "location": "querystring",
-          "locationName": "Long"
-        },
-        "ShortQueryParam": {
-          "shape": "Short",
-          "location": "querystring",
-          "locationName": "Short"
-        },
-        "FloatQueryParam": {
-          "shape": "Float",
-          "location": "querystring",
-          "locationName": "Float"
-        },
-        "DoubleQueryParam": {
-          "shape": "Double",
-          "location": "querystring",
-          "locationName": "Double"
-        },
-        "TimestampQueryParam": {
-          "shape": "Timestamp",
-          "location": "querystring",
-          "locationName": "Timestamp"
-        },
-        "ListOfStrings": {
-          "shape": "ListOfStrings",
-          "location": "querystring",
-          "locationName": "item"
-        },
-        "MapOfStringToString": {
-          "shape": "MapOfStringToString",
-          "location": "querystring"
-        }
-      }
-    },
-    "MultiLocationOperationInput": {
-      "type": "structure",
-      "required": [
-        "PathParam"
-      ],
-      "members": {
-        "PathParam": {
-          "shape": "String",
-          "location": "uri",
-          "locationName": "PathParam"
-        },
-        "QueryParamOne": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "QueryParamOne"
-        },
-        "QueryParamTwo": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "QueryParamTwo"
-        },
-        "StringHeaderMember": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-header-string"
-        },
-        "TimestampHeaderMember": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timearg"
-        },
-        "PayloadStructParam": {
-          "shape": "PayloadStructType"
-        }
-      }
-    },
-    "NestedContainersStructure": {
-      "type": "structure",
-      "members": {
-        "ListOfListsOfStrings": {
-          "shape": "ListOfListsOfStrings"
-        },
-        "ListOfListsOfStructs": {
-          "shape": "ListOfListsOfStructs"
-        },
-        "ListOfListsOfAllTypesStructs": {
-          "shape": "ListOfListsOfAllTypesStructs"
-        },
-        "ListOfListOfListsOfStrings": {
-          "shape": "ListOfListOfListsOfStrings"
-        },
-        "MapOfStringToListOfListsOfStrings": {
-          "shape": "MapOfStringToListOfListsOfStrings"
-        },
-        "StringMember": {
-          "shape": "String"
-        }
-      }
-    },
-    "OperationWithExplicitPayloadBlobInput": {
-      "type": "structure",
-      "members": {
-        "PayloadMember": {
-          "shape": "BlobType"
-        }
-      },
-      "payload": "PayloadMember"
-    },
-    "OperationWithExplicitPayloadStringInput": {
-      "type": "structure",
-      "members": {
-        "PayloadMember": {
-          "shape": "String"
-        }
-      },
-      "payload": "PayloadMember"
-    },
-    "OperationWithExplicitPayloadStructureInput": {
-      "type": "structure",
-      "members": {
-        "PayloadMember": {
-          "shape": "SimpleStruct"
-        }
-      },
-      "payload": "PayloadMember"
-    },
-    "OperationWithGreedyLabelInput": {
-      "type": "structure",
-      "required": [
+    "OperationWithGreedyLabelInput":{
+      "type":"structure",
+      "required":[
         "NonGreedyPathParam",
         "GreedyPathParam"
       ],
-      "members": {
-        "NonGreedyPathParam": {
-          "shape": "String",
-          "location": "uri",
-          "locationName": "NonGreedyPathParam"
+      "members":{
+        "NonGreedyPathParam":{
+          "shape":"String",
+          "location":"uri",
+          "locationName":"NonGreedyPathParam"
         },
-        "GreedyPathParam": {
-          "shape": "String",
-          "location": "uri",
-          "locationName": "GreedyPathParam"
+        "GreedyPathParam":{
+          "shape":"String",
+          "location":"uri",
+          "locationName":"GreedyPathParam"
         }
       }
     },
-    "OperationWithModeledContentTypeInput": {
-      "type": "structure",
-      "members": {
-        "ContentType": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "Content-Type"
+    "OperationWithModeledContentTypeInput":{
+      "type":"structure",
+      "members":{
+        "ContentType":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"Content-Type"
         }
       }
     },
-    "PayloadStructType": {
-      "type": "structure",
-      "members": {
-        "PayloadMemberOne": {
-          "shape": "String"
+    "PayloadStructType":{
+      "type":"structure",
+      "members":{
+        "PayloadMemberOne":{"shape":"String"},
+        "PayloadMemberTwo":{"shape":"String"}
+      }
+    },
+    "QueryParamWithoutValueInput":{
+      "type":"structure",
+      "members":{
+      }
+    },
+    "RecursiveListType":{
+      "type":"list",
+      "member":{"shape":"RecursiveStructType"}
+    },
+    "RecursiveMapType":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"RecursiveStructType"}
+    },
+    "RecursiveStructType":{
+      "type":"structure",
+      "members":{
+        "NoRecurse":{"shape":"String"},
+        "RecursiveStruct":{"shape":"RecursiveStructType"},
+        "RecursiveList":{"shape":"RecursiveListType"},
+        "RecursiveMap":{"shape":"RecursiveMapType"}
+      }
+    },
+    "SimpleStruct":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "NestedLocationOperationInput":{
+      "type":"structure",
+      "members":{
+        "TopLevelQueryParam":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"topLevel"
         },
-        "PayloadMemberTwo": {
-          "shape": "String"
+        "Nested":{"shape":"NestedShapeWithLocations"}
+      }
+    },
+    "NestedShapeWithLocations":{
+      "type":"structure",
+      "members":{
+        "NestedQueryParam":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"shouldBeIgnored"
+        },
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "NestedLocationOperationOutput":{
+      "type":"structure",
+      "members":{
+        "TopLevelHeader":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-top-level"
+        },
+        "NestedResult":{"shape":"NestedResponseData"}
+      }
+    },
+    "NestedResponseData":{
+      "type":"structure",
+      "members":{
+        "NestedHeader":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-should-be-ignored"
+        },
+        "Value":{"shape":"String"}
+      }
+    },
+    "StatusCodeInOutputStructure":{
+      "type":"structure",
+      "members":{
+        "StatusCodeMember":{
+          "shape":"Integer",
+          "location":"statusCode"
         }
       }
     },
-    "QueryParamWithoutValueInput": {
-      "type": "structure",
-      "members": {}
-    },
-    "RecursiveListType": {
-      "type": "list",
-      "member": {
-        "shape": "RecursiveStructType"
+    "MixedLocationOperationInput":{
+      "type":"structure",
+      "members":{
+        "StringMember":{
+          "shape":"String"
+        },
+        "IntegerMember":{
+          "shape":"Integer"
+        }
       }
     },
-    "RecursiveMapType": {
-      "type": "map",
-      "key": {
-        "shape": "String"
+    "MixedLocationOperationOutput":{
+      "type":"structure",
+      "members":{
+        "StringMember":{
+          "shape":"String"
+        },
+        "IntegerMember":{
+          "shape":"Integer"
+        },
+        "StatusCodeMember":{
+          "shape":"Integer",
+          "location":"statusCode"
+        },
+        "StringHeaderMember":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-string"
+        }
+      }
+    },
+    "StreamType":{
+      "type":"blob",
+      "streaming":true,
+      "requiresLength":true
+    },
+    "StreamTypeChunkedEncoding":{
+      "type":"blob",
+      "streaming":true,
+      "requiresLength":false
+    },
+    "String":{"type":"string"},
+    "StructWithNestedBlobType":{
+      "type":"structure",
+      "members":{
+        "NestedBlob":{"shape":"BlobType"}
+      }
+    },
+    "StructWithTimestamp":{
+      "type":"structure",
+      "members":{
+        "NestedTimestamp":{"shape":"Timestamp"}
+      }
+    },
+    "StructureWithStreamingMember":{
+      "type":"structure",
+      "members":{
+        "StreamingMember":{"shape":"StreamType"}
       },
-      "value": {
-        "shape": "RecursiveStructType"
-      }
+      "payload":"StreamingMember"
     },
-    "RecursiveStructType": {
-      "type": "structure",
-      "members": {
-        "NoRecurse": {
-          "shape": "String"
-        },
-        "RecursiveStruct": {
-          "shape": "RecursiveStructType"
-        },
-        "RecursiveList": {
-          "shape": "RecursiveListType"
-        },
-        "RecursiveMap": {
-          "shape": "RecursiveMapType"
-        }
-      }
-    },
-    "SimpleStruct": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        }
-      }
-    },
-    "NestedLocationOperationInput": {
-      "type": "structure",
-      "members": {
-        "TopLevelQueryParam": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "topLevel"
-        },
-        "Nested": {
-          "shape": "NestedShapeWithLocations"
-        }
-      }
-    },
-    "NestedShapeWithLocations": {
-      "type": "structure",
-      "members": {
-        "NestedQueryParam": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "shouldBeIgnored"
-        },
-        "StringMember": {
-          "shape": "String"
-        }
-      }
-    },
-    "NestedLocationOperationOutput": {
-      "type": "structure",
-      "members": {
-        "TopLevelHeader": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-top-level"
-        },
-        "NestedResult": {
-          "shape": "NestedResponseData"
-        }
-      }
-    },
-    "NestedResponseData": {
-      "type": "structure",
-      "members": {
-        "NestedHeader": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-should-be-ignored"
-        },
-        "Value": {
-          "shape": "String"
-        }
-      }
-    },
-    "StatusCodeInOutputStructure": {
-      "type": "structure",
-      "members": {
-        "StatusCodeMember": {
-          "shape": "Integer",
-          "location": "statusCode"
-        }
-      }
-    },
-    "MixedLocationOperationInput": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        },
-        "IntegerMember": {
-          "shape": "Integer"
-        }
-      }
-    },
-    "MixedLocationOperationOutput": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        },
-        "IntegerMember": {
-          "shape": "Integer"
-        },
-        "StatusCodeMember": {
-          "shape": "Integer",
-          "location": "statusCode"
-        },
-        "StringHeaderMember": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-string"
-        }
-      }
-    },
-    "StreamType": {
-      "type": "blob",
-      "streaming": true,
-      "requiresLength": true
-    },
-    "StreamTypeChunkedEncoding": {
-      "type": "blob",
-      "streaming": true,
-      "requiresLength": false
-    },
-    "String": {
-      "type": "string"
-    },
-    "StructWithNestedBlobType": {
-      "type": "structure",
-      "members": {
-        "NestedBlob": {
-          "shape": "BlobType"
-        }
-      }
-    },
-    "StructWithTimestamp": {
-      "type": "structure",
-      "members": {
-        "NestedTimestamp": {
-          "shape": "Timestamp"
-        }
-      }
-    },
-    "StructureWithStreamingMember": {
-      "type": "structure",
-      "members": {
-        "StreamingMember": {
-          "shape": "StreamType"
-        }
+    "StructureWithStreamingMemberChunkedEncoding":{
+      "type":"structure",
+      "members":{
+        "StreamingMember":{"shape":"StreamTypeChunkedEncoding"}
       },
-      "payload": "StreamingMember"
+      "payload":"StreamingMember"
     },
-    "StructureWithStreamingMemberChunkedEncoding": {
-      "type": "structure",
-      "members": {
-        "StreamingMember": {
-          "shape": "StreamTypeChunkedEncoding"
-        }
-      },
-      "payload": "StreamingMember"
-    },
-    "SubTypeOne": {
-      "type": "structure",
-      "members": {
-        "SubTypeOneMember": {
-          "shape": "String"
-        }
+    "SubTypeOne":{
+      "type":"structure",
+      "members":{
+        "SubTypeOneMember":{"shape":"String"}
       }
     },
-    "Timestamp": {
-      "type": "timestamp"
+    "Timestamp":{"type":"timestamp"},
+    "ListOfTimeStamp":{
+      "type":"list",
+      "member":{"shape":"UnixTimestamp"}
     },
-    "ListOfTimeStamp": {
-      "type": "list",
-      "member": {
-        "shape": "UnixTimestamp"
-      }
-    },
-    "MapOfTimeStamp": {
-      "type": "map",
-      "key": {
-        "shape": "String"
-      },
-      "value": {
-        "shape": "UnixTimestamp"
-      }
+    "MapOfTimeStamp":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"UnixTimestamp"}
     },
     "EventStreamOperationRequest": {
       "type": "structure",
@@ -1285,7 +963,7 @@
           "shape": "InputEventStream"
         }
       },
-      "payload": "InputEventStream"
+      "payload":"InputEventStream"
     },
     "EventStreamStringPayloadOperationRequest": {
       "type": "structure",
@@ -1297,7 +975,7 @@
           "shape": "InputEventStreamStringPayload"
         }
       },
-      "payload": "InputEventStreamStringPayload"
+      "payload":"InputEventStreamStringPayload"
     },
     "EventStreamOutput": {
       "type": "structure",
@@ -1332,8 +1010,8 @@
       "type": "structure",
       "members": {
         "ExplicitPayloadMember": {
-          "shape": "ExplicitPayloadMember",
-          "eventpayload": true
+          "shape":"ExplicitPayloadMember",
+          "eventpayload":true
         },
         "HeaderMember": {
           "shape": "String",
@@ -1346,8 +1024,8 @@
       "type": "structure",
       "members": {
         "ExplicitPayloadStringMember": {
-          "shape": "String",
-          "eventpayload": true
+          "shape":"String",
+          "eventpayload":true
         },
         "HeaderMember": {
           "shape": "String",
@@ -1356,9 +1034,7 @@
       },
       "event": true
     },
-    "ExplicitPayloadMember": {
-      "type": "blob"
-    },
+    "ExplicitPayloadMember":{"type":"blob"},
     "EventStream": {
       "type": "structure",
       "members": {
@@ -1396,12 +1072,10 @@
       "type": "structure",
       "document": true
     },
-    "StructureWithDocumentMember": {
-      "type": "structure",
-      "members": {
-        "DocumentMember": {
-          "shape": "MyDocument"
-        }
+    "StructureWithDocumentMember":{
+      "type":"structure",
+      "members":{
+        "DocumentMember":{"shape":"MyDocument"}
       }
     },
     "AllTypesUnionStructure": {

--- a/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
@@ -1,191 +1,149 @@
 {
-  "version": "2.0",
-  "metadata": {
-    "apiVersion": "2016-03-11",
-    "endpointPrefix": "restxml",
-    "protocol": "rest-xml",
-    "serviceAbbreviation": "AmazonProtocolRestXml",
-    "serviceFullName": "AWS DR Tools Rest-XML Protocol Tests",
-    "serviceId": "AmazonProtocolRestXml",
-    "signatureVersion": "v4",
-    "targetPrefix": "ProtocolTestsRestXmlService",
-    "timestampFormat": "unixTimestamp"
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"restxml",
+    "protocol":"rest-xml",
+    "serviceAbbreviation":"AmazonProtocolRestXml",
+    "serviceFullName":"AWS DR Tools Rest-XML Protocol Tests",
+    "serviceId":"AmazonProtocolRestXml",
+    "signatureVersion":"v4",
+    "targetPrefix":"ProtocolTestsRestXmlService",
+    "timestampFormat":"unixTimestamp"
   },
-  "operations": {
-    "AllTypes": {
-      "name": "AllTypes",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/allTypes"
+  "operations":{
+    "AllTypes":{
+      "name":"AllTypes",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypes"
       },
-      "input": {
-        "shape": "AllTypesStructure",
-        "locationName": "AllTypesRequest",
-        "xmlNamespace": {
-          "uri": "https://restxml/"
-        }
+      "input":{
+        "shape":"AllTypesStructure",
+        "locationName":"AllTypesRequest",
+        "xmlNamespace":{"uri":"https://restxml/"}
       },
-      "output": {
-        "shape": "AllTypesStructure"
-      },
-      "errors": [
-        {
-          "shape": "EmptyModeledException"
-        },
-        {
-          "shape": "ExplicitPayloadAndHeadersException"
-        },
-        {
-          "shape": "ImplicitPayloadException"
-        }
+      "output":{"shape":"AllTypesStructure"},
+      "errors":[
+        {"shape":"EmptyModeledException"},
+        {"shape":"ExplicitPayloadAndHeadersException"},
+        {"shape":"ImplicitPayloadException"}
       ]
     },
-    "DeleteOperation": {
-      "name": "DeleteOperation",
-      "http": {
-        "method": "DELETE",
-        "requestUri": "/2016-03-11/deleteOperation"
+    "DeleteOperation":{
+      "name":"DeleteOperation",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/2016-03-11/deleteOperation"
       }
     },
-    "IdempotentOperation": {
-      "name": "IdempotentOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/idempotentOperation/{PathParam}"
+    "IdempotentOperation":{
+      "name":"IdempotentOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/idempotentOperation/{PathParam}"
       },
-      "input": {
-        "shape": "IdempotentOperationStructure"
+      "input":{"shape":"IdempotentOperationStructure"}
+    },
+    "MapOfStringToListOfStringInQueryParams":{
+      "name":"MapOfStringToListOfStringInQueryParams",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/mapOfStringToListOfStringInQueryParams"
+      },
+      "input":{"shape":"MapOfStringToListOfStringInQueryParamsInput"}
+    },
+    "MembersInHeaders":{
+      "name":"MembersInHeaders",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/membersInHeaders"
+      },
+      "input":{"shape":"MembersInHeadersInput"},
+      "output":{"shape":"MembersInHeadersInput"}
+    },
+    "MapInHeaders":{
+      "name":"MapInHeaders",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/mapInHeaders"
+      },
+      "input":{"shape":"MapInHeadersInput"}
+    },
+    "MembersInQueryParams":{
+      "name":"MembersInQueryParams",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
+      },
+      "input":{"shape":"MembersInQueryParamsInput"}
+    },
+    "MultiLocationOperation":{
+      "name":"MultiLocationOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/multiLocationOperation/{PathParam}"
+      },
+      "input":{
+        "shape":"MultiLocationOperationInput",
+        "locationName":"MultiLocationOperationRequest",
+        "xmlNamespace":{"uri":"https://restxml/"}
       }
     },
-    "MapOfStringToListOfStringInQueryParams": {
-      "name": "MapOfStringToListOfStringInQueryParams",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/mapOfStringToListOfStringInQueryParams"
+    "OperationWithExplicitPayloadBlob":{
+      "name":"OperationWithExplicitPayloadBlob",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadBlob"
       },
-      "input": {
-        "shape": "MapOfStringToListOfStringInQueryParamsInput"
-      }
+      "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
+      "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
     },
-    "MembersInHeaders": {
-      "name": "MembersInHeaders",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/membersInHeaders"
+    "OperationWithExplicitPayloadString":{
+      "name":"OperationWithExplicitPayloadString",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
       },
-      "input": {
-        "shape": "MembersInHeadersInput"
-      },
-      "output": {
-        "shape": "MembersInHeadersInput"
-      }
+      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
+      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
     },
-    "MapInHeaders": {
-      "name": "MapInHeaders",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/mapInHeaders"
+    "OperationWithGreedyLabel":{
+      "name":"OperationWithGreedyLabel",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
       },
-      "input": {
-        "shape": "MapInHeadersInput"
-      }
+      "input":{"shape":"OperationWithGreedyLabelInput"}
     },
-    "MembersInQueryParams": {
-      "name": "MembersInQueryParams",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
+    "OperationWithModeledContentType":{
+      "name":"OperationWithModeledContentType",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/operationWithModeledContentType"
       },
-      "input": {
-        "shape": "MembersInQueryParamsInput"
-      }
+      "input":{"shape":"OperationWithModeledContentTypeInput"}
     },
-    "MultiLocationOperation": {
-      "name": "MultiLocationOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/multiLocationOperation/{PathParam}"
+    "QueryParamWithoutValue":{
+      "name":"QueryParamWithoutValue",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/queryParamWithoutValue?param"
       },
-      "input": {
-        "shape": "MultiLocationOperationInput",
-        "locationName": "MultiLocationOperationRequest",
-        "xmlNamespace": {
-          "uri": "https://restxml/"
-        }
-      }
+      "input":{"shape":"QueryParamWithoutValueInput"}
     },
-    "OperationWithExplicitPayloadBlob": {
-      "name": "OperationWithExplicitPayloadBlob",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithExplicitPayloadBlob"
+    "RestXmlTypes":{
+      "name":"RestXmlTypes",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/restXmlTypes"
       },
-      "input": {
-        "shape": "OperationWithExplicitPayloadBlobInput"
+      "input":{
+        "shape":"RestXmlTypesStructure",
+        "locationName":"RestXmlTypesRequest",
+        "xmlNamespace":{"uri":"https://restxml/"}
       },
-      "output": {
-        "shape": "OperationWithExplicitPayloadBlobInput"
-      }
-    },
-    "OperationWithExplicitPayloadString": {
-      "name": "OperationWithExplicitPayloadString",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithExplicitPayloadString"
-      },
-      "input": {
-        "shape": "OperationWithExplicitPayloadStringInput"
-      },
-      "output": {
-        "shape": "OperationWithExplicitPayloadStringInput"
-      }
-    },
-    "OperationWithGreedyLabel": {
-      "name": "OperationWithGreedyLabel",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
-      },
-      "input": {
-        "shape": "OperationWithGreedyLabelInput"
-      }
-    },
-    "OperationWithModeledContentType": {
-      "name": "OperationWithModeledContentType",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/operationWithModeledContentType"
-      },
-      "input": {
-        "shape": "OperationWithModeledContentTypeInput"
-      }
-    },
-    "QueryParamWithoutValue": {
-      "name": "QueryParamWithoutValue",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/queryParamWithoutValue?param"
-      },
-      "input": {
-        "shape": "QueryParamWithoutValueInput"
-      }
-    },
-    "RestXmlTypes": {
-      "name": "RestXmlTypes",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/restXmlTypes"
-      },
-      "input": {
-        "shape": "RestXmlTypesStructure",
-        "locationName": "RestXmlTypesRequest",
-        "xmlNamespace": {
-          "uri": "https://restxml/"
-        }
-      },
-      "output": {
-        "shape": "RestXmlTypesOutput"
-      }
+      "output":{"shape":"RestXmlTypesOutput"}
     },
     "EventStreamOperation": {
       "name": "EventStreamOperation",
@@ -201,657 +159,512 @@
       }
     }
   },
-  "shapes": {
-    "AllTypesStructure": {
-      "type": "structure",
-      "members": {
-        "stringMember": {
-          "shape": "String"
+  "shapes":{
+    "AllTypesStructure":{
+      "type":"structure",
+      "members":{
+        "stringMember":{"shape":"String"},
+        "integerMember":{"shape":"Integer"},
+        "booleanMember":{"shape":"Boolean"},
+        "floatMember":{"shape":"Float"},
+        "doubleMember":{"shape":"Double"},
+        "longMember":{"shape":"Long"},
+        "shortMember":{"shape":"Short"},
+        "simpleStructMember":{"shape":"SimpleStruct"},
+        "simpleList":{"shape":"ListOfStrings"},
+        "listOfStructs":{"shape":"ListOfSimpleStructs"},
+        "mapOfStringToString":{"shape":"MapOfStringToString"},
+        "timestampMember":{"shape":"Timestamp"},
+        "structWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
+        "blobArg":{"shape":"BlobType"},
+        "blobMap":{"shape":"BlobMapType"},
+        "listOfBlobs":{"shape":"ListOfBlobsType"}
+      }
+    },
+    "BlobMapType":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"BlobType"}
+    },
+    "BlobType":{"type":"blob"},
+    "Boolean":{"type":"boolean"},
+    "Double":{"type":"double"},
+    "EmptyModeledException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
+    "FlattenedListOfStrings":{
+      "type":"list",
+      "member":{"shape":"String"},
+      "flattened":true
+    },
+    "FlattenedListOfStructs":{
+      "type":"list",
+      "member":{"shape":"SimpleStruct"},
+      "flattened":true
+    },
+    "FlattenedListWithLocation":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"item"
+      },
+      "flattened":true
+    },
+    "FlattenedMap":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"},
+      "flattened":true
+    },
+    "FlattenedMapWithLocation":{
+      "type":"map",
+      "key":{
+        "shape":"String",
+        "locationName":"thekey"
+      },
+      "value":{
+        "shape":"String",
+        "locationName":"thevalue"
+      },
+      "flattened":true
+    },
+    "Float":{"type":"float"},
+    "IdempotentOperationStructure":{
+      "type":"structure",
+      "required":["PathIdempotentToken"],
+      "members":{
+        "PathIdempotentToken":{
+          "shape":"String",
+          "idempotencyToken":true,
+          "location":"uri",
+          "locationName":"PathParam"
         },
-        "integerMember": {
-          "shape": "Integer"
+        "QueryIdempotentToken":{
+          "shape":"String",
+          "idempotencyToken":true,
+          "location":"querystring",
+          "locationName":"QueryParam"
         },
-        "booleanMember": {
-          "shape": "Boolean"
-        },
-        "floatMember": {
-          "shape": "Float"
-        },
-        "doubleMember": {
-          "shape": "Double"
-        },
-        "longMember": {
-          "shape": "Long"
-        },
-        "shortMember": {
-          "shape": "Short"
-        },
-        "simpleStructMember": {
-          "shape": "SimpleStruct"
-        },
-        "simpleList": {
-          "shape": "ListOfStrings"
-        },
-        "listOfStructs": {
-          "shape": "ListOfSimpleStructs"
-        },
-        "mapOfStringToString": {
-          "shape": "MapOfStringToString"
-        },
-        "timestampMember": {
-          "shape": "Timestamp"
-        },
-        "structWithNestedTimestampMember": {
-          "shape": "StructWithTimestamp"
-        },
-        "blobArg": {
-          "shape": "BlobType"
-        },
-        "blobMap": {
-          "shape": "BlobMapType"
-        },
-        "listOfBlobs": {
-          "shape": "ListOfBlobsType"
+        "HeaderIdempotentToken":{
+          "shape":"String",
+          "idempotencyToken":true,
+          "location":"header",
+          "locationName":"x-amz-idempotent-header"
         }
       }
     },
-    "BlobMapType": {
-      "type": "map",
-      "key": {
-        "shape": "String"
-      },
-      "value": {
-        "shape": "BlobType"
-      }
+    "Integer":{"type":"integer"},
+    "ListOfBlobsType":{
+      "type":"list",
+      "member":{"shape":"BlobType"}
     },
-    "BlobType": {
-      "type": "blob"
+    "ListOfSimpleStructs":{
+      "type":"list",
+      "member":{"shape":"SimpleStruct"}
     },
-    "Boolean": {
-      "type": "boolean"
+    "ListOfStrings":{
+      "type":"list",
+      "member":{"shape":"String"}
     },
-    "Double": {
-      "type": "double"
-    },
-    "EmptyModeledException": {
-      "type": "structure",
-      "members": {},
-      "exception": true
-    },
-    "FlattenedListOfStrings": {
-      "type": "list",
-      "member": {
-        "shape": "String"
-      },
-      "flattened": true
-    },
-    "FlattenedListOfStructs": {
-      "type": "list",
-      "member": {
-        "shape": "SimpleStruct"
-      },
-      "flattened": true
-    },
-    "FlattenedListWithLocation": {
-      "type": "list",
-      "member": {
-        "shape": "String",
-        "locationName": "item"
-      },
-      "flattened": true
-    },
-    "FlattenedMap": {
-      "type": "map",
-      "key": {
-        "shape": "String"
-      },
-      "value": {
-        "shape": "String"
-      },
-      "flattened": true
-    },
-    "FlattenedMapWithLocation": {
-      "type": "map",
-      "key": {
-        "shape": "String",
-        "locationName": "thekey"
-      },
-      "value": {
-        "shape": "String",
-        "locationName": "thevalue"
-      },
-      "flattened": true
-    },
-    "Float": {
-      "type": "float"
-    },
-    "IdempotentOperationStructure": {
-      "type": "structure",
-      "required": [
-        "PathIdempotentToken"
-      ],
-      "members": {
-        "PathIdempotentToken": {
-          "shape": "String",
-          "idempotencyToken": true,
-          "location": "uri",
-          "locationName": "PathParam"
-        },
-        "QueryIdempotentToken": {
-          "shape": "String",
-          "idempotencyToken": true,
-          "location": "querystring",
-          "locationName": "QueryParam"
-        },
-        "HeaderIdempotentToken": {
-          "shape": "String",
-          "idempotencyToken": true,
-          "location": "header",
-          "locationName": "x-amz-idempotent-header"
+    "Long":{"type":"long"},
+    "Short":{"type":"short"},
+    "MapOfStringToListOfStringInQueryParamsInput":{
+      "type":"structure",
+      "members":{
+        "MapOfStringToListOfStrings":{
+          "shape":"MapOfStringToListOfStrings",
+          "location":"querystring"
         }
       }
     },
-    "Integer": {
-      "type": "integer"
+    "MapOfStringToListOfStrings":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfStrings"}
     },
-    "ListOfBlobsType": {
-      "type": "list",
-      "member": {
-        "shape": "BlobType"
-      }
+    "MapOfStringToString":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
     },
-    "ListOfSimpleStructs": {
-      "type": "list",
-      "member": {
-        "shape": "SimpleStruct"
-      }
-    },
-    "ListOfStrings": {
-      "type": "list",
-      "member": {
-        "shape": "String"
-      }
-    },
-    "Long": {
-      "type": "long"
-    },
-    "Short": {
-      "type": "short"
-    },
-    "MapOfStringToListOfStringInQueryParamsInput": {
-      "type": "structure",
-      "members": {
-        "MapOfStringToListOfStrings": {
-          "shape": "MapOfStringToListOfStrings",
-          "location": "querystring"
+    "MembersInHeadersInput":{
+      "type":"structure",
+      "members":{
+        "StringMember":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-string"
+        },
+        "ListOfStringsMember":{
+          "shape":"ListOfStrings",
+          "location":"header",
+          "locationName":"x-amz-string-list"
+        },
+        "BooleanMember":{
+          "shape":"Boolean",
+          "location":"header",
+          "locationName":"x-amz-boolean"
+        },
+        "IntegerMember":{
+          "shape":"Integer",
+          "location":"header",
+          "locationName":"x-amz-integer"
+        },
+        "LongMember":{
+          "shape":"Long",
+          "location":"header",
+          "locationName":"x-amz-long"
+        },
+        "ShortMember":{
+          "shape":"Short",
+          "location":"header",
+          "locationName":"x-amz-short"
+        },
+        "FloatMember":{
+          "shape":"Float",
+          "location":"header",
+          "locationName":"x-amz-float"
+        },
+        "DoubleMember":{
+          "shape":"Double",
+          "location":"header",
+          "locationName":"x-amz-double"
+        },
+        "TimestampMember":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timestamp"
+        },
+        "MetadataMember":{
+          "shape":"Metadata",
+          "location":"header",
+          "locationName":"x-amz-meta-"
         }
       }
     },
-    "MapOfStringToListOfStrings": {
-      "type": "map",
-      "key": {
-        "shape": "String"
+    "MembersInQueryParamsInput":{
+      "type":"structure",
+      "members":{
+        "StringQueryParam":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"String"
+        },
+        "BooleanQueryParam":{
+          "shape":"Boolean",
+          "location":"querystring",
+          "locationName":"Boolean"
+        },
+        "IntegerQueryParam":{
+          "shape":"Integer",
+          "location":"querystring",
+          "locationName":"Integer"
+        },
+        "LongQueryParam":{
+          "shape":"Long",
+          "location":"querystring",
+          "locationName":"Long"
+        },
+        "ShortQueryParam":{
+          "shape":"Short",
+          "location":"querystring",
+          "locationName":"Short"
+        },
+        "FloatQueryParam":{
+          "shape":"Float",
+          "location":"querystring",
+          "locationName":"Float"
+        },
+        "DoubleQueryParam":{
+          "shape":"Double",
+          "location":"querystring",
+          "locationName":"Double"
+        },
+        "TimestampQueryParam":{
+          "shape":"Timestamp",
+          "location":"querystring",
+          "locationName":"Timestamp"
+        },
+        "ListOfStrings":{
+          "shape":"ListOfStrings",
+          "location":"querystring",
+          "locationName":"item"
+        },
+        "MapOfStringToString":{
+          "shape":"MapOfStringToString",
+          "location":"querystring"
+        }
+      }
+    },
+    "MultiLocationOperationInput":{
+      "type":"structure",
+      "required":["PathParam"],
+      "members":{
+        "PathParam":{
+          "shape":"String",
+          "location":"uri",
+          "locationName":"PathParam"
+        },
+        "QueryParamOne":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"QueryParamOne"
+        },
+        "QueryParamTwo":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"QueryParamTwo"
+        },
+        "StringHeaderMember":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-header-string"
+        },
+        "TimestampHeaderMember":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timearg"
+        },
+        "PayloadStructParam":{"shape":"PayloadStructType"}
+      }
+    },
+    "NonFlattenedListWithLocation":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"item"
+      }
+    },
+    "NonFlattenedMapWithLocation":{
+      "type":"map",
+      "key":{
+        "shape":"String",
+        "locationName":"thekey"
       },
-      "value": {
-        "shape": "ListOfStrings"
+      "value":{
+        "shape":"String",
+        "locationName":"thevalue"
       }
     },
-    "MapOfStringToString": {
-      "type": "map",
-      "key": {
-        "shape": "String"
+    "OperationWithExplicitPayloadBlobInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"BlobType"}
       },
-      "value": {
-        "shape": "String"
-      }
+      "payload":"PayloadMember"
     },
-    "MembersInHeadersInput": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-string"
-        },
-        "ListOfStringsMember": {
-          "shape": "ListOfStrings",
-          "location": "header",
-          "locationName": "x-amz-string-list"
-        },
-        "BooleanMember": {
-          "shape": "Boolean",
-          "location": "header",
-          "locationName": "x-amz-boolean"
-        },
-        "IntegerMember": {
-          "shape": "Integer",
-          "location": "header",
-          "locationName": "x-amz-integer"
-        },
-        "LongMember": {
-          "shape": "Long",
-          "location": "header",
-          "locationName": "x-amz-long"
-        },
-        "ShortMember": {
-          "shape": "Short",
-          "location": "header",
-          "locationName": "x-amz-short"
-        },
-        "FloatMember": {
-          "shape": "Float",
-          "location": "header",
-          "locationName": "x-amz-float"
-        },
-        "DoubleMember": {
-          "shape": "Double",
-          "location": "header",
-          "locationName": "x-amz-double"
-        },
-        "TimestampMember": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timestamp"
-        },
-        "MetadataMember": {
-          "shape": "Metadata",
-          "location": "header",
-          "locationName": "x-amz-meta-"
-        }
-      }
-    },
-    "MembersInQueryParamsInput": {
-      "type": "structure",
-      "members": {
-        "StringQueryParam": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "String"
-        },
-        "BooleanQueryParam": {
-          "shape": "Boolean",
-          "location": "querystring",
-          "locationName": "Boolean"
-        },
-        "IntegerQueryParam": {
-          "shape": "Integer",
-          "location": "querystring",
-          "locationName": "Integer"
-        },
-        "LongQueryParam": {
-          "shape": "Long",
-          "location": "querystring",
-          "locationName": "Long"
-        },
-        "ShortQueryParam": {
-          "shape": "Short",
-          "location": "querystring",
-          "locationName": "Short"
-        },
-        "FloatQueryParam": {
-          "shape": "Float",
-          "location": "querystring",
-          "locationName": "Float"
-        },
-        "DoubleQueryParam": {
-          "shape": "Double",
-          "location": "querystring",
-          "locationName": "Double"
-        },
-        "TimestampQueryParam": {
-          "shape": "Timestamp",
-          "location": "querystring",
-          "locationName": "Timestamp"
-        },
-        "ListOfStrings": {
-          "shape": "ListOfStrings",
-          "location": "querystring",
-          "locationName": "item"
-        },
-        "MapOfStringToString": {
-          "shape": "MapOfStringToString",
-          "location": "querystring"
-        }
-      }
-    },
-    "MultiLocationOperationInput": {
-      "type": "structure",
-      "required": [
-        "PathParam"
-      ],
-      "members": {
-        "PathParam": {
-          "shape": "String",
-          "location": "uri",
-          "locationName": "PathParam"
-        },
-        "QueryParamOne": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "QueryParamOne"
-        },
-        "QueryParamTwo": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "QueryParamTwo"
-        },
-        "StringHeaderMember": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-header-string"
-        },
-        "TimestampHeaderMember": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timearg"
-        },
-        "PayloadStructParam": {
-          "shape": "PayloadStructType"
-        }
-      }
-    },
-    "NonFlattenedListWithLocation": {
-      "type": "list",
-      "member": {
-        "shape": "String",
-        "locationName": "item"
-      }
-    },
-    "NonFlattenedMapWithLocation": {
-      "type": "map",
-      "key": {
-        "shape": "String",
-        "locationName": "thekey"
+    "OperationWithExplicitPayloadStringInput":{
+      "type":"structure",
+      "members":{
+        "PayloadMember":{"shape":"String"}
       },
-      "value": {
-        "shape": "String",
-        "locationName": "thevalue"
-      }
+      "payload":"PayloadMember"
     },
-    "OperationWithExplicitPayloadBlobInput": {
-      "type": "structure",
-      "members": {
-        "PayloadMember": {
-          "shape": "BlobType"
-        }
-      },
-      "payload": "PayloadMember"
-    },
-    "OperationWithExplicitPayloadStringInput": {
-      "type": "structure",
-      "members": {
-        "PayloadMember": {
-          "shape": "String"
-        }
-      },
-      "payload": "PayloadMember"
-    },
-    "OperationWithGreedyLabelInput": {
-      "type": "structure",
-      "required": [
+    "OperationWithGreedyLabelInput":{
+      "type":"structure",
+      "required":[
         "NonGreedyPathParam",
         "GreedyPathParam"
       ],
-      "members": {
-        "NonGreedyPathParam": {
-          "shape": "String",
-          "location": "uri",
-          "locationName": "NonGreedyPathParam"
+      "members":{
+        "NonGreedyPathParam":{
+          "shape":"String",
+          "location":"uri",
+          "locationName":"NonGreedyPathParam"
         },
-        "GreedyPathParam": {
-          "shape": "String",
-          "location": "uri",
-          "locationName": "GreedyPathParam"
+        "GreedyPathParam":{
+          "shape":"String",
+          "location":"uri",
+          "locationName":"GreedyPathParam"
         }
       }
     },
-    "OperationWithModeledContentTypeInput": {
-      "type": "structure",
-      "members": {
-        "ContentType": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "Content-Type"
+    "OperationWithModeledContentTypeInput":{
+      "type":"structure",
+      "members":{
+        "ContentType":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"Content-Type"
         }
       }
     },
-    "PayloadStructType": {
-      "type": "structure",
-      "members": {
-        "PayloadMemberOne": {
-          "shape": "String"
+    "PayloadStructType":{
+      "type":"structure",
+      "members":{
+        "PayloadMemberOne":{"shape":"String"},
+        "PayloadMemberTwo":{"shape":"String"}
+      }
+    },
+    "QueryParamWithoutValueInput":{
+      "type":"structure",
+      "members":{
+      }
+    },
+    "RestXmlTypesOutput":{
+      "type":"structure",
+      "members":{
+        "FlattenedListOfStrings":{"shape":"FlattenedListOfStrings"},
+        "NonFlattenedListWithLocation":{"shape":"NonFlattenedListWithLocation"},
+        "FlattenedListOfStructs":{"shape":"FlattenedListOfStructs"},
+        "FlattenedListWithLocation":{"shape":"FlattenedListWithLocation"},
+        "FlattenedMap":{"shape":"FlattenedMap"},
+        "FlattenedMapWithLocation":{
+          "shape":"FlattenedMapWithLocation",
+          "locationName":"flatmap"
         },
-        "PayloadMemberTwo": {
-          "shape": "String"
+        "NonFlattenedMapWithLocation":{
+          "shape":"NonFlattenedMapWithLocation",
+          "locationName":"themap"
+        },
+        "TimestampMemberInHeader":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timearg"
         }
       }
     },
-    "QueryParamWithoutValueInput": {
-      "type": "structure",
-      "members": {}
-    },
-    "RestXmlTypesOutput": {
-      "type": "structure",
-      "members": {
-        "FlattenedListOfStrings": {
-          "shape": "FlattenedListOfStrings"
+    "RestXmlTypesStructure":{
+      "type":"structure",
+      "members":{
+        "FlattenedListOfStrings":{"shape":"FlattenedListOfStrings"},
+        "NonFlattenedListWithLocation":{"shape":"NonFlattenedListWithLocation"},
+        "FlattenedListOfStructs":{"shape":"FlattenedListOfStructs"},
+        "FlattenedListWithLocation":{"shape":"FlattenedListWithLocation"},
+        "FlattenedMap":{"shape":"FlattenedMap"},
+        "FlattenedMapWithLocation":{
+          "shape":"FlattenedMapWithLocation",
+          "locationName":"flatmap"
         },
-        "NonFlattenedListWithLocation": {
-          "shape": "NonFlattenedListWithLocation"
+        "NonFlattenedMapWithLocation":{
+          "shape":"NonFlattenedMapWithLocation",
+          "locationName":"themap"
         },
-        "FlattenedListOfStructs": {
-          "shape": "FlattenedListOfStructs"
+        "StringMemberInQuery":{
+          "shape":"String",
+          "location":"querystring",
+          "locationName":"stringMemberInQuery"
         },
-        "FlattenedListWithLocation": {
-          "shape": "FlattenedListWithLocation"
+        "TimestampMemberInHeader":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timearg"
         },
-        "FlattenedMap": {
-          "shape": "FlattenedMap"
+        "ListOfStringsInQuery":{
+          "shape":"ListOfStrings",
+          "location":"querystring",
+          "locationName":"listOfStrings"
         },
-        "FlattenedMapWithLocation": {
-          "shape": "FlattenedMapWithLocation",
-          "locationName": "flatmap"
-        },
-        "NonFlattenedMapWithLocation": {
-          "shape": "NonFlattenedMapWithLocation",
-          "locationName": "themap"
-        },
-        "TimestampMemberInHeader": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timearg"
+        "MapOfStringToStringInQuery":{
+          "shape":"MapOfStringToString",
+          "location":"querystring"
         }
       }
     },
-    "RestXmlTypesStructure": {
-      "type": "structure",
-      "members": {
-        "FlattenedListOfStrings": {
-          "shape": "FlattenedListOfStrings"
-        },
-        "NonFlattenedListWithLocation": {
-          "shape": "NonFlattenedListWithLocation"
-        },
-        "FlattenedListOfStructs": {
-          "shape": "FlattenedListOfStructs"
-        },
-        "FlattenedListWithLocation": {
-          "shape": "FlattenedListWithLocation"
-        },
-        "FlattenedMap": {
-          "shape": "FlattenedMap"
-        },
-        "FlattenedMapWithLocation": {
-          "shape": "FlattenedMapWithLocation",
-          "locationName": "flatmap"
-        },
-        "NonFlattenedMapWithLocation": {
-          "shape": "NonFlattenedMapWithLocation",
-          "locationName": "themap"
-        },
-        "StringMemberInQuery": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "stringMemberInQuery"
-        },
-        "TimestampMemberInHeader": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timearg"
-        },
-        "ListOfStringsInQuery": {
-          "shape": "ListOfStrings",
-          "location": "querystring",
-          "locationName": "listOfStrings"
-        },
-        "MapOfStringToStringInQuery": {
-          "shape": "MapOfStringToString",
-          "location": "querystring"
-        }
+    "SimpleStruct":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"}
       }
     },
-    "SimpleStruct": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        }
+    "String":{"type":"string"},
+    "StructWithTimestamp":{
+      "type":"structure",
+      "members":{
+        "NestedTimestamp":{"shape":"Timestamp"}
       }
     },
-    "String": {
-      "type": "string"
-    },
-    "StructWithTimestamp": {
-      "type": "structure",
-      "members": {
-        "NestedTimestamp": {
-          "shape": "Timestamp"
-        }
-      }
-    },
-    "ImplicitPayloadException": {
-      "type": "structure",
-      "members": {
-        "StringMember": {
-          "shape": "String"
-        },
-        "IntegerMember": {
-          "shape": "Integer"
-        },
-        "LongMember": {
-          "shape": "Long"
-        },
-        "ShortMember": {
-          "shape": "Short"
-        },
-        "DoubleMember": {
-          "shape": "Double"
-        },
-        "FloatMember": {
-          "shape": "Float"
-        },
-        "TimestampMember": {
-          "shape": "Timestamp"
-        },
-        "BooleanMember": {
-          "shape": "Boolean"
-        },
-        "BlobMember": {
-          "shape": "BlobType"
-        },
-        "ListMember": {
-          "shape": "ListOfStrings"
-        },
-        "MapMember": {
-          "shape": "MapOfStringToString"
-        },
-        "SimpleStructMember": {
-          "shape": "SimpleStruct"
-        }
+    "ImplicitPayloadException":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"},
+        "IntegerMember":{"shape":"Integer"},
+        "LongMember":{"shape":"Long"},
+        "ShortMember":{"shape":"Short"},
+        "DoubleMember":{"shape":"Double"},
+        "FloatMember":{"shape":"Float"},
+        "TimestampMember":{"shape":"Timestamp"},
+        "BooleanMember":{"shape":"Boolean"},
+        "BlobMember":{"shape":"BlobType"},
+        "ListMember":{"shape":"ListOfStrings"},
+        "MapMember":{"shape":"MapOfStringToString"},
+        "SimpleStructMember":{"shape":"SimpleStruct"}
       },
-      "exception": true
+      "exception":true
     },
-    "ExplicitPayloadAndHeadersException": {
-      "type": "structure",
-      "members": {
-        "StringHeader": {
-          "shape": "String",
-          "location": "header",
-          "locationName": "x-amz-string"
+    "ExplicitPayloadAndHeadersException":{
+      "type":"structure",
+      "members":{
+        "StringHeader":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"x-amz-string"
         },
-        "IntegerHeader": {
-          "shape": "Integer",
-          "location": "header",
-          "locationName": "x-amz-integer"
+        "IntegerHeader":{
+          "shape":"Integer",
+          "location":"header",
+          "locationName":"x-amz-integer"
         },
-        "LongHeader": {
-          "shape": "Long",
-          "location": "header",
-          "locationName": "x-amz-long"
+        "LongHeader":{
+          "shape":"Long",
+          "location":"header",
+          "locationName":"x-amz-long"
         },
-        "ShortHeader": {
-          "shape": "Short",
-          "location": "header",
-          "locationName": "x-amz-short"
+        "ShortHeader":{
+          "shape":"Short",
+          "location":"header",
+          "locationName":"x-amz-short"
         },
-        "DoubleHeader": {
-          "shape": "Double",
-          "location": "header",
-          "locationName": "x-amz-double"
+        "DoubleHeader":{
+          "shape":"Double",
+          "location":"header",
+          "locationName":"x-amz-double"
         },
-        "FloatHeader": {
-          "shape": "Float",
-          "location": "header",
-          "locationName": "x-amz-float"
+        "FloatHeader":{
+          "shape":"Float",
+          "location":"header",
+          "locationName":"x-amz-float"
         },
-        "TimestampHeader": {
-          "shape": "Timestamp",
-          "location": "header",
-          "locationName": "x-amz-timestamp"
+        "TimestampHeader":{
+          "shape":"Timestamp",
+          "location":"header",
+          "locationName":"x-amz-timestamp"
         },
-        "BooleanHeader": {
-          "shape": "Boolean",
-          "location": "header",
-          "locationName": "x-amz-boolean"
+        "BooleanHeader":{
+          "shape":"Boolean",
+          "location":"header",
+          "locationName":"x-amz-boolean"
         },
-        "PayloadMember": {
-          "shape": "SimpleStruct"
-        }
+        "PayloadMember":{"shape":"SimpleStruct"}
       },
-      "exception": true,
-      "payload": "PayloadMember"
+      "exception":true,
+      "payload":"PayloadMember"
     },
-    "Timestamp": {
-      "type": "timestamp"
+    "Timestamp":{"type":"timestamp"},
+    "Metadata":{
+      "type":"map",
+      "key":{"shape":"MetadataKey"},
+      "value":{"shape":"MetadataValue"}
     },
-    "Metadata": {
-      "type": "map",
-      "key": {
-        "shape": "MetadataKey"
-      },
-      "value": {
-        "shape": "MetadataValue"
-      }
-    },
-    "MetadataKey": {
-      "type": "string"
-    },
-    "MetadataValue": {
-      "type": "string"
-    },
-    "MapInHeadersInput": {
-      "type": "structure",
-      "members": {
-        "MetadataMember": {
-          "shape": "Metadata",
-          "location": "header",
-          "locationName": "x-amz-meta-"
+    "MetadataKey":{"type":"string"},
+    "MetadataValue":{"type":"string"},
+    "MapInHeadersInput":{
+      "type":"structure",
+      "members":{
+        "MetadataMember":{
+          "shape":"Metadata",
+          "location":"header",
+          "locationName":"x-amz-meta-"
         }
       }
     },
     "EventStreamOperationRequest": {
       "type": "structure",
-      "members": {}
+      "members": {
+      }
     },
     "EventStreamOutput": {
       "type": "structure",

--- a/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
@@ -1,141 +1,191 @@
 {
-  "version":"2.0",
-  "metadata":{
-    "apiVersion":"2016-03-11",
-    "endpointPrefix":"restxml",
-    "protocol":"rest-xml",
-    "serviceAbbreviation":"AmazonProtocolRestXml",
-    "serviceFullName":"AWS DR Tools Rest-XML Protocol Tests",
-    "serviceId":"AmazonProtocolRestXml",
-    "signatureVersion":"v4",
-    "targetPrefix":"ProtocolTestsRestXmlService",
-    "timestampFormat":"unixTimestamp"
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2016-03-11",
+    "endpointPrefix": "restxml",
+    "protocol": "rest-xml",
+    "serviceAbbreviation": "AmazonProtocolRestXml",
+    "serviceFullName": "AWS DR Tools Rest-XML Protocol Tests",
+    "serviceId": "AmazonProtocolRestXml",
+    "signatureVersion": "v4",
+    "targetPrefix": "ProtocolTestsRestXmlService",
+    "timestampFormat": "unixTimestamp"
   },
-  "operations":{
-    "AllTypes":{
-      "name":"AllTypes",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/allTypes"
+  "operations": {
+    "AllTypes": {
+      "name": "AllTypes",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/allTypes"
       },
-      "input":{
-        "shape":"AllTypesStructure",
-        "locationName":"AllTypesRequest",
-        "xmlNamespace":{"uri":"https://restxml/"}
+      "input": {
+        "shape": "AllTypesStructure",
+        "locationName": "AllTypesRequest",
+        "xmlNamespace": {
+          "uri": "https://restxml/"
+        }
       },
-      "output":{"shape":"AllTypesStructure"},
-      "errors":[
-        {"shape":"EmptyModeledException"},
-        {"shape":"ExplicitPayloadAndHeadersException"},
-        {"shape":"ImplicitPayloadException"}
+      "output": {
+        "shape": "AllTypesStructure"
+      },
+      "errors": [
+        {
+          "shape": "EmptyModeledException"
+        },
+        {
+          "shape": "ExplicitPayloadAndHeadersException"
+        },
+        {
+          "shape": "ImplicitPayloadException"
+        }
       ]
     },
-    "DeleteOperation":{
-      "name":"DeleteOperation",
-      "http":{
-        "method":"DELETE",
-        "requestUri":"/2016-03-11/deleteOperation"
+    "DeleteOperation": {
+      "name": "DeleteOperation",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/2016-03-11/deleteOperation"
       }
     },
-    "IdempotentOperation":{
-      "name":"IdempotentOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/idempotentOperation/{PathParam}"
+    "IdempotentOperation": {
+      "name": "IdempotentOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/idempotentOperation/{PathParam}"
       },
-      "input":{"shape":"IdempotentOperationStructure"}
-    },
-    "MapOfStringToListOfStringInQueryParams":{
-      "name":"MapOfStringToListOfStringInQueryParams",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/mapOfStringToListOfStringInQueryParams"
-      },
-      "input":{"shape":"MapOfStringToListOfStringInQueryParamsInput"}
-    },
-    "MembersInHeaders":{
-      "name":"MembersInHeaders",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/membersInHeaders"
-      },
-      "input":{"shape":"MembersInHeadersInput"},
-      "output":{"shape":"MembersInHeadersInput"}
-    },
-    "MembersInQueryParams":{
-      "name":"MembersInQueryParams",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
-      },
-      "input":{"shape":"MembersInQueryParamsInput"}
-    },
-    "MultiLocationOperation":{
-      "name":"MultiLocationOperation",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/multiLocationOperation/{PathParam}"
-      },
-      "input":{
-        "shape":"MultiLocationOperationInput",
-        "locationName":"MultiLocationOperationRequest",
-        "xmlNamespace":{"uri":"https://restxml/"}
+      "input": {
+        "shape": "IdempotentOperationStructure"
       }
     },
-    "OperationWithExplicitPayloadBlob":{
-      "name":"OperationWithExplicitPayloadBlob",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithExplicitPayloadBlob"
+    "MapOfStringToListOfStringInQueryParams": {
+      "name": "MapOfStringToListOfStringInQueryParams",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/mapOfStringToListOfStringInQueryParams"
       },
-      "input":{"shape":"OperationWithExplicitPayloadBlobInput"},
-      "output":{"shape":"OperationWithExplicitPayloadBlobInput"}
+      "input": {
+        "shape": "MapOfStringToListOfStringInQueryParamsInput"
+      }
     },
-    "OperationWithExplicitPayloadString":{
-      "name":"OperationWithExplicitPayloadString",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithExplicitPayloadString"
+    "MembersInHeaders": {
+      "name": "MembersInHeaders",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/membersInHeaders"
       },
-      "input":{"shape":"OperationWithExplicitPayloadStringInput"},
-      "output":{"shape":"OperationWithExplicitPayloadStringInput"}
+      "input": {
+        "shape": "MembersInHeadersInput"
+      },
+      "output": {
+        "shape": "MembersInHeadersInput"
+      }
     },
-    "OperationWithGreedyLabel":{
-      "name":"OperationWithGreedyLabel",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
+    "MapInHeaders": {
+      "name": "MapInHeaders",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/mapInHeaders"
       },
-      "input":{"shape":"OperationWithGreedyLabelInput"}
+      "input": {
+        "shape": "MapInHeadersInput"
+      }
     },
-    "OperationWithModeledContentType":{
-      "name":"OperationWithModeledContentType",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/operationWithModeledContentType"
+    "MembersInQueryParams": {
+      "name": "MembersInQueryParams",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
       },
-      "input":{"shape":"OperationWithModeledContentTypeInput"}
+      "input": {
+        "shape": "MembersInQueryParamsInput"
+      }
     },
-    "QueryParamWithoutValue":{
-      "name":"QueryParamWithoutValue",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/queryParamWithoutValue?param"
+    "MultiLocationOperation": {
+      "name": "MultiLocationOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/multiLocationOperation/{PathParam}"
       },
-      "input":{"shape":"QueryParamWithoutValueInput"}
+      "input": {
+        "shape": "MultiLocationOperationInput",
+        "locationName": "MultiLocationOperationRequest",
+        "xmlNamespace": {
+          "uri": "https://restxml/"
+        }
+      }
     },
-    "RestXmlTypes":{
-      "name":"RestXmlTypes",
-      "http":{
-        "method":"POST",
-        "requestUri":"/2016-03-11/restXmlTypes"
+    "OperationWithExplicitPayloadBlob": {
+      "name": "OperationWithExplicitPayloadBlob",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithExplicitPayloadBlob"
       },
-      "input":{
-        "shape":"RestXmlTypesStructure",
-        "locationName":"RestXmlTypesRequest",
-        "xmlNamespace":{"uri":"https://restxml/"}
+      "input": {
+        "shape": "OperationWithExplicitPayloadBlobInput"
       },
-      "output":{"shape":"RestXmlTypesOutput"}
+      "output": {
+        "shape": "OperationWithExplicitPayloadBlobInput"
+      }
+    },
+    "OperationWithExplicitPayloadString": {
+      "name": "OperationWithExplicitPayloadString",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithExplicitPayloadString"
+      },
+      "input": {
+        "shape": "OperationWithExplicitPayloadStringInput"
+      },
+      "output": {
+        "shape": "OperationWithExplicitPayloadStringInput"
+      }
+    },
+    "OperationWithGreedyLabel": {
+      "name": "OperationWithGreedyLabel",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithGreedyLabel/{NonGreedyPathParam}/{GreedyPathParam+}"
+      },
+      "input": {
+        "shape": "OperationWithGreedyLabelInput"
+      }
+    },
+    "OperationWithModeledContentType": {
+      "name": "OperationWithModeledContentType",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/operationWithModeledContentType"
+      },
+      "input": {
+        "shape": "OperationWithModeledContentTypeInput"
+      }
+    },
+    "QueryParamWithoutValue": {
+      "name": "QueryParamWithoutValue",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/queryParamWithoutValue?param"
+      },
+      "input": {
+        "shape": "QueryParamWithoutValueInput"
+      }
+    },
+    "RestXmlTypes": {
+      "name": "RestXmlTypes",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/restXmlTypes"
+      },
+      "input": {
+        "shape": "RestXmlTypesStructure",
+        "locationName": "RestXmlTypesRequest",
+        "xmlNamespace": {
+          "uri": "https://restxml/"
+        }
+      },
+      "output": {
+        "shape": "RestXmlTypesOutput"
+      }
     },
     "EventStreamOperation": {
       "name": "EventStreamOperation",
@@ -151,502 +201,657 @@
       }
     }
   },
-  "shapes":{
-    "AllTypesStructure":{
-      "type":"structure",
-      "members":{
-        "stringMember":{"shape":"String"},
-        "integerMember":{"shape":"Integer"},
-        "booleanMember":{"shape":"Boolean"},
-        "floatMember":{"shape":"Float"},
-        "doubleMember":{"shape":"Double"},
-        "longMember":{"shape":"Long"},
-        "shortMember":{"shape":"Short"},
-        "simpleStructMember":{"shape":"SimpleStruct"},
-        "simpleList":{"shape":"ListOfStrings"},
-        "listOfStructs":{"shape":"ListOfSimpleStructs"},
-        "mapOfStringToString":{"shape":"MapOfStringToString"},
-        "timestampMember":{"shape":"Timestamp"},
-        "structWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
-        "blobArg":{"shape":"BlobType"},
-        "blobMap":{"shape":"BlobMapType"},
-        "listOfBlobs":{"shape":"ListOfBlobsType"}
-      }
-    },
-    "BlobMapType":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"BlobType"}
-    },
-    "BlobType":{"type":"blob"},
-    "Boolean":{"type":"boolean"},
-    "Double":{"type":"double"},
-    "EmptyModeledException":{
-      "type":"structure",
-      "members":{
-      },
-      "exception":true
-    },
-    "FlattenedListOfStrings":{
-      "type":"list",
-      "member":{"shape":"String"},
-      "flattened":true
-    },
-    "FlattenedListOfStructs":{
-      "type":"list",
-      "member":{"shape":"SimpleStruct"},
-      "flattened":true
-    },
-    "FlattenedListWithLocation":{
-      "type":"list",
-      "member":{
-        "shape":"String",
-        "locationName":"item"
-      },
-      "flattened":true
-    },
-    "FlattenedMap":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"String"},
-      "flattened":true
-    },
-    "FlattenedMapWithLocation":{
-      "type":"map",
-      "key":{
-        "shape":"String",
-        "locationName":"thekey"
-      },
-      "value":{
-        "shape":"String",
-        "locationName":"thevalue"
-      },
-      "flattened":true
-    },
-    "Float":{"type":"float"},
-    "IdempotentOperationStructure":{
-      "type":"structure",
-      "required":["PathIdempotentToken"],
-      "members":{
-        "PathIdempotentToken":{
-          "shape":"String",
-          "idempotencyToken":true,
-          "location":"uri",
-          "locationName":"PathParam"
+  "shapes": {
+    "AllTypesStructure": {
+      "type": "structure",
+      "members": {
+        "stringMember": {
+          "shape": "String"
         },
-        "QueryIdempotentToken":{
-          "shape":"String",
-          "idempotencyToken":true,
-          "location":"querystring",
-          "locationName":"QueryParam"
+        "integerMember": {
+          "shape": "Integer"
         },
-        "HeaderIdempotentToken":{
-          "shape":"String",
-          "idempotencyToken":true,
-          "location":"header",
-          "locationName":"x-amz-idempotent-header"
+        "booleanMember": {
+          "shape": "Boolean"
+        },
+        "floatMember": {
+          "shape": "Float"
+        },
+        "doubleMember": {
+          "shape": "Double"
+        },
+        "longMember": {
+          "shape": "Long"
+        },
+        "shortMember": {
+          "shape": "Short"
+        },
+        "simpleStructMember": {
+          "shape": "SimpleStruct"
+        },
+        "simpleList": {
+          "shape": "ListOfStrings"
+        },
+        "listOfStructs": {
+          "shape": "ListOfSimpleStructs"
+        },
+        "mapOfStringToString": {
+          "shape": "MapOfStringToString"
+        },
+        "timestampMember": {
+          "shape": "Timestamp"
+        },
+        "structWithNestedTimestampMember": {
+          "shape": "StructWithTimestamp"
+        },
+        "blobArg": {
+          "shape": "BlobType"
+        },
+        "blobMap": {
+          "shape": "BlobMapType"
+        },
+        "listOfBlobs": {
+          "shape": "ListOfBlobsType"
         }
       }
     },
-    "Integer":{"type":"integer"},
-    "ListOfBlobsType":{
-      "type":"list",
-      "member":{"shape":"BlobType"}
+    "BlobMapType": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "BlobType"
+      }
     },
-    "ListOfSimpleStructs":{
-      "type":"list",
-      "member":{"shape":"SimpleStruct"}
+    "BlobType": {
+      "type": "blob"
     },
-    "ListOfStrings":{
-      "type":"list",
-      "member":{"shape":"String"}
+    "Boolean": {
+      "type": "boolean"
     },
-    "Long":{"type":"long"},
-    "Short":{"type":"short"},
-    "MapOfStringToListOfStringInQueryParamsInput":{
-      "type":"structure",
-      "members":{
-        "MapOfStringToListOfStrings":{
-          "shape":"MapOfStringToListOfStrings",
-          "location":"querystring"
+    "Double": {
+      "type": "double"
+    },
+    "EmptyModeledException": {
+      "type": "structure",
+      "members": {},
+      "exception": true
+    },
+    "FlattenedListOfStrings": {
+      "type": "list",
+      "member": {
+        "shape": "String"
+      },
+      "flattened": true
+    },
+    "FlattenedListOfStructs": {
+      "type": "list",
+      "member": {
+        "shape": "SimpleStruct"
+      },
+      "flattened": true
+    },
+    "FlattenedListWithLocation": {
+      "type": "list",
+      "member": {
+        "shape": "String",
+        "locationName": "item"
+      },
+      "flattened": true
+    },
+    "FlattenedMap": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "String"
+      },
+      "flattened": true
+    },
+    "FlattenedMapWithLocation": {
+      "type": "map",
+      "key": {
+        "shape": "String",
+        "locationName": "thekey"
+      },
+      "value": {
+        "shape": "String",
+        "locationName": "thevalue"
+      },
+      "flattened": true
+    },
+    "Float": {
+      "type": "float"
+    },
+    "IdempotentOperationStructure": {
+      "type": "structure",
+      "required": [
+        "PathIdempotentToken"
+      ],
+      "members": {
+        "PathIdempotentToken": {
+          "shape": "String",
+          "idempotencyToken": true,
+          "location": "uri",
+          "locationName": "PathParam"
+        },
+        "QueryIdempotentToken": {
+          "shape": "String",
+          "idempotencyToken": true,
+          "location": "querystring",
+          "locationName": "QueryParam"
+        },
+        "HeaderIdempotentToken": {
+          "shape": "String",
+          "idempotencyToken": true,
+          "location": "header",
+          "locationName": "x-amz-idempotent-header"
         }
       }
     },
-    "MapOfStringToListOfStrings":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"ListOfStrings"}
+    "Integer": {
+      "type": "integer"
     },
-    "MapOfStringToString":{
-      "type":"map",
-      "key":{"shape":"String"},
-      "value":{"shape":"String"}
+    "ListOfBlobsType": {
+      "type": "list",
+      "member": {
+        "shape": "BlobType"
+      }
     },
-    "MembersInHeadersInput":{
-      "type":"structure",
-      "members":{
-        "StringMember":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-string"
-        },
-        "ListOfStringsMember":{
-          "shape":"ListOfStrings",
-          "location":"header",
-          "locationName":"x-amz-string-list"
-        },
-        "BooleanMember":{
-          "shape":"Boolean",
-          "location":"header",
-          "locationName":"x-amz-boolean"
-        },
-        "IntegerMember":{
-          "shape":"Integer",
-          "location":"header",
-          "locationName":"x-amz-integer"
-        },
-        "LongMember":{
-          "shape":"Long",
-          "location":"header",
-          "locationName":"x-amz-long"
-        },
-        "ShortMember":{
-          "shape":"Short",
-          "location":"header",
-          "locationName":"x-amz-short"
-        },
-        "FloatMember":{
-          "shape":"Float",
-          "location":"header",
-          "locationName":"x-amz-float"
-        },
-        "DoubleMember":{
-          "shape":"Double",
-          "location":"header",
-          "locationName":"x-amz-double"
-        },
-        "TimestampMember":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timestamp"
-        },
-        "MetadataMember":{
-          "shape":"Metadata",
-          "location":"header",
-          "locationName":"x-amz-meta-"
+    "ListOfSimpleStructs": {
+      "type": "list",
+      "member": {
+        "shape": "SimpleStruct"
+      }
+    },
+    "ListOfStrings": {
+      "type": "list",
+      "member": {
+        "shape": "String"
+      }
+    },
+    "Long": {
+      "type": "long"
+    },
+    "Short": {
+      "type": "short"
+    },
+    "MapOfStringToListOfStringInQueryParamsInput": {
+      "type": "structure",
+      "members": {
+        "MapOfStringToListOfStrings": {
+          "shape": "MapOfStringToListOfStrings",
+          "location": "querystring"
         }
       }
     },
-    "MembersInQueryParamsInput":{
-      "type":"structure",
-      "members":{
-        "StringQueryParam":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"String"
+    "MapOfStringToListOfStrings": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "ListOfStrings"
+      }
+    },
+    "MapOfStringToString": {
+      "type": "map",
+      "key": {
+        "shape": "String"
+      },
+      "value": {
+        "shape": "String"
+      }
+    },
+    "MembersInHeadersInput": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-string"
         },
-        "BooleanQueryParam":{
-          "shape":"Boolean",
-          "location":"querystring",
-          "locationName":"Boolean"
+        "ListOfStringsMember": {
+          "shape": "ListOfStrings",
+          "location": "header",
+          "locationName": "x-amz-string-list"
         },
-        "IntegerQueryParam":{
-          "shape":"Integer",
-          "location":"querystring",
-          "locationName":"Integer"
+        "BooleanMember": {
+          "shape": "Boolean",
+          "location": "header",
+          "locationName": "x-amz-boolean"
         },
-        "LongQueryParam":{
-          "shape":"Long",
-          "location":"querystring",
-          "locationName":"Long"
+        "IntegerMember": {
+          "shape": "Integer",
+          "location": "header",
+          "locationName": "x-amz-integer"
         },
-        "ShortQueryParam":{
-          "shape":"Short",
-          "location":"querystring",
-          "locationName":"Short"
+        "LongMember": {
+          "shape": "Long",
+          "location": "header",
+          "locationName": "x-amz-long"
         },
-        "FloatQueryParam":{
-          "shape":"Float",
-          "location":"querystring",
-          "locationName":"Float"
+        "ShortMember": {
+          "shape": "Short",
+          "location": "header",
+          "locationName": "x-amz-short"
         },
-        "DoubleQueryParam":{
-          "shape":"Double",
-          "location":"querystring",
-          "locationName":"Double"
+        "FloatMember": {
+          "shape": "Float",
+          "location": "header",
+          "locationName": "x-amz-float"
         },
-        "TimestampQueryParam":{
-          "shape":"Timestamp",
-          "location":"querystring",
-          "locationName":"Timestamp"
+        "DoubleMember": {
+          "shape": "Double",
+          "location": "header",
+          "locationName": "x-amz-double"
         },
-        "ListOfStrings":{
-          "shape":"ListOfStrings",
-          "location":"querystring",
-          "locationName":"item"
+        "TimestampMember": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timestamp"
         },
-        "MapOfStringToString":{
-          "shape":"MapOfStringToString",
-          "location":"querystring"
+        "MetadataMember": {
+          "shape": "Metadata",
+          "location": "header",
+          "locationName": "x-amz-meta-"
         }
       }
     },
-    "MultiLocationOperationInput":{
-      "type":"structure",
-      "required":["PathParam"],
-      "members":{
-        "PathParam":{
-          "shape":"String",
-          "location":"uri",
-          "locationName":"PathParam"
+    "MembersInQueryParamsInput": {
+      "type": "structure",
+      "members": {
+        "StringQueryParam": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "String"
         },
-        "QueryParamOne":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"QueryParamOne"
+        "BooleanQueryParam": {
+          "shape": "Boolean",
+          "location": "querystring",
+          "locationName": "Boolean"
         },
-        "QueryParamTwo":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"QueryParamTwo"
+        "IntegerQueryParam": {
+          "shape": "Integer",
+          "location": "querystring",
+          "locationName": "Integer"
         },
-        "StringHeaderMember":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-header-string"
+        "LongQueryParam": {
+          "shape": "Long",
+          "location": "querystring",
+          "locationName": "Long"
         },
-        "TimestampHeaderMember":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timearg"
+        "ShortQueryParam": {
+          "shape": "Short",
+          "location": "querystring",
+          "locationName": "Short"
         },
-        "PayloadStructParam":{"shape":"PayloadStructType"}
+        "FloatQueryParam": {
+          "shape": "Float",
+          "location": "querystring",
+          "locationName": "Float"
+        },
+        "DoubleQueryParam": {
+          "shape": "Double",
+          "location": "querystring",
+          "locationName": "Double"
+        },
+        "TimestampQueryParam": {
+          "shape": "Timestamp",
+          "location": "querystring",
+          "locationName": "Timestamp"
+        },
+        "ListOfStrings": {
+          "shape": "ListOfStrings",
+          "location": "querystring",
+          "locationName": "item"
+        },
+        "MapOfStringToString": {
+          "shape": "MapOfStringToString",
+          "location": "querystring"
+        }
       }
     },
-    "NonFlattenedListWithLocation":{
-      "type":"list",
-      "member":{
-        "shape":"String",
-        "locationName":"item"
+    "MultiLocationOperationInput": {
+      "type": "structure",
+      "required": [
+        "PathParam"
+      ],
+      "members": {
+        "PathParam": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "PathParam"
+        },
+        "QueryParamOne": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "QueryParamOne"
+        },
+        "QueryParamTwo": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "QueryParamTwo"
+        },
+        "StringHeaderMember": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-header-string"
+        },
+        "TimestampHeaderMember": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timearg"
+        },
+        "PayloadStructParam": {
+          "shape": "PayloadStructType"
+        }
       }
     },
-    "NonFlattenedMapWithLocation":{
-      "type":"map",
-      "key":{
-        "shape":"String",
-        "locationName":"thekey"
-      },
-      "value":{
-        "shape":"String",
-        "locationName":"thevalue"
+    "NonFlattenedListWithLocation": {
+      "type": "list",
+      "member": {
+        "shape": "String",
+        "locationName": "item"
       }
     },
-    "OperationWithExplicitPayloadBlobInput":{
-      "type":"structure",
-      "members":{
-        "PayloadMember":{"shape":"BlobType"}
+    "NonFlattenedMapWithLocation": {
+      "type": "map",
+      "key": {
+        "shape": "String",
+        "locationName": "thekey"
       },
-      "payload":"PayloadMember"
+      "value": {
+        "shape": "String",
+        "locationName": "thevalue"
+      }
     },
-    "OperationWithExplicitPayloadStringInput":{
-      "type":"structure",
-      "members":{
-        "PayloadMember":{"shape":"String"}
+    "OperationWithExplicitPayloadBlobInput": {
+      "type": "structure",
+      "members": {
+        "PayloadMember": {
+          "shape": "BlobType"
+        }
       },
-      "payload":"PayloadMember"
+      "payload": "PayloadMember"
     },
-    "OperationWithGreedyLabelInput":{
-      "type":"structure",
-      "required":[
+    "OperationWithExplicitPayloadStringInput": {
+      "type": "structure",
+      "members": {
+        "PayloadMember": {
+          "shape": "String"
+        }
+      },
+      "payload": "PayloadMember"
+    },
+    "OperationWithGreedyLabelInput": {
+      "type": "structure",
+      "required": [
         "NonGreedyPathParam",
         "GreedyPathParam"
       ],
-      "members":{
-        "NonGreedyPathParam":{
-          "shape":"String",
-          "location":"uri",
-          "locationName":"NonGreedyPathParam"
+      "members": {
+        "NonGreedyPathParam": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "NonGreedyPathParam"
         },
-        "GreedyPathParam":{
-          "shape":"String",
-          "location":"uri",
-          "locationName":"GreedyPathParam"
+        "GreedyPathParam": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "GreedyPathParam"
         }
       }
     },
-    "OperationWithModeledContentTypeInput":{
-      "type":"structure",
-      "members":{
-        "ContentType":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"Content-Type"
-        }
-      }
-    },
-    "PayloadStructType":{
-      "type":"structure",
-      "members":{
-        "PayloadMemberOne":{"shape":"String"},
-        "PayloadMemberTwo":{"shape":"String"}
-      }
-    },
-    "QueryParamWithoutValueInput":{
-      "type":"structure",
-      "members":{
-      }
-    },
-    "RestXmlTypesOutput":{
-      "type":"structure",
-      "members":{
-        "FlattenedListOfStrings":{"shape":"FlattenedListOfStrings"},
-        "NonFlattenedListWithLocation":{"shape":"NonFlattenedListWithLocation"},
-        "FlattenedListOfStructs":{"shape":"FlattenedListOfStructs"},
-        "FlattenedListWithLocation":{"shape":"FlattenedListWithLocation"},
-        "FlattenedMap":{"shape":"FlattenedMap"},
-        "FlattenedMapWithLocation":{
-          "shape":"FlattenedMapWithLocation",
-          "locationName":"flatmap"
-        },
-        "NonFlattenedMapWithLocation":{
-          "shape":"NonFlattenedMapWithLocation",
-          "locationName":"themap"
-        },
-        "TimestampMemberInHeader":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timearg"
-        }
-      }
-    },
-    "RestXmlTypesStructure":{
-      "type":"structure",
-      "members":{
-        "FlattenedListOfStrings":{"shape":"FlattenedListOfStrings"},
-        "NonFlattenedListWithLocation":{"shape":"NonFlattenedListWithLocation"},
-        "FlattenedListOfStructs":{"shape":"FlattenedListOfStructs"},
-        "FlattenedListWithLocation":{"shape":"FlattenedListWithLocation"},
-        "FlattenedMap":{"shape":"FlattenedMap"},
-        "FlattenedMapWithLocation":{
-          "shape":"FlattenedMapWithLocation",
-          "locationName":"flatmap"
-        },
-        "NonFlattenedMapWithLocation":{
-          "shape":"NonFlattenedMapWithLocation",
-          "locationName":"themap"
-        },
-        "StringMemberInQuery":{
-          "shape":"String",
-          "location":"querystring",
-          "locationName":"stringMemberInQuery"
-        },
-        "TimestampMemberInHeader":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timearg"
-        },
-        "ListOfStringsInQuery":{
-          "shape":"ListOfStrings",
-          "location":"querystring",
-          "locationName":"listOfStrings"
-        },
-        "MapOfStringToStringInQuery":{
-          "shape":"MapOfStringToString",
-          "location":"querystring"
-        }
-      }
-    },
-    "SimpleStruct":{
-      "type":"structure",
-      "members":{
-        "StringMember":{"shape":"String"}
-      }
-    },
-    "String":{"type":"string"},
-    "StructWithTimestamp":{
-      "type":"structure",
-      "members":{
-        "NestedTimestamp":{"shape":"Timestamp"}
-      }
-    },
-    "ImplicitPayloadException":{
-      "type":"structure",
-      "members":{
-        "StringMember":{"shape":"String"},
-        "IntegerMember":{"shape":"Integer"},
-        "LongMember":{"shape":"Long"},
-        "ShortMember":{"shape":"Short"},
-        "DoubleMember":{"shape":"Double"},
-        "FloatMember":{"shape":"Float"},
-        "TimestampMember":{"shape":"Timestamp"},
-        "BooleanMember":{"shape":"Boolean"},
-        "BlobMember":{"shape":"BlobType"},
-        "ListMember":{"shape":"ListOfStrings"},
-        "MapMember":{"shape":"MapOfStringToString"},
-        "SimpleStructMember":{"shape":"SimpleStruct"}
-      },
-      "exception":true
-    },
-    "ExplicitPayloadAndHeadersException":{
-      "type":"structure",
-      "members":{
-        "StringHeader":{
-          "shape":"String",
-          "location":"header",
-          "locationName":"x-amz-string"
-        },
-        "IntegerHeader":{
-          "shape":"Integer",
-          "location":"header",
-          "locationName":"x-amz-integer"
-        },
-        "LongHeader":{
-          "shape":"Long",
-          "location":"header",
-          "locationName":"x-amz-long"
-        },
-        "ShortHeader":{
-          "shape":"Short",
-          "location":"header",
-          "locationName":"x-amz-short"
-        },
-        "DoubleHeader":{
-          "shape":"Double",
-          "location":"header",
-          "locationName":"x-amz-double"
-        },
-        "FloatHeader":{
-          "shape":"Float",
-          "location":"header",
-          "locationName":"x-amz-float"
-        },
-        "TimestampHeader":{
-          "shape":"Timestamp",
-          "location":"header",
-          "locationName":"x-amz-timestamp"
-        },
-        "BooleanHeader":{
-          "shape":"Boolean",
-          "location":"header",
-          "locationName":"x-amz-boolean"
-        },
-        "PayloadMember":{"shape":"SimpleStruct"}
-      },
-      "exception":true,
-      "payload":"PayloadMember"
-    },
-    "Timestamp":{"type":"timestamp"},
-    "Metadata":{
-      "type":"map",
-      "key":{"shape":"MetadataKey"},
-      "value":{"shape":"MetadataValue"}
-    },
-    "MetadataKey":{"type":"string"},
-    "MetadataValue":{"type":"string"},
-    "EventStreamOperationRequest": {
+    "OperationWithModeledContentTypeInput": {
       "type": "structure",
       "members": {
+        "ContentType": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "Content-Type"
+        }
       }
+    },
+    "PayloadStructType": {
+      "type": "structure",
+      "members": {
+        "PayloadMemberOne": {
+          "shape": "String"
+        },
+        "PayloadMemberTwo": {
+          "shape": "String"
+        }
+      }
+    },
+    "QueryParamWithoutValueInput": {
+      "type": "structure",
+      "members": {}
+    },
+    "RestXmlTypesOutput": {
+      "type": "structure",
+      "members": {
+        "FlattenedListOfStrings": {
+          "shape": "FlattenedListOfStrings"
+        },
+        "NonFlattenedListWithLocation": {
+          "shape": "NonFlattenedListWithLocation"
+        },
+        "FlattenedListOfStructs": {
+          "shape": "FlattenedListOfStructs"
+        },
+        "FlattenedListWithLocation": {
+          "shape": "FlattenedListWithLocation"
+        },
+        "FlattenedMap": {
+          "shape": "FlattenedMap"
+        },
+        "FlattenedMapWithLocation": {
+          "shape": "FlattenedMapWithLocation",
+          "locationName": "flatmap"
+        },
+        "NonFlattenedMapWithLocation": {
+          "shape": "NonFlattenedMapWithLocation",
+          "locationName": "themap"
+        },
+        "TimestampMemberInHeader": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timearg"
+        }
+      }
+    },
+    "RestXmlTypesStructure": {
+      "type": "structure",
+      "members": {
+        "FlattenedListOfStrings": {
+          "shape": "FlattenedListOfStrings"
+        },
+        "NonFlattenedListWithLocation": {
+          "shape": "NonFlattenedListWithLocation"
+        },
+        "FlattenedListOfStructs": {
+          "shape": "FlattenedListOfStructs"
+        },
+        "FlattenedListWithLocation": {
+          "shape": "FlattenedListWithLocation"
+        },
+        "FlattenedMap": {
+          "shape": "FlattenedMap"
+        },
+        "FlattenedMapWithLocation": {
+          "shape": "FlattenedMapWithLocation",
+          "locationName": "flatmap"
+        },
+        "NonFlattenedMapWithLocation": {
+          "shape": "NonFlattenedMapWithLocation",
+          "locationName": "themap"
+        },
+        "StringMemberInQuery": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "stringMemberInQuery"
+        },
+        "TimestampMemberInHeader": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timearg"
+        },
+        "ListOfStringsInQuery": {
+          "shape": "ListOfStrings",
+          "location": "querystring",
+          "locationName": "listOfStrings"
+        },
+        "MapOfStringToStringInQuery": {
+          "shape": "MapOfStringToString",
+          "location": "querystring"
+        }
+      }
+    },
+    "SimpleStruct": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "String": {
+      "type": "string"
+    },
+    "StructWithTimestamp": {
+      "type": "structure",
+      "members": {
+        "NestedTimestamp": {
+          "shape": "Timestamp"
+        }
+      }
+    },
+    "ImplicitPayloadException": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        },
+        "IntegerMember": {
+          "shape": "Integer"
+        },
+        "LongMember": {
+          "shape": "Long"
+        },
+        "ShortMember": {
+          "shape": "Short"
+        },
+        "DoubleMember": {
+          "shape": "Double"
+        },
+        "FloatMember": {
+          "shape": "Float"
+        },
+        "TimestampMember": {
+          "shape": "Timestamp"
+        },
+        "BooleanMember": {
+          "shape": "Boolean"
+        },
+        "BlobMember": {
+          "shape": "BlobType"
+        },
+        "ListMember": {
+          "shape": "ListOfStrings"
+        },
+        "MapMember": {
+          "shape": "MapOfStringToString"
+        },
+        "SimpleStructMember": {
+          "shape": "SimpleStruct"
+        }
+      },
+      "exception": true
+    },
+    "ExplicitPayloadAndHeadersException": {
+      "type": "structure",
+      "members": {
+        "StringHeader": {
+          "shape": "String",
+          "location": "header",
+          "locationName": "x-amz-string"
+        },
+        "IntegerHeader": {
+          "shape": "Integer",
+          "location": "header",
+          "locationName": "x-amz-integer"
+        },
+        "LongHeader": {
+          "shape": "Long",
+          "location": "header",
+          "locationName": "x-amz-long"
+        },
+        "ShortHeader": {
+          "shape": "Short",
+          "location": "header",
+          "locationName": "x-amz-short"
+        },
+        "DoubleHeader": {
+          "shape": "Double",
+          "location": "header",
+          "locationName": "x-amz-double"
+        },
+        "FloatHeader": {
+          "shape": "Float",
+          "location": "header",
+          "locationName": "x-amz-float"
+        },
+        "TimestampHeader": {
+          "shape": "Timestamp",
+          "location": "header",
+          "locationName": "x-amz-timestamp"
+        },
+        "BooleanHeader": {
+          "shape": "Boolean",
+          "location": "header",
+          "locationName": "x-amz-boolean"
+        },
+        "PayloadMember": {
+          "shape": "SimpleStruct"
+        }
+      },
+      "exception": true,
+      "payload": "PayloadMember"
+    },
+    "Timestamp": {
+      "type": "timestamp"
+    },
+    "Metadata": {
+      "type": "map",
+      "key": {
+        "shape": "MetadataKey"
+      },
+      "value": {
+        "shape": "MetadataValue"
+      }
+    },
+    "MetadataKey": {
+      "type": "string"
+    },
+    "MetadataValue": {
+      "type": "string"
+    },
+    "MapInHeadersInput": {
+      "type": "structure",
+      "members": {
+        "MetadataMember": {
+          "shape": "Metadata",
+          "location": "header",
+          "locationName": "x-amz-meta-"
+        }
+      }
+    },
+    "EventStreamOperationRequest": {
+      "type": "structure",
+      "members": {}
     },
     "EventStreamOutput": {
       "type": "structure",


### PR DESCRIPTION
Support prefix headers in RestJson

## Motivation and Context
 We do not currently support [httpPrefixHeaders](https://smithy.io/2.0/spec/http-bindings.html#httpprefixheaders-trait) in rest-json.  We do support them in rest-xml (example, [Metadata in S3](https://github.com/aws/aws-sdk-java-v2/blob/master/services/s3/src/main/resources/codegen-resources/service-2.json#L2824)).
There is one rest-json service that uses these - DataExchange, but we have a [customization](https://github.com/aws/aws-sdk-java-v2/blob/29676c4128af8e667ae8ecec982da35a2cf0aa9f/services/dataexchange/src/main/resources/codegen-resources/customization.config#L3) that excludes the operation ([SendApiAssets](https://github.com/aws/aws-sdk-java-v2/blob/29676c4128af8e667ae8ecec982da35a2cf0aa9f/services/dataexchange/src/main/resources/codegen-resources/service-2.json#L3359)) with them.

## Modifications
* Port Header Map support from Rest-Xml into json marshaller registory.
* Ported protocol tests from [Smithy](https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy)
* Remove customization in DataExchange

## Testing
New unit tests + new protocol tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
