### PR TITLE
Fix concurrency bug in S3 parallel multipart download

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-0288228.json
+++ b/.changes/next-release/bugfix-AmazonS3-0288228.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "Amazon S3",
     "contributor": "",
-    "description": "Fix concurrency bug in S3 parallel multipart download"
+    "description": "Fix concurrency bug where downloading multipart objects with `MultipartS3AsyncClient` could enter infinite loop"
 }

--- a/.changes/next-release/bugfix-AmazonS3-0288228.json
+++ b/.changes/next-release/bugfix-AmazonS3-0288228.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fix concurrency bug in S3 parallel multipart download"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadResumeContext.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadResumeContext.java
@@ -45,12 +45,12 @@ public class MultipartDownloadResumeContext {
     /**
      * The total number of parts of the multipart download.
      */
-    private Integer totalParts;
+    private volatile Integer totalParts;
 
     /**
      * The GetObjectResponse to return to the user.
      */
-    private GetObjectResponse response;
+    private volatile GetObjectResponse response;
 
     public MultipartDownloadResumeContext() {
         this(new ConcurrentSkipListSet<>(), 0L);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadResumeContext.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadResumeContext.java
@@ -19,7 +19,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicLong;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.utils.ToString;
@@ -39,7 +40,7 @@ public class MultipartDownloadResumeContext {
     /**
      * Keep track of the byte index to the last byte of the last completed part
      */
-    private Long bytesToLastCompletedParts;
+    private final AtomicLong bytesToLastCompletedParts;
 
     /**
      * The total number of parts of the multipart download.
@@ -52,14 +53,14 @@ public class MultipartDownloadResumeContext {
     private GetObjectResponse response;
 
     public MultipartDownloadResumeContext() {
-        this(new TreeSet<>(), 0L);
+        this(new ConcurrentSkipListSet<>(), 0L);
     }
 
     public MultipartDownloadResumeContext(Collection<Integer> completedParts, Long bytesToLastCompletedParts) {
-        this.completedParts = new TreeSet<>(Validate.notNull(
+        this.completedParts = new ConcurrentSkipListSet<>(Validate.notNull(
             completedParts, "completedParts must not be null"));
-        this.bytesToLastCompletedParts = Validate.notNull(
-            bytesToLastCompletedParts, "bytesToLastCompletedParts must not be null");
+        this.bytesToLastCompletedParts = new AtomicLong(Validate.notNull(
+            bytesToLastCompletedParts, "bytesToLastCompletedParts must not be null"));
     }
 
     public List<Integer> completedParts() {
@@ -67,7 +68,7 @@ public class MultipartDownloadResumeContext {
     }
 
     public Long bytesToLastCompletedParts() {
-        return bytesToLastCompletedParts;
+        return bytesToLastCompletedParts.get();
     }
 
     public void addCompletedPart(int partNumber) {
@@ -75,7 +76,7 @@ public class MultipartDownloadResumeContext {
     }
 
     public void addToBytesToLastCompletedParts(long bytes) {
-        bytesToLastCompletedParts += bytes;
+        bytesToLastCompletedParts.addAndGet(bytes);
     }
 
     public void totalParts(int totalParts) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/multipart/MultipartDownloadResumeContextConcurrencyTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/multipart/MultipartDownloadResumeContextConcurrencyTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.multipart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.internal.multipart.MultipartDownloadResumeContext;
+
+/**
+ * Tests that verify thread-safety of {@link MultipartDownloadResumeContext} when accessed concurrently,
+ * as happens in the parallel multipart download path.
+ */
+class MultipartDownloadResumeContextConcurrencyTest {
+
+    private static final int NUM_THREADS = 32;
+    private static final int TOTAL_PARTS = 1000;
+
+    @Test
+    void addCompletedPart_concurrentAccess_doesNotCorruptState() throws Exception {
+        MultipartDownloadResumeContext context = new MultipartDownloadResumeContext();
+        context.totalParts(TOTAL_PARTS);
+        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 1; i <= TOTAL_PARTS; i++) {
+            int partNumber = i;
+            futures.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                context.addCompletedPart(partNumber);
+            }));
+        }
+
+        // Release all threads simultaneously to maximize contention
+        startLatch.countDown();
+
+        for (Future<?> future : futures) {
+            future.get(10, TimeUnit.SECONDS);
+        }
+
+        executor.shutdown();
+
+        assertThat(context.completedParts()).hasSize(TOTAL_PARTS);
+        assertThat(context.isComplete()).isTrue();
+        assertThat(context.highestSequentialCompletedPart()).isEqualTo(TOTAL_PARTS);
+    }
+
+    @Test
+    void addToBytesToLastCompletedParts_concurrentAccess_correctSum() throws Exception {
+        MultipartDownloadResumeContext context = new MultipartDownloadResumeContext();
+        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        long bytesPerPart = 8 * 1024 * 1024; // 8 MiB
+        for (int i = 0; i < TOTAL_PARTS; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                context.addToBytesToLastCompletedParts(bytesPerPart);
+            }));
+        }
+
+        startLatch.countDown();
+
+        for (Future<?> future : futures) {
+            future.get(10, TimeUnit.SECONDS);
+        }
+
+        executor.shutdown();
+
+        assertThat(context.bytesToLastCompletedParts()).isEqualTo(bytesPerPart * TOTAL_PARTS);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
S3 parallel multipart downloads with `MultipartS3AsyncClient` can enter an unrecoverable infinite loop, causing threads to spin at 100% CPU indefinitely


`MultipartDownloadResumeContext` uses a non-thread-safe `TreeSet` that is accessed concurrently from `CompletableFuture.whenComplete()` callbacks in the parallel download path. Concurrent `TreeSet.add()` corrupts the red-black tree, creating circular references that cause infinite loops in `TreeMap.put()`.

## Modifications
<!--- Describe your changes in detail -->
- Replace `TreeSet` with `ConcurrentSkipListSet`
- Replace `Long` with `AtomicLong` for `bytesToLastCompletedParts`


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
