### PR TITLE
Fix presigned URL download progress tracking for range requests and add listener tests

### DIFF
--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloa
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.transfer.s3.model.CompletedDownload;
 import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.Download;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
@@ -107,6 +108,75 @@ public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3Inte
             tm.downloadWithPresignedUrl(createBytesDownloadRequest(key)).completionFuture().join();
 
         assertThat(completed.result().asByteArray()).hasSize(objSize);
+    }
+
+    static Stream<Arguments> progressTestCases() {
+        return Stream.of(
+            Arguments.of("multipart", tmJava, LARGE_KEY, null, LARGE_OBJ_SIZE),
+            Arguments.of("multipart", tmJava, LARGE_KEY, "bytes=0-1048575", 1048576),
+            Arguments.of("nonMultipart", tmNonMultipartJava, LARGE_KEY, null, LARGE_OBJ_SIZE),
+            Arguments.of("nonMultipart", tmNonMultipartJava, LARGE_KEY, "bytes=0-1048575", 1048576)
+        );
+    }
+
+    @ParameterizedTest(name = "downloadFileWithPresignedUrl_progress_{0}_range={3}")
+    @MethodSource("progressTestCases")
+    void downloadFileWithPresignedUrl_progressTracking(String tmType, S3TransferManager tm, String key,
+                                                       String range, int expectedSize) throws Exception {
+        Path downloadPath = RandomTempFile.randomUncreatedFile().toPath();
+
+        PresignedUrlDownloadRequest.Builder requestBuilder = PresignedUrlDownloadRequest.builder()
+                                                                                        .presignedUrl(createPresignedRequest(key).url());
+        if (range != null) {
+            requestBuilder.range(range);
+        }
+
+        FileDownload download = tm.downloadFileWithPresignedUrl(
+            PresignedDownloadFileRequest.builder()
+                                        .presignedUrlDownloadRequest(requestBuilder.build())
+                                        .destination(downloadPath)
+                                        .addTransferListener(LoggingTransferListener.create())
+                                        .build());
+
+        download.completionFuture().join();
+
+        // Verify progress tracking worked - totalBytes is set correctly
+        assertThat(download.progress().snapshot().totalBytes()).isPresent();
+        assertThat(download.progress().snapshot().totalBytes().getAsLong()).isEqualTo(expectedSize);
+
+        // Verify transferredBytes reached expectedSize
+        assertThat(download.progress().snapshot().transferredBytes()).isEqualTo(expectedSize);
+
+        // Verify file size matches expected
+        assertThat(downloadPath.toFile().length()).isEqualTo(expectedSize);
+    }
+
+    @ParameterizedTest(name = "downloadWithPresignedUrl_toBytes_progress_{0}_range={3}")
+    @MethodSource("progressTestCases")
+    void downloadWithPresignedUrl_toBytes_progressTracking(String tmType, S3TransferManager tm, String key,
+                                                           String range, int expectedSize) throws Exception {
+
+        PresignedUrlDownloadRequest.Builder requestBuilder = PresignedUrlDownloadRequest.builder()
+                                                                                        .presignedUrl(createPresignedRequest(key).url());
+        if (range != null) {
+            requestBuilder.range(range);
+        }
+
+        Download<ResponseBytes<GetObjectResponse>> download = tm.downloadWithPresignedUrl(
+            PresignedDownloadRequest.<ResponseBytes<GetObjectResponse>>builder()
+                                    .presignedUrlDownloadRequest(requestBuilder.build())
+                                    .responseTransformer(AsyncResponseTransformer.toBytes())
+                                    .addTransferListener(LoggingTransferListener.create())
+                                    .build());
+
+        CompletedDownload<ResponseBytes<GetObjectResponse>> completed = download.completionFuture().join();
+
+        assertThat(download.progress().snapshot().totalBytes()).isPresent();
+        assertThat(download.progress().snapshot().totalBytes().getAsLong()).isEqualTo(expectedSize);
+
+        assertThat(download.progress().snapshot().transferredBytes()).isEqualTo(expectedSize);
+
+        assertThat(completed.result().asByteArray()).hasSize(expectedSize);
     }
 
     private static PresignedDownloadFileRequest createFileDownloadRequest(String key, Path destination) {

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -613,8 +613,9 @@ class GenericS3TransferManager implements S3TransferManager {
         progressUpdater.transferInitiated();
 
         responseTransformer = isS3ClientMultipartEnabled()
+                              && presignedDownloadFileRequest.presignedUrlDownloadRequest().range() == null
                               ? progressUpdater.wrapForNonSerialFileDownload(
-            responseTransformer, GetObjectRequest.builder().build())
+                                  responseTransformer, GetObjectRequest.builder().build())
                               : progressUpdater.wrapResponseTransformer(responseTransformer);
         progressUpdater.registerCompletion(returnFuture);
 
@@ -652,8 +653,9 @@ class GenericS3TransferManager implements S3TransferManager {
         progressUpdater.transferInitiated();
 
         responseTransformer = isS3ClientMultipartEnabled()
+                              && presignedDownloadRequest.presignedUrlDownloadRequest().range() == null
                               ? progressUpdater.wrapForNonSerialFileDownload(
-            responseTransformer, GetObjectRequest.builder().build())
+                                  responseTransformer, GetObjectRequest.builder().build())
                               : progressUpdater.wrapResponseTransformer(responseTransformer);
         progressUpdater.registerCompletion(returnFuture);
 

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerListenerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerListenerTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -52,8 +51,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
-import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
-import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Download;
 import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
@@ -61,24 +58,17 @@ import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
-import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.TransferObjectRequest;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
-import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 public class S3TransferManagerListenerTest {
     private final FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
     private S3CrtAsyncClient s3Crt;
     private S3TransferManager tm;
     private long contentLength;
-    private static final String PRESIGNED_URL = "https://test-bucket.s3.amazonaws.com/test-key"
-                                                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKID"
-                                                + "&X-Amz-Date=20260101T000000Z&X-Amz-Expires=600"
-                                                + "&X-Amz-SignedHeaders=host&X-Amz-Signature=abc123";
 
     @BeforeEach
     public void methodSetup() {
@@ -340,126 +330,6 @@ public class S3TransferManagerListenerTest {
         verifyNoMoreInteractions(listener);
     }
 
-    @Test
-    public void downloadFileWithPresignedUrl_success_shouldInvokeListener() throws Exception {
-        stubPresignedUrlExtension();
-        TransferListener listener = mock(TransferListener.class);
-
-        PresignedDownloadFileRequest downloadRequest = PresignedDownloadFileRequest.builder()
-                                                                                   .presignedUrlDownloadRequest(presignedUrlDownloadRequest())
-                                                                                   .destination(newTempFile())
-                                                                                   .addTransferListener(listener)
-                                                                                   .build();
-
-        FileDownload download = tm.downloadFileWithPresignedUrl(downloadRequest);
-
-        ArgumentCaptor<TransferListener.Context.TransferInitiated> captor1 =
-            ArgumentCaptor.forClass(TransferListener.Context.TransferInitiated.class);
-        verify(listener, timeout(1000).times(1)).transferInitiated(captor1.capture());
-        TransferListener.Context.TransferInitiated ctx1 = captor1.getValue();
-        assertThat(ctx1.request()).isSameAs(downloadRequest);
-        assertThat(ctx1.progressSnapshot().totalBytes()).isNotPresent();
-        assertThat(ctx1.progressSnapshot().transferredBytes()).isZero();
-
-        ArgumentCaptor<TransferListener.Context.BytesTransferred> captor2 =
-            ArgumentCaptor.forClass(TransferListener.Context.BytesTransferred.class);
-        verify(listener, timeout(1000).atLeastOnce()).bytesTransferred(captor2.capture());
-        TransferListener.Context.BytesTransferred ctx2 = captor2.getValue();
-        assertThat(ctx2.request()).isSameAs(downloadRequest);
-        assertThat(ctx2.progressSnapshot().totalBytes()).hasValue(contentLength);
-        assertThat(ctx2.progressSnapshot().transferredBytes()).isPositive();
-
-        ArgumentCaptor<TransferListener.Context.TransferComplete> captor3 =
-            ArgumentCaptor.forClass(TransferListener.Context.TransferComplete.class);
-        verify(listener, timeout(1000).times(1)).transferComplete(captor3.capture());
-        TransferListener.Context.TransferComplete ctx3 = captor3.getValue();
-        assertThat(ctx3.request()).isSameAs(downloadRequest);
-        assertThat(ctx3.progressSnapshot().totalBytes()).hasValue(contentLength);
-        assertThat(ctx3.progressSnapshot().transferredBytes()).isEqualTo(contentLength);
-        assertThat(ctx3.completedTransfer()).isSameAs(download.completionFuture().get());
-
-        download.completionFuture().join();
-        verifyNoMoreInteractions(listener);
-    }
-
-    @Test
-    public void downloadWithPresignedUrl_success_shouldInvokeListener() throws Exception {
-        stubPresignedUrlExtension();
-        TransferListener listener = mock(TransferListener.class);
-
-        PresignedDownloadRequest<ResponseBytes<GetObjectResponse>> downloadRequest =
-            PresignedDownloadRequest.<ResponseBytes<GetObjectResponse>>builder()
-                                    .presignedUrlDownloadRequest(presignedUrlDownloadRequest())
-                                    .responseTransformer(AsyncResponseTransformer.toBytes())
-                                    .addTransferListener(listener)
-                                    .build();
-
-        Download<ResponseBytes<GetObjectResponse>> download = tm.downloadWithPresignedUrl(downloadRequest);
-
-        ArgumentCaptor<TransferListener.Context.TransferInitiated> captor1 =
-            ArgumentCaptor.forClass(TransferListener.Context.TransferInitiated.class);
-        verify(listener, timeout(1000).times(1)).transferInitiated(captor1.capture());
-        TransferListener.Context.TransferInitiated ctx1 = captor1.getValue();
-        assertThat(ctx1.request()).isSameAs(downloadRequest);
-        assertThat(ctx1.progressSnapshot().totalBytes()).isNotPresent();
-        assertThat(ctx1.progressSnapshot().transferredBytes()).isZero();
-
-        ArgumentCaptor<TransferListener.Context.BytesTransferred> captor2 =
-            ArgumentCaptor.forClass(TransferListener.Context.BytesTransferred.class);
-        verify(listener, timeout(1000).atLeastOnce()).bytesTransferred(captor2.capture());
-        TransferListener.Context.BytesTransferred ctx2 = captor2.getValue();
-        assertThat(ctx2.request()).isSameAs(downloadRequest);
-        assertThat(ctx2.progressSnapshot().totalBytes()).hasValue(contentLength);
-        assertThat(ctx2.progressSnapshot().transferredBytes()).isPositive();
-
-        ArgumentCaptor<TransferListener.Context.TransferComplete> captor3 =
-            ArgumentCaptor.forClass(TransferListener.Context.TransferComplete.class);
-        verify(listener, timeout(1000).times(1)).transferComplete(captor3.capture());
-        TransferListener.Context.TransferComplete ctx3 = captor3.getValue();
-        assertThat(ctx3.request()).isSameAs(downloadRequest);
-        assertThat(ctx3.progressSnapshot().totalBytes()).hasValue(contentLength);
-        assertThat(ctx3.progressSnapshot().transferredBytes()).isEqualTo(contentLength);
-        assertThat(ctx3.completedTransfer()).isSameAs(download.completionFuture().get());
-
-        download.completionFuture().join();
-        verifyNoMoreInteractions(listener);
-    }
-
-    @Test
-    public void downloadFileWithPresignedUrl_failure_shouldInvokeListener() throws Exception {
-        SdkClientException sdkClientException = SdkClientException.create("download failed");
-        stubPresignedUrlExtensionWithFailure(sdkClientException);
-        TransferListener listener = mock(TransferListener.class);
-
-        PresignedDownloadFileRequest downloadRequest = PresignedDownloadFileRequest.builder()
-                                                                                   .presignedUrlDownloadRequest(presignedUrlDownloadRequest())
-                                                                                   .destination(newTempFile())
-                                                                                   .addTransferListener(listener)
-                                                                                   .build();
-
-        FileDownload download = tm.downloadFileWithPresignedUrl(downloadRequest);
-        assertThatThrownBy(() -> download.completionFuture().join())
-            .isInstanceOf(CompletionException.class)
-            .hasCause(sdkClientException);
-
-        ArgumentCaptor<TransferListener.Context.TransferInitiated> captor1 =
-            ArgumentCaptor.forClass(TransferListener.Context.TransferInitiated.class);
-        verify(listener, timeout(1000).times(1)).transferInitiated(captor1.capture());
-        TransferListener.Context.TransferInitiated ctx1 = captor1.getValue();
-        assertThat(ctx1.request()).isSameAs(downloadRequest);
-        assertThat(ctx1.progressSnapshot().transferredBytes()).isZero();
-
-        ArgumentCaptor<TransferListener.Context.TransferFailed> captor2 =
-            ArgumentCaptor.forClass(TransferListener.Context.TransferFailed.class);
-        verify(listener, timeout(1000).times(1)).transferFailed(captor2.capture());
-        TransferListener.Context.TransferFailed ctx2 = captor2.getValue();
-        assertThat(ctx2.request()).isSameAs(downloadRequest);
-        assertThat(ctx2.progressSnapshot().transferredBytes()).isZero();
-        assertThat(ctx2.exception()).isEqualTo(sdkClientException);
-
-        verifyNoMoreInteractions(listener);
-    }
-
     private static TransferListener throwingListener() {
         TransferListener listener = mock(TransferListener.class);
         RuntimeException e = new RuntimeException("Intentional exception for testing purposes");
@@ -468,26 +338,6 @@ public class S3TransferManagerListenerTest {
         doThrow(e).when(listener).transferComplete(any());
         doThrow(e).when(listener).transferFailed(any());
         return listener;
-    }
-
-    private void stubPresignedUrlExtension() {
-        AsyncPresignedUrlExtension mockExtension = mock(AsyncPresignedUrlExtension.class);
-        when(s3Crt.presignedUrlExtension()).thenReturn(mockExtension);
-        when(mockExtension.getObject(any(PresignedUrlDownloadRequest.class), any(AsyncResponseTransformer.class)))
-            .thenAnswer(randomGetResponseBody(contentLength));
-    }
-
-    private void stubPresignedUrlExtensionWithFailure(Throwable error) {
-        AsyncPresignedUrlExtension mockExtension = mock(AsyncPresignedUrlExtension.class);
-        when(s3Crt.presignedUrlExtension()).thenReturn(mockExtension);
-        when(mockExtension.getObject(any(PresignedUrlDownloadRequest.class), any(AsyncResponseTransformer.class)))
-            .thenReturn(CompletableFutureUtils.failedFuture(error));
-    }
-
-    private PresignedUrlDownloadRequest presignedUrlDownloadRequest() throws Exception {
-        return PresignedUrlDownloadRequest.builder()
-                                          .presignedUrl(new URL(PRESIGNED_URL))
-                                          .build();
     }
 
     private static Answer<CompletableFuture<PutObjectResponse>> drainPutRequestBody() {

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerListenerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerListenerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -51,6 +52,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Download;
 import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
@@ -58,17 +61,24 @@ import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.TransferObjectRequest;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 public class S3TransferManagerListenerTest {
     private final FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
     private S3CrtAsyncClient s3Crt;
     private S3TransferManager tm;
     private long contentLength;
+    private static final String PRESIGNED_URL = "https://test-bucket.s3.amazonaws.com/test-key"
+                                                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKID"
+                                                + "&X-Amz-Date=20260101T000000Z&X-Amz-Expires=600"
+                                                + "&X-Amz-SignedHeaders=host&X-Amz-Signature=abc123";
 
     @BeforeEach
     public void methodSetup() {
@@ -330,6 +340,126 @@ public class S3TransferManagerListenerTest {
         verifyNoMoreInteractions(listener);
     }
 
+    @Test
+    public void downloadFileWithPresignedUrl_success_shouldInvokeListener() throws Exception {
+        stubPresignedUrlExtension();
+        TransferListener listener = mock(TransferListener.class);
+
+        PresignedDownloadFileRequest downloadRequest = PresignedDownloadFileRequest.builder()
+                                                                                   .presignedUrlDownloadRequest(presignedUrlDownloadRequest())
+                                                                                   .destination(newTempFile())
+                                                                                   .addTransferListener(listener)
+                                                                                   .build();
+
+        FileDownload download = tm.downloadFileWithPresignedUrl(downloadRequest);
+
+        ArgumentCaptor<TransferListener.Context.TransferInitiated> captor1 =
+            ArgumentCaptor.forClass(TransferListener.Context.TransferInitiated.class);
+        verify(listener, timeout(1000).times(1)).transferInitiated(captor1.capture());
+        TransferListener.Context.TransferInitiated ctx1 = captor1.getValue();
+        assertThat(ctx1.request()).isSameAs(downloadRequest);
+        assertThat(ctx1.progressSnapshot().totalBytes()).isNotPresent();
+        assertThat(ctx1.progressSnapshot().transferredBytes()).isZero();
+
+        ArgumentCaptor<TransferListener.Context.BytesTransferred> captor2 =
+            ArgumentCaptor.forClass(TransferListener.Context.BytesTransferred.class);
+        verify(listener, timeout(1000).atLeastOnce()).bytesTransferred(captor2.capture());
+        TransferListener.Context.BytesTransferred ctx2 = captor2.getValue();
+        assertThat(ctx2.request()).isSameAs(downloadRequest);
+        assertThat(ctx2.progressSnapshot().totalBytes()).hasValue(contentLength);
+        assertThat(ctx2.progressSnapshot().transferredBytes()).isPositive();
+
+        ArgumentCaptor<TransferListener.Context.TransferComplete> captor3 =
+            ArgumentCaptor.forClass(TransferListener.Context.TransferComplete.class);
+        verify(listener, timeout(1000).times(1)).transferComplete(captor3.capture());
+        TransferListener.Context.TransferComplete ctx3 = captor3.getValue();
+        assertThat(ctx3.request()).isSameAs(downloadRequest);
+        assertThat(ctx3.progressSnapshot().totalBytes()).hasValue(contentLength);
+        assertThat(ctx3.progressSnapshot().transferredBytes()).isEqualTo(contentLength);
+        assertThat(ctx3.completedTransfer()).isSameAs(download.completionFuture().get());
+
+        download.completionFuture().join();
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    public void downloadWithPresignedUrl_success_shouldInvokeListener() throws Exception {
+        stubPresignedUrlExtension();
+        TransferListener listener = mock(TransferListener.class);
+
+        PresignedDownloadRequest<ResponseBytes<GetObjectResponse>> downloadRequest =
+            PresignedDownloadRequest.<ResponseBytes<GetObjectResponse>>builder()
+                                    .presignedUrlDownloadRequest(presignedUrlDownloadRequest())
+                                    .responseTransformer(AsyncResponseTransformer.toBytes())
+                                    .addTransferListener(listener)
+                                    .build();
+
+        Download<ResponseBytes<GetObjectResponse>> download = tm.downloadWithPresignedUrl(downloadRequest);
+
+        ArgumentCaptor<TransferListener.Context.TransferInitiated> captor1 =
+            ArgumentCaptor.forClass(TransferListener.Context.TransferInitiated.class);
+        verify(listener, timeout(1000).times(1)).transferInitiated(captor1.capture());
+        TransferListener.Context.TransferInitiated ctx1 = captor1.getValue();
+        assertThat(ctx1.request()).isSameAs(downloadRequest);
+        assertThat(ctx1.progressSnapshot().totalBytes()).isNotPresent();
+        assertThat(ctx1.progressSnapshot().transferredBytes()).isZero();
+
+        ArgumentCaptor<TransferListener.Context.BytesTransferred> captor2 =
+            ArgumentCaptor.forClass(TransferListener.Context.BytesTransferred.class);
+        verify(listener, timeout(1000).atLeastOnce()).bytesTransferred(captor2.capture());
+        TransferListener.Context.BytesTransferred ctx2 = captor2.getValue();
+        assertThat(ctx2.request()).isSameAs(downloadRequest);
+        assertThat(ctx2.progressSnapshot().totalBytes()).hasValue(contentLength);
+        assertThat(ctx2.progressSnapshot().transferredBytes()).isPositive();
+
+        ArgumentCaptor<TransferListener.Context.TransferComplete> captor3 =
+            ArgumentCaptor.forClass(TransferListener.Context.TransferComplete.class);
+        verify(listener, timeout(1000).times(1)).transferComplete(captor3.capture());
+        TransferListener.Context.TransferComplete ctx3 = captor3.getValue();
+        assertThat(ctx3.request()).isSameAs(downloadRequest);
+        assertThat(ctx3.progressSnapshot().totalBytes()).hasValue(contentLength);
+        assertThat(ctx3.progressSnapshot().transferredBytes()).isEqualTo(contentLength);
+        assertThat(ctx3.completedTransfer()).isSameAs(download.completionFuture().get());
+
+        download.completionFuture().join();
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    public void downloadFileWithPresignedUrl_failure_shouldInvokeListener() throws Exception {
+        SdkClientException sdkClientException = SdkClientException.create("download failed");
+        stubPresignedUrlExtensionWithFailure(sdkClientException);
+        TransferListener listener = mock(TransferListener.class);
+
+        PresignedDownloadFileRequest downloadRequest = PresignedDownloadFileRequest.builder()
+                                                                                   .presignedUrlDownloadRequest(presignedUrlDownloadRequest())
+                                                                                   .destination(newTempFile())
+                                                                                   .addTransferListener(listener)
+                                                                                   .build();
+
+        FileDownload download = tm.downloadFileWithPresignedUrl(downloadRequest);
+        assertThatThrownBy(() -> download.completionFuture().join())
+            .isInstanceOf(CompletionException.class)
+            .hasCause(sdkClientException);
+
+        ArgumentCaptor<TransferListener.Context.TransferInitiated> captor1 =
+            ArgumentCaptor.forClass(TransferListener.Context.TransferInitiated.class);
+        verify(listener, timeout(1000).times(1)).transferInitiated(captor1.capture());
+        TransferListener.Context.TransferInitiated ctx1 = captor1.getValue();
+        assertThat(ctx1.request()).isSameAs(downloadRequest);
+        assertThat(ctx1.progressSnapshot().transferredBytes()).isZero();
+
+        ArgumentCaptor<TransferListener.Context.TransferFailed> captor2 =
+            ArgumentCaptor.forClass(TransferListener.Context.TransferFailed.class);
+        verify(listener, timeout(1000).times(1)).transferFailed(captor2.capture());
+        TransferListener.Context.TransferFailed ctx2 = captor2.getValue();
+        assertThat(ctx2.request()).isSameAs(downloadRequest);
+        assertThat(ctx2.progressSnapshot().transferredBytes()).isZero();
+        assertThat(ctx2.exception()).isEqualTo(sdkClientException);
+
+        verifyNoMoreInteractions(listener);
+    }
+
     private static TransferListener throwingListener() {
         TransferListener listener = mock(TransferListener.class);
         RuntimeException e = new RuntimeException("Intentional exception for testing purposes");
@@ -338,6 +468,26 @@ public class S3TransferManagerListenerTest {
         doThrow(e).when(listener).transferComplete(any());
         doThrow(e).when(listener).transferFailed(any());
         return listener;
+    }
+
+    private void stubPresignedUrlExtension() {
+        AsyncPresignedUrlExtension mockExtension = mock(AsyncPresignedUrlExtension.class);
+        when(s3Crt.presignedUrlExtension()).thenReturn(mockExtension);
+        when(mockExtension.getObject(any(PresignedUrlDownloadRequest.class), any(AsyncResponseTransformer.class)))
+            .thenAnswer(randomGetResponseBody(contentLength));
+    }
+
+    private void stubPresignedUrlExtensionWithFailure(Throwable error) {
+        AsyncPresignedUrlExtension mockExtension = mock(AsyncPresignedUrlExtension.class);
+        when(s3Crt.presignedUrlExtension()).thenReturn(mockExtension);
+        when(mockExtension.getObject(any(PresignedUrlDownloadRequest.class), any(AsyncResponseTransformer.class)))
+            .thenReturn(CompletableFutureUtils.failedFuture(error));
+    }
+
+    private PresignedUrlDownloadRequest presignedUrlDownloadRequest() throws Exception {
+        return PresignedUrlDownloadRequest.builder()
+                                          .presignedUrl(new URL(PRESIGNED_URL))
+                                          .build();
     }
 
     private static Answer<CompletableFuture<PutObjectResponse>> drainPutRequestBody() {

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlListenerWiremockTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlListenerWiremockTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.Download;
+import software.amazon.awssdk.transfer.s3.model.FileDownload;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
+
+/**
+ * Tests that TransferListener callbacks fire correctly for presigned URL downloads
+ * with both multipart-enabled and non-multipart clients.
+ */
+@WireMockTest
+public class S3TransferManagerPresignedUrlListenerWiremockTest {
+
+    private static URI testEndpoint;
+    private static RandomTempFile testFile;
+
+    @BeforeAll
+    public static void init(WireMockRuntimeInfo wm) throws IOException {
+        testEndpoint = URI.create(wm.getHttpBaseUrl());
+        testFile = new RandomTempFile("presigned-listener-test", 1024);
+    }
+
+    @BeforeEach
+    void resetWireMock() {
+        WireMock.reset();
+    }
+
+    private static S3AsyncClient s3AsyncClient(boolean multipartEnabled) {
+        return S3AsyncClient.builder()
+                            .multipartEnabled(multipartEnabled)
+                            .region(Region.US_EAST_1)
+                            .endpointOverride(testEndpoint)
+                            .credentialsProvider(
+                                StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")))
+                            .build();
+    }
+
+    static Stream<Arguments> presignedUrlTestCases() {
+        return Stream.of(
+            Arguments.of(true, "toFile", null),
+            Arguments.of(true, "toFile", "bytes=0-511"),
+            Arguments.of(true, "toBytes", null),
+            Arguments.of(true, "toBytes", "bytes=0-511"),
+            Arguments.of(false, "toFile", null),
+            Arguments.of(false, "toFile", "bytes=0-511"),
+            Arguments.of(false, "toBytes", null),
+            Arguments.of(false, "toBytes", "bytes=0-511")
+        );
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_multipart={0}_type={1}_range={2}")
+    @MethodSource("presignedUrlTestCases")
+    void presignedUrlDownload_shouldInvokeListener(boolean multipartEnabled, String type, String range) throws Exception {
+        S3AsyncClient s3Async = s3AsyncClient(multipartEnabled);
+        S3TransferManager tm = new GenericS3TransferManager(s3Async, mock(UploadDirectoryHelper.class),
+                                                            mock(TransferManagerConfiguration.class),
+                                                            mock(DownloadDirectoryHelper.class));
+
+        byte[] responseBody = new byte[512];
+        stubFor(get(urlPathEqualTo("/presigned-key")).willReturn(aResponse()
+                                                                    .withStatus(206)
+                                                                    .withHeader("Content-Length", "512")
+                                                                    .withHeader("Content-Range", "bytes 0-511/512")
+                                                                    .withHeader("ETag", "\"test-etag\"")
+                                                                    .withBody(responseBody)));
+
+        TransferListener listener = mock(TransferListener.class);
+        URL presignedUrl = new URL(testEndpoint + "/presigned-key?X-Amz-Algorithm=AWS4-HMAC-SHA256");
+
+        PresignedUrlDownloadRequest.Builder requestBuilder = PresignedUrlDownloadRequest.builder()
+                                                                                       .presignedUrl(presignedUrl);
+        if (range != null) {
+            requestBuilder.range(range);
+        }
+
+        if ("toFile".equals(type)) {
+            FileDownload download = tm.downloadFileWithPresignedUrl(
+                PresignedDownloadFileRequest.builder()
+                    .presignedUrlDownloadRequest(requestBuilder.build())
+                    .destination(testFile.toPath())
+                    .addTransferListener(listener)
+                    .build());
+            download.completionFuture().join();
+        } else {
+            Download<?> download = tm.downloadWithPresignedUrl(
+                PresignedDownloadRequest.builder()
+                    .presignedUrlDownloadRequest(requestBuilder.build())
+                    .responseTransformer(AsyncResponseTransformer.toBytes())
+                    .addTransferListener(listener)
+                    .build());
+            download.completionFuture().join();
+        }
+
+        Mockito.verify(listener, timeout(1000).times(1)).transferInitiated(ArgumentMatchers.any());
+        Mockito.verify(listener, timeout(1000).atLeastOnce()).bytesTransferred(ArgumentMatchers.any());
+
+        tm.close();
+        s3Async.close();
+    }
+
+    static Stream<Arguments> presignedUrlFailureTestCases() {
+        return Stream.of(
+            Arguments.of(true, "toFile"),
+            Arguments.of(true, "toBytes"),
+            Arguments.of(false, "toFile"),
+            Arguments.of(false, "toBytes")
+        );
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_failure_multipart={0}_type={1}")
+    @MethodSource("presignedUrlFailureTestCases")
+    void presignedUrlDownload_failure_shouldInvokeListener(boolean multipartEnabled, String type) throws Exception {
+        S3AsyncClient s3Async = s3AsyncClient(multipartEnabled);
+        S3TransferManager tm = new GenericS3TransferManager(s3Async, mock(UploadDirectoryHelper.class),
+                                                            mock(TransferManagerConfiguration.class),
+                                                            mock(DownloadDirectoryHelper.class));
+
+        stubFor(get(urlPathEqualTo("/presigned-key"))
+                    .willReturn(aResponse().withStatus(404)
+                                           .withBody("<Error><Code>TestError</Code><Message>Test failure</Message></Error>")));
+
+        TransferListener listener = mock(TransferListener.class);
+        URL presignedUrl = new URL(testEndpoint + "/presigned-key?X-Amz-Algorithm=AWS4-HMAC-SHA256");
+
+        if ("toFile".equals(type)) {
+            FileDownload download = tm.downloadFileWithPresignedUrl(
+                PresignedDownloadFileRequest.builder()
+                    .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                                                                           .presignedUrl(presignedUrl)
+                                                                           .build())
+                    .destination(testFile.toPath())
+                    .addTransferListener(listener)
+                    .build());
+            assertThatExceptionOfType(CompletionException.class).isThrownBy(() -> download.completionFuture().join());
+        } else {
+            Download<?> download = tm.downloadWithPresignedUrl(
+                PresignedDownloadRequest.builder()
+                    .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                                                                           .presignedUrl(presignedUrl)
+                                                                           .build())
+                    .responseTransformer(AsyncResponseTransformer.toBytes())
+                    .addTransferListener(listener)
+                    .build());
+            assertThatExceptionOfType(CompletionException.class).isThrownBy(() -> download.completionFuture().join());
+        }
+
+        Mockito.verify(listener, timeout(1000).times(1)).transferInitiated(ArgumentMatchers.any());
+        Mockito.verify(listener, timeout(1000).times(1)).transferFailed(ArgumentMatchers.any());
+        Mockito.verify(listener, times(0)).transferComplete(ArgumentMatchers.any());
+
+        tm.close();
+        s3Async.close();
+    }
+
+    @ParameterizedTest(name = "presignedUrlDownload_cancelled_multipart={0}_type={1}")
+    @MethodSource("presignedUrlFailureTestCases")
+    void presignedUrlDownload_cancelled_shouldInvokeTransferFailed(boolean multipartEnabled, String type) throws Exception {
+        S3AsyncClient s3Async = s3AsyncClient(multipartEnabled);
+        S3TransferManager tm = new GenericS3TransferManager(s3Async, mock(UploadDirectoryHelper.class),
+                                                            mock(TransferManagerConfiguration.class),
+                                                            mock(DownloadDirectoryHelper.class));
+
+        // Slow response to keep request in-flight during cancellation
+        stubFor(get(urlPathEqualTo("/presigned-key")).willReturn(aResponse()
+                                                                     .withStatus(206)
+                                                                     .withHeader("Content-Length", "512")
+                                                                     .withHeader("Content-Range", "bytes 0-511/512")
+                                                                     .withHeader("ETag", "\"test-etag\"")
+                                                                     .withBody(new byte[512])
+                                                                     .withFixedDelay(5000)));
+
+        TransferListener listener = mock(TransferListener.class);
+        URL presignedUrl = new URL(testEndpoint + "/presigned-key?X-Amz-Algorithm=AWS4-HMAC-SHA256");
+
+        if ("toFile".equals(type)) {
+            FileDownload download = tm.downloadFileWithPresignedUrl(
+                PresignedDownloadFileRequest.builder()
+                                            .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                                                                                                    .presignedUrl(presignedUrl)
+                                                                                                    .build())
+                                            .destination(testFile.toPath())
+                                            .addTransferListener(listener)
+                                            .build());
+            download.completionFuture().cancel(true);
+        } else {
+            Download<?> download = tm.downloadWithPresignedUrl(
+                PresignedDownloadRequest.builder()
+                                        .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
+                                                                                                .presignedUrl(presignedUrl)
+                                                                                                .build())
+                                        .responseTransformer(AsyncResponseTransformer.toBytes())
+                                        .addTransferListener(listener)
+                                        .build());
+            download.completionFuture().cancel(true);
+        }
+
+        Mockito.verify(listener, timeout(1000).times(1)).transferInitiated(ArgumentMatchers.any());
+        Mockito.verify(listener, timeout(1000).times(1)).transferFailed(ArgumentMatchers.any());
+        Mockito.verify(listener, times(0)).transferComplete(ArgumentMatchers.any());
+
+        tm.close();
+        s3Async.close();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Presigned URL downloads with a user-specified range and multipart enabled produced no progress tracking output. The `wrapForNonSerialFileDownload` wrapper was applied, but when range is set, multipart is skipped (single request) and split() is never called — so the wrapper's progress hooks never fire.

## Modifications
- `GenericS3TransferManager.downloadFileWithPresignedUrl`: Added range == null check — uses wrapForNonSerialFileDownload for multipart without range, falls back to wrapResponseTransformer when range is set.
- `GenericS3TransferManager.downloadWithPresignedUrl:` Same range == null check.

## Testing
- `S3TransferManagerListenerTest`: Added TransferListener callback verification tests for presigned URL downloads — verifies transferInitiated, bytesTransferred, transferComplete fire on success, and transferInitiated, transferFailed fire on failure.
- `S3TransferManagerPresignedUrlDownloadIntegrationTest`: Added parameterized progress tracking tests (multipart/non-multipart × range/no-range) asserting totalBytes, transferredBytes, and downloaded size correctness.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
