### PR TITLE
Preserve source object metadata during multipart copy

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-aee65f7.json
+++ b/.changes/next-release/bugfix-AmazonS3-aee65f7.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fixed an issue where copying large objects using the multipart S3 client silently dropped source object metadata on the destination."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
@@ -108,7 +108,8 @@ public final class CopyObjectHelper {
         CreateMultipartUploadRequest request = SdkPojoConversionUtils.toCreateMultipartUploadRequest(copyObjectRequest);
 
         // Preserve source metadata for multipart copy since CreateMultipartUpload has no MetadataDirective support.
-        if (copyObjectRequest.metadataDirective() != MetadataDirective.REPLACE) {
+        if (copyObjectRequest.metadataDirective() == null
+            || copyObjectRequest.metadataDirective() == MetadataDirective.COPY) {
             request = request.toBuilder()
                              .metadata(headObjectResponse.metadata())
                              .contentType(headObjectResponse.contentType())

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.s3.model.CopyPartResult;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.MetadataDirective;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
@@ -95,15 +96,30 @@ public final class CopyObjectHelper {
             copyInOneChunk(copyObjectRequest, returnFuture);
         } else {
             log.debug(() -> "Starting the copy as multipart copy request");
-            copyInParts(copyObjectRequest, contentLength, returnFuture);
+            copyInParts(copyObjectRequest, contentLength, returnFuture, headObjectResponse);
         }
     }
 
     private void copyInParts(CopyObjectRequest copyObjectRequest,
                              Long contentLength,
-                             CompletableFuture<CopyObjectResponse> returnFuture) {
+                             CompletableFuture<CopyObjectResponse> returnFuture,
+                             HeadObjectResponse headObjectResponse) {
 
         CreateMultipartUploadRequest request = SdkPojoConversionUtils.toCreateMultipartUploadRequest(copyObjectRequest);
+
+        // Preserve source metadata for multipart copy since CreateMultipartUpload has no MetadataDirective support.
+        if (copyObjectRequest.metadataDirective() != MetadataDirective.REPLACE) {
+            request = request.toBuilder()
+                             .metadata(headObjectResponse.metadata())
+                             .contentType(headObjectResponse.contentType())
+                             .cacheControl(headObjectResponse.cacheControl())
+                             .contentDisposition(headObjectResponse.contentDisposition())
+                             .contentEncoding(headObjectResponse.contentEncoding())
+                             .contentLanguage(headObjectResponse.contentLanguage())
+                             .expires(headObjectResponse.expires())
+                             .build();
+        }
+
         CompletableFuture<CreateMultipartUploadResponse> createMultipartUploadFuture =
             s3AsyncClient.createMultipartUpload(request);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -23,7 +23,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -402,7 +406,7 @@ class CopyObjectHelperTest {
         assertThat(actualRequest.contentDisposition()).isEqualTo("attachment");
         assertThat(actualRequest.contentEncoding()).isEqualTo("gzip");
         assertThat(actualRequest.contentLanguage()).isEqualTo("en-US");
-        assertThat(actualRequest.expires()).isEqualTo(java.time.Instant.ofEpochSecond(1700000000L));
+        assertThat(actualRequest.expires()).isEqualTo(Instant.ofEpochSecond(1700000000L));
     }
 
     @Test
@@ -413,7 +417,7 @@ class CopyObjectHelperTest {
                                                                .destinationBucket(DESTINATION_BUCKET)
                                                                .destinationKey(DESTINATION_KEY)
                                                                .metadataDirective(MetadataDirective.REPLACE)
-                                                               .metadata(java.util.Collections.singletonMap("newKey", "newValue"))
+                                                               .metadata(Collections.singletonMap("newKey", "newValue"))
                                                                .contentType("text/plain")
                                                                .build();
 
@@ -433,8 +437,37 @@ class CopyObjectHelperTest {
         assertThat(actualRequest.contentType()).isEqualTo("text/plain");
     }
 
+    @Test
+    void multiPartCopy_metadataDirectiveCopyWithCustomerMetadata_sourceMetadataShouldWin() {
+        CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
+                                                               .sourceBucket(SOURCE_BUCKET)
+                                                               .sourceKey(SOURCE_KEY)
+                                                               .destinationBucket(DESTINATION_BUCKET)
+                                                               .destinationKey(DESTINATION_KEY)
+                                                               .metadataDirective(MetadataDirective.COPY)
+                                                               .metadata(Collections.singletonMap("ignored", "value"))
+                                                               .contentType("text/html")
+                                                               .build();
+
+        stubSuccessfulHeadObjectCallWithMetadata(4000L);
+        stubSuccessfulCreateMulipartCall();
+        stubSuccessfulUploadPartCopyCalls();
+        stubSuccessfulCompleteMultipartCall();
+
+        copyHelper.copyObject(copyObjectRequest).join();
+
+        ArgumentCaptor<CreateMultipartUploadRequest> captor = ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+        verify(s3AsyncClient).createMultipartUpload(captor.capture());
+
+        CreateMultipartUploadRequest actualRequest = captor.getValue();
+        // Source metadata wins when directive is COPY, matching S3 CopyObject API behavior
+        assertThat(actualRequest.metadata()).containsEntry("customKey", "customValue");
+        assertThat(actualRequest.metadata()).doesNotContainKey("ignored");
+        assertThat(actualRequest.contentType()).isEqualTo("application/zip");
+    }
+
     private void stubSuccessfulHeadObjectCallWithMetadata(long contentLength) {
-        java.util.Map<String, String> metadata = new java.util.HashMap<>();
+        Map<String, String> metadata = new HashMap<>();
         metadata.put("customKey", "customValue");
 
         CompletableFuture<HeadObjectResponse> headFuture =
@@ -446,7 +479,7 @@ class CopyObjectHelperTest {
                                                                 .contentDisposition("attachment")
                                                                 .contentEncoding("gzip")
                                                                 .contentLanguage("en-US")
-                                                                .expires(java.time.Instant.ofEpochSecond(1700000000L))
+                                                                .expires(Instant.ofEpochSecond(1700000000L))
                                                                 .build());
 
         when(s3AsyncClient.headObject(any(HeadObjectRequest.class)))

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.MetadataDirective;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
@@ -378,6 +379,78 @@ class CopyObjectHelperTest {
 
         when(s3AsyncClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
             .thenReturn(completeMultipartUploadFuture);
+    }
+
+    @Test
+    void multiPartCopy_metadataDirectiveUnset_shouldForwardSourceMetadata() {
+        CopyObjectRequest copyObjectRequest = copyObjectRequest();
+
+        stubSuccessfulHeadObjectCallWithMetadata(4000L);
+        stubSuccessfulCreateMulipartCall();
+        stubSuccessfulUploadPartCopyCalls();
+        stubSuccessfulCompleteMultipartCall();
+
+        copyHelper.copyObject(copyObjectRequest).join();
+
+        ArgumentCaptor<CreateMultipartUploadRequest> captor = ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+        verify(s3AsyncClient).createMultipartUpload(captor.capture());
+
+        CreateMultipartUploadRequest actualRequest = captor.getValue();
+        assertThat(actualRequest.metadata()).containsEntry("customKey", "customValue");
+        assertThat(actualRequest.contentType()).isEqualTo("application/zip");
+        assertThat(actualRequest.cacheControl()).isEqualTo("max-age=86400");
+        assertThat(actualRequest.contentDisposition()).isEqualTo("attachment");
+        assertThat(actualRequest.contentEncoding()).isEqualTo("gzip");
+        assertThat(actualRequest.contentLanguage()).isEqualTo("en-US");
+        assertThat(actualRequest.expires()).isEqualTo(java.time.Instant.ofEpochSecond(1700000000L));
+    }
+
+    @Test
+    void multiPartCopy_metadataDirectiveReplace_shouldNotForwardSourceMetadata() {
+        CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
+                                                               .sourceBucket(SOURCE_BUCKET)
+                                                               .sourceKey(SOURCE_KEY)
+                                                               .destinationBucket(DESTINATION_BUCKET)
+                                                               .destinationKey(DESTINATION_KEY)
+                                                               .metadataDirective(MetadataDirective.REPLACE)
+                                                               .metadata(java.util.Collections.singletonMap("newKey", "newValue"))
+                                                               .contentType("text/plain")
+                                                               .build();
+
+        stubSuccessfulHeadObjectCallWithMetadata(4000L);
+        stubSuccessfulCreateMulipartCall();
+        stubSuccessfulUploadPartCopyCalls();
+        stubSuccessfulCompleteMultipartCall();
+
+        copyHelper.copyObject(copyObjectRequest).join();
+
+        ArgumentCaptor<CreateMultipartUploadRequest> captor = ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+        verify(s3AsyncClient).createMultipartUpload(captor.capture());
+
+        CreateMultipartUploadRequest actualRequest = captor.getValue();
+        assertThat(actualRequest.metadata()).containsEntry("newKey", "newValue");
+        assertThat(actualRequest.metadata()).doesNotContainKey("customKey");
+        assertThat(actualRequest.contentType()).isEqualTo("text/plain");
+    }
+
+    private void stubSuccessfulHeadObjectCallWithMetadata(long contentLength) {
+        java.util.Map<String, String> metadata = new java.util.HashMap<>();
+        metadata.put("customKey", "customValue");
+
+        CompletableFuture<HeadObjectResponse> headFuture =
+            CompletableFuture.completedFuture(HeadObjectResponse.builder()
+                                                                .contentLength(contentLength)
+                                                                .metadata(metadata)
+                                                                .contentType("application/zip")
+                                                                .cacheControl("max-age=86400")
+                                                                .contentDisposition("attachment")
+                                                                .contentEncoding("gzip")
+                                                                .contentLanguage("en-US")
+                                                                .expires(java.time.Instant.ofEpochSecond(1700000000L))
+                                                                .build());
+
+        when(s3AsyncClient.headObject(any(HeadObjectRequest.class)))
+            .thenReturn(headFuture);
     }
 
     private void stubSuccessfulHeadObjectCall(long contentLength) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When the multipart-enabled S3 client copies an object, it uses CreateMultipartUpload + UploadPartCopy instead of a single CopyObject call. Unlike CopyObject, CreateMultipartUpload has no MetadataDirective support, so source object metadata was silently dropped on the destination. 

## Modifications
 - Pass HeadObjectResponse (already retrieved for content-length) into copyInParts()
 - When MetadataDirective is not REPLACE, forward source metadata fields from the HeadObjectResponse to the CreateMultipartUploadRequest: metadata, contentType, cacheControl, contentDisposition, contentEncoding, contentLanguage, expires
- When MetadataDirective is REPLACE, behavior is unchanged, customer-provided values on CopyObjectRequest are used as before

## Testing
  - Added multiPartCopy_metadataDirectiveUnset_shouldForwardSourceMetadata — verifies all metadata fields from HeadObject are forwarded to CreateMultipartUpload when MetadataDirective is unset (default COPY behavior)
   - Added multiPartCopy_metadataDirectiveReplace_shouldNotForwardSourceMetadata — verifies customer-provided metadata is used and source metadata is not forwarded when MetadataDirective is REPLACE
   - All existing CopyObjectHelper tests continue to pass

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
