### PR TITLE
Skip auth scheme and endpoint resolution if already resolved by old interceptors

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
@@ -74,7 +74,9 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
 
         IdentityProviders identityProviders = updateIdentityProvidersIfNeeded(executionAttributes, sdkRequest);
 
-        // Skip resolution if auth scheme was already resolved by an old service interceptor.
+        // Skip resolution if auth scheme was already resolved by an old service interceptor
+        // With old service + new core, resolution would happen twice (interceptor + pipeline stage),
+        // so we skip here to avoid redundant resolution.
         SelectedAuthScheme<?> existing = executionAttributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
         if (existing != null && !"unset".equals(existing.authSchemeOption().schemeId())) {
             updateIdentityOnExistingScheme(existing, identityProviders, executionAttributes);
@@ -133,6 +135,9 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
         return identityProviders;
     }
 
+    /**
+     * Re-resolves identity to ensure credential overrides via interceptors are respected, even with old service clients.
+     */
     @SuppressWarnings("unchecked")
     private <T extends Identity> void updateIdentityOnExistingScheme(SelectedAuthScheme<T> existing,
                                                                      IdentityProviders identityProviders,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
@@ -63,6 +63,13 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
             return request;
         }
 
+        // Skip if auth scheme was already resolved by an old service interceptor
+        // The "unset" scheme ID indicates the placeholder - anything else means it's already resolved.
+        SelectedAuthScheme<?> existing = executionAttributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+        if (existing != null && !"unset".equals(existing.authSchemeOption().schemeId())) {
+            return request;
+        }
+
         SdkRequest sdkRequest = context.executionContext().interceptorContext().request();
         List<AuthSchemeOption> authOptions = resolveAuthSchemeOptions(executionAttributes, sdkRequest);
         if (authOptions == null || authOptions.isEmpty()) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
@@ -75,10 +75,10 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
         IdentityProviders identityProviders = updateIdentityProvidersIfNeeded(executionAttributes, sdkRequest);
 
         // Skip resolution if auth scheme was already resolved by an old service interceptor
-        // With old service + new core, resolution would happen twice (interceptor + pipeline stage),
-        // so we skip here to avoid redundant resolution.
         SelectedAuthScheme<?> existing = executionAttributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
         if (existing != null && !"unset".equals(existing.authSchemeOption().schemeId())) {
+            //Updates the identity on an already-resolved auth scheme, ensuring credential overrides via interceptors
+            //are respected even with old service clients.
             updateIdentityOnExistingScheme(existing, identityProviders, executionAttributes);
             return request;
         }
@@ -135,9 +135,6 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
         return identityProviders;
     }
 
-    /**
-     * Re-resolves identity to ensure credential overrides via interceptors are respected, even with old service clients.
-     */
     @SuppressWarnings("unchecked")
     private <T extends Identity> void updateIdentityOnExistingScheme(SelectedAuthScheme<T> existing,
                                                                      IdentityProviders identityProviders,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStage.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
@@ -37,7 +38,9 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.identity.spi.Identity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.metrics.MetricCollector;
 
@@ -63,13 +66,6 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
             return request;
         }
 
-        // Skip if auth scheme was already resolved by an old service interceptor
-        // The "unset" scheme ID indicates the placeholder - anything else means it's already resolved.
-        SelectedAuthScheme<?> existing = executionAttributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
-        if (existing != null && !"unset".equals(existing.authSchemeOption().schemeId())) {
-            return request;
-        }
-
         SdkRequest sdkRequest = context.executionContext().interceptorContext().request();
         List<AuthSchemeOption> authOptions = resolveAuthSchemeOptions(executionAttributes, sdkRequest);
         if (authOptions == null || authOptions.isEmpty()) {
@@ -77,6 +73,13 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
         }
 
         IdentityProviders identityProviders = updateIdentityProvidersIfNeeded(executionAttributes, sdkRequest);
+
+        // Skip resolution if auth scheme was already resolved by an old service interceptor.
+        SelectedAuthScheme<?> existing = executionAttributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+        if (existing != null && !"unset".equals(existing.authSchemeOption().schemeId())) {
+            updateIdentityOnExistingScheme(existing, identityProviders, executionAttributes);
+            return request;
+        }
 
         MetricCollector metricCollector =
             executionAttributes.getAttribute(SdkExecutionAttribute.API_CALL_METRIC_COLLECTOR);
@@ -128,6 +131,25 @@ public final class AuthSchemeResolutionStage implements MutableRequestToRequestP
             identityProviders = updater.update(request, identityProviders, executionAttributes);
         }
         return identityProviders;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Identity> void updateIdentityOnExistingScheme(SelectedAuthScheme<T> existing,
+                                                                     IdentityProviders identityProviders,
+                                                                     ExecutionAttributes executionAttributes) {
+        AuthScheme<T> authScheme = (AuthScheme<T>) executionAttributes
+            .getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES)
+            .get(existing.authSchemeOption().schemeId());
+        if (authScheme == null) {
+            return;
+        }
+        IdentityProvider<T> identityProvider = authScheme.identityProvider(identityProviders);
+        if (identityProvider == null) {
+            return;
+        }
+        CompletableFuture<? extends T> identity = identityProvider.resolveIdentity(ResolveIdentityRequest.builder().build());
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME,
+                                         new SelectedAuthScheme<>(identity, existing.signer(), existing.authSchemeOption()));
     }
 
     private void recordBusinessMetrics(SelectedAuthScheme<? extends Identity> selectedAuthScheme,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
@@ -61,6 +61,12 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
             return request;
         }
 
+        // Skip if endpoint was already resolved by an old service interceptor
+        Endpoint existingEndpoint = attrs.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
+        if (existingEndpoint != null) {
+            return request;
+        }
+
         EndpointResolver resolver = attrs.getAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER);
         if (resolver == null) {
             return request;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AuthSchemeResolutionStageTest.java
@@ -228,4 +228,47 @@ class AuthSchemeResolutionStageTest {
             AuthSchemeOption.builder().schemeId(SCHEME_ID).build()
         );
     }
+
+    @Test
+    void execute_authSchemeAlreadyResolved_skipsResolution() throws Exception {
+        // Simulate old service interceptor already resolved auth scheme
+        SelectedAuthScheme<Identity> alreadyResolved = new SelectedAuthScheme<>(
+            CompletableFuture.completedFuture(mock(Identity.class)),
+            mock(HttpSigner.class),
+            AuthSchemeOption.builder().schemeId("aws.auth#sigv4").build()
+        );
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, alreadyResolved);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES, createAuthSchemes());
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_OPTIONS_RESOLVER,
+            (AuthSchemeOptionsResolver) req -> createAuthOptions());
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDERS, createIdentityProviders());
+
+        SdkHttpFullRequest.Builder result = stage.execute(httpRequestBuilder, context);
+
+        assertThat(result).isSameAs(httpRequestBuilder);
+        // Auth scheme should still be the one set by the old interceptor (not re-resolved)
+        SelectedAuthScheme<?> finalScheme = executionAttributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+        assertThat(finalScheme.authSchemeOption().schemeId()).isEqualTo("aws.auth#sigv4");
+    }
+
+    @Test
+    void execute_authSchemeUnset_proceedsWithResolution() throws Exception {
+        // "unset" placeholder — pipeline should resolve
+        SelectedAuthScheme<Identity> unsetPlaceholder = new SelectedAuthScheme<>(
+            CompletableFuture.completedFuture(mock(Identity.class)),
+            mock(HttpSigner.class),
+            AuthSchemeOption.builder().schemeId("unset").build()
+        );
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME, unsetPlaceholder);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEMES, createAuthSchemes());
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_OPTIONS_RESOLVER,
+            (AuthSchemeOptionsResolver) req -> createAuthOptions());
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.IDENTITY_PROVIDERS, createIdentityProviders());
+
+        stage.execute(httpRequestBuilder, context);
+
+        // Should have resolved to the test scheme
+        SelectedAuthScheme<?> finalScheme = executionAttributes.getAttribute(SdkInternalExecutionAttribute.SELECTED_AUTH_SCHEME);
+        assertThat(finalScheme.authSchemeOption().schemeId()).isEqualTo(SCHEME_ID);
+    }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
@@ -260,4 +260,17 @@ class EndpointResolutionStageTest {
                                      .originalRequest(request)
                                      .build();
     }
+
+    @Test
+    void execute_endpointAlreadyResolved_skipsResolution() throws Exception {
+        Endpoint preResolved = Endpoint.builder().url(URI.create("https://pre-resolved.example.com")).build();
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT, preResolved);
+
+        SdkHttpFullRequest.Builder request = defaultRequest();
+        SdkHttpFullRequest.Builder result = stage.execute(request, createContext());
+
+
+        assertThat(result).isSameAs(request);
+        assertThat(executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT)).isSameAs(preResolved);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
  When new core + old service, auth scheme and endpoint resolution would happen twice (once by old interceptors, once by pipeline stages). This adds unnecessary overhead, updating it to only resolve once.

## Modifications
- AuthSchemeResolutionStage: Skip resolution if auth scheme is already resolved (scheme ID is not "unset"). Still re-resolves identity to respect credential overrides.
- EndpointResolutionStage: Skip resolution if RESOLVED_ENDPOINT is already set.

## Testing
- Added unit tests for AuthSchemeResolutionStage (skip when resolved, proceed when "unset").
- Added unit test for EndpointResolutionStage (skip when endpoint already set).

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
