### PR TITLE
BenchmarkRunner get shard classes

### DIFF
--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkRunner.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkRunner.java
@@ -110,6 +110,16 @@ public class BenchmarkRunner {
 
     private static final Logger log = Logger.loggerFor(BenchmarkRunner.class);
 
+    private final List<String> benchmarksToRun;
+    private final BenchmarkResultProcessor resultProcessor;
+    private final BenchmarkRunnerOptions options;
+
+    private BenchmarkRunner(List<String> benchmarksToRun, BenchmarkRunnerOptions options) {
+        this.benchmarksToRun = benchmarksToRun;
+        this.resultProcessor = new BenchmarkResultProcessor();
+        this.options = options;
+    }
+
     static List<String> getShardClasses(String shard) {
         switch (shard) {
             case "sync": return SYNC_BENCHMARKS;
@@ -125,19 +135,11 @@ public class BenchmarkRunner {
         }
     }
 
-    private final List<String> benchmarksToRun;
-    private final BenchmarkResultProcessor resultProcessor;
-    private final BenchmarkRunnerOptions options;
-
-    private BenchmarkRunner(List<String> benchmarksToRun, BenchmarkRunnerOptions options) {
-        this.benchmarksToRun = benchmarksToRun;
-        this.resultProcessor = new BenchmarkResultProcessor();
-        this.options = options;
-    }
-
     public static void main(String... args) throws Exception {
         if (args.length >= 2 && args[0].equals("--list")) {
+            // CHECKSTYLE:OFF
             System.out.println(String.join("|", getShardClasses(args[1])));
+            // CHECKSTYLE:ON
             return;
         }
 

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkRunner.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkRunner.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -109,6 +110,21 @@ public class BenchmarkRunner {
 
     private static final Logger log = Logger.loggerFor(BenchmarkRunner.class);
 
+    static List<String> getShardClasses(String shard) {
+        switch (shard) {
+            case "sync": return SYNC_BENCHMARKS;
+            case "async": return ASYNC_BENCHMARKS;
+            case "protocol": return PROTOCOL_BENCHMARKS;
+            case "coldStart": return COLD_START_BENCHMARKS;
+            case "metrics": return Stream.concat(METRIC_BENCHMARKS.stream(), METRIC_PUBLISHER_BENCHMARKS.stream())
+                                         .collect(Collectors.toList());
+            case "all": return Stream.of(SYNC_BENCHMARKS, ASYNC_BENCHMARKS, PROTOCOL_BENCHMARKS,
+                                         COLD_START_BENCHMARKS, METRIC_BENCHMARKS, METRIC_PUBLISHER_BENCHMARKS)
+                                     .flatMap(List::stream).collect(Collectors.toList());
+            default: throw new IllegalArgumentException("Unknown shard: " + shard);
+        }
+    }
+
     private final List<String> benchmarksToRun;
     private final BenchmarkResultProcessor resultProcessor;
     private final BenchmarkRunnerOptions options;
@@ -120,6 +136,11 @@ public class BenchmarkRunner {
     }
 
     public static void main(String... args) throws Exception {
+        if (args.length >= 2 && args[0].equals("--list")) {
+            System.out.println(String.join("|", getShardClasses(args[1])));
+            return;
+        }
+
         List<String> benchmarksToRun = new ArrayList<>();
         benchmarksToRun.addAll(SYNC_BENCHMARKS);
         benchmarksToRun.addAll(ASYNC_BENCHMARKS);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Add method to `BenchmarkRunner` to return shard classes when `--list` flag is passed with shard type

## Testing
Tested locally on CLI
