### PR TITLE
Fix Sts flakey test

### DIFF
--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/StsRetryStrategyTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/StsRetryStrategyTest.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.services.sts.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.time.Duration;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -98,7 +97,8 @@ public class StsRetryStrategyTest {
                                                                    .token(token)
                                                                    .failure(failure)
                                                                    .build();
-        assertThat(strategy.refreshRetryToken(refresh).delay()).isGreaterThan(Duration.ZERO);
+        // Should not throw TokenAcquisitionFailedException
+        assertThat(strategy.refreshRetryToken(refresh)).isNotNull();
     }
 
     private static Stream<Arguments> retryModeResolutionCases() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Test checks that token delay is greater than 0, but `Random.nextInt(x)` in fact does has a small chance of returning 0
- https://github.com/aws/aws-sdk-java-v2/blob/master/core/retries-spi/src/main/java/software/amazon/awssdk/retries/api/internal/backoff/ExponentialDelayWithJitter.java#L57

Purpose of test is to ensure that `IdpCommunicationErrorException` is retried. `strategy.refreshRetryToken(refresh)` succeeding validates this, otherwise it would throw `TokenAcquisitionFailedException`
## Modifications
<!--- Describe your changes in detail -->
Update assertion to `.isNotNull()`