### PR TITLE
Add dependency CVE monitor workflow

### DIFF
--- a/.github/workflows/dependency-cve-monitor.yml
+++ b/.github/workflows/dependency-cve-monitor.yml
@@ -28,6 +28,7 @@ jobs:
     needs: submit-dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Wait for alert processing
         run: sleep 60

--- a/.github/workflows/dependency-cve-monitor.yml
+++ b/.github/workflows/dependency-cve-monitor.yml
@@ -1,0 +1,67 @@
+name: "dependency-cve-monitor"
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  submit-dependencies:
+    if: github.repository == 'aws/aws-sdk-java-v2'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: advanced-security/maven-dependency-submission-action@v5
+        with:
+          maven-args: >-
+            -DtransitiveExcludes=*:*
+            -DclasspathScope=runtime
+            -pl !build-tools,!release-scripts,!archetypes,!test/test-utils,!test/sdk-benchmarks,!test/http-client-tests,!test/http-client-benchmarks,!test/s3-benchmarks,!test/protocol-tests-core,!test/ruleset-testing-core,!test/protocol-tests,!test/service-test-utils,!test/codegen-generated-classes-test,!test/sdk-standard-benchmarks,!test/module-path-tests,!test/tests-coverage-reporting,!test/stability-tests,!test/sdk-native-image-test,!test/auth-tests,!test/region-testing,!test/old-client-version-compatibility-test,!test/bundle-logging-bridge-binding-test,!test/v2-migration-tests,!test/bundle-shading-tests,!test/crt-unavailable-tests,!test/architecture-tests,!test/s3-tests
+
+  notify-alerts:
+    if: github.repository == 'aws/aws-sdk-java-v2'
+    needs: submit-dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Wait for alert processing
+        run: sleep 60
+      - name: Check and notify actionable alerts
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
+          JQ_FILTER_B64: "Wy5bXSB8IHNlbGVjdCguY3JlYXRlZF9hdCA+ICRjdXRvZmYgYW5kIC5zZWN1cml0eV92dWxuZXJhYmlsaXR5LmZpcnN0X3BhdGNoZWRfdmVyc2lvbiAhPSBudWxsKV0KfCBncm91cF9ieSguc2VjdXJpdHlfdnVsbmVyYWJpbGl0eS5wYWNrYWdlLm5hbWUpCnwgbWFwKHsKICAgIHBrZzogLlswXS5zZWN1cml0eV92dWxuZXJhYmlsaXR5LnBhY2thZ2UubmFtZSwKICAgIGZpeDogLlswXS5zZWN1cml0eV92dWxuZXJhYmlsaXR5LmZpcnN0X3BhdGNoZWRfdmVyc2lvbi5pZGVudGlmaWVyLAogICAgbWFuaWZlc3RzOiAoWy5bXS5kZXBlbmRlbmN5Lm1hbmlmZXN0X3BhdGhdIHwgdW5pcXVlIHwgbWFwKGdzdWIoIi9wb20ueG1sJCI7ICIiKSB8IGdzdWIoIi4qLyI7ICIiKSkpLAogICAgY3ZlczogKGdyb3VwX2J5KC5zZWN1cml0eV9hZHZpc29yeS5jdmVfaWQgLy8gLnNlY3VyaXR5X2Fkdmlzb3J5Lmdoc2FfaWQpIHwgbWFwKHsKICAgICAgY3ZlOiAoLlswXS5zZWN1cml0eV9hZHZpc29yeS5jdmVfaWQgLy8gLlswXS5zZWN1cml0eV9hZHZpc29yeS5naHNhX2lkKSwKICAgICAgZ2hzYTogLlswXS5zZWN1cml0eV9hZHZpc29yeS5naHNhX2lkLAogICAgICBzZXZlcml0eTogKC5bMF0uc2VjdXJpdHlfYWR2aXNvcnkuc2V2ZXJpdHkgfCBhc2NpaV91cGNhc2UpCiAgICB9KSkKICB9KQp8IGlmIGxlbmd0aCA9PSAwIHRoZW4gZW1wdHkKICBlbHNlCiAgICAiOndhcm5pbmc6ICpcKG1hcCguY3ZlcyB8IGxlbmd0aCkgfCBhZGQpIG5ldyBDVkUocykgZGV0ZWN0ZWQgaW4gU0RLIGRlcGVuZGVuY2llcyB3aXRoIGZpeGVzIGF2YWlsYWJsZSpcblxuIiArCiAgICAobWFwKAogICAgICAiYFwoLnBrZylgIChcKC5tYW5pZmVzdHMgfCBqb2luKCIsICIpKSkgXHUyMTkyIFVwZ3JhZGUgdG8gYFwoLmZpeClgXG4iICsKICAgICAgKC5jdmVzIHwgbWFwKCIgIFx1MjAyMiA8aHR0cHM6Ly9naXRodWIuY29tL2Fkdmlzb3JpZXMvXCguZ2hzYSl8XCguY3ZlKT4gKFwoLnNldmVyaXR5KSkiKSB8IGpvaW4oIlxuIikpCiAgICApIHwgam9pbigiXG5cbiIpKSArCiAgICAiXG5cbipBY3Rpb24gbmVlZGVkKjogVXBncmFkZSB0aGUgYWZmZWN0ZWQgZGVwZW5kZW5jeSB2ZXJzaW9ucyB0byB0aGUgZml4IHZlcnNpb25zIGxpc3RlZCBhYm92ZS4iCiAgZW5kCg=="
+        shell: bash
+        run: |
+          ONE_DAY_AGO=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
+
+          ALERTS=$(gh api repos/${{ github.repository }}/dependabot/alerts?state=open\&per_page=100)
+          if [ $? -ne 0 ]; then
+            echo "Failed to fetch alerts"
+            exit 1
+          fi
+
+          echo "$JQ_FILTER_B64" | base64 -d > /tmp/filter.jq
+
+          MESSAGE=$(echo "$ALERTS" | jq -r --arg cutoff "$ONE_DAY_AGO" -f /tmp/filter.jq)
+
+          if [ -z "$MESSAGE" ]; then
+            echo "No new actionable alerts in the last 24 hours."
+            exit 0
+          fi
+
+          echo "Sending Slack notification..."
+          echo "$MESSAGE"
+
+          PAYLOAD=$(jq -n --arg text "$MESSAGE" '{text: $text}')
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD"
+
+          echo ""
+          echo "Slack notification sent."


### PR DESCRIPTION
## Summary

Adds a daily workflow that resolves Maven property-based dependency versions and submits them to the GitHub dependency graph, enabling Dependabot security alerts for critical runtime dependencies (Netty, httpclient5, Jackson, etc.).

Also includes Slack notification to the team channel when new actionable CVEs are detected with fixes available.

## Motivation

[CVE-2026-40542](https://nvd.nist.gov/vuln/detail/CVE-2026-40542) (HIGH, httpclient5) — fixed in [#7003](https://github.com/aws/aws-sdk-java-v2/pull/7003). GitHub's dependency graph cannot resolve Maven property-based versions (`${netty.version}`, `${httpcomponents.client5.version}`). Without resolved versions in the graph, Dependabot cannot match dependencies against the advisory database, so security alerts don't fire for the SDK's critical runtime dependencies.

This workflow resolves the versions via Maven and submits them to the graph, enabling Dependabot alerts to work correctly.

## Solution

Uses `advanced-security/maven-dependency-submission-action@v5` with:
- `-DtransitiveExcludes=*:*` — only direct dependencies
- `-DclasspathScope=runtime` — only runtime/compile scope
- `-pl !test/...,!build-tools,...` — excludes internal-only modules

After submission, checks for new actionable Dependabot alerts and posts to the team Slack channel.

## Testing

Validated end-to-end:
- Dependabot alerts fire correctly for httpclient5, Netty, Jackson CVEs
- Zero noise from test dependencies
- Dependabot alerts auto-close after version upgrade
- Slack notification groups by package, deduplicates, only notifies for fixes available
- Runs in under 1 minute

## Secrets Required

- `CI_SLACK_WEBHOOK_URL` — already exists
- `DEPENDABOT_ALERTS_TOKEN` — added (fine-grained PAT, Dependabot alerts read-only)