### PR TITLE
Improve Javadoc for IgnoreNullsMode enum

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/IgnoreNullsMode.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/IgnoreNullsMode.java
@@ -18,20 +18,41 @@ package software.amazon.awssdk.enhanced.dynamodb.model;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
- * <p>
- * The SCALAR_ONLY mode supports updates to scalar attributes to any level (top level, first nested level, second nested level,
- * etc.) when the user wants to update scalar attributes by providing only the delta of changes to be updated. This mode
- * does not support updates to maps and is expected to throw a 4xx DynamoDB exception if done so.
- * <p>
- * In the MAPS_ONLY mode, creation of new map/bean structures through update statements are supported, i.e. setting
- * null/non-existent maps to non-null values. If users try to update scalar attributes in this mode, it will overwrite
- * existing values in the table.
- * <p>
- * The DEFAULT mode disables any special handling around null values in the update query expression
+ * Determines how null-valued attributes in a Java object are handled during an update operation.
+ * This replaces the deprecated 'ignoreNulls' boolean parameter.
+ *
+ * <p>{@code ignoreNulls(false)} is equivalent to {@link #DEFAULT} and {@code ignoreNulls(true)} is equivalent to
+ * {@link #MAPS_ONLY}.
  */
 @SdkPublicApi
 public enum IgnoreNullsMode {
+
+    /**
+     * Ignores all null-valued properties and updates only the non-null scalar attributes at any nesting level.
+     * The SDK constructs update expressions that target individual nested attributes, allowing partial updates
+     * of nested beans or maps without overwriting sibling attributes.
+     *
+     * <p>The target bean or map must already exist in DynamoDB. If it does not, DynamoDB returns a validation
+     * exception because the document path does not exist. Use {@link #MAPS_ONLY} first to create the nested
+     * structure, then use {@code SCALAR_ONLY} for subsequent partial updates.
+     */
     SCALAR_ONLY,
+
+    /**
+     * Ignores null-valued top-level properties and replaces or adds entire beans and maps as whole values.
+     * Null-valued scalar attributes within a provided bean or map are retained (saved as null in DynamoDB).
+     *
+     * <p>Use this mode to add a new nested bean or map that does not yet exist in DynamoDB, or to fully
+     * replace an existing one. This is equivalent to the deprecated {@code ignoreNulls(true)}.
+     */
     MAPS_ONLY,
+
+    /**
+     * Does not ignore any null values. Null-valued attributes in the Java object generate REMOVE actions in the
+     * update expression, deleting those attributes from the item in DynamoDB.
+     *
+     * <p>This is the default mode and is equivalent to the deprecated {@code ignoreNulls(false)}. When using this
+     * mode, you should typically retrieve the item first to avoid unintentionally removing attributes.
+     */
     DEFAULT
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactUpdateItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactUpdateItemEnhancedRequest.java
@@ -83,7 +83,9 @@ public class TransactUpdateItemEnhancedRequest<T> {
 
     /**
      * Returns if the update operation should ignore attributes with null values, or false if it has not been set.
-     * This is deprecated in favour of ignoreNullsMode()
+     *
+     * @deprecated Use {@link #ignoreNullsMode()} instead, which provides more granular control
+     * over null handling behavior.
      */
     @Deprecated
     public Boolean ignoreNulls() {
@@ -190,6 +192,10 @@ public class TransactUpdateItemEnhancedRequest<T> {
          *
          * @param ignoreNulls the boolean value
          * @return a builder of this type
+         * @deprecated Use {@link #ignoreNullsMode(IgnoreNullsMode)} instead, which provides more granular control
+         * over null handling behavior.
+         * {@code ignoreNulls(true)} is equivalent to {@link IgnoreNullsMode#MAPS_ONLY};
+         * {@code ignoreNulls(false)} is equivalent to {@link IgnoreNullsMode#DEFAULT}.
          */
         @Deprecated
         public Builder<T> ignoreNulls(Boolean ignoreNulls) {
@@ -197,6 +203,12 @@ public class TransactUpdateItemEnhancedRequest<T> {
             return this;
         }
 
+        /**
+         * Sets the mode that determines how null-valued attributes are handled during the update operation.
+         *
+         * @param ignoreNullsMode the {@link IgnoreNullsMode} to use
+         * @return a builder of this type
+         */
         public Builder<T> ignoreNullsMode(IgnoreNullsMode ignoreNullsMode) {
             this.ignoreNullsMode = ignoreNullsMode;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
@@ -100,7 +100,9 @@ public final class UpdateItemEnhancedRequest<T> {
 
     /**
      * Returns if the update operation should ignore attributes with null values, or false if it has not been set.
-     * This is deprecated in favour of ignoreNullsMode()
+     *
+     * @deprecated Use {@link #ignoreNullsMode()} instead, which provides more granular control
+     * over null handling behavior.
      */
     @Deprecated
     public Boolean ignoreNulls() {
@@ -248,14 +250,19 @@ public final class UpdateItemEnhancedRequest<T> {
         }
 
         /**
-         *  Sets if the update operation should ignore attributes with null values. By default, the value is false.
-         *  <p>
-         *  If set to true, any null values in the Java object will be ignored and not be updated on the persisted
-         *  record. This is commonly referred to as a 'partial update'.
-         *  If set to false, null values in the Java object will cause those attributes to be removed from the persisted
-         *  record on update.
+         * Sets if the update operation should ignore attributes with null values. By default, the value is false.
+         * <p>
+         * If set to true, any null values in the Java object will be ignored and not be updated on the persisted
+         * record. This is commonly referred to as a 'partial update'.
+         * If set to false, null values in the Java object will cause those attributes to be removed from the persisted
+         * record on update.
+         *
          * @param ignoreNulls the boolean value
          * @return a builder of this type
+         * @deprecated Use {@link #ignoreNullsMode(IgnoreNullsMode)} instead, which provides more granular control
+         * over null handling behavior.
+         * {@code ignoreNulls(true)} is equivalent to {@link IgnoreNullsMode#MAPS_ONLY};
+         * {@code ignoreNulls(false)} is equivalent to {@link IgnoreNullsMode#DEFAULT}.
          */
         @Deprecated
         public Builder<T> ignoreNulls(Boolean ignoreNulls) {
@@ -263,6 +270,12 @@ public final class UpdateItemEnhancedRequest<T> {
             return this;
         }
 
+        /**
+         * Sets the mode that determines how null-valued attributes are handled during the update operation.
+         *
+         * @param ignoreNullsMode the {@link IgnoreNullsMode} to use
+         * @return a builder of this type
+         */
         public Builder<T> ignoreNullsMode(IgnoreNullsMode ignoreNullsMode) {
             this.ignoreNullsMode = ignoreNullsMode;
             return this;


### PR DESCRIPTION
## Motivation and Context

Resolves #5668

The IgnoreNullsMode enum Javadoc was unclear about what each mode does and how it maps from the deprecated ignoreNulls boolean parameter.

## Modifications

- Added clear per-constant Javadoc to IgnoreNullsMode enum
- Added migration mapping from ignoreNulls(true/false) to the enum values
- Added `@deprecated` tag with replacement info to ignoreNulls() methods
- Added Javadoc to the undocumented ignoreNullsMode() builder methods

## Testing

- Javadoc generates without errors (verified locally)
- Behavioral claims validated via POC against real DynamoDB

## License

- I confirm that this pull request can be released under the Apache 2 license