### PR TITLE
Fix streaming timeout exception decoration

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-0bec94c.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-0bec94c.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO HTTP Client",
+    "description": "Decorate streaming response publisher failures so S3AsyncClient getObject can retry Netty read timeouts.",
+    "contributor": "adwantg"
+}

--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-0bec94c.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-0bec94c.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "Netty NIO HTTP Client",
     "description": "Decorate streaming response publisher failures so S3AsyncClient getObject can retry Netty read timeouts.",
-    "contributor": "adwantg"
+    "contributor": "goutamadwant"
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -342,11 +342,12 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                     if (!isDone.compareAndSet(false, true)) {
                         return;
                     }
+                    Throwable throwable = NettyUtils.decorateException(channelContext.channel(), t);
                     try {
                         runAndLogError(channelContext.channel(),
                                        () -> String.format("Subscriber %s threw an exception in onError.", subscriber),
-                                       () -> subscriber.onError(t));
-                        notifyError(t);
+                                       () -> subscriber.onError(throwable));
+                        notifyError(throwable);
                     } finally {
                         runAndLogError(channelContext.channel(), () -> "Could not release channel back to the pool",
                             () -> closeAndRelease(channelContext));

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
@@ -37,13 +37,16 @@ import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.timeout.ReadTimeoutException;
 import io.reactivex.Flowable;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.reactivestreams.Publisher;
@@ -120,8 +123,6 @@ public class PublisherAdapterTest {
                                                                                     HttpResponseStatus.ACCEPTED,
                                                                                     testPublisher);
 
-
-
         ResponseHandler.PublisherAdapter publisherAdapter = new ResponseHandler.PublisherAdapter(streamedHttpResponse,
                                                                                                  ctx,
                                                                                                  requestContext,
@@ -148,8 +149,6 @@ public class PublisherAdapterTest {
                                                                                     HttpResponseStatus.ACCEPTED,
                                                                                     testPublisher);
 
-
-
         ResponseHandler.PublisherAdapter publisherAdapter = new ResponseHandler.PublisherAdapter(streamedHttpResponse,
                                                                                                  ctx,
                                                                                                  requestContext,
@@ -165,6 +164,33 @@ public class PublisherAdapterTest {
         verify(channelPool).release(channel);
         assertThat(executeFuture).isCompletedExceptionally();
         verify(responseHandler).onError(exception);
+    }
+
+    @Test
+    public void streamingReadTimeout_shouldDecorateExceptionBeforeNotifyingHandlers() {
+        Flowable<HttpContent> testPublisher = Flowable.error(ReadTimeoutException.INSTANCE);
+
+        StreamedHttpResponse streamedHttpResponse = new DefaultStreamedHttpResponse(HttpVersion.HTTP_1_1,
+                                                                                    HttpResponseStatus.ACCEPTED,
+                                                                                    testPublisher);
+
+
+
+        ResponseHandler.PublisherAdapter publisherAdapter = new ResponseHandler.PublisherAdapter(streamedHttpResponse,
+                                                                                                 ctx,
+                                                                                                 requestContext,
+                                                                                                 executeFuture
+        );
+        TestSubscriber subscriber = new TestSubscriber();
+
+        publisherAdapter.subscribe(subscriber);
+
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(responseHandler).onError(errorCaptor.capture());
+        assertThat(errorCaptor.getValue()).isInstanceOf(IOException.class)
+                                          .hasCauseInstanceOf(ReadTimeoutException.class);
+        assertThat(subscriber.error).isSameAs(errorCaptor.getValue());
+        assertThat(executeFuture).isCompletedExceptionally();
     }
 
     @Test
@@ -290,6 +316,7 @@ public class PublisherAdapterTest {
         private Subscription subscription;
         private boolean isCompleted = false;
         private boolean errorOccurred = false;
+        private Throwable error;
 
         @Override
         public void onSubscribe(Subscription s) {
@@ -305,6 +332,7 @@ public class PublisherAdapterTest {
         @Override
         public void onError(Throwable t) {
             errorOccurred = true;
+            error = t;
         }
 
         @Override


### PR DESCRIPTION
## Motivation and Context

Fixes aws/aws-sdk-java-v2#6866.

For streamed `S3AsyncClient#getObject` responses, Netty can surface `ReadTimeoutException` through `ResponseHandler.PublisherAdapter.onError`. That path was forwarding the raw Netty exception, unlike the `exceptionCaught` path, so the SDK retry path could miss the decorated `IOException`.

## Modifications

- Decorate publisher errors with `NettyUtils.decorateException` before notifying the downstream subscriber and response handler.
- Add a regression test for the streamed publisher error path.
- Add a changelog entry for the Netty NIO HTTP Client.

## Testing

- `./mvnw -pl :netty-nio-client -am -Dtest=PublisherAdapterTest#streamingReadTimeout_shouldDecorateExceptionBeforeNotifyingHandlers -Dsurefire.failIfNoSpecifiedTests=false -Dspotbugs.skip=true -Dcheckstyle.skip=true test`
- `./mvnw -pl :netty-nio-client -am -Dtest=PublisherAdapterTest -Dsurefire.failIfNoSpecifiedTests=false -Dspotbugs.skip=true -Dcheckstyle.skip=true test`

I also attempted the broader netty module test command:

- `./mvnw -pl :netty-nio-client -am -Dsurefire.failIfNoSpecifiedTests=false -Dspotbugs.skip=true -Dcheckstyle.skip=true test`

That broader local run reached the netty client suite but failed in `ServerConnectivityErrorMessageTest.closeTimeHasCorrectMessage` on my JDK 21 environment because two local socket-close cases reported `Connection reset`. The touched `PublisherAdapterTest` class passed.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
