### PR TITLE
fix(integ-test): Fix Integ test issue after making Apache5 as default

### DIFF
--- a/services/dynamodb/src/test/resources/software/amazon/awssdk/services/dynamodb/security-manager-integ-test.policy
+++ b/services/dynamodb/src/test/resources/software/amazon/awssdk/services/dynamodb/security-manager-integ-test.policy
@@ -6,6 +6,11 @@ grant {
     permission "javax.net.ssl.SSLPermission" "setDefaultSSLContext";
     permission "java.net.SocketPermission" "*", "connect,resolve";
 
+    // Needed for Apache HTTP Client 5 TCP keep-alive socket options
+    permission jdk.net.NetworkPermission "setOption.TCP_KEEPIDLE";
+    permission jdk.net.NetworkPermission "setOption.TCP_KEEPINTERVAL";
+    permission jdk.net.NetworkPermission "setOption.TCP_KEEPCOUNT";
+
     // Needed for test to remove the security manager
     permission java.lang.RuntimePermission "setSecurityManager";
 

--- a/services/dynamodb/src/test/resources/software/amazon/awssdk/services/dynamodb/security-manager-integ-test.policy
+++ b/services/dynamodb/src/test/resources/software/amazon/awssdk/services/dynamodb/security-manager-integ-test.policy
@@ -6,7 +6,7 @@ grant {
     permission "javax.net.ssl.SSLPermission" "setDefaultSSLContext";
     permission "java.net.SocketPermission" "*", "connect,resolve";
 
-    // Needed for Apache HTTP Client 5 TCP keep-alive socket options
+    // Needed for Apache5 HTTP Client TCP keep-alive socket options
     permission jdk.net.NetworkPermission "setOption.TCP_KEEPIDLE";
     permission jdk.net.NetworkPermission "setOption.TCP_KEEPINTERVAL";
     permission jdk.net.NetworkPermission "setOption.TCP_KEEPCOUNT";

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -210,6 +210,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache5-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
             <scope>test</scope>

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -210,12 +210,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache5-client</artifactId>
-            <version>${awsjavasdk.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
             <scope>test</scope>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ResponseInputStreamTimeoutIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ResponseInputStreamTimeoutIntegrationTest.java
@@ -21,7 +21,7 @@ import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBu
 
 import java.io.IOException;
 import java.time.Duration;
-import org.apache.http.conn.ConnectionPoolTimeoutException;
+import org.apache.hc.core5.http.ConnectionRequestTimeoutException;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -74,8 +74,8 @@ public class ResponseInputStreamTimeoutIntegrationTest extends S3IntegrationTest
         s3Client.getObject(getObjectRequest);
 
         assertThatThrownBy(() -> s3Client.getObject(getObjectRequest))
-            .hasRootCauseInstanceOf(ConnectionPoolTimeoutException.class)
-            .hasMessageContaining("Timeout waiting for connection from pool");
+            .hasRootCauseInstanceOf(ConnectionRequestTimeoutException.class)
+            .hasMessageContaining("Timeout deadline");
     }
 
     @Test

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ResponseInputStreamTimeoutIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ResponseInputStreamTimeoutIntegrationTest.java
@@ -21,7 +21,6 @@ import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBu
 
 import java.io.IOException;
 import java.time.Duration;
-import org.apache.hc.core5.http.ConnectionRequestTimeoutException;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -74,7 +73,6 @@ public class ResponseInputStreamTimeoutIntegrationTest extends S3IntegrationTest
         s3Client.getObject(getObjectRequest);
 
         assertThatThrownBy(() -> s3Client.getObject(getObjectRequest))
-            .hasRootCauseInstanceOf(ConnectionRequestTimeoutException.class)
             .hasMessageContaining("Timeout deadline");
     }
 


### PR DESCRIPTION
Update tests for Apache HttpClient 5 compatibility: TCP keep-alive permissions, exception assertions, and dependency cleanup

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
 
1. Apache HttpClient 5.6 enables TCP keep-alive socket options (TCP_KEEPIDLE, TCP_KEEPINTERVAL, TCP_KEEPCOUNT) by default. Setting these options requires jdk.net.NetworkPermission when a SecurityManager is active. After Phase 2 switches the default HTTP client to Apache 5, the SecurityManagerIntegrationTest fails because the test's security policy does not  grant these permissions.

</details>
<details>
<summary>Click here to expand the long callstack</summary>

```text
[INFO] Running software.amazon.awssdk.services.dynamodb.SecurityManagerIntegrationTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.013 s <<< FAILURE! - in software.amazon.awssdk.services.dynamodb.SecurityManagerIntegrationTest
[ERROR] software.amazon.awssdk.services.dynamodb.SecurityManagerIntegrationTest.securityManagerEnabled  Time elapsed: 0.012 s  <<< ERROR!
java.security.AccessControlException: access denied ("jdk.net.NetworkPermission" "setOption.TCP_KEEPIDLE")
        at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
        at java.security.AccessController.checkPermission(AccessController.java:886)
        at java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
        at sun.net.ExtendedOptionsImpl.checkSetOptionPermission(ExtendedOptionsImpl.java:62)
        at java.net.PlainSocketImpl.checkSetOption(PlainSocketImpl.java:82)
        at java.net.PlainSocketImpl.setOption(PlainSocketImpl.java:65)
        at java.net.SocketSecrets.setOption(SocketSecrets.java:46)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at jdk.net.Sockets.invokeSet(Sockets.java:117)
        at jdk.net.Sockets.setOption(Sockets.java:179)
        at org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator.configureSocket(DefaultHttpClientConnectionOperator.java:341)
        at org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:218)
        at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:547)
        at software.amazon.awssdk.http.apache5.internal.conn.ClientConnectionManagerFactory$DelegatingHttpClientConnectionManager.connect(ClientConnectionManagerFactory.java:91)
        at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:164)
        at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:174)
        at org.apache.hc.client5.http.impl.classic.ConnectExec.execute(ConnectExec.java:144)
        at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
        at org.apache.hc.client5.http.impl.classic.ProtocolExec.execute(ProtocolExec.java:195)
        at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
        at org.apache.hc.client5.http.impl.classic.InternalHttpClient.doExecute(InternalHttpClient.java:185)
        at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:87)
        at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:55)
        at org.apache.hc.client5.http.classic.HttpClient.executeOpen(HttpClient.java:183)
        at software.amazon.awssdk.http.apache5.internal.impl.Apache5SdkHttpClient.executeOpen(Apache5SdkHttpClient.java:70)
        at software.amazon.awssdk.http.apache5.Apache5HttpClient.execute(Apache5HttpClient.java:292)
        at software.amazon.awssdk.http.apache5.Apache5HttpClient.access$700(Apache5HttpClient.java:129)
        at software.amazon.awssdk.http.apache5.Apache5HttpClient$1.call(Apache5HttpClient.java:268)
        at software.amazon.awssdk.http.apache5.Apache5HttpClient$1.call(Apache5HttpClient.java:265)
        at software.amazon.awssdk.core.internal.util.MetricUtils.measureDurationUnsafe(MetricUtils.java:103)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.executeHttpRequest(MakeHttpRequestStage.java:92)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.execute(MakeHttpRequestStage.java:68)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.execute(MakeHttpRequestStage.java:50)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:74)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:43)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:79)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:41)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:58)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:41)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.executeRequest(RetryableStage.java:106)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:62)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:39)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:53)
        at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:35)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:82)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:62)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:43)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:50)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:32)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
        at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:210)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:173)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:80)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:182)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:74)
        at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
        at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:53)
        at software.amazon.awssdk.services.dynamodb.DefaultDynamoDbClient.listTables(DefaultDynamoDbClient.java:8413)
        at software.amazon.awssdk.services.dynamodb.SecurityManagerIntegrationTest.securityManagerEnabled(SecurityManagerIntegrationTest.java:45)
        at java.lang.reflect.Method.invoke(Method.java:498)
... 
```

</details>


2. **Apache-specific exception imports in Test**: `ResponseInputStreamTimeoutIntegrationTest` previously asserted on `org.apache.http.conn.ConnectionPoolTimeoutException` (Apache 4 specific). After the Apache 5 migration, the actual exception type changes, causing dependency analysis to fail since it found classes of Apache5 that were undeclared dependencies (not defined in s3/pom.xml)

<details>
<summary>Click here to expand the long callstack</summary>

```text

   [INFO] --- dependency:3.1.1:analyze-only (default) @ s3 ---
   [WARNING] Used undeclared dependencies found:
   [WARNING]    org.apache.httpcomponents.core5:httpcore5:jar:5.4.2:test

```

</details>


3. **Apche5 test Dependency declaration in S3**: `services/s3/pom.xml` declared `apache5-client` with `<scope>test</scope>`, duplicating what's already inherited from `services/pom.xml` at `<scope>runtime</scope>`. Runtime-scope dependencies are available on the testCompile classpath, so the explicit test-scope declaration was causing s3-transfer manager test failures as below
<details>
<summary>Click here to expand the long callstack</summary>

```text
 software.amazon.awssdk.core.exception.SdkClientException: Unable to load an HTTP implementation from any provider in the chain. You must declare a dependency on an appropriate
   HTTP implementation or pass in an SdkHttpClient explicitly to the client builder.
     at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:130)
... 
```
</details>

## Modifications
1. **`services/dynamodb/.../security-manager-integ-test.policy`**: Added `jdk.net.NetworkPermission` entries for `setOption.TCP_KEEPIDLE`, `setOption.TCP_KEEPINTERVAL`, and `setOption.TCP_KEEPCOUNT` to allow the SecurityManager test to pass with Apache HttpClient 5.6's default TCP keep-alive behavior.

2. **`services/s3/.../ResponseInputStreamTimeoutIntegrationTest.java`**: Removed the import and assertion on `ConnectionPoolTimeoutException` (Apache 4-specific class). Replaced the exception type check with a message-only assertion (`hasMessageContaining("Timeout deadline")`) to make the test independent of the underlying HTTP client classes.

3. **`services/s3/pom.xml`**: Removed the redundant `apache5-client` test-scope dependency declaration. The dependency is already inherited from `services/pom.xml` at runtime  scope, which provides classpath visibility for both test compilation and execution.

  
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
