### PR TITLE
Propagate error to active chunk subscriber in SplittingPublisher

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-773e2a6.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-773e2a6.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue where `AsyncRequestBody.split()` did not propagate upstream errors to the in-progress chunk subscriber"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/NonRetryableSubAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/NonRetryableSubAsyncRequestBody.java
@@ -97,6 +97,7 @@ public final class NonRetryableSubAsyncRequestBody implements SubAsyncRequestBod
         return partNumber;
     }
 
+    @Override
     public void error(Throwable error) {
         delegate.error(error);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/RetryableSubAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/RetryableSubAsyncRequestBody.java
@@ -109,6 +109,11 @@ public final class RetryableSubAsyncRequestBody implements SubAsyncRequestBody {
     }
 
     @Override
+    public void error(Throwable error) {
+        delegate.error(error);
+    }
+
+    @Override
     public long receivedBytesLength() {
         return bufferedLength;
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingPublisher.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingPublisher.java
@@ -250,6 +250,7 @@ public class SplittingPublisher implements SdkPublisher<CloseableAsyncRequestBod
         @Override
         public void onError(Throwable t) {
             log.debug(() -> "Received onError()", t);
+            currentBody.error(t);
             downstreamPublisher.error(t);
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SubAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SubAsyncRequestBody.java
@@ -40,6 +40,11 @@ public interface SubAsyncRequestBody extends CloseableAsyncRequestBody {
     void complete();
 
     /**
+     * Signal that the stream has terminated with an error. No more {@link #send(ByteBuffer)} calls will be made.
+     */
+    void error(Throwable error);
+
+    /**
      * The maximum length of the content this AsyncRequestBody can hold. If the upstream content length is known, this should be
      * the same as receivedBytesLength
      */

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/SplittingPublisherTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/SplittingPublisherTest.java
@@ -229,6 +229,75 @@ public class SplittingPublisherTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void upstreamError_shouldPropagateToCurrentBodySubscriber(boolean enableRetryableSubAsyncRequestBody) throws Exception {
+        RuntimeException upstreamError = new RuntimeException("upstream failure");
+        AsyncRequestBody errorBody = new AsyncRequestBody() {
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of(20L);
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                s.onSubscribe(new Subscription() {
+                    private int calls = 0;
+
+                    @Override
+                    public void request(long n) {
+                        if (calls++ == 0) {
+                            // Send partial data, then error
+                            s.onNext(ByteBuffer.wrap(new byte[3]));
+                        } else {
+                            s.onError(upstreamError);
+                        }
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+            }
+        };
+
+        SplittingPublisher splittingPublisher =
+            SplittingPublisher.builder()
+                              .asyncRequestBody(errorBody)
+                              .splitConfiguration(AsyncRequestBodySplitConfiguration.builder()
+                                                                                    .chunkSizeInBytes(10L)
+                                                                                    .bufferSizeInBytes(20L)
+                                                                                    .build())
+                              .retryableSubAsyncRequestBodyEnabled(enableRetryableSubAsyncRequestBody)
+                              .build();
+
+        CompletableFuture<Throwable> bodyError = new CompletableFuture<>();
+        splittingPublisher.subscribe(requestBody -> {
+            requestBody.subscribe(new Subscriber<ByteBuffer>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(ByteBuffer byteBuffer) {
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    bodyError.complete(t);
+                }
+
+                @Override
+                public void onComplete() {
+                }
+            });
+        });
+
+        Throwable error = bodyError.get(5, TimeUnit.SECONDS);
+        assertThat(error).isEqualTo(upstreamError);
+    }
+
     private static void verifySplitContent(AsyncRequestBody asyncRequestBody, int chunkSize) throws Exception {
         SplittingPublisher splittingPublisher = SplittingPublisher.builder()
                 .asyncRequestBody(asyncRequestBody)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixed bug where `SplittingPublisher.onError()` did not signal the active `SubAsyncRequestBody`, causing its subscriber to hang until timeout instead of being notified immediately

## Modifications
<!--- Describe your changes in detail -->
- Call `currentBody.error(t)` in `SplittingSubscriber.onError()`
-  Add `error(Throwable)` to `SubAsyncRequestBody` interface
     - Implement `error()` in `RetryableSubAsyncRequestBody`
     - Override `error()` in `NonRetryableSubAsyncRequestBody`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
