### PR TITLE
Fix residual leak in `downloadDirectory` by skipping file downloads after cancellation.

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-8858.json
+++ b/.changes/next-release/bugfix-S3TransferManager-8858.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "S3 Transfer Manager",
     "contributor": "",
-    "description": "Fix a resource leak in `downloadDirectory` where cancelling the download could still allow late-arriving file transfers to recreate the destination directory. Added a guard in `DownloadDirectoryHelper` to skip file downloads after the operation is cancelled."
+    "description": "Fix a resource leak in `downloadDirectory` where cancelling the download could still allow file transfers that arrive late to recreate the destination directory. Added a guard in `DownloadDirectoryHelper` to skip file downloads after the operation is cancelled."
 }

--- a/.changes/next-release/bugfix-S3TransferManager-8858.json
+++ b/.changes/next-release/bugfix-S3TransferManager-8858.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Fix a resource leak in `downloadDirectory` where cancelling the download could still allow late-arriving file transfers to recreate the destination directory. Added a guard in `DownloadDirectoryHelper` to skip file downloads after the operation is cancelled."
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
@@ -93,6 +93,10 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
         }
 
         requestsInFlight.add(currentRequest);
+
+        // When returnFuture completes exceptionally, the cancel handler iterates requestsInFlight and cancels every future in
+        // it. That iteration only happens once. If it already ran before we added currentRequest to the set, currentRequest
+        // was missed. This check ensures we cancel it ourselves in that case.
         if (returnFuture.isCompletedExceptionally()) {
             currentRequest.cancel(true);
         }

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
@@ -93,6 +93,9 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
         }
 
         requestsInFlight.add(currentRequest);
+        if (returnFuture.isCompletedExceptionally()) {
+            currentRequest.cancel(true);
+        }
         currentRequest.whenComplete((r, t) -> {
             checkForCompletion(numRequestsInFlight.decrementAndGet());
             requestsInFlight.remove(currentRequest);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
@@ -106,7 +106,7 @@ public class DownloadDirectoryHelper {
 
         CompletableFuture<Void> allOfFutures = new CompletableFuture<>();
         AsyncBufferingSubscriber<S3Object> asyncBufferingSubscriber =
-            new AsyncBufferingSubscriber<>(downloadSingleFile(downloadDirectoryRequest, request,
+            new AsyncBufferingSubscriber<>(downloadSingleFile(returnFuture, downloadDirectoryRequest, request,
                                                               failedFileDownloads),
                                            allOfFutures,
                                            transferConfiguration.option(
@@ -129,11 +129,13 @@ public class DownloadDirectoryHelper {
     }
 
     private Function<S3Object, CompletableFuture<?>> downloadSingleFile(
+        CompletableFuture<CompletedDirectoryDownload> returnFuture,
         DownloadDirectoryRequest downloadDirectoryRequest,
         ListObjectsV2Request listRequest,
         Queue<FailedFileDownload> failedFileDownloads) {
 
-        return s3Object -> doDownloadSingleFile(downloadDirectoryRequest,
+        return s3Object -> doDownloadSingleFile(returnFuture,
+                                            downloadDirectoryRequest,
                                             failedFileDownloads,
                                             listRequest,
                                             s3Object);
@@ -158,10 +160,17 @@ public class DownloadDirectoryHelper {
         }
     }
 
-    private CompletableFuture<CompletedFileDownload> doDownloadSingleFile(DownloadDirectoryRequest downloadDirectoryRequest,
-                                                                          Collection<FailedFileDownload> failedFileDownloads,
-                                                                          ListObjectsV2Request listRequest,
-                                                                          S3Object s3Object) {
+    private CompletableFuture<CompletedFileDownload> doDownloadSingleFile(
+        CompletableFuture<CompletedDirectoryDownload> returnFuture,
+        DownloadDirectoryRequest downloadDirectoryRequest,
+        Collection<FailedFileDownload> failedFileDownloads,
+        ListObjectsV2Request listRequest,
+        S3Object s3Object) {
+
+        if (returnFuture.isDone()) {
+            return CompletableFutureUtils.failedFuture(
+                SdkClientException.create("Download was cancelled before file could be started"));
+        }
 
         Path destinationPath = determineDestinationPath(downloadDirectoryRequest, listRequest, s3Object);
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
@@ -167,7 +167,7 @@ public class DownloadDirectoryHelper {
         ListObjectsV2Request listRequest,
         S3Object s3Object) {
 
-        if (returnFuture.isDone()) {
+        if (returnFuture.isCompletedExceptionally()) {
             return CompletableFutureUtils.failedFuture(
                 SdkClientException.create("Download was cancelled before file could be started"));
         }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
@@ -150,4 +150,25 @@ class AsyncBufferingSubscriberTest {
         future.cancel(true);
         verify(mockSubscription, times(1)).cancel();
     }
+
+    @Test
+    void returnFutureCancelledDuringOnNext_shouldCancelInFlightFuture() {
+        CompletableFuture<Void> returnFuture = new CompletableFuture<>();
+        CompletableFuture<Object> consumerFuture = new CompletableFuture<>();
+
+        AsyncBufferingSubscriber<String> subscriber = new AsyncBufferingSubscriber<>(
+            item -> {
+                returnFuture.completeExceptionally(new RuntimeException("cancelled"));
+                return consumerFuture;
+            },
+            returnFuture,
+            1
+        );
+
+        SimplePublisher<String> publisher = new SimplePublisher<>();
+        publisher.subscribe(subscriber);
+        publisher.send("item1");
+
+        assertThat(consumerFuture.isCancelled()).isTrue();
+    }
 }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
@@ -213,7 +213,6 @@ public class DownloadDirectoryHelperTest {
                                                                               .bucket("bucket")
                                                                               .build());
 
-        // Wait for both downloads to have started before cancelling
         assertThat(bothStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
         downloadDirectory.completionFuture().cancel(true);
@@ -579,12 +578,6 @@ public class DownloadDirectoryHelperTest {
         return fileDownload2;
     }
 
-    /**
-     * Verifies that after a directory download is cancelled, subsequent S3 objects do not cause
-     * directories to be created on the filesystem. This reproduces the bug where a late-arriving
-     * S3Object would call createParentDirectoriesIfNeeded() and recreate a directory that was
-     * already cleaned up.
-     */
     @Test
     void downloadDirectory_cancelledFuture_shouldNotCreateDirectories() throws Exception {
         SimplePublisher<S3Object> publisher = new SimplePublisher<>();
@@ -602,16 +595,13 @@ public class DownloadDirectoryHelperTest {
                                     .bucket("bucket")
                                     .build());
 
-        // Cancel before any items are delivered
         directoryDownload.completionFuture().cancel(true);
 
-        // Now deliver an item — this simulates a late-arriving S3Object after cancel
         publisher.send(S3Object.builder().key("subdir/file.txt").size(100L).build());
         publisher.complete();
 
         Thread.sleep(200);
 
-        // The subdirectory should NOT have been created
         Path subdir = directory.resolve("subdir");
         assertThat(Files.exists(subdir)).isFalse();
     }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelperTest.java
@@ -39,6 +39,7 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -55,6 +56,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.EncodingType;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -72,6 +74,7 @@ import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
+import software.amazon.awssdk.utils.async.SimplePublisher;
 
 public class DownloadDirectoryHelperTest {
     private static final String DIRECTORY_NAME = "test";
@@ -197,13 +200,22 @@ public class DownloadDirectoryHelperTest {
         CompletableFuture<CompletedFileDownload> future2 = new CompletableFuture<>();
         FileDownload fileDownload2 = newDownload(future2);
 
-        when(singleDownloadFunction.apply(any(DownloadFileRequest.class))).thenReturn(fileDownload, fileDownload2);
+        AtomicInteger callCount = new AtomicInteger(0);
+        CountDownLatch bothStarted = new CountDownLatch(2);
+        when(singleDownloadFunction.apply(any(DownloadFileRequest.class))).thenAnswer(invocation -> {
+            bothStarted.countDown();
+            return callCount.incrementAndGet() == 1 ? fileDownload : fileDownload2;
+        });
 
         DirectoryDownload downloadDirectory =
             downloadDirectoryHelper.downloadDirectory(DownloadDirectoryRequest.builder()
                                                                               .destination(directory)
                                                                               .bucket("bucket")
                                                                               .build());
+
+        // Wait for both downloads to have started before cancelling
+        assertThat(bothStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
         downloadDirectory.completionFuture().cancel(true);
 
         assertThatThrownBy(() -> future.get(1, TimeUnit.SECONDS))
@@ -565,6 +577,43 @@ public class DownloadDirectoryHelperTest {
         FileDownload fileDownload2 = newDownload(failedFuture);
         failedFuture.completeExceptionally(exception);
         return fileDownload2;
+    }
+
+    /**
+     * Verifies that after a directory download is cancelled, subsequent S3 objects do not cause
+     * directories to be created on the filesystem. This reproduces the bug where a late-arriving
+     * S3Object would call createParentDirectoriesIfNeeded() and recreate a directory that was
+     * already cleaned up.
+     */
+    @Test
+    void downloadDirectory_cancelledFuture_shouldNotCreateDirectories() throws Exception {
+        SimplePublisher<S3Object> publisher = new SimplePublisher<>();
+        when(listObjectsHelper.listS3ObjectsRecursively(any(ListObjectsV2Request.class)))
+            .thenReturn(SdkPublisher.adapt(publisher));
+
+        DownloadDirectoryHelper helper = new DownloadDirectoryHelper(
+            TransferManagerConfiguration.builder().build(),
+            listObjectsHelper,
+            singleDownloadFunction);
+
+        DirectoryDownload directoryDownload = helper.downloadDirectory(
+            DownloadDirectoryRequest.builder()
+                                    .destination(directory)
+                                    .bucket("bucket")
+                                    .build());
+
+        // Cancel before any items are delivered
+        directoryDownload.completionFuture().cancel(true);
+
+        // Now deliver an item — this simulates a late-arriving S3Object after cancel
+        publisher.send(S3Object.builder().key("subdir/file.txt").size(100L).build());
+        publisher.complete();
+
+        Thread.sleep(200);
+
+        // The subdirectory should NOT have been created
+        Path subdir = directory.resolve("subdir");
+        assertThat(Files.exists(subdir)).isFalse();
     }
 
     private FileDownload newDownload(CompletableFuture<CompletedFileDownload> future) {


### PR DESCRIPTION
In #6875, we addressed canceling in flight transfers when a directory download is cancelled. That fix reduced the leaked files per orphaned directory from thousands to single digits in stress test. However there was a residual leak for downloads that were already dispatched to `doDownloadSingleFile` (the method that creates the destination directory and initiates the file download) before the cancellation signal propagated.


When cancellation occurs, thread A calls `subscription.cancel()` to stop new items from being delivered. Meanwhile, thread B has already picked up an item from `onNext` and is inside `doDownloadSingleFile`. Since it entered before thread A's cancellation took effect, it creates the destination directory and starts a download into it.

This PR adds an `isCompletedExceptionally()` guard at the top of `doDownloadSingleFile` so that any thread that entered the method before cancellation took effect will return early before touching the filesystem.

The PR also adds a `isCompletedExceptionally()` check in `AsyncBufferingSubscriber.onNext`, immediately after adding the future to `requestsInFlight`. When `returnFuture` completes exceptionally, the cancel handler iterates `requestsInFlight` and cancels every future in it. That iteration only happens once. If it already ran before the future was added to the set, the future was missed. The additional check ensures we cancel it in that case. 

The tests:


1.  Updated `downloadDirectory_cancel_shouldCancelAllFutures` - now waits for both downloads to start before cancelling. The original test called `cancel()` immediately after `downloadDirectory()`, implicitly assuming all downloads would always start regardless of cancellation state. With the new `isCompletedExceptionally()` guard, that assumption is not always true since cancel can now prevent downloads from starting. The test's intent is unchanged (in flight futures get cancelled), we just make sure both futures are actually in flight before cancelling. (Sanity check tested this with a repeated test suite 1000 times to make sure its deterministic)

2. Added `downloadDirectory_cancelledFuture_shouldNotCreateDirectories` - The test cancels the directory download future, then delivers an S3 object through the publisher. Asserts that the destination subdirectory was never created on the filesystem. Without the fix, `doDownloadSingleFile` would call `createParentDirectoriesIfNeeded()` and create the directory despite the cancellation.

3. Added `returnFutureCancelledDuringOnNext_shouldCancelInFlightFuture` in `AsyncBufferingSubscriberTest` - Forces the race outcome by triggering cancellation inside `consumer.apply()`, guaranteeing the cancel handler iterates an empty set. Asserts the future gets cancelled via the post add check.