### PR TITLE
Add PresignedFileDownload return type for presigned URL downloads

### DIFF
--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
@@ -41,8 +41,8 @@ import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloa
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.transfer.s3.model.CompletedDownload;
 import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.PresignedFileDownload;
 import software.amazon.awssdk.transfer.s3.model.Download;
-import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
@@ -92,7 +92,7 @@ public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3Inte
     void downloadFileWithPresignedUrl_shouldDownloadCorrectly(S3TransferManager tm, String key,
                                                               File sourceFile, int objSize) throws Exception {
         Path downloadPath = RandomTempFile.randomUncreatedFile().toPath();
-        FileDownload download = tm.downloadFileWithPresignedUrl(createFileDownloadRequest(key, downloadPath));
+        PresignedFileDownload download = tm.downloadFileWithPresignedUrl(createFileDownloadRequest(key, downloadPath));
         CompletedFileDownload completed = download.completionFuture().join();
 
         assertThat(Files.exists(downloadPath)).isTrue();
@@ -131,7 +131,7 @@ public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3Inte
             requestBuilder.range(range);
         }
 
-        FileDownload download = tm.downloadFileWithPresignedUrl(
+        PresignedFileDownload download = tm.downloadFileWithPresignedUrl(
             PresignedDownloadFileRequest.builder()
                                         .presignedUrlDownloadRequest(requestBuilder.build())
                                         .destination(downloadPath)

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedFileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
@@ -730,16 +731,16 @@ public interface S3TransferManager extends SdkAutoCloseable {
      *                                                                                    LoggingTransferListener.create())
      *                                                                            .build();
      *         
-     *         FileDownload download = transferManager.downloadFileWithPresignedUrl(request);
+     *         PresignedFileDownload download = transferManager.downloadFileWithPresignedUrl(request);
      *         download.completionFuture().join();
      * }
      *
      * @param presignedDownloadFileRequest the presigned download file request
-     * @return A {@link FileDownload} that can be used to track the ongoing transfer
+     * @return A {@link PresignedFileDownload} that can be used to track the ongoing transfer
      * @see #downloadFileWithPresignedUrl(Consumer)
      * @see #downloadWithPresignedUrl(PresignedDownloadRequest)
      */
-    default FileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
+    default PresignedFileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
         throw new UnsupportedOperationException();
     }
 
@@ -752,7 +753,7 @@ public interface S3TransferManager extends SdkAutoCloseable {
      *
      * @see #downloadFileWithPresignedUrl(PresignedDownloadFileRequest)
      */
-    default FileDownload downloadFileWithPresignedUrl(
+    default PresignedFileDownload downloadFileWithPresignedUrl(
             Consumer<PresignedDownloadFileRequest.Builder> presignedDownloadFileRequest) {
         return downloadFileWithPresignedUrl(
                 PresignedDownloadFileRequest.builder().applyMutation(presignedDownloadFileRequest).build());

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DelegatingS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DelegatingS3TransferManager.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedFileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 import software.amazon.awssdk.transfer.s3.model.UploadDirectoryRequest;
@@ -88,7 +89,7 @@ abstract class DelegatingS3TransferManager implements S3TransferManager {
     }
 
     @Override
-    public FileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
+    public PresignedFileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
         return delegate.downloadFileWithPresignedUrl(presignedDownloadFileRequest);
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -55,6 +55,7 @@ import software.amazon.awssdk.transfer.s3.internal.model.DefaultDirectoryUpload;
 import software.amazon.awssdk.transfer.s3.internal.model.DefaultDownload;
 import software.amazon.awssdk.transfer.s3.internal.model.DefaultFileDownload;
 import software.amazon.awssdk.transfer.s3.internal.model.DefaultFileUpload;
+import software.amazon.awssdk.transfer.s3.internal.model.DefaultPresignedFileDownload;
 import software.amazon.awssdk.transfer.s3.internal.model.DefaultUpload;
 import software.amazon.awssdk.transfer.s3.internal.progress.DefaultTransferProgress;
 import software.amazon.awssdk.transfer.s3.internal.progress.DefaultTransferProgressSnapshot;
@@ -77,6 +78,7 @@ import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
+import software.amazon.awssdk.transfer.s3.model.PresignedFileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
@@ -600,7 +602,7 @@ class GenericS3TransferManager implements S3TransferManager {
     }
 
     @Override
-    public final FileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
+    public final PresignedFileDownload downloadFileWithPresignedUrl(PresignedDownloadFileRequest presignedDownloadFileRequest) {
         Validate.paramNotNull(presignedDownloadFileRequest, "presignedDownloadFileRequest");
 
         AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> responseTransformer =
@@ -632,11 +634,7 @@ class GenericS3TransferManager implements S3TransferManager {
             returnFuture.completeExceptionally(throwable);
         }
 
-        return new DefaultFileDownload(returnFuture, progressUpdater.progress(),
-                                       () -> {
-                                           throw new UnsupportedOperationException(
-                                               "Pause is not supported for presigned URL downloads");
-                                       }, null);
+        return new DefaultPresignedFileDownload(returnFuture, progressUpdater.progress());
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/model/DefaultPresignedFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/model/DefaultPresignedFileDownload.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal.model;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.PresignedFileDownload;
+import software.amazon.awssdk.transfer.s3.progress.TransferProgress;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public final class DefaultPresignedFileDownload implements PresignedFileDownload {
+    private final CompletableFuture<CompletedFileDownload> completionFuture;
+    private final TransferProgress progress;
+
+    public DefaultPresignedFileDownload(CompletableFuture<CompletedFileDownload> completionFuture,
+                                        TransferProgress progress) {
+        this.completionFuture = Validate.paramNotNull(completionFuture, "completionFuture");
+        this.progress = Validate.paramNotNull(progress, "progress");
+    }
+
+    @Override
+    public CompletableFuture<CompletedFileDownload> completionFuture() {
+        return completionFuture;
+    }
+
+    @Override
+    public TransferProgress progress() {
+        return progress;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("DefaultPresignedFileDownload")
+                       .add("completionFuture", completionFuture)
+                       .add("progress", progress)
+                       .build();
+    }
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/model/DefaultPresignedFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/model/DefaultPresignedFileDownload.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.transfer.s3.internal.model;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
@@ -42,6 +43,30 @@ public final class DefaultPresignedFileDownload implements PresignedFileDownload
     @Override
     public TransferProgress progress() {
         return progress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultPresignedFileDownload that = (DefaultPresignedFileDownload) o;
+
+        if (!Objects.equals(completionFuture, that.completionFuture)) {
+            return false;
+        }
+        return Objects.equals(progress, that.progress);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = completionFuture != null ? completionFuture.hashCode() : 0;
+        result = 31 * result + (progress != null ? progress.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/PresignedFileDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/PresignedFileDownload.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.model;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * A download transfer of a single object from S3 using a presigned URL.
+ *
+ * <p>Unlike {@link FileDownload}, this type does not support pause/resume because presigned URLs
+ * have a limited lifetime and cannot be reliably resumed after expiration.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface PresignedFileDownload extends ObjectTransfer {
+
+    @Override
+    CompletableFuture<CompletedFileDownload> completionFuture();
+}

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DefaultPresignedFileDownloadTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/DefaultPresignedFileDownloadTest.java
@@ -13,21 +13,18 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.transfer.s3.model;
+package software.amazon.awssdk.transfer.s3.internal;
 
-import java.util.concurrent.CompletableFuture;
-import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.annotations.ThreadSafe;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.transfer.s3.internal.model.DefaultPresignedFileDownload;
 
-/**
- * A download transfer of a single object from S3 using a presigned URL.
- *
- * <p>Unlike {@link FileDownload}, this type does not support pause/resume.
- */
-@SdkPublicApi
-@ThreadSafe
-public interface PresignedFileDownload extends ObjectTransfer {
+public class DefaultPresignedFileDownloadTest {
 
-    @Override
-    CompletableFuture<CompletedFileDownload> completionFuture();
+    @Test
+    public void equals_hashcode() {
+        EqualsVerifier.forClass(DefaultPresignedFileDownload.class)
+                      .withNonnullFields("completionFuture", "progress")
+                      .verify();
+    }
 }

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlDownloadTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlDownloadTest.java
@@ -35,7 +35,6 @@ import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtensio
 import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.CompletedDownload;
 import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
-import software.amazon.awssdk.transfer.s3.model.FileDownload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 
@@ -153,18 +152,6 @@ class S3TransferManagerPresignedUrlDownloadTest {
     void downloadWithPresignedUrl_withNullRequest_shouldThrowNullPointerException() {
         assertThatThrownBy(() -> tm.downloadWithPresignedUrl(null))
             .isInstanceOf(NullPointerException.class);
-    }
-    @Test
-    void downloadFileWithPresignedUrl_pause_shouldThrowUnsupportedOperationException() {
-        GetObjectResponse response = GetObjectResponse.builder().build();
-        stubGetObject(CompletableFuture.completedFuture(response));
-
-        FileDownload download = tm.downloadFileWithPresignedUrl(fileDownloadRequest());
-        download.completionFuture().join();
-
-        assertThatThrownBy(download::pause)
-            .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("Pause is not supported for presigned URL downloads");
     }
 
     private PresignedDownloadFileRequest fileDownloadRequest() {

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlListenerWiremockTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlListenerWiremockTest.java
@@ -48,7 +48,7 @@ import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloa
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.Download;
-import software.amazon.awssdk.transfer.s3.model.FileDownload;
+import software.amazon.awssdk.transfer.s3.model.PresignedFileDownload;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.PresignedDownloadRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
@@ -123,7 +123,7 @@ public class S3TransferManagerPresignedUrlListenerWiremockTest {
         }
 
         if ("toFile".equals(type)) {
-            FileDownload download = tm.downloadFileWithPresignedUrl(
+            PresignedFileDownload download = tm.downloadFileWithPresignedUrl(
                 PresignedDownloadFileRequest.builder()
                     .presignedUrlDownloadRequest(requestBuilder.build())
                     .destination(testFile.toPath())
@@ -172,7 +172,7 @@ public class S3TransferManagerPresignedUrlListenerWiremockTest {
         URL presignedUrl = new URL(testEndpoint + "/presigned-key?X-Amz-Algorithm=AWS4-HMAC-SHA256");
 
         if ("toFile".equals(type)) {
-            FileDownload download = tm.downloadFileWithPresignedUrl(
+            PresignedFileDownload download = tm.downloadFileWithPresignedUrl(
                 PresignedDownloadFileRequest.builder()
                     .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(presignedUrl)
@@ -222,7 +222,7 @@ public class S3TransferManagerPresignedUrlListenerWiremockTest {
         URL presignedUrl = new URL(testEndpoint + "/presigned-key?X-Amz-Algorithm=AWS4-HMAC-SHA256");
 
         if ("toFile".equals(type)) {
-            FileDownload download = tm.downloadFileWithPresignedUrl(
+            PresignedFileDownload download = tm.downloadFileWithPresignedUrl(
                 PresignedDownloadFileRequest.builder()
                                             .presignedUrlDownloadRequest(PresignedUrlDownloadRequest.builder()
                                                                                                     .presignedUrl(presignedUrl)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`downloadFileWithPresignedUrl`() previously returned `FileDownload`, which exposes `pause`(). Pause is not supported for presigned URL downloads. Calling pause() threw `UnsupportedOperationException` at runtime - a bad customer experience. This PR introduces `PresignedFileDownload`, a new return type that provides compile-time safety by not exposing pause().

## Modifications
- Added `PresignedFileDownload` interface (extends `ObjectTransfer` — has `completionFuture`() and `progress`(), no `pause`())
- Added `DefaultPresignedFileDownload` internal implementation
- Changed `S3TransferManager`.`downloadFileWithPresignedUrl`() return type from `FileDownload` to PresignedFileDownload
- Updated `DelegatingS3TransferManager` and `GenericS3TransferManager` accordingly
- Removed runtime `UnsupportedOperationException` from `GenericS3TransferManager`

## Testing
- Updated existing unit and integration tests to use `PresignedFileDownload` return type
- All existing presigned URL download tests pass (progress tracking, multipart, error cases)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
