### PR TITLE
[Credential Cache Pr 2/3] Enable static stability for STS, Container, SSO, and Login credential providers

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.auth.credentials;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static software.amazon.awssdk.utils.cache.CachedSupplier.StaleValueBehavior.ALLOW;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -113,10 +114,12 @@ public final class ContainerCredentialsProvider
             this.credentialsCache = CachedSupplier.builder(this::refreshCredentials)
                                                   .cachedValueName(toString())
                                                   .prefetchStrategy(new NonBlocking(builder.asyncThreadName))
+                                                  .staleValueBehavior(ALLOW)
                                                   .build();
         } else {
             this.credentialsCache = CachedSupplier.builder(this::refreshCredentials)
                                                   .cachedValueName(toString())
+                                                  .staleValueBehavior(ALLOW)
                                                   .build();
         }
     }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
@@ -140,4 +140,54 @@ public class ContainerCredentialsProviderTest {
                "\"Token\":\"TOKEN_TOKEN_TOKEN\"," +
                "\"Expiration\":\"3000-05-03T04:55:54Z\"}";
     }
+
+    /**
+     * Tests that when the cache is stale and refresh fails, the provider returns cached credentials
+     * instead of throwing an exception (ALLOW behavior / static stability).
+     */
+    @Test
+    public void testRefreshFailureReturnsCachedCredentials_whenCacheIsStale() {
+        // First call succeeds with credentials that are already expired (stale immediately on next get)
+        String alreadyExpiredBody = "{\"AccessKeyId\":\"ACCESS_KEY_ID\"," +
+                                    "\"SecretAccessKey\":\"SECRET_ACCESS_KEY\"," +
+                                    "\"Token\":\"TOKEN_TOKEN_TOKEN\"," +
+                                    "\"Expiration\":\"2020-01-01T00:00:00Z\"}";
+
+        stubFor(get(urlPathEqualTo(CREDENTIALS_PATH))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(alreadyExpiredBody)));
+
+        // First call succeeds (initial fetch always succeeds even if credentials are expired)
+        AwsCredentials firstCredentials = credentialsProvider.resolveCredentials();
+        assertThat(firstCredentials.accessKeyId()).isEqualTo(ACCESS_KEY_ID);
+
+        // Now stub the endpoint to return a 500 error (simulating container metadata endpoint failure)
+        stubFor(get(urlPathEqualTo(CREDENTIALS_PATH))
+                    .willReturn(aResponse()
+                                    .withStatus(500)
+                                    .withBody("Internal Server Error")));
+
+        // Second call: cache is stale (expiration is in the past), refresh fails with 500,
+        // but ALLOW behavior should return the cached credentials
+        AwsCredentials secondCredentials = credentialsProvider.resolveCredentials();
+        assertThat(secondCredentials.accessKeyId()).isEqualTo(ACCESS_KEY_ID);
+        assertThat(secondCredentials.secretAccessKey()).isEqualTo(SECRET_ACCESS_KEY);
+    }
+
+    /**
+     * Tests that when no credentials are cached (initial fetch) and the endpoint fails,
+     * an exception is thrown.
+     */
+    @Test
+    public void testInitialFetchFailure_throwsException() {
+        stubFor(get(urlPathEqualTo(CREDENTIALS_PATH))
+                    .willReturn(aResponse()
+                                    .withStatus(500)
+                                    .withBody("Internal Server Error")));
+
+        assertThatThrownBy(credentialsProvider::resolveCredentials)
+            .isInstanceOf(SdkClientException.class);
+    }
 }

--- a/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
+++ b/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
@@ -214,6 +214,7 @@ public final class LoginCredentialsProvider implements
                     // on CachedSupplier will identify it and bypass static stability.
                     throw accessDeniedException;
                 case INSUFFICIENT_PERMISSIONS:
+                    // Wrap with a helpful message, but still cache-invalidating — the predicate checks the cause.
                     throw SdkClientException.create(
                         "Unable to refresh credentials due to insufficient permissions. You may be missing permission "
                         + "for the 'CreateOAuth2Token' action.",
@@ -229,15 +230,27 @@ public final class LoginCredentialsProvider implements
     /**
      * Determines whether a given exception represents a non-recoverable refresh failure that should bypass
      * static stability. For Login, this is an {@link AccessDeniedException} with error code
-     * {@link OAuth2ErrorCode#TOKEN_EXPIRED} or {@link OAuth2ErrorCode#USER_CREDENTIALS_CHANGED}.
+     * {@link OAuth2ErrorCode#TOKEN_EXPIRED}, {@link OAuth2ErrorCode#USER_CREDENTIALS_CHANGED},
+     * or {@link OAuth2ErrorCode#INSUFFICIENT_PERMISSIONS}.
      */
     private static boolean isCacheInvalidating(RuntimeException e) {
-        if (!(e instanceof AccessDeniedException)) {
+        AccessDeniedException ade = extractAccessDeniedException(e);
+        if (ade == null) {
             return false;
         }
-        AccessDeniedException ade = (AccessDeniedException) e;
         return ade.error() == OAuth2ErrorCode.TOKEN_EXPIRED
-               || ade.error() == OAuth2ErrorCode.USER_CREDENTIALS_CHANGED;
+               || ade.error() == OAuth2ErrorCode.USER_CREDENTIALS_CHANGED
+               || ade.error() == OAuth2ErrorCode.INSUFFICIENT_PERMISSIONS;
+    }
+
+    private static AccessDeniedException extractAccessDeniedException(RuntimeException e) {
+        if (e instanceof AccessDeniedException) {
+            return (AccessDeniedException) e;
+        }
+        if (e.getCause() instanceof AccessDeniedException) {
+            return (AccessDeniedException) e.getCause();
+        }
+        return null;
     }
 
     /**

--- a/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
+++ b/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.signin.auth;
 import static software.amazon.awssdk.utils.UserHomeDirectoryUtils.userHomeDirectory;
 import static software.amazon.awssdk.utils.Validate.notNull;
 import static software.amazon.awssdk.utils.Validate.paramNotBlank;
+import static software.amazon.awssdk.utils.cache.CachedSupplier.StaleValueBehavior.ALLOW;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,6 +44,7 @@ import software.amazon.awssdk.services.signin.internal.OnDiskTokenManager;
 import software.amazon.awssdk.services.signin.model.AccessDeniedException;
 import software.amazon.awssdk.services.signin.model.CreateOAuth2TokenRequest;
 import software.amazon.awssdk.services.signin.model.CreateOAuth2TokenResponse;
+import software.amazon.awssdk.services.signin.model.OAuth2ErrorCode;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.StringUtils;
@@ -120,7 +122,9 @@ public final class LoginCredentialsProvider implements
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
         CachedSupplier.Builder<AwsCredentials> cacheBuilder =
             CachedSupplier.builder(this::updateSigninCredentials)
-                          .cachedValueName(toString());
+                          .cachedValueName(toString())
+                          .staleValueBehavior(ALLOW)
+                          .cacheInvalidatingPredicate(LoginCredentialsProvider::isCacheInvalidating);
         if (builder.asyncCredentialUpdateEnabled) {
             cacheBuilder.prefetchStrategy(new NonBlocking(ASYNC_THREAD_NAME));
         }
@@ -205,15 +209,10 @@ public final class LoginCredentialsProvider implements
 
             switch (accessDeniedException.error()) {
                 case TOKEN_EXPIRED:
-                    throw SdkClientException.create(
-                        "Your session has expired. Please reauthenticate.",
-                        accessDeniedException);
                 case USER_CREDENTIALS_CHANGED:
-                    throw SdkClientException.create(
-                        "Unable to refresh credentials because of a change in your password. "
-                        + "Please reauthenticate with your new password.",
-                        accessDeniedException
-                    );
+                    // Let the original AccessDeniedException propagate — the cacheInvalidatingPredicate
+                    // on CachedSupplier will identify it and bypass static stability.
+                    throw accessDeniedException;
                 case INSUFFICIENT_PERMISSIONS:
                     throw SdkClientException.create(
                         "Unable to refresh credentials due to insufficient permissions. You may be missing permission "
@@ -225,6 +224,20 @@ public final class LoginCredentialsProvider implements
 
             }
         }
+    }
+
+    /**
+     * Determines whether a given exception represents a non-recoverable refresh failure that should bypass
+     * static stability. For Login, this is an {@link AccessDeniedException} with error code
+     * {@link OAuth2ErrorCode#TOKEN_EXPIRED} or {@link OAuth2ErrorCode#USER_CREDENTIALS_CHANGED}.
+     */
+    private static boolean isCacheInvalidating(RuntimeException e) {
+        if (!(e instanceof AccessDeniedException)) {
+            return false;
+        }
+        AccessDeniedException ade = (AccessDeniedException) e;
+        return ade.error() == OAuth2ErrorCode.TOKEN_EXPIRED
+               || ade.error() == OAuth2ErrorCode.USER_CREDENTIALS_CHANGED;
     }
 
     /**

--- a/services/signin/src/test/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProviderTest.java
+++ b/services/signin/src/test/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProviderTest.java
@@ -54,6 +54,7 @@ import software.amazon.awssdk.services.signin.internal.AccessTokenManager;
 import software.amazon.awssdk.services.signin.internal.LoginAccessToken;
 import software.amazon.awssdk.services.signin.internal.OnDiskTokenManager;
 import software.amazon.awssdk.services.signin.model.CreateOAuth2TokenRequest;
+import software.amazon.awssdk.services.signin.model.AccessDeniedException;
 import software.amazon.awssdk.services.signin.model.OAuth2ErrorCode;
 import software.amazon.awssdk.services.signin.model.SigninException;
 import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
@@ -182,7 +183,7 @@ public class LoginCredentialsProviderTest {
 
     @Test
     public void resolveCredentials_whenCredentialsExpired_serviceCallFailsWithGeneric500_raisesException() {
-        // expired
+        // expired - no cached value in CachedSupplier yet, so ALLOW still throws on first failure
         AwsSessionCredentials creds = buildCredentials(Instant.now().minusSeconds(60));
         LoginAccessToken token = buildAccessToken(creds);
         tokenManager.storeToken(token);
@@ -196,6 +197,50 @@ public class LoginCredentialsProviderTest {
     }
 
     @Test
+    public void resolveCredentials_transientFailureAfterSuccessfulCache_returnsCachedCredentials() {
+        // First: store token with expired credentials so it triggers refresh from service
+        AwsSessionCredentials creds = buildCredentials(Instant.now().minusSeconds(600));
+        LoginAccessToken token = buildAccessToken(creds);
+        tokenManager.storeToken(token);
+
+        // First response: successful refresh with short-lived credentials (expires in 30s)
+        // staleTime will be now+30s - 1min = now-30s (already stale), so next get() will refresh again
+        String shortLivedJsonBody =
+            "{\"accessToken\":"
+            + "{\"accessKeyId\":\"new-akid\","
+            + "\"secretAccessKey\":\"new-skid\","
+            + "\"sessionToken\":\"new-session-token\"},"
+            + "\"tokenType\":\"aws_sigv4\","
+            + "\"expiresIn\":30,"
+            + "\"refreshToken\":\"new-refresh-token\"}";
+
+        HttpExecuteResponse successResponse = HttpExecuteResponse
+            .builder()
+            .response(SdkHttpResponse.builder().statusCode(200).build())
+            .responseBody(AbortableInputStream.create(
+                new ByteArrayInputStream(shortLivedJsonBody.getBytes(StandardCharsets.UTF_8))))
+            .build();
+
+        // Second response: transient 500 error
+        HttpExecuteResponse failureResponse = HttpExecuteResponse
+            .builder()
+            .response(SdkHttpResponse.builder().statusCode(500).build())
+            .build();
+
+        mockHttpClient.stubResponses(successResponse, failureResponse);
+
+        // First call: succeeds and populates the CachedSupplier cache
+        AwsCredentials firstResolve = loginCredentialsProvider.resolveCredentials();
+        assertEquals("new-akid", firstResolve.accessKeyId());
+
+        // Second call: the cached value is already stale (30s expiry - 1min staleTime < now),
+        // so CachedSupplier tries to refresh, gets 500, and with ALLOW behavior returns cached value
+        AwsCredentials secondResolve = loginCredentialsProvider.resolveCredentials();
+        assertEquals("new-akid", secondResolve.accessKeyId());
+        assertEquals("new-skid", secondResolve.secretAccessKey());
+    }
+
+    @Test
     public void resolveCredentials_whenCredentialsExpired_serviceCallFailsWithTokenExpired_raisesException() {
         // expired
         AwsSessionCredentials creds = buildCredentials(Instant.now().minusSeconds(60));
@@ -203,8 +248,9 @@ public class LoginCredentialsProviderTest {
         tokenManager.storeToken(token);
 
         stubAccessDeniedException(OAuth2ErrorCode.TOKEN_EXPIRED);
-        SdkClientException e = assertThrows(SdkClientException.class, () -> loginCredentialsProvider.resolveCredentials());
-        assertTrue(e.getMessage().contains("Your session has expired"));
+        AccessDeniedException e = assertThrows(AccessDeniedException.class,
+                                               () -> loginCredentialsProvider.resolveCredentials());
+        assertNotNull(e);
     }
 
     @Test
@@ -215,8 +261,9 @@ public class LoginCredentialsProviderTest {
         tokenManager.storeToken(token);
 
         stubAccessDeniedException(OAuth2ErrorCode.USER_CREDENTIALS_CHANGED);
-        SdkClientException e = assertThrows(SdkClientException.class, () -> loginCredentialsProvider.resolveCredentials());
-        assertTrue(e.getMessage().contains("change in your password"));
+        AccessDeniedException e = assertThrows(AccessDeniedException.class,
+                                               () -> loginCredentialsProvider.resolveCredentials());
+        assertNotNull(e);
     }
 
     @Test

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.sso.SsoClient;
 import software.amazon.awssdk.services.sso.internal.SessionCredentialsHolder;
 import software.amazon.awssdk.services.sso.model.GetRoleCredentialsRequest;
 import software.amazon.awssdk.services.sso.model.RoleCredentials;
+import software.amazon.awssdk.services.sso.model.UnauthorizedException;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -90,7 +91,10 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
         CachedSupplier.Builder<SessionCredentialsHolder> cacheBuilder =
             CachedSupplier.builder(this::updateSsoCredentials)
-                          .cachedValueName(toString());
+                          .cachedValueName(toString())
+                          .staleValueBehavior(CachedSupplier.StaleValueBehavior.ALLOW)
+                          .cacheInvalidatingPredicate(
+                              e -> e instanceof ExpiredTokenException || e instanceof UnauthorizedException);
         if (builder.asyncCredentialUpdateEnabled) {
             cacheBuilder.prefetchStrategy(new NonBlocking(ASYNC_THREAD_NAME));
         }
@@ -115,6 +119,7 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
     private SessionCredentialsHolder getUpdatedCredentials(SsoClient ssoClient) {
         GetRoleCredentialsRequest request = getRoleCredentialsRequestSupplier.get();
         notNull(request, "GetRoleCredentialsRequest can't be null.");
+
         RoleCredentials roleCredentials = ssoClient.getRoleCredentials(request).roleCredentials();
         AwsSessionCredentials sessionCredentials = AwsSessionCredentials.builder()
                                                                         .accessKeyId(roleCredentials.accessKeyId())

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sso.auth;
 
 import static software.amazon.awssdk.utils.Validate.notNull;
+import static software.amazon.awssdk.utils.cache.CachedSupplier.StaleValueBehavior.ALLOW;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -92,7 +93,7 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
         CachedSupplier.Builder<SessionCredentialsHolder> cacheBuilder =
             CachedSupplier.builder(this::updateSsoCredentials)
                           .cachedValueName(toString())
-                          .staleValueBehavior(CachedSupplier.StaleValueBehavior.ALLOW)
+                          .staleValueBehavior(ALLOW)
                           .cacheInvalidatingPredicate(
                               e -> e instanceof ExpiredTokenException || e instanceof UnauthorizedException);
         if (builder.asyncCredentialUpdateEnabled) {

--- a/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProviderTest.java
+++ b/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProviderTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sso.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,11 +28,13 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.services.sso.SsoClient;
 import software.amazon.awssdk.services.sso.model.GetRoleCredentialsRequest;
 import software.amazon.awssdk.services.sso.model.GetRoleCredentialsResponse;
 import software.amazon.awssdk.services.sso.model.RoleCredentials;
+import software.amazon.awssdk.services.sso.model.UnauthorizedException;
 
 /**
  * Validates the functionality of {@link SsoCredentialsProvider}.
@@ -86,6 +89,122 @@ public class SsoCredentialsProviderTest {
         }
 
         callClient(verify(ssoClient, times(2)), Mockito.any());
+    }
+
+    @Test
+    public void refreshFailureReturnsCachedCredentials_staticStability() {
+        ssoClient = mock(SsoClient.class);
+        RoleCredentials credentials = RoleCredentials.builder()
+                                                     .accessKeyId("a")
+                                                     .secretAccessKey("b")
+                                                     .sessionToken("c")
+                                                     .expiration(Instant.now().minus(Duration.ofSeconds(5)).toEpochMilli())
+                                                     .build();
+
+        Supplier<GetRoleCredentialsRequest> supplier = getRequestSupplier();
+        GetRoleCredentialsResponse response = getResponse(credentials);
+
+        // First call succeeds, second call fails with transient error
+        when(ssoClient.getRoleCredentials(supplier.get()))
+            .thenReturn(response)
+            .thenThrow(SdkClientException.create("SSO service unavailable"));
+
+        try (SsoCredentialsProvider credentialsProvider = SsoCredentialsProvider.builder()
+                                                                               .refreshRequest(supplier)
+                                                                               .ssoClient(ssoClient)
+                                                                               .build()) {
+            // First call succeeds and caches credentials
+            AwsSessionCredentials firstResult = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
+            assertThat(firstResult.accessKeyId()).isEqualTo("a");
+
+            // Second call should return cached credentials because ALLOW is set
+            AwsSessionCredentials secondResult = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
+            assertThat(secondResult.accessKeyId()).isEqualTo("a");
+            assertThat(secondResult.secretAccessKey()).isEqualTo("b");
+            assertThat(secondResult.sessionToken()).isEqualTo("c");
+        }
+    }
+
+    @Test
+    public void unauthorizedException_bypassesStaticStability() {
+        ssoClient = mock(SsoClient.class);
+        RoleCredentials credentials = RoleCredentials.builder()
+                                                     .accessKeyId("a")
+                                                     .secretAccessKey("b")
+                                                     .sessionToken("c")
+                                                     .expiration(Instant.now().minus(Duration.ofSeconds(5)).toEpochMilli())
+                                                     .build();
+
+        Supplier<GetRoleCredentialsRequest> supplier = getRequestSupplier();
+        GetRoleCredentialsResponse response = getResponse(credentials);
+
+        UnauthorizedException unauthorizedException = (UnauthorizedException) UnauthorizedException.builder()
+            .message("Token is expired")
+            .build();
+
+        // First call succeeds, second call fails with UnauthorizedException
+        when(ssoClient.getRoleCredentials(supplier.get()))
+            .thenReturn(response)
+            .thenThrow(unauthorizedException);
+
+        try (SsoCredentialsProvider credentialsProvider = SsoCredentialsProvider.builder()
+                                                                               .refreshRequest(supplier)
+                                                                               .ssoClient(ssoClient)
+                                                                               .build()) {
+            // First call succeeds and caches credentials
+            AwsSessionCredentials firstResult = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
+            assertThat(firstResult.accessKeyId()).isEqualTo("a");
+
+            // Second call should throw UnauthorizedException directly (bypasses static stability)
+            assertThatThrownBy(credentialsProvider::resolveCredentials)
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessageContaining("Token is expired");
+        }
+    }
+
+    @Test
+    public void expiredTokenException_bypassesStaticStability() {
+        ssoClient = mock(SsoClient.class);
+
+        ExpiredTokenException expiredTokenException = (ExpiredTokenException) ExpiredTokenException.builder()
+            .message("The SSO session associated with this profile has expired")
+            .build();
+
+        // Request supplier throws ExpiredTokenException (client-side token expiry)
+        Supplier<GetRoleCredentialsRequest> expiredSupplier = () -> {
+            throw expiredTokenException;
+        };
+
+        try (SsoCredentialsProvider credentialsProvider = SsoCredentialsProvider.builder()
+                                                                               .refreshRequest(expiredSupplier)
+                                                                               .ssoClient(ssoClient)
+                                                                               .build()) {
+            // Should throw ExpiredTokenException directly (bypasses static stability)
+            assertThatThrownBy(credentialsProvider::resolveCredentials)
+                .isInstanceOf(ExpiredTokenException.class)
+                .hasMessageContaining("The SSO session associated with this profile has expired");
+        }
+    }
+
+    @Test
+    public void noCachedCredentials_anyFailure_throwsImmediately() {
+        ssoClient = mock(SsoClient.class);
+
+        Supplier<GetRoleCredentialsRequest> supplier = getRequestSupplier();
+
+        // First call fails with a transient error — no cached credentials exist
+        when(ssoClient.getRoleCredentials(supplier.get()))
+            .thenThrow(SdkClientException.create("SSO service unavailable"));
+
+        try (SsoCredentialsProvider credentialsProvider = SsoCredentialsProvider.builder()
+                                                                               .refreshRequest(supplier)
+                                                                               .ssoClient(ssoClient)
+                                                                               .build()) {
+            // Should throw immediately since no cached credentials exist
+            assertThatThrownBy(credentialsProvider::resolveCredentials)
+                .isInstanceOf(SdkClientException.class)
+                .hasMessageContaining("SSO service unavailable");
+        }
     }
 
 

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
@@ -78,7 +78,8 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
         CachedSupplier.Builder<AwsSessionCredentials> cacheBuilder =
             CachedSupplier.builder(this::updateSessionCredentials)
-                          .cachedValueName(toString());
+                          .cachedValueName(toString())
+                          .staleValueBehavior(CachedSupplier.StaleValueBehavior.ALLOW);
         if (builder.asyncCredentialUpdateEnabled) {
             cacheBuilder.prefetchStrategy(new NonBlocking(asyncThreadName));
         }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sts.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,7 +28,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.endpoints.internal.Arn;
 import software.amazon.awssdk.services.sts.model.Credentials;
@@ -100,6 +103,61 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
     protected abstract ResponseT callClient(StsClient client, RequestT request);
 
     protected abstract String providerName();
+
+    @Test
+    public void refreshFailureReturnsCachedCredentials_staticStability() {
+        // First call returns valid credentials that are already expired (to force a refresh on next call)
+        Credentials validCredentials = Credentials.builder()
+                                                  .accessKeyId("a")
+                                                  .secretAccessKey("b")
+                                                  .sessionToken("c")
+                                                  .expiration(Instant.now().minus(Duration.ofSeconds(5)))
+                                                  .build();
+        RequestT request = getRequest();
+        ResponseT response = getResponse(validCredentials);
+
+        // First call succeeds, second call fails
+        when(callClient(stsClient, request))
+            .thenReturn(response)
+            .thenThrow(SdkClientException.create("STS service unavailable"));
+
+        StsCredentialsProvider.BaseBuilder<?, ? extends StsCredentialsProvider> credentialsProviderBuilder =
+            createCredentialsProviderBuilder(request);
+
+        try (StsCredentialsProvider credentialsProvider = credentialsProviderBuilder.stsClient(stsClient).build()) {
+            // First call should succeed and cache credentials
+            AwsCredentials firstResult = credentialsProvider.resolveCredentials();
+            assertThat(firstResult).isInstanceOf(AwsSessionCredentials.class);
+            assertThat(((AwsSessionCredentials) firstResult).accessKeyId()).isEqualTo("a");
+
+            // Second call should return cached credentials instead of throwing
+            // because StaleValueBehavior.ALLOW is now set
+            AwsCredentials secondResult = credentialsProvider.resolveCredentials();
+            assertThat(secondResult).isInstanceOf(AwsSessionCredentials.class);
+            assertThat(((AwsSessionCredentials) secondResult).accessKeyId()).isEqualTo("a");
+            assertThat(((AwsSessionCredentials) secondResult).secretAccessKey()).isEqualTo("b");
+            assertThat(((AwsSessionCredentials) secondResult).sessionToken()).isEqualTo("c");
+        }
+    }
+
+    @Test
+    public void initialFetchFailureThrowsException_noCachedCredentials() {
+        RequestT request = getRequest();
+
+        // The very first call to STS fails — no credentials have ever been cached
+        when(callClient(stsClient, request))
+            .thenThrow(SdkClientException.create("STS service unavailable"));
+
+        StsCredentialsProvider.BaseBuilder<?, ? extends StsCredentialsProvider> credentialsProviderBuilder =
+            createCredentialsProviderBuilder(request);
+
+        try (StsCredentialsProvider credentialsProvider = credentialsProviderBuilder.stsClient(stsClient).build()) {
+            // Should throw because there are no cached credentials to fall back on
+            assertThatThrownBy(credentialsProvider::resolveCredentials)
+                .isInstanceOf(SdkClientException.class)
+                .hasMessageContaining("STS service unavailable");
+        }
+    }
 
     public void callClientWithCredentialsProvider(Instant credentialsExpirationDate, int numTimesInvokeCredentialsProvider, boolean overrideStaleAndPrefetchTimes) {
         Credentials credentials = Credentials.builder().accessKeyId("a").secretAccessKey("b").sessionToken("c").expiration(credentialsExpirationDate).build();


### PR DESCRIPTION
**This PR merges to feature/master/credential_cache, NOT to master**
[Credential Cache Pr 2/3].

## Motivation and Context

This is part 2 of 3 implementing the cross-SDK [Credential Refresh Behavior SEP](https://quip-amazon.com/tlmsA1Wlwgq9). With the `CachedSupplier` ALLOW behavior established in PR 1, this PR switches the relevant credential providers to use it — so that refresh failures return cached credentials instead of propagating exceptions to callers.

Additionally, this PR wraps non-recoverable authentication errors (expired SSO tokens, changed Login passwords) in `CacheInvalidatingException` so they bypass static stability and are immediately surfaced to the user.

**PR chain**: [PR 1: CachedSupplier ALLOW engine](https://github.com/aws/aws-sdk-java-v2/pull/7028) → PR 2 (this) → [PR 3: Unified timing configuration]

**Depends on**:  https://github.com/aws/aws-sdk-java-v2/pull/7028

## Modifications

- **`StsCredentialsProvider`**: Added `.staleValueBehavior(CachedSupplier.StaleValueBehavior.ALLOW)` to the CachedSupplier builder. On refresh failure, STS providers now return cached credentials instead of throwing. Initial fetch failure (no cache) still throws.

- **`ContainerCredentialsProvider`**: Added `.staleValueBehavior(ALLOW)` to the CachedSupplier builder. Container metadata endpoint failures now return cached credentials.

- **`SsoCredentialsProvider`**: Added `.staleValueBehavior(ALLOW)`. `UnauthorizedException` (from SSO service) and `ExpiredTokenException` are considered cache invalidating exceptions so expired SSO tokens bypass static stability and immediately prompt re-authentication.

- **`LoginCredentialsProvider`**: Added `.staleValueBehavior(ALLOW)`.   Made `TOKEN_EXPIRED` and `USER_CREDENTIALS_CHANGED` errors cache invalidating.

- **`ProcessCredentialsProvider`**: Intentionally NOT changed — keeps `STRICT` behavior since process execution is local and we do not know the source of the credentials.


## Testing
New tests for static stability in updated credential providers.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
- [x] I confirm that this pull request can be released under the Apache 2 license