### PR TITLE
Fix flaky NettyClientProxyConfigurationTest proxy error assertion

### DIFF
--- a/http-clients/netty-nio-client/src/test/java/NettyClientProxyConfigurationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/NettyClientProxyConfigurationTest.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import java.net.ConnectException;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -43,6 +43,6 @@ public class NettyClientProxyConfigurationTest extends HttpClientDefaultProxyCon
 
     @Override
     protected Class<? extends Exception> getProxyFailedCauseExceptionType() {
-        return ConnectException.class;
+        return IOException.class;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The test ```ensureProxyErrorsWhenIncorrectPortUsed``` asserts that connecting to an incorrect proxy port throws a ```ConnectException```. However, in the Netty async client, the channel can go inactive before the connection refused (RST) is received, causing ```ProxyTunnelInitHandler.channelInactive()``` to throw ```IOException: Unable to send CONNECT request to proxy instead```. This is a race condition that manifests under high load, so the test assertion failed and caused a release build failure.

## Modifications
Changed the expected cause exception type from ConnectException to IOException, so that both error paths (connection refused and channel inactive) are accepted. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
