### PR TITLE
Add validation for buffer lengthwhen multipart upload with unknown contentlength

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-31226da.json
+++ b/.changes/next-release/bugfix-AmazonS3-31226da.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fixed an issue where S3 multipart uploads with unknown content length could hang indefinitely when apiCallBufferSizeInBytes was less than twice minimumPartSizeInBytes. The SDK now validates this at request time and fails fast with a descriptive error instead of deadlocking"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelper.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -60,6 +61,13 @@ public final class UploadWithUnknownContentLengthHelper {
     public CompletableFuture<PutObjectResponse> uploadObject(PutObjectRequest putObjectRequest,
                                                              AsyncRequestBody asyncRequestBody) {
         CompletableFuture<PutObjectResponse> returnFuture = new CompletableFuture<>();
+
+        if (maxMemoryUsageInBytes < 2 * partSizeInBytes) {
+            returnFuture.completeExceptionally(SdkClientException.create(
+                "apiCallBufferSizeInBytes (" + maxMemoryUsageInBytes + ") must be at least 2 x minimumPartSizeInBytes ("
+                + partSizeInBytes + ") when uploading content with an unknown content length"));
+            return returnFuture;
+        }
 
         SdkPublisher<CloseableAsyncRequestBody> splitAsyncRequestBodyResponse =
             asyncRequestBody.splitCloseable(b -> b.chunkSizeInBytes(partSizeInBytes)

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/MultipartConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/MultipartConfiguration.java
@@ -175,7 +175,7 @@ public final class MultipartConfiguration implements ToCopyableBuilder<Multipart
          * Default value: If not specified, the SDK will use the equivalent of four parts worth of memory, so 32 Mib by default.
          * <p>
          * When uploading content with an unknown content length, this value
-         * must be at least 2 x {@code minimumPartSizeInBytes}. The unknown-length upload path buffers one part while it buffers
+         * must be at least 2 x {@link #minimumPartSizeInBytes(Long)}. The unknown-length upload path buffers one part while it buffers
          * the next to determine whether a single-part or multipart upload is needed, so it requires room for two parts. A value
          * smaller than that will be rejected.
          * <p>

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/MultipartConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/MultipartConfiguration.java
@@ -175,9 +175,9 @@ public final class MultipartConfiguration implements ToCopyableBuilder<Multipart
          * Default value: If not specified, the SDK will use the equivalent of four parts worth of memory, so 32 Mib by default.
          * <p>
          * When uploading content with an unknown content length, this value
-         * must be at least 2 x {@link #minimumPartSizeInBytes(Long)}. The unknown-length upload path buffers one part while it buffers
-         * the next to determine whether a single-part or multipart upload is needed, so it requires room for two parts. A value
-         * smaller than that will be rejected.
+         * must be at least 2 x {@link #minimumPartSizeInBytes(Long)}.
+         * The unknown-length upload path buffers one part while it buffers the next to determine whether a single-part or
+         * multipart upload is needed, so it requires room for two parts. A value smaller than that will be rejected.
          * <p>
          * This setting does not apply if you are using an {@link AsyncResponseTransformer} implementation that downloads the
          * object into memory such as {@link AsyncResponseTransformer#toBytes}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/MultipartConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/multipart/MultipartConfiguration.java
@@ -174,6 +174,11 @@ public final class MultipartConfiguration implements ToCopyableBuilder<Multipart
          * <p>
          * Default value: If not specified, the SDK will use the equivalent of four parts worth of memory, so 32 Mib by default.
          * <p>
+         * When uploading content with an unknown content length, this value
+         * must be at least 2 x {@code minimumPartSizeInBytes}. The unknown-length upload path buffers one part while it buffers
+         * the next to determine whether a single-part or multipart upload is needed, so it requires room for two parts. A value
+         * smaller than that will be rejected.
+         * <p>
          * This setting does not apply if you are using an {@link AsyncResponseTransformer} implementation that downloads the
          * object into memory such as {@link AsyncResponseTransformer#toBytes}
          *

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
@@ -146,6 +146,37 @@ public class UploadWithUnknownContentLengthHelperTest {
     }
 
     @Test
+    void uploadObject_apiCallBufferSizeLessThanTwicePartSize_shouldFailFastWithoutSplitting() {
+        UploadWithUnknownContentLengthHelper helperWithSmallBuffer =
+            new UploadWithUnknownContentLengthHelper(s3AsyncClient, PART_SIZE, PART_SIZE, 2 * PART_SIZE - 1, 50);
+
+        CloseableAsyncRequestBody asyncRequestBody = createMockAsyncRequestBody(PART_SIZE);
+
+        CompletableFuture<PutObjectResponse> future =
+            helperWithSmallBuffer.uploadObject(createPutObjectRequest(), asyncRequestBody);
+
+        verifyFailureWithMessage(future, "must be at least 2 x minimumPartSizeInBytes");
+
+        verify(asyncRequestBody, times(0)).splitCloseable(any(Consumer.class));
+    }
+
+    @Test
+    void uploadObject_apiCallBufferSizeEqualToTwicePartSize_shouldNotFailFast() {
+        UploadWithUnknownContentLengthHelper helperWithBoundaryBuffer =
+            new UploadWithUnknownContentLengthHelper(s3AsyncClient, PART_SIZE, PART_SIZE, 2 * PART_SIZE, 50);
+
+        CloseableAsyncRequestBody asyncRequestBody = createMockAsyncRequestBody(PART_SIZE);
+        SdkPublisher<CloseableAsyncRequestBody> mockPublisher = mock(SdkPublisher.class);
+        when(asyncRequestBody.splitCloseable(any(Consumer.class))).thenReturn(mockPublisher);
+
+        CompletableFuture<PutObjectResponse> future =
+            helperWithBoundaryBuffer.uploadObject(createPutObjectRequest(), asyncRequestBody);
+
+        assertThat(future).isNotCompleted();
+        verify(asyncRequestBody, times(1)).splitCloseable(any(Consumer.class));
+    }
+
+    @Test
     void uploadObject_withPartSizeExceedingLimit_shouldFailRequest() {
         CloseableAsyncRequestBody asyncRequestBody = createMockAsyncRequestBody(PART_SIZE + 1);
         CompletableFuture<PutObjectResponse> future = setupAndTriggerUploadFailure(asyncRequestBody);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UploadWithUnknownContentLengthHelperTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -157,7 +158,7 @@ public class UploadWithUnknownContentLengthHelperTest {
 
         verifyFailureWithMessage(future, "must be at least 2 x minimumPartSizeInBytes");
 
-        verify(asyncRequestBody, times(0)).splitCloseable(any(Consumer.class));
+        verify(asyncRequestBody, never()).splitCloseable(any(Consumer.class));
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

S3 multipart uploads with unknown content length could hang when apiCallBufferSizeInBytes was less than 2 × minimumPartSizeInBytes. The unknown-length path holds the first part in memory while buffering the second, so it needs room for two parts; a smaller buffer causes a circular wait before any HTTP request is made, so no timeout applies.

## Modifications
<!--- Describe your changes in detail -->
- UploadWithUnknownContentLengthHelper: fail fast with a descriptive message instead of deadlocking.
- MultipartConfiguration: documented the 2× requirement on apiCallBufferSizeInBytes.
- Only the unknown-length path is affected. Known-length uploads and default configs (buffer defaults to 4 × part size) are unchanged.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test and ran local integration test. 
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [x] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
