### PR TITLE
Update codegen fixture files and fix tests

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -1483,9 +1483,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        JsonAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(JsonAuthSchemeProvider.class,
-                                                                          clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                          "Expected an instance of JsonAuthSchemeProvider");
+        JsonAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate
+                .isInstanceOf(JsonAuthSchemeProvider.class, p, "Expected an instance of JsonAuthSchemeProvider"))
+            .orElse(null);
+        JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(JsonAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of JsonAuthSchemeProvider");
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
@@ -205,9 +205,15 @@ final class DefaultQueryToJsonCompatibleAsyncClient implements QueryToJsonCompat
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        QueryToJsonCompatibleAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            QueryToJsonCompatibleAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
+        QueryToJsonCompatibleAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(QueryToJsonCompatibleAuthSchemeProvider.class, p,
+                                            "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider")).orElse(null);
+        QueryToJsonCompatibleAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                       : Validate.isInstanceOf(QueryToJsonCompatibleAuthSchemeProvider.class,
+                                                                                                                               clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                               "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
         QueryToJsonCompatibleAuthSchemeParams.Builder paramsBuilder = QueryToJsonCompatibleAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
@@ -175,9 +175,15 @@ final class DefaultQueryToJsonCompatibleClient implements QueryToJsonCompatibleC
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        QueryToJsonCompatibleAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            QueryToJsonCompatibleAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
+        QueryToJsonCompatibleAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(QueryToJsonCompatibleAuthSchemeProvider.class, p,
+                                            "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider")).orElse(null);
+        QueryToJsonCompatibleAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                       : Validate.isInstanceOf(QueryToJsonCompatibleAuthSchemeProvider.class,
+                                                                                                                               clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                               "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
         QueryToJsonCompatibleAuthSchemeParams.Builder paramsBuilder = QueryToJsonCompatibleAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
@@ -197,9 +197,15 @@ final class DefaultBatchManagerTestAsyncClient implements BatchManagerTestAsyncC
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        BatchManagerTestAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(BatchManagerTestAuthSchemeProvider.class,
-                                                                                      clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                                      "Expected an instance of BatchManagerTestAuthSchemeProvider");
+        BatchManagerTestAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(BatchManagerTestAuthSchemeProvider.class, p,
+                                            "Expected an instance of BatchManagerTestAuthSchemeProvider")).orElse(null);
+        BatchManagerTestAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                  : Validate.isInstanceOf(BatchManagerTestAuthSchemeProvider.class,
+                                                                                                                          clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                          "Expected an instance of BatchManagerTestAuthSchemeProvider");
         BatchManagerTestAuthSchemeParams.Builder paramsBuilder = BatchManagerTestAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-async-client-class.java
@@ -1487,9 +1487,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        JsonAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(JsonAuthSchemeProvider.class,
-                                                                          clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                          "Expected an instance of JsonAuthSchemeProvider");
+        JsonAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate
+                .isInstanceOf(JsonAuthSchemeProvider.class, p, "Expected an instance of JsonAuthSchemeProvider"))
+            .orElse(null);
+        JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(JsonAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of JsonAuthSchemeProvider");
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-client-class.java
@@ -983,9 +983,15 @@ final class DefaultJsonClient implements JsonClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        JsonAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(JsonAuthSchemeProvider.class,
-                                                                          clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                          "Expected an instance of JsonAuthSchemeProvider");
+        JsonAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate
+                .isInstanceOf(JsonAuthSchemeProvider.class, p, "Expected an instance of JsonAuthSchemeProvider"))
+            .orElse(null);
+        JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(JsonAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of JsonAuthSchemeProvider");
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-sync-client-class.java
@@ -168,9 +168,14 @@ final class DefaultFooBarClient implements FooBarClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        FooBarAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(FooBarAuthSchemeProvider.class,
-                                                                            clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                            "Expected an instance of FooBarAuthSchemeProvider");
+        FooBarAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(FooBarAuthSchemeProvider.class, p,
+                                            "Expected an instance of FooBarAuthSchemeProvider")).orElse(null);
+        FooBarAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(FooBarAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of FooBarAuthSchemeProvider");
         FooBarAuthSchemeParams.Builder paramsBuilder = FooBarAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
@@ -191,10 +191,15 @@ final class DefaultProtocolRestJsonWithCustomPackageAsyncClient implements Proto
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        ProtocolRestJsonWithCustomPackageAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class,
-            clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
+        ProtocolRestJsonWithCustomPackageAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class, p,
+                                            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider")).orElse(null);
+        ProtocolRestJsonWithCustomPackageAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                                   : Validate.isInstanceOf(ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class,
+                                                                                                                                           clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                                           "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
         ProtocolRestJsonWithCustomPackageAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomPackageAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
@@ -165,10 +165,15 @@ final class DefaultProtocolRestJsonWithCustomPackageClient implements ProtocolRe
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        ProtocolRestJsonWithCustomPackageAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class,
-            clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
+        ProtocolRestJsonWithCustomPackageAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class, p,
+                                            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider")).orElse(null);
+        ProtocolRestJsonWithCustomPackageAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                                   : Validate.isInstanceOf(ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class,
+                                                                                                                                           clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                                           "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
         ProtocolRestJsonWithCustomPackageAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomPackageAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
@@ -191,10 +191,15 @@ final class DefaultProtocolRestJsonWithCustomContentTypeAsyncClient implements P
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class,
-            clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
+        ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class, p,
+                                            "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider")).orElse(null);
+        ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                                       : Validate.isInstanceOf(ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class,
+                                                                                                                                               clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                                               "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
         ProtocolRestJsonWithCustomContentTypeAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomContentTypeAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
@@ -165,10 +165,15 @@ final class DefaultProtocolRestJsonWithCustomContentTypeClient implements Protoc
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class,
-            clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
+        ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class, p,
+                                            "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider")).orElse(null);
+        ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                                       : Validate.isInstanceOf(ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class,
+                                                                                                                                               clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                                               "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
         ProtocolRestJsonWithCustomContentTypeAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomContentTypeAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
@@ -503,9 +503,15 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        EndpointDiscoveryTestAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            EndpointDiscoveryTestAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
+        EndpointDiscoveryTestAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(EndpointDiscoveryTestAuthSchemeProvider.class, p,
+                                            "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider")).orElse(null);
+        EndpointDiscoveryTestAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                       : Validate.isInstanceOf(EndpointDiscoveryTestAuthSchemeProvider.class,
+                                                                                                                               clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                               "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
         EndpointDiscoveryTestAuthSchemeParams.Builder paramsBuilder = EndpointDiscoveryTestAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
@@ -425,9 +425,15 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        EndpointDiscoveryTestAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            EndpointDiscoveryTestAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
+        EndpointDiscoveryTestAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(EndpointDiscoveryTestAuthSchemeProvider.class, p,
+                                            "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider")).orElse(null);
+        EndpointDiscoveryTestAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                       : Validate.isInstanceOf(EndpointDiscoveryTestAuthSchemeProvider.class,
+                                                                                                                               clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                               "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
         EndpointDiscoveryTestAuthSchemeParams.Builder paramsBuilder = EndpointDiscoveryTestAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -1689,9 +1689,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        JsonAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(JsonAuthSchemeProvider.class,
-                                                                          clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                          "Expected an instance of JsonAuthSchemeProvider");
+        JsonAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate
+                .isInstanceOf(JsonAuthSchemeProvider.class, p, "Expected an instance of JsonAuthSchemeProvider"))
+            .orElse(null);
+        JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(JsonAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of JsonAuthSchemeProvider");
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -1136,9 +1136,15 @@ final class DefaultJsonClient implements JsonClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        JsonAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(JsonAuthSchemeProvider.class,
-                                                                          clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                          "Expected an instance of JsonAuthSchemeProvider");
+        JsonAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate
+                .isInstanceOf(JsonAuthSchemeProvider.class, p, "Expected an instance of JsonAuthSchemeProvider"))
+            .orElse(null);
+        JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(JsonAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of JsonAuthSchemeProvider");
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -1286,9 +1286,14 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        QueryAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(QueryAuthSchemeProvider.class,
-                                                                           clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                           "Expected an instance of QueryAuthSchemeProvider");
+        QueryAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(QueryAuthSchemeProvider.class, p,
+                                            "Expected an instance of QueryAuthSchemeProvider")).orElse(null);
+        QueryAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(QueryAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of QueryAuthSchemeProvider");
         QueryAuthSchemeParams.Builder paramsBuilder = QueryAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-async-client-class.java
@@ -1214,9 +1214,15 @@ final class DefaultSmithyRpcV2ProtocolAsyncClient implements SmithyRpcV2Protocol
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        SmithyRpcV2ProtocolAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            SmithyRpcV2ProtocolAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
+        SmithyRpcV2ProtocolAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(SmithyRpcV2ProtocolAuthSchemeProvider.class, p,
+                                            "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider")).orElse(null);
+        SmithyRpcV2ProtocolAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                     : Validate.isInstanceOf(SmithyRpcV2ProtocolAuthSchemeProvider.class,
+                                                                                                                             clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                             "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
         SmithyRpcV2ProtocolAuthSchemeParams.Builder paramsBuilder = SmithyRpcV2ProtocolAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-sync.java
@@ -1028,9 +1028,15 @@ final class DefaultSmithyRpcV2ProtocolClient implements SmithyRpcV2ProtocolClien
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        SmithyRpcV2ProtocolAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(
-            SmithyRpcV2ProtocolAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-            "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
+        SmithyRpcV2ProtocolAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(SmithyRpcV2ProtocolAuthSchemeProvider.class, p,
+                                            "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider")).orElse(null);
+        SmithyRpcV2ProtocolAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider
+                                                                                                     : Validate.isInstanceOf(SmithyRpcV2ProtocolAuthSchemeProvider.class,
+                                                                                                                             clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                                                                                                                             "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
         SmithyRpcV2ProtocolAuthSchemeParams.Builder paramsBuilder = SmithyRpcV2ProtocolAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-async-client-class.java
@@ -1038,9 +1038,14 @@ final class DefaultDatabaseAsyncClient implements DatabaseAsyncClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        DatabaseAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(DatabaseAuthSchemeProvider.class,
-                                                                              clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                              "Expected an instance of DatabaseAuthSchemeProvider");
+        DatabaseAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(DatabaseAuthSchemeProvider.class, p,
+                                            "Expected an instance of DatabaseAuthSchemeProvider")).orElse(null);
+        DatabaseAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(DatabaseAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of DatabaseAuthSchemeProvider");
         DatabaseAuthSchemeParams.Builder paramsBuilder = DatabaseAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         Set<String> sigv4aRegionSet = clientConfiguration.option(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-sync-client-class.java
@@ -923,9 +923,14 @@ final class DefaultDatabaseClient implements DatabaseClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        DatabaseAuthSchemeProvider authSchemeProvider = Validate.isInstanceOf(DatabaseAuthSchemeProvider.class,
-                                                                              clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
-                                                                              "Expected an instance of DatabaseAuthSchemeProvider");
+        DatabaseAuthSchemeProvider requestAuthSchemeProvider = request
+            .overrideConfiguration()
+            .flatMap(c -> c.authSchemeProvider())
+            .map(p -> Validate.isInstanceOf(DatabaseAuthSchemeProvider.class, p,
+                                            "Expected an instance of DatabaseAuthSchemeProvider")).orElse(null);
+        DatabaseAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
+            .isInstanceOf(DatabaseAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
+                          "Expected an instance of DatabaseAuthSchemeProvider");
         DatabaseAuthSchemeParams.Builder paramsBuilder = DatabaseAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(clientConfiguration.option(AwsClientOption.AWS_REGION));
         Set<String> sigv4aRegionSet = clientConfiguration.option(AwsClientOption.AWS_SIGV4A_SIGNING_REGION_SET);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -971,7 +971,10 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        XmlAuthSchemeProvider authSchemeProvider = Validate
+        XmlAuthSchemeProvider requestAuthSchemeProvider = request.overrideConfiguration().flatMap(c -> c.authSchemeProvider())
+                                                                 .map(p -> Validate.isInstanceOf(XmlAuthSchemeProvider.class, p, "Expected an instance of XmlAuthSchemeProvider"))
+                                                                 .orElse(null);
+        XmlAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(XmlAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
                           "Expected an instance of XmlAuthSchemeProvider");
         XmlAuthSchemeParams.Builder paramsBuilder = XmlAuthSchemeParams.builder().operation(operationName);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -726,7 +726,10 @@ final class DefaultXmlClient implements XmlClient {
 
     private List<AuthSchemeOption> resolveAuthSchemeOptions(SdkRequest request, String operationName,
                                                             SdkClientConfiguration clientConfiguration) {
-        XmlAuthSchemeProvider authSchemeProvider = Validate
+        XmlAuthSchemeProvider requestAuthSchemeProvider = request.overrideConfiguration().flatMap(c -> c.authSchemeProvider())
+                                                                 .map(p -> Validate.isInstanceOf(XmlAuthSchemeProvider.class, p, "Expected an instance of XmlAuthSchemeProvider"))
+                                                                 .orElse(null);
+        XmlAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(XmlAuthSchemeProvider.class, clientConfiguration.option(SdkClientOption.AUTH_SCHEME_PROVIDER),
                           "Expected an instance of XmlAuthSchemeProvider");
         XmlAuthSchemeParams.Builder paramsBuilder = XmlAuthSchemeParams.builder().operation(operationName);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -423,15 +423,19 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                                          existingHttpAttributes.toBuilder() :
                                                          SdkHttpExecutionAttributes.builder();
 
+            Region signingRegion = S3ExpressUtils.resolveSigningRegion(context.request(), executionAttributes,
+                                       executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION));
+            String signingName = S3ExpressUtils.resolveSigningName(context.request(), executionAttributes,
+                                     executionAttributes.getAttribute(SERVICE_SIGNING_NAME));
+
             builder.put(OPERATION_NAME,
                         executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME))
                    .put(HTTP_CHECKSUM, executionAttributes.getAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM))
-                   .put(SIGNING_REGION, executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION))
+                   .put(SIGNING_REGION, signingRegion)
                    .put(S3InternalSdkHttpExecutionAttribute.OBJECT_FILE_PATH,
                         executionAttributes.getAttribute(OBJECT_FILE_PATH))
                    .put(USE_S3_EXPRESS_AUTH, S3ExpressUtils.isS3ExpressAuthRequest(context.request(), executionAttributes))
-                   .put(SIGNING_NAME, S3ExpressUtils.resolveSigningName(context.request(), executionAttributes,
-                                                                        executionAttributes.getAttribute(SERVICE_SIGNING_NAME)))
+                   .put(SIGNING_NAME, signingName)
                    .put(REQUEST_CHECKSUM_CALCULATION,
                         executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_CHECKSUM_CALCULATION))
                    .put(RESPONSE_CHECKSUM_VALIDATION,

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -423,19 +423,14 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                                          existingHttpAttributes.toBuilder() :
                                                          SdkHttpExecutionAttributes.builder();
 
-            Region signingRegion = S3ExpressUtils.resolveSigningRegion(context.request(), executionAttributes,
-                                       executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION));
-            String signingName = S3ExpressUtils.resolveSigningName(context.request(), executionAttributes,
-                                     executionAttributes.getAttribute(SERVICE_SIGNING_NAME));
-
             builder.put(OPERATION_NAME,
                         executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME))
                    .put(HTTP_CHECKSUM, executionAttributes.getAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM))
-                   .put(SIGNING_REGION, signingRegion)
+                   .put(SIGNING_REGION, executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION))
                    .put(S3InternalSdkHttpExecutionAttribute.OBJECT_FILE_PATH,
                         executionAttributes.getAttribute(OBJECT_FILE_PATH))
                    .put(USE_S3_EXPRESS_AUTH, S3ExpressUtils.isS3ExpressAuthRequest(context.request(), executionAttributes))
-                   .put(SIGNING_NAME, signingName)
+                   .put(SIGNING_NAME, executionAttributes.getAttribute(SERVICE_SIGNING_NAME))
                    .put(REQUEST_CHECKSUM_CALCULATION,
                         executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_CHECKSUM_CALCULATION))
                    .put(RESPONSE_CHECKSUM_VALIDATION,
@@ -466,6 +461,19 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
 
             executionAttributes.putAttribute(SDK_HTTP_EXECUTION_ATTRIBUTES,
                                              attributes);
+        }
+
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission context,
+                                       ExecutionAttributes executionAttributes) {
+            SdkHttpExecutionAttributes httpAttributes = executionAttributes.getAttribute(SDK_HTTP_EXECUTION_ATTRIBUTES);
+            if (httpAttributes != null) {
+                executionAttributes.putAttribute(SDK_HTTP_EXECUTION_ATTRIBUTES,
+                    httpAttributes.toBuilder()
+                                  .put(SIGNING_REGION, executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION))
+                                  .put(SIGNING_NAME, executionAttributes.getAttribute(SERVICE_SIGNING_NAME))
+                                  .build());
+            }
         }
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -430,7 +430,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                    .put(S3InternalSdkHttpExecutionAttribute.OBJECT_FILE_PATH,
                         executionAttributes.getAttribute(OBJECT_FILE_PATH))
                    .put(USE_S3_EXPRESS_AUTH, S3ExpressUtils.isS3ExpressAuthRequest(context.request(), executionAttributes))
-                   .put(SIGNING_NAME, executionAttributes.getAttribute(SERVICE_SIGNING_NAME))
+                   .put(SIGNING_NAME, S3ExpressUtils.resolveSigningName(context.request(), executionAttributes,
+                                                                        executionAttributes.getAttribute(SERVICE_SIGNING_NAME)))
                    .put(REQUEST_CHECKSUM_CALCULATION,
                         executionAttributes.getAttribute(SdkInternalExecutionAttribute.REQUEST_CHECKSUM_CALCULATION))
                    .put(RESPONSE_CHECKSUM_VALIDATION,

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -470,7 +470,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
             if (httpAttributes != null) {
                 executionAttributes.putAttribute(SDK_HTTP_EXECUTION_ATTRIBUTES,
                     httpAttributes.toBuilder()
-                                  .put(SIGNING_REGION, executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION))
+                                  .put(SIGNING_REGION, executionAttributes.getAttribute(
+                                      AwsSignerExecutionAttribute.SIGNING_REGION))
                                   .put(SIGNING_NAME, executionAttributes.getAttribute(SERVICE_SIGNING_NAME))
                                   .build());
             }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressUtils.java
@@ -19,9 +19,6 @@ import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttrib
 
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
-import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
-import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -29,13 +26,8 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.spi.identity.AuthSchemeOptionsResolver;
 import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.endpoints.Endpoint;
-import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.endpoints.S3EndpointParams;
-import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.endpoints.internal.KnownS3ExpressEndpointProperty;
-import software.amazon.awssdk.services.s3.endpoints.internal.S3EndpointResolverUtils;
 import software.amazon.awssdk.services.s3.s3express.S3ExpressAuthScheme;
 
 @SdkInternalApi
@@ -79,61 +71,6 @@ public final class S3ExpressUtils {
             return S3ExpressAuthScheme.SCHEME_ID.equals(authSchemeOption.schemeId());
         }
         return false;
-    }
-
-    /**
-     * Resolves the signing service name from the auth scheme options. This is needed because the endpoint rules may
-     * specify a different signing name (e.g., "s3express" for S3Express control plane APIs) than the client-level
-     * default ("s3"). Returns the fallback value if the signing name cannot be resolved from auth scheme options.
-     */
-    public static String resolveSigningName(SdkRequest request, ExecutionAttributes executionAttributes, String fallback) {
-        Endpoint endpoint = resolveEndpoint(request, executionAttributes);
-        if (endpoint != null) {
-            List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
-            if (authSchemes != null && !authSchemes.isEmpty()) {
-                EndpointAuthScheme authScheme = authSchemes.get(0);
-                if (authScheme instanceof SigV4AuthScheme) {
-                    return ((SigV4AuthScheme) authScheme).signingName();
-                }
-            }
-        }
-        return fallback;
-    }
-
-    /**
-     * Resolves the signing region from the endpoint resolution. This is needed because the endpoint rules may
-     * specify a different region (e.g., for cross-region access) than the client-level default.
-     * Returns the fallback value if the region cannot be resolved.
-     */
-    public static Region resolveSigningRegion(SdkRequest request, ExecutionAttributes executionAttributes, Region fallback) {
-        Endpoint endpoint = resolveEndpoint(request, executionAttributes);
-        if (endpoint != null) {
-            List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
-            if (authSchemes != null && !authSchemes.isEmpty()) {
-                EndpointAuthScheme authScheme = authSchemes.get(0);
-                if (authScheme instanceof SigV4AuthScheme) {
-                    String region = ((SigV4AuthScheme) authScheme).signingRegion();
-                    if (region != null) {
-                        return Region.of(region);
-                    }
-                }
-            }
-        }
-        return fallback;
-    }
-
-    private static Endpoint resolveEndpoint(SdkRequest request, ExecutionAttributes executionAttributes) {
-        EndpointProvider endpointProvider =
-            executionAttributes.getAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER);
-        if (endpointProvider instanceof S3EndpointProvider) {
-            try {
-                S3EndpointParams endpointParams = S3EndpointResolverUtils.ruleParams(request, executionAttributes);
-                return ((S3EndpointProvider) endpointProvider).resolveEndpoint(endpointParams).join();
-            } catch (Exception e) {
-                // If resolution fails, fall back to defaults
-            }
-        }
-        return null;
     }
 
     /**

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressUtils.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.spi.identity.AuthSchemeOptionsResolver;
 import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.services.s3.endpoints.internal.KnownS3ExpressEndpointProperty;
 import software.amazon.awssdk.services.s3.s3express.S3ExpressAuthScheme;
@@ -71,6 +72,26 @@ public final class S3ExpressUtils {
             return S3ExpressAuthScheme.SCHEME_ID.equals(authSchemeOption.schemeId());
         }
         return false;
+    }
+
+    /**
+     * Resolves the signing service name from the auth scheme options. This is needed because the endpoint rules may
+     * specify a different signing name (e.g., "s3express" for S3Express control plane APIs) than the client-level
+     * default ("s3"). Returns the fallback value if the signing name cannot be resolved from auth scheme options.
+     */
+    public static String resolveSigningName(SdkRequest request, ExecutionAttributes executionAttributes, String fallback) {
+        AuthSchemeOptionsResolver resolver =
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_OPTIONS_RESOLVER);
+        if (resolver != null) {
+            List<AuthSchemeOption> options = resolver.resolve(request);
+            if (!options.isEmpty()) {
+                String name = options.get(0).signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME);
+                if (name != null) {
+                    return name;
+                }
+            }
+        }
+        return fallback;
     }
 
     /**

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressUtils.java
@@ -19,6 +19,9 @@ import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttrib
 
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -26,9 +29,13 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.spi.identity.AuthSchemeOptionsResolver;
 import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.endpoints.Endpoint;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointParams;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.endpoints.internal.KnownS3ExpressEndpointProperty;
+import software.amazon.awssdk.services.s3.endpoints.internal.S3EndpointResolverUtils;
 import software.amazon.awssdk.services.s3.s3express.S3ExpressAuthScheme;
 
 @SdkInternalApi
@@ -80,18 +87,53 @@ public final class S3ExpressUtils {
      * default ("s3"). Returns the fallback value if the signing name cannot be resolved from auth scheme options.
      */
     public static String resolveSigningName(SdkRequest request, ExecutionAttributes executionAttributes, String fallback) {
-        AuthSchemeOptionsResolver resolver =
-            executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_OPTIONS_RESOLVER);
-        if (resolver != null) {
-            List<AuthSchemeOption> options = resolver.resolve(request);
-            if (!options.isEmpty()) {
-                String name = options.get(0).signerProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME);
-                if (name != null) {
-                    return name;
+        Endpoint endpoint = resolveEndpoint(request, executionAttributes);
+        if (endpoint != null) {
+            List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+            if (authSchemes != null && !authSchemes.isEmpty()) {
+                EndpointAuthScheme authScheme = authSchemes.get(0);
+                if (authScheme instanceof SigV4AuthScheme) {
+                    return ((SigV4AuthScheme) authScheme).signingName();
                 }
             }
         }
         return fallback;
+    }
+
+    /**
+     * Resolves the signing region from the endpoint resolution. This is needed because the endpoint rules may
+     * specify a different region (e.g., for cross-region access) than the client-level default.
+     * Returns the fallback value if the region cannot be resolved.
+     */
+    public static Region resolveSigningRegion(SdkRequest request, ExecutionAttributes executionAttributes, Region fallback) {
+        Endpoint endpoint = resolveEndpoint(request, executionAttributes);
+        if (endpoint != null) {
+            List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+            if (authSchemes != null && !authSchemes.isEmpty()) {
+                EndpointAuthScheme authScheme = authSchemes.get(0);
+                if (authScheme instanceof SigV4AuthScheme) {
+                    String region = ((SigV4AuthScheme) authScheme).signingRegion();
+                    if (region != null) {
+                        return Region.of(region);
+                    }
+                }
+            }
+        }
+        return fallback;
+    }
+
+    private static Endpoint resolveEndpoint(SdkRequest request, ExecutionAttributes executionAttributes) {
+        EndpointProvider endpointProvider =
+            executionAttributes.getAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER);
+        if (endpointProvider instanceof S3EndpointProvider) {
+            try {
+                S3EndpointParams endpointParams = S3EndpointResolverUtils.ruleParams(request, executionAttributes);
+                return ((S3EndpointProvider) endpointProvider).resolveEndpoint(endpointParams).join();
+            } catch (Exception e) {
+                // If resolution fails, fall back to defaults
+            }
+        }
+        return null;
     }
 
     /**

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/S3ExpressCreateSessionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/S3ExpressCreateSessionTest.java
@@ -71,8 +71,10 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 public class S3ExpressCreateSessionTest extends BaseRuleSetClientTest {
     private static final Logger log = Logger.loggerFor(S3ExpressCreateSessionTest.class);
 
-    private static final Function<WireMockRuntimeInfo, URI> WM_HTTP_ENDPOINT = wm -> URI.create(wm.getHttpBaseUrl());
-    private static final Function<WireMockRuntimeInfo, URI> WM_HTTPS_ENDPOINT = wm -> URI.create(wm.getHttpsBaseUrl());
+    private static final Function<WireMockRuntimeInfo, URI> WM_HTTP_ENDPOINT =
+        wm -> URI.create("http://127.0.0.1:" + wm.getHttpPort());
+    private static final Function<WireMockRuntimeInfo, URI> WM_HTTPS_ENDPOINT =
+        wm -> URI.create("https://127.0.0.1:" + wm.getHttpsPort());
     private static final AwsCredentialsProvider CREDENTIALS_PROVIDER =
         StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
     private static final PathStyleEnforcingInterceptor PATH_STYLE_INTERCEPTOR = new PathStyleEnforcingInterceptor();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/S3ExpressTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/S3ExpressTest.java
@@ -76,8 +76,10 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @WireMockTest(httpsEnabled = true)
 public class S3ExpressTest extends BaseRuleSetClientTest {
     private static final Logger log = Logger.loggerFor(S3ExpressTest.class);
-    private static final Function<WireMockRuntimeInfo, URI> WM_HTTP_ENDPOINT = wm -> URI.create(wm.getHttpBaseUrl());
-    private static final Function<WireMockRuntimeInfo, URI> WM_HTTPS_ENDPOINT = wm -> URI.create(wm.getHttpsBaseUrl());
+    private static final Function<WireMockRuntimeInfo, URI> WM_HTTP_ENDPOINT =
+        wm -> URI.create("http://127.0.0.1:" + wm.getHttpPort());
+    private static final Function<WireMockRuntimeInfo, URI> WM_HTTPS_ENDPOINT =
+        wm -> URI.create("https://127.0.0.1:" + wm.getHttpsPort());
     private static final AwsCredentialsProvider CREDENTIALS_PROVIDER =
         StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
     private static final PathStyleEnforcingInterceptor PATH_STYLE_INTERCEPTOR = new PathStyleEnforcingInterceptor();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressCacheFunctionalTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/s3express/S3ExpressCacheFunctionalTest.java
@@ -69,7 +69,8 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @WireMockTest(httpsEnabled = true)
 public class S3ExpressCacheFunctionalTest {
 
-    private static final Function<WireMockRuntimeInfo, URI> WM_HTTPS_ENDPOINT = wm -> URI.create(wm.getHttpsBaseUrl());
+    private static final Function<WireMockRuntimeInfo, URI> WM_HTTPS_ENDPOINT =
+        wm -> URI.create("https://127.0.0.1:" + wm.getHttpsPort());
     private static final PathStyleEnforcingInterceptor PATH_STYLE_INTERCEPTOR = new PathStyleEnforcingInterceptor();
     private static final String S3EXPRESS_BUCKET_1 = "s3express-cache-1--use1-az1--x-s3";
     private static final String S3EXPRESS_BUCKET_2 = "s3express-cache-2--use1-az1--x-s3";


### PR DESCRIPTION
### **Motivation and Context**
The core interceptors to pipeline migration moves auth scheme resolution and endpoint resolution from generated interceptors to dedicated pipeline stages. This changes the generated code, the AuthSchemeInterceptor and EndpointResolverInterceptor are no longer generated with resolution logic (it now lives in AuthSchemeResolutionStage and EndpointResolutionStage).

This PR updates the codegen test fixture files to match the new generated output, and fixes a bug in DefaultS3CrtAsyncClient where signing attributes were being read before they were resolved.

### **Modifications**
- Updated codegen fixture/expected files to reflect the removal of auth scheme resolution and endpoint resolution logic from generated interceptors.
- **DefaultS3CrtAsyncClient**: Moved SIGNING_REGION and SERVICE_SIGNING_NAME reads to beforeTransmission where the values are available after pipeline stages have run.
   Previously these were read in afterMarshalling which now runs before auth scheme and endpoint resolution.
- **S3Express WireMock tests**: Changed endpoint override from localhost to 127.0.0.1. With endpoint resolution now running after modifyHttpRequest interceptors, the PathStyleEnforcingInterceptor can no longer rewrite virtual-hosted URLs. Using an IP-based endpoint causes the S3 endpoint rules to produce path-style URLs directly.

### **Testing**
- Codegen unit tests pass with updated fixtures.
- S3Express integration tests pass with the CRT client fix.
- S3Express integration tests pass with the CRT client signing fix.
- Cross-region CRT integration test passes with correct signing region.