### PR TITLE
Fix HttpChecksumStage ordering and SIGNING_METHOD resolution for interceptors to pipeline migration

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
@@ -183,6 +184,13 @@ public final class AwsExecutionContextBuilder {
                                          resolveSigningMethodUsed(
                                              signer, executionAttributes, executionAttributes.getOptionalAttribute(
                                                  AwsSignerExecutionAttribute.AWS_CREDENTIALS).orElse(null)));
+
+        Signer resolvedSigner = signer;
+        AwsCredentials capturedCredentials = executionAttributes.getOptionalAttribute(
+            AwsSignerExecutionAttribute.AWS_CREDENTIALS).orElse(null);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.SIGNING_METHOD_UPDATER, attrs ->
+            attrs.putAttribute(HttpChecksumConstant.SIGNING_METHOD,
+                               resolveSigningMethodUsed(resolvedSigner, attrs, capturedCredentials)));
 
         putStreamingInputOutputTypesMetadata(executionAttributes, executionParams);
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkClient;
@@ -183,6 +184,13 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<AuthSchemeOptionsResolver> AUTH_SCHEME_OPTIONS_RESOLVER =
         new ExecutionAttribute<>("AuthSchemeOptionsResolver");
+
+    /**
+     * Callback to recompute {@code SIGNING_METHOD} after auth scheme resolution.
+     * Set by {@code AwsExecutionContextBuilder}
+     */
+    public static final ExecutionAttribute<Consumer<ExecutionAttributes>> SIGNING_METHOD_UPDATER =
+        new ExecutionAttribute<>("SigningMethodUpdater");
 
     /**
      * Callback for resolving the endpoint. Generated per-service as a lambda in the client class.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
@@ -199,9 +199,9 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
                                 .then(MergeCustomQueryParamsStage::new)
                                 .then(QueryParametersToBodyStage::new)
                                 .then(() -> new CompressRequestStage(httpClientDependencies))
-                                .then(() -> new HttpChecksumStage(ClientType.ASYNC))
                                 .then(AuthSchemeResolutionStage::new)
                                 .then(EndpointResolutionStage::new)
+                                .then(() -> new HttpChecksumStage(ClientType.ASYNC))
                                 .then(ApplyUserAgentStage::new)
                                 .then(MakeRequestImmutableStage::new)
                                 .then(RequestPipelineBuilder

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
@@ -187,9 +187,9 @@ public final class AmazonSyncHttpClient implements SdkAutoCloseable {
                                .then(MergeCustomQueryParamsStage::new)
                                .then(QueryParametersToBodyStage::new)
                                .then(() -> new CompressRequestStage(httpClientDependencies))
-                               .then(() -> new HttpChecksumStage(ClientType.SYNC))
                                .then(AuthSchemeResolutionStage::new)
                                .then(EndpointResolutionStage::new)
+                               .then(() -> new HttpChecksumStage(ClientType.SYNC))
                                .then(ApplyUserAgentStage::new)
                                .then(MakeRequestImmutableStage::new)
                                // End of mutating request

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkRequest;
@@ -79,6 +80,12 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
         selectedAuthScheme = AuthSchemeResolver.mergePreExistingAuthSchemeProperties(selectedAuthScheme, executionAttributes);
 
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, selectedAuthScheme);
+
+        Consumer<ExecutionAttributes> signingMethodUpdater =
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.SIGNING_METHOD_UPDATER);
+        if (signingMethodUpdater != null) {
+            signingMethodUpdater.accept(executionAttributes);
+        }
 
         recordBusinessMetrics(selectedAuthScheme, sdkRequest, executionAttributes);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

After moving auth scheme resolution to a pipeline stage, SIGNING_METHOD is computed too early — before SELECTED_AUTH_SCHEME has the resolved values. This causes HttpChecksumStage to skip adding trailing checksums for requests that need them (e.g., S3 PutObject with MRAP + old signer), because ENABLE_CHUNKED_ENCODING is null at computation time.

## Modifications
 - `AmazonSyncHttpClient` / `AmazonAsyncHttpClient` — Moved HttpChecksumStage to run after AuthSchemeResolutionStage and EndpointResolutionStage, so it reads SIGNING_METHOD after it's been recomputed.
- `SdkInternalExecutionAttribute` — Added SIGNING_METHOD_UPDATER callback attribute.
- `AwsExecutionContextBuilder` — Sets the SIGNING_METHOD_UPDATER callback that recomputes SIGNING_METHOD using resolveSigningMethodUsed() with the correct values.
- `AuthSchemeResolutionStage` — Invokes the SIGNING_METHOD_UPDATER callback after resolving the auth scheme, when ENABLE_CHUNKED_ENCODING is available on SELECTED_AUTH_SCHEME.

## Testing
Verified with existing ChecksumReuseTest - all 6 tests pass including the previously failing MRAP + old signer case.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
