### PR TITLE
Fix overflow and precision issues in total parts calculation in presigned URL multipart download

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadUtils.java
@@ -121,8 +121,9 @@ public final class MultipartDownloadUtils {
      * @param partSize      size of each part in bytes
      * @return the number of parts
      */
-    public static int calculateTotalParts(long contentLength, long partSize) {
-        return (int) Math.ceil((double) contentLength / partSize);
+    public static long calculateTotalParts(long contentLength, long partSize) {
+        return (contentLength / partSize) + (contentLength % partSize == 0 ? 0 : 1);
+
     }
 
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -62,23 +62,23 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
     private final CompletableFuture<GetObjectResponse> resultFuture;
     private final int maxInFlightParts;
 
-    private final AtomicInteger partNumber = new AtomicInteger(0);
-    private final AtomicInteger completedParts = new AtomicInteger(0);
+    private final AtomicLong partNumber = new AtomicLong(0);
+    private final AtomicLong completedParts = new AtomicLong(0);
     private final Semaphore inFlightPermits;
     /**
      * CAS gate ensuring only the first part failure triggers error handling and cancellation.
      */
     private final AtomicBoolean downloadFailed = new AtomicBoolean(false);
     private final AtomicBoolean processingPending = new AtomicBoolean(false);
-    private final Map<Integer, CompletableFuture<GetObjectResponse>> inFlightRequests = new ConcurrentHashMap<>();
-    private final Queue<Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>>> pendingTransformers =
+    private final Map<Long, CompletableFuture<GetObjectResponse>> inFlightRequests = new ConcurrentHashMap<>();
+    private final Queue<Pair<Long, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>>> pendingTransformers =
         new ConcurrentLinkedQueue<>();
 
     private final Object subscriptionLock = new Object();
     private Subscription subscription;
 
     private volatile Long totalContentLength;
-    private volatile Integer totalParts;
+    private volatile Long totalParts;
     private volatile String eTag;
     private volatile GetObjectResponse firstResponse;
 
@@ -112,7 +112,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             throw new NullPointerException("onNext must not be called with null asyncResponseTransformer");
         }
 
-        int currentPart = partNumber.getAndIncrement();
+        long currentPart = partNumber.getAndIncrement();
 
         if (currentPart == 0) {
             sendFirstRequest(asyncResponseTransformer);
@@ -129,7 +129,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
     }
 
     private void sendFirstRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer) {
-        PresignedUrlDownloadRequest partRequest = createRangedGetRequest(0);
+        PresignedUrlDownloadRequest partRequest = createRangedGetRequest(0L);
         log.debug(() -> "Sending first range request with range=" + partRequest.range());
 
         if (!inFlightPermits.tryAcquire()) {
@@ -139,11 +139,11 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
         CompletableFuture<GetObjectResponse> response =
             s3AsyncClient.presignedUrlExtension().getObject(partRequest, transformer);
 
-        inFlightRequests.put(0, response);
+        inFlightRequests.put(0L, response);
         CompletableFutureUtils.forwardExceptionTo(resultFuture, response);
 
         response.whenComplete((res, error) -> {
-            inFlightRequests.remove(0);
+            inFlightRequests.remove(0L);
             inFlightPermits.release();
 
             if (error != null) {
@@ -154,7 +154,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
                         subscription.cancel();
                     }
                 } else {
-                    handlePartError(error, 0);
+                    handlePartError(error, 0L);
                 }
                 return;
             }
@@ -170,13 +170,13 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
 
             String contentRange = res.contentRange();
             if (contentRange == null) {
-                handlePartError(PresignedUrlDownloadHelper.missingContentRangeHeader(), 0);
+                handlePartError(PresignedUrlDownloadHelper.missingContentRangeHeader(), 0L);
                 return;
             }
 
             Optional<Long> parsedTotal = MultipartDownloadUtils.parseContentRangeForTotalSize(contentRange);
             if (!parsedTotal.isPresent()) {
-                handlePartError(PresignedUrlDownloadHelper.invalidContentRangeHeader(contentRange), 0);
+                handlePartError(PresignedUrlDownloadHelper.invalidContentRangeHeader(contentRange), 0L);
                 return;
             }
 
@@ -184,9 +184,9 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             this.totalParts = MultipartDownloadUtils.calculateTotalParts(totalContentLength, configuredPartSizeInBytes);
             log.debug(() -> String.format("Total content length: %d, Total parts: %d", totalContentLength, totalParts));
 
-            Optional<SdkClientException> validationError = validatePartResponse(res, 0);
+            Optional<SdkClientException> validationError = validatePartResponse(res, 0L);
             if (validationError.isPresent()) {
-                handlePartError(validationError.get(), 0);
+                handlePartError(validationError.get(), 0L);
                 return;
             }
 
@@ -200,8 +200,8 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
 
             processPendingTransformers();
 
-            int remainingParts = totalParts - 1;
-            int toRequest = Math.min(remainingParts, maxInFlightParts);
+            long remainingParts = totalParts - 1;
+            long toRequest = Math.min(remainingParts, maxInFlightParts);
             synchronized (subscriptionLock) {
                 subscription.request(toRequest);
             }
@@ -209,7 +209,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
     }
 
     private void processRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer,
-                                int currentPart) {
+                                long currentPart) {
         if (currentPart >= totalParts) {
             return;
         }
@@ -224,7 +224,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
     }
 
     private void sendPartRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer,
-                                 int partIndex) {
+                                 long partIndex) {
         if (downloadFailed.get()) {
             inFlightPermits.release();
             return;
@@ -259,7 +259,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             }
 
             log.debug(() -> "Completed part: " + partIndex);
-            int totalComplete = completedParts.incrementAndGet();
+            long totalComplete = completedParts.incrementAndGet();
 
             if (totalComplete == totalParts) {
                 resultFuture.complete(firstResponse);
@@ -285,7 +285,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
             try {
                 // Drain pending queue while permits are available
                 while (!pendingTransformers.isEmpty() && inFlightPermits.tryAcquire()) {
-                    Pair<Integer, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> pendingPart =
+                    Pair<Long, AsyncResponseTransformer<GetObjectResponse, GetObjectResponse>> pendingPart =
                         pendingTransformers.poll();
                     if (pendingPart != null && pendingPart.left() < totalParts) {
                         sendPartRequest(pendingPart.right(), pendingPart.left());
@@ -299,12 +299,12 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
         } while (!pendingTransformers.isEmpty() && inFlightPermits.availablePermits() > 0);
     }
 
-    private Optional<SdkClientException> validatePartResponse(GetObjectResponse response, int partIndex) {
+    private Optional<SdkClientException> validatePartResponse(GetObjectResponse response, long partIndex) {
         return PresignedUrlDownloadHelper.validatePartResponse(
             response, partIndex, configuredPartSizeInBytes, totalContentLength, totalParts);
     }
 
-    private void handlePartError(Throwable error, int partIndex) {
+    private void handlePartError(Throwable error, long partIndex) {
         if (downloadFailed.compareAndSet(false, true)) {
             log.debug(() -> "Error on part " + partIndex, error);
             resultFuture.completeExceptionally(error);
@@ -317,7 +317,7 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
         }
     }
 
-    private PresignedUrlDownloadRequest createRangedGetRequest(int partIndex) {
+    private PresignedUrlDownloadRequest createRangedGetRequest(long partIndex) {
         return PresignedUrlDownloadHelper.createRangedGetRequest(
             presignedUrlDownloadRequest, partIndex, configuredPartSizeInBytes, totalContentLength, eTag);
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
@@ -155,10 +155,10 @@ public class PresignedUrlDownloadHelper {
      * @return empty if valid, or an SdkClientException describing the mismatch
      */
     static Optional<SdkClientException> validatePartResponse(GetObjectResponse response,
-                                                             int partIndex,
+                                                             long partIndex,
                                                              long partSizeInBytes,
                                                              Long totalContentLength,
-                                                             Integer totalParts) {
+                                                             Long totalParts) {
         String contentRange = response.contentRange();
         if (contentRange == null) {
             return Optional.of(missingContentRangeHeader());
@@ -214,7 +214,7 @@ public class PresignedUrlDownloadHelper {
      * @return a new PresignedUrlDownloadRequest with the appropriate Range and If-Match headers
      */
     static PresignedUrlDownloadRequest createRangedGetRequest(PresignedUrlDownloadRequest originalRequest,
-                                                              int partIndex,
+                                                              long partIndex,
                                                               long partSizeInBytes,
                                                               Long totalContentLength,
                                                               String eTag) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -67,8 +67,8 @@ public class PresignedUrlMultipartDownloaderSubscriber
      */
     private final CompletableFuture<?> resultFuture;
     private final Object lock = new Object();
-    private final AtomicInteger nextPartIndex;
-    private final AtomicInteger requestsSent;
+    private final AtomicLong nextPartIndex;
+    private final AtomicLong requestsSent;
 
     /**
      * Store the GetObject futures so we can cancel them if onError() is invoked.
@@ -76,7 +76,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
     private final Queue<CompletableFuture<GetObjectResponse>> getObjectFutures = new ConcurrentLinkedQueue<>();
 
     private volatile Long totalContentLength;
-    private volatile Integer totalParts;
+    private volatile Long totalParts;
     private volatile String eTag;
     private Subscription subscription;
 
@@ -88,8 +88,8 @@ public class PresignedUrlMultipartDownloaderSubscriber
         this.s3AsyncClient = s3AsyncClient;
         this.presignedUrlDownloadRequest = presignedUrlDownloadRequest;
         this.configuredPartSizeInBytes = configuredPartSizeInBytes;
-        this.nextPartIndex = new AtomicInteger(0);
-        this.requestsSent = new AtomicInteger(0);
+        this.nextPartIndex = new AtomicLong(0);
+        this.requestsSent = new AtomicLong(0);
         this.future = new CompletableFuture<>();
         this.resultFuture = resultFuture;
     }
@@ -110,7 +110,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
             throw new NullPointerException("onNext must not be called with null asyncResponseTransformer");
         }
 
-        int currentPartIndex;
+        long currentPartIndex;
         synchronized (lock) {
             currentPartIndex = nextPartIndex.get();
             if (totalParts != null && currentPartIndex >= totalParts) {
@@ -123,7 +123,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
         makeRangeRequest(currentPartIndex, asyncResponseTransformer);
     }
 
-    private void makeRangeRequest(int partIndex,
+    private void makeRangeRequest(long partIndex,
                                   AsyncResponseTransformer<GetObjectResponse,
                                       GetObjectResponse> asyncResponseTransformer) {
         PresignedUrlDownloadRequest partRequest = createRangedGetRequest(partIndex);
@@ -153,9 +153,9 @@ public class PresignedUrlMultipartDownloaderSubscriber
         });
     }
 
-    private boolean validatePart(GetObjectResponse response, int partIndex,
+    private boolean validatePart(GetObjectResponse response, long partIndex,
                                  AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> asyncResponseTransformer) {
-        int dispatched = nextPartIndex.get();
+        long dispatched = nextPartIndex.get();
         log.debug(() -> String.format("Dispatched %d parts so far", dispatched));
 
         String responseETag = response.eTag();
@@ -191,7 +191,7 @@ public class PresignedUrlMultipartDownloaderSubscriber
         return true;
     }
 
-    private void requestMoreIfNeeded(int dispatched) {
+    private void requestMoreIfNeeded(long dispatched) {
         synchronized (lock) {
             if (hasMoreParts(dispatched)) {
                 subscription.request(1);
@@ -207,16 +207,16 @@ public class PresignedUrlMultipartDownloaderSubscriber
         }
     }
 
-    private Optional<SdkClientException> validateResponse(GetObjectResponse response, int partIndex) {
+    private Optional<SdkClientException> validateResponse(GetObjectResponse response, long partIndex) {
         return PresignedUrlDownloadHelper.validatePartResponse(
             response, partIndex, configuredPartSizeInBytes, totalContentLength, totalParts);
     }
 
-    private boolean hasMoreParts(int dispatched) {
+    private boolean hasMoreParts(long dispatched) {
         return totalParts != null && dispatched < totalParts;
     }
 
-    private PresignedUrlDownloadRequest createRangedGetRequest(int partIndex) {
+    private PresignedUrlDownloadRequest createRangedGetRequest(long partIndex) {
         return PresignedUrlDownloadHelper.createRangedGetRequest(
             presignedUrlDownloadRequest, partIndex, configuredPartSizeInBytes, totalContentLength, eTag);
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadUtilsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartDownloadUtilsTest.java
@@ -91,5 +91,12 @@ class MultipartDownloadUtilsTest {
         assertThat(MultipartDownloadUtils.calculateTotalParts(1, 16)).isEqualTo(1);    // smaller than part size
         assertThat(MultipartDownloadUtils.calculateTotalParts(16, 16)).isEqualTo(1);   // exactly one part
         assertThat(MultipartDownloadUtils.calculateTotalParts(0, 16)).isEqualTo(0);    // empty object
+        // 5 GiB / 1 byte = 5_368_709_120 parts (exceeds Integer.MAX_VALUE)
+        long fiveGiB = 5L * 1024L * 1024L * 1024L;
+        assertThat(MultipartDownloadUtils.calculateTotalParts(fiveGiB, 1L)).isEqualTo(fiveGiB);
+        assertThat(MultipartDownloadUtils.calculateTotalParts(Long.MAX_VALUE - 1, 1L))
+            .isEqualTo(Long.MAX_VALUE - 1);
+        assertThat(MultipartDownloadUtils.calculateTotalParts(Long.MAX_VALUE, 2))
+            .isEqualTo((Long.MAX_VALUE / 2) + 1);
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelperTest.java
@@ -35,7 +35,7 @@ class PresignedUrlDownloadHelperTest {
                                                       .build();
 
         Optional<SdkClientException> result = PresignedUrlDownloadHelper.validatePartResponse(
-            response, 0, 16L, 32L, 2);
+            response, 0, 16L, 32L, 2L);
 
         assertThat(result).isEmpty();
     }
@@ -47,7 +47,7 @@ class PresignedUrlDownloadHelperTest {
                                                       .build();
 
         Optional<SdkClientException> result = PresignedUrlDownloadHelper.validatePartResponse(
-            response, 0, 16L, 32L, 2);
+            response, 0, 16L, 32L, 2L);
 
         assertThat(result).isPresent();
         assertThat(result.get().getMessage()).contains("No Content-Range header");
@@ -61,7 +61,7 @@ class PresignedUrlDownloadHelperTest {
                                                       .build();
 
         Optional<SdkClientException> result = PresignedUrlDownloadHelper.validatePartResponse(
-            response, 0, 16L, 32L, 2);
+            response, 0, 16L, 32L, 2L);
 
         assertThat(result).isPresent();
         assertThat(result.get().getMessage()).contains("Invalid or missing Content-Length");
@@ -75,7 +75,7 @@ class PresignedUrlDownloadHelperTest {
                                                       .build();
 
         Optional<SdkClientException> result = PresignedUrlDownloadHelper.validatePartResponse(
-            response, 0, 16L, 32L, 2);
+            response, 0, 16L, 32L, 2L);
 
         assertThat(result).isPresent();
         assertThat(result.get().getMessage()).contains("Content-Range mismatch for part 0");
@@ -89,7 +89,7 @@ class PresignedUrlDownloadHelperTest {
                                                       .build();
 
         Optional<SdkClientException> result = PresignedUrlDownloadHelper.validatePartResponse(
-            response, 0, 16L, 32L, 2);
+            response, 0, 16L, 32L, 2L);
 
         assertThat(result).isPresent();
         assertThat(result.get().getMessage()).contains("content length validation failed");
@@ -104,7 +104,7 @@ class PresignedUrlDownloadHelperTest {
                                                       .build();
 
         Optional<SdkClientException> result = PresignedUrlDownloadHelper.validatePartResponse(
-            response, 1, 16L, 30L, 2);
+            response, 1, 16L, 30L, 2L);
 
         assertThat(result).isEmpty();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The S3 presigned URL multipart download feature uses range-based GETs to download large objects in chunks. The number of parts is calculated client-side from the total object size and the configured part size.
Unlike the standard multipart download (`MultipartDownloaderSubscriber`), which reads `totalParts` from the `x-amz-mp-parts-count` response header (always ≤ 10,000 since S3 caps multipart uploads at 10,000 parts), the presigned URL multipart download calculates `totalParts` client-side from `contentLength / partSize. `This calculation has no S3-enforced upper bound — the only constraint is the configured `minimumPartSizeInBytes`.

**The current implementation has two issues:**
Issue 1: Floating-point precision loss Casting long → double loses precision for values > 2^53. With small partSize, the division loses precision and the result can be off.
Issue 2: Silent integer saturation When contentLength / partSize > Integer.MAX_VALUE, the (int) cast on the Math.ceil result silently saturates to Integer.MAX_VALUE rather than failing. The downloader uses this incorrect totalParts, the completion gate (completedParts == totalParts) fires before all data is downloaded, and the customer receives a truncated download reported as success

**When the bug is reachable:** The SDK does not enforce a minimum on `MultipartConfiguration.minimumPartSizeInBytes()`, so a customer can set it as low as 1L. With sub-KB part sizes against multi-GB objects, contentLength / partSize exceeds Integer.MAX_VALUE and the bug manifests.

## Modifications
Replaced the floating-point ceiling division with exact integer arithmetic and 
Changed calculateTotalParts return type from int to long
Changed totalParts field from Integer to Long in both subscribers

## Testing
- Unit tests (`MultipartDownloadUtilsTest`):
  Existing cases continue to pass (last-part smaller, exact boundary, contentLength == partSize, contentLength == 0, contentLength < partSize).
  Added 5 GiB / 1 byte → returns 5_368_709_120 (exceeds Integer.MAX_VALUE, previously saturated).
  Added Long.MAX_VALUE - 1 with partSize = 1 → returns Long.MAX_VALUE - 1 (verifies no overflow at the upper bound).
- Updated tests (`PresignedUrlDownloadHelperTest`):

All validatePartResponse call sites updated from 2 to 2L to match the new Long parameter type.
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
