### PR TITLE
Enable checksum validation for presigned URL downloads

### DIFF
--- a/core/checksums/src/main/java/software/amazon/awssdk/checksums/DefaultChecksumAlgorithm.java
+++ b/core/checksums/src/main/java/software/amazon/awssdk/checksums/DefaultChecksumAlgorithm.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.checksums;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
@@ -50,6 +52,13 @@ public final class DefaultChecksumAlgorithm {
         }
 
         return ChecksumAlgorithmsCache.VALUES.get(algorithm.toUpperCase(Locale.US));
+    }
+
+    /**
+     * Returns all registered checksum algorithms.
+     */
+    public static Collection<ChecksumAlgorithm> values() {
+        return Collections.unmodifiableCollection(ChecksumAlgorithmsCache.VALUES.values());
     }
 
     private static final class ChecksumAlgorithmsCache {

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTestSuite.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTestSuite.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -278,6 +279,61 @@ public abstract class AsyncPresignedUrlExtensionTestSuite extends S3IntegrationT
         assertThatThrownBy(() -> presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes())
                                                       .get(30, TimeUnit.SECONDS))
             .hasCauseInstanceOf(S3Exception.class);
+    }
+
+    @Test
+    void getObject_withChecksumModeEnabled_returnsChecksumHeaders() throws Exception {
+        PresignedGetObjectRequest presigned = presigner.presignGetObject(r -> r
+            .getObjectRequest(req -> req.bucket(testBucket).key(testGetObjectKey)
+                                        .checksumMode(ChecksumMode.ENABLED))
+            .signatureDuration(Duration.ofMinutes(10)));
+
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presigned.url())
+                                                                         .build();
+
+        ResponseBytes<GetObjectResponse> response =
+            presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes())
+                                 .get(30, TimeUnit.SECONDS);
+
+        assertThat(response.asUtf8String()).isEqualTo(testObjectContent);
+        assertThat(response.response().checksumTypeAsString()).isNotNull();
+    }
+
+    @Test
+    void getObject_withoutChecksumMode_doesNotReturnChecksumHeaders() throws Exception {
+        PresignedUrlDownloadRequest request = createRequestForKey(testGetObjectKey);
+
+        ResponseBytes<GetObjectResponse> response =
+            presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes())
+                                 .get(30, TimeUnit.SECONDS);
+
+        assertThat(response.asUtf8String()).isEqualTo(testObjectContent);
+        assertThat(response.response().checksumTypeAsString()).isNull();
+    }
+
+    @Test
+    void getObject_withChecksumModeEnabled_requestContainsChecksumHeader() throws Exception {
+        PresignedGetObjectRequest presigned = presigner.presignGetObject(r -> r
+            .getObjectRequest(req -> req.bucket(testBucket).key(testGetObjectKey)
+                                        .checksumMode(ChecksumMode.ENABLED))
+            .signatureDuration(Duration.ofMinutes(10)));
+
+        // Verify the presigned URL has checksum-mode in SignedHeaders
+        assertThat(presigned.signedHeaders()).containsKey("x-amz-checksum-mode");
+        assertThat(presigned.isBrowserExecutable()).isFalse();
+
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presigned.url())
+                                                                         .build();
+
+        // Download should succeed (proves marshaller sent the header)
+        ResponseBytes<GetObjectResponse> response =
+            presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes())
+                                 .get(30, TimeUnit.SECONDS);
+
+        assertThat(response).isNotNull();
+        assertThat(response.asUtf8String()).isEqualTo(testObjectContent);
     }
 
     static Stream<Arguments> basicFunctionalityTestData() {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/GetObjectInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/GetObjectInterceptor.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.internal.util.HttpChecksumUtils;
 import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.internal.presignedurl.model.PresignedUrlDownloadRequestWrapper;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.utils.Pair;
@@ -43,7 +44,8 @@ public class GetObjectInterceptor implements ExecutionInterceptor {
     @Override
     public void afterTransmission(Context.AfterTransmission context, ExecutionAttributes executionAttributes) {
 
-        if (!(context.request() instanceof GetObjectRequest)) {
+        if (!(context.request() instanceof GetObjectRequest)
+            && !(context.request() instanceof PresignedUrlDownloadRequestWrapper)) {
             return;
         }
         ChecksumSpecs resolvedChecksumSpecs = executionAttributes.getAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.internal.AwsProtocolMetadata;
 import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
+import software.amazon.awssdk.checksums.spi.ChecksumAlgorithm;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.AsyncResponseTransformerUtils;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
@@ -67,20 +68,13 @@ public final class DefaultAsyncPresignedUrlExtension implements AsyncPresignedUr
      * Checksum configuration matching the codegen-produced GetObject operation.
      * Enables the HttpChecksumValidationInterceptor to validate response checksums.
      */
-    private static final HttpChecksum RESPONSE_CHECKSUM_CONFIG = HttpChecksum.builder()
-                                                                             .requestValidationMode("ENABLED")
-                                                                             .responseAlgorithmsV2(
-                                                                                 DefaultChecksumAlgorithm.XXHASH3,
-                                                                                 DefaultChecksumAlgorithm.XXHASH128,
-                                                                                 DefaultChecksumAlgorithm.CRC64NVME,
-                                                                                 DefaultChecksumAlgorithm.CRC32C,
-                                                                                 DefaultChecksumAlgorithm.CRC32,
-                                                                                 DefaultChecksumAlgorithm.XXHASH64,
-                                                                                 DefaultChecksumAlgorithm.SHA512,
-                                                                                 DefaultChecksumAlgorithm.SHA256,
-                                                                                 DefaultChecksumAlgorithm.SHA1,
-                                                                                 DefaultChecksumAlgorithm.MD5)
-                                                                             .build();
+    private static final HttpChecksum RESPONSE_CHECKSUM_CONFIG =
+        HttpChecksum.builder()
+                    .requestValidationMode("ENABLED")
+                    .responseAlgorithmsV2(
+                        DefaultChecksumAlgorithm.values()
+                                                .toArray(new ChecksumAlgorithm[0]))
+                    .build();
 
     private final AsyncClientHandler clientHandler;
     private final AwsS3ProtocolFactory protocolFactory;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.internal.AwsProtocolMetadata;
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.AsyncResponseTransformerUtils;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
@@ -37,6 +38,7 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.signer.NoOpSigner;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -61,12 +63,31 @@ import software.amazon.awssdk.utils.Pair;
 public final class DefaultAsyncPresignedUrlExtension implements AsyncPresignedUrlExtension {
     private static final Logger log = LoggerFactory.getLogger(DefaultAsyncPresignedUrlExtension.class);
 
+    /**
+     * Checksum configuration matching the codegen-produced GetObject operation.
+     * Enables the HttpChecksumValidationInterceptor to validate response checksums.
+     */
+    private static final HttpChecksum RESPONSE_CHECKSUM_CONFIG = HttpChecksum.builder()
+                                                                             .requestValidationMode("ENABLED")
+                                                                             .responseAlgorithmsV2(
+                                                                                 DefaultChecksumAlgorithm.XXHASH3,
+                                                                                 DefaultChecksumAlgorithm.XXHASH128,
+                                                                                 DefaultChecksumAlgorithm.CRC64NVME,
+                                                                                 DefaultChecksumAlgorithm.CRC32C,
+                                                                                 DefaultChecksumAlgorithm.CRC32,
+                                                                                 DefaultChecksumAlgorithm.XXHASH64,
+                                                                                 DefaultChecksumAlgorithm.SHA512,
+                                                                                 DefaultChecksumAlgorithm.SHA256,
+                                                                                 DefaultChecksumAlgorithm.SHA1,
+                                                                                 DefaultChecksumAlgorithm.MD5)
+                                                                             .build();
+
     private final AsyncClientHandler clientHandler;
     private final AwsS3ProtocolFactory protocolFactory;
     private final SdkClientConfiguration clientConfiguration;
     private final List<MetricPublisher> metricPublishers;
     private final AwsProtocolMetadata protocolMetadata;
-    
+
     public DefaultAsyncPresignedUrlExtension(AsyncClientHandler clientHandler,
                                            AwsS3ProtocolFactory protocolFactory,
                                            SdkClientConfiguration clientConfiguration,
@@ -122,6 +143,8 @@ public final class DefaultAsyncPresignedUrlExtension implements AsyncPresignedUr
                             .withMetricCollector(apiCallMetricCollector)
                             // TODO: Deprecate IS_DISCOVERED_ENDPOINT, use new SKIP_ENDPOINT_RESOLUTION for better semantics
                             .putExecutionAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT, true)
+                            .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM,
+                                          checksumConfigForUrl(presignedUrlDownloadRequest.presignedUrl()))
                             .withMarshaller(new PresignedUrlDownloadRequestMarshaller(protocolFactory)),
                                                                                         asyncResponseTransformer);
             
@@ -149,6 +172,17 @@ public final class DefaultAsyncPresignedUrlExtension implements AsyncPresignedUr
         configBuilder.option(SdkAdvancedClientOption.SIGNER, new NoOpSigner());
         configBuilder.option(SIGNER_OVERRIDDEN, true);
         return configBuilder.build();
+    }
+
+    /**
+     * Returns the checksum validation config if the presigned URL was signed with checksum mode,
+     * or null otherwise.
+     */
+    private static HttpChecksum checksumConfigForUrl(java.net.URL presignedUrl) {
+        if (PresignedUrlDownloadRequestMarshaller.hasChecksumModeInSignedHeaders(presignedUrl.getQuery())) {
+            return RESPONSE_CHECKSUM_CONFIG;
+        }
+        return null;
     }
 
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
@@ -63,14 +63,43 @@ public class PresignedUrlDownloadRequestMarshaller implements Marshaller<Presign
                 .createProtocolMarshaller(SDK_OPERATION_BINDING);
             URI presignedUri = presignedUrlDownloadRequestWrapper.url().toURI();
 
-            return protocolMarshaller.marshall(presignedUrlDownloadRequestWrapper)
-                                     .toBuilder()
-                                     .uri(presignedUri)
-                                     .build();
+            SdkHttpFullRequest.Builder requestBuilder = protocolMarshaller
+                .marshall(presignedUrlDownloadRequestWrapper)
+                .toBuilder()
+                .uri(presignedUri);
+
+            addChecksumModeHeaderIfSignedInUrl(requestBuilder, presignedUri);
+
+            return requestBuilder.build();
         } catch (Exception e) {
             throw SdkClientException.builder()
                     .message("Unable to marshall pre-signed URL Request: " + e.getMessage())
                     .cause(e).build();
         }
+    }
+
+    /**
+     * If the presigned URL's X-Amz-SignedHeaders contains "x-amz-checksum-mode", automatically add
+     * the header with value "ENABLED" so S3 returns checksum headers in the response.
+     */
+    private void addChecksumModeHeaderIfSignedInUrl(SdkHttpFullRequest.Builder requestBuilder, URI uri) {
+        if (hasChecksumModeInSignedHeaders(uri.getQuery())) {
+            requestBuilder.putHeader("x-amz-checksum-mode", "ENABLED");
+        }
+    }
+
+    /**
+     * Returns true if the decoded query string's X-Amz-SignedHeaders parameter contains "x-amz-checksum-mode".
+     */
+    static boolean hasChecksumModeInSignedHeaders(String query) {
+        if (query == null) {
+            return false;
+        }
+        for (String param : query.split("&")) {
+            if (param.startsWith("X-Amz-SignedHeaders=")) {
+                return param.substring("X-Amz-SignedHeaders=".length()).contains("x-amz-checksum-mode");
+            }
+        }
+        return false;
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtension.java
@@ -29,6 +29,14 @@ import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloa
 /**
  * Interface for executing S3 operations asynchronously using presigned URLs. This can be accessed using
  * {@link S3AsyncClient#presignedUrlExtension()}.
+ *
+ * <p><b>Checksum Validation:</b> If the presigned URL was generated with
+ * {@link software.amazon.awssdk.services.s3.presigner.S3Presigner#presignGetObject} using
+ * {@code checksumMode(ChecksumMode.ENABLED)}, the SDK automatically sends the required header
+ * and S3 returns checksums for full object downloads (HTTP 200). For ranged downloads (HTTP 206),
+ * checksums are only returned for multipart-uploaded objects when the range aligns with original
+ * upload part boundaries. The downloader cannot enable checksums if the URL was not presigned
+ * with checksum mode.
  */
 @SdkPublicApi
 public interface AsyncPresignedUrlExtension {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -294,6 +294,12 @@ public interface S3Presigner extends SdkPresigner {
      * signing or authentication.
      * <p/>
      *
+     * <b>Checksum support:</b> Setting {@code checksumMode(ChecksumMode.ENABLED)} on the
+     * {@code GetObjectRequest} enables the downloader to receive checksums from S3 for data integrity
+     * validation. The resulting URL will not be browser-executable (requires the
+     * {@code x-amz-checksum-mode} header at download time, which the SDK sends automatically).
+     * <p/>
+     *
      * <b>Example Usage</b>
      * <p/>
      *

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtensionTest.java
@@ -341,6 +341,71 @@ class DefaultAsyncPresignedUrlExtensionTest {
         }
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checksumValidationTestCases")
+    void getObject_withChecksumHeaderInResponse_shouldDownloadSuccessfully(
+        String testName,
+        HttpExecuteResponse response,
+        String testUrl,
+        boolean expectSuccess) throws Exception {
+
+        mockHttpClient.stubNextResponse(response);
+
+        URL presignedUrl = new URL(testUrl);
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedUrl(presignedUrl)
+                                                                         .build();
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> future =
+            presignedUrlExtension.getObject(request, AsyncResponseTransformer.toBytes());
+
+        ResponseBytes<GetObjectResponse> result = future.get();
+        assertThat(result).isNotNull();
+        assertThat(result.asUtf8String()).isEqualTo(TEST_CONTENT);
+    }
+
+    private static Stream<Arguments> checksumValidationTestCases() {
+        // CRC32 of "test-content" = 0x6B59FCDE → base64 = a1n83g==
+        String correctCrc32 = "a1n83g==";
+        String urlWithChecksumSigned = "https://test-bucket.s3.us-east-1.amazonaws.com/test-key?" +
+                                       "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                       "X-Amz-Date=20250707T000000Z&" +
+                                       "X-Amz-SignedHeaders=host%3Bx-amz-checksum-mode&" +
+                                       "X-Amz-Signature=test-signature&" +
+                                       "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20250707%2Fus-east-1%2Fs3%2Faws4_request&" +
+                                       "X-Amz-Expires=600";
+
+        return Stream.of(
+            Arguments.of(
+                "With checksum in response - should succeed",
+                createResponseWithChecksum("x-amz-checksum-crc32", correctCrc32),
+                urlWithChecksumSigned,
+                true
+            ),
+            Arguments.of(
+                "No checksum header in response - should succeed without validation",
+                createSuccessResponse(),
+                TEST_URL,
+                true
+            )
+        );
+    }
+
+    private static HttpExecuteResponse createResponseWithChecksum(String checksumHeader, String checksumValue) {
+        SdkHttpFullResponse httpResponse = SdkHttpFullResponse.builder()
+                                                              .statusCode(200)
+                                                              .putHeader("Content-Length", "12")
+                                                              .putHeader("ETag", "\"test-etag\"")
+                                                              .putHeader("Content-Type", "text/plain")
+                                                              .putHeader(checksumHeader, checksumValue)
+                                                              .build();
+        return HttpExecuteResponse.builder()
+                                  .response(httpResponse)
+                                  .responseBody(AbortableInputStream.create(
+                                      new ByteArrayInputStream(TEST_CONTENT.getBytes(StandardCharsets.UTF_8))))
+                                  .build();
+    }
+
     private static HttpExecuteResponse createSuccessResponse() {
         SdkHttpFullResponse httpResponse = SdkHttpFullResponse.builder()
                                                               .statusCode(200)

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlChecksumValidationWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlChecksumValidationWiremockTest.java
@@ -25,14 +25,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.checksums.ChecksumValidation;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
@@ -44,19 +51,27 @@ import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloa
 class PresignedUrlChecksumValidationWiremockTest {
 
     private static final String BODY = "test-content-for-checksum";
-    // Correct CRC32 of "test-content-for-checksum" encoded as base64
     private static final String CORRECT_CRC32 = "HUUjuQ=="; // CRC32 of "test-content-for-checksum"
     private static final String INCORRECT_CRC32 = "AAAAAAAA==";
 
     private S3AsyncClient s3Client;
+    private final AtomicReference<ChecksumValidation> checksumValidationStatus = new AtomicReference<>();
 
     @BeforeEach
     void setUp(WireMockRuntimeInfo wmInfo) {
+        checksumValidationStatus.set(null);
         s3Client = S3AsyncClient.builder()
                                 .endpointOverride(java.net.URI.create(wmInfo.getHttpBaseUrl()))
-                                .region(software.amazon.awssdk.regions.Region.US_EAST_1)
-                                .credentialsProvider(software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider.create())
+                                .region(Region.US_EAST_1)
+                                .credentialsProvider(AnonymousCredentialsProvider.create())
                                 .forcePathStyle(true)
+                                .overrideConfiguration(c -> c.addExecutionInterceptor(new ExecutionInterceptor() {
+                                    @Override
+                                    public void afterExecution(Context.AfterExecution context, ExecutionAttributes attrs) {
+                                        checksumValidationStatus.set(
+                                            attrs.getAttribute(SdkExecutionAttribute.HTTP_RESPONSE_CHECKSUM_VALIDATION));
+                                    }
+                                }))
                                 .build();
     }
 
@@ -90,6 +105,8 @@ class PresignedUrlChecksumValidationWiremockTest {
                                                           .join();
 
         assertThat(result.asUtf8String()).isEqualTo(BODY);
+        assertThat(checksumValidationStatus.get())
+            .isEqualTo(ChecksumValidation.VALIDATED);
     }
 
     @Test
@@ -139,11 +156,38 @@ class PresignedUrlChecksumValidationWiremockTest {
                                                           .join();
 
         assertThat(result.asUtf8String()).isEqualTo(BODY);
+        assertThat(checksumValidationStatus.get()).isNull();
+    }
+
+    @Test
+    void getObject_withChecksumModeButNoChecksumInResponse_shouldSetAlgorithmNotFound(WireMockRuntimeInfo wmInfo)
+        throws Exception {
+        // URL has checksum mode signed, but S3 response has no checksum header (e.g., ranged GET on single-PUT)
+        stubFor(get(urlPathEqualTo("/test-key"))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withBody(BODY)));
+
+        URL presignedUrl = new URL(wmInfo.getHttpBaseUrl() + "/test-key?" +
+                                   "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                   "X-Amz-SignedHeaders=host%3Bx-amz-checksum-mode&" +
+                                   "X-Amz-Signature=fake&" +
+                                   "X-Amz-Expires=600");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+                                                          .getObject(
+                                                              PresignedUrlDownloadRequest.builder().presignedUrl(presignedUrl).build(),
+                                                              AsyncResponseTransformer.toBytes())
+                                                          .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+        assertThat(checksumValidationStatus.get())
+            .isEqualTo(ChecksumValidation.CHECKSUM_ALGORITHM_NOT_FOUND);
     }
 
     @Test
     void getObject_withCompositeChecksum_shouldSkipValidationAndSucceed(WireMockRuntimeInfo wmInfo) throws Exception {
-        // COMPOSITE checksum (suffix -3 indicates 3 parts) — cannot be validated by raw byte CRC
         stubFor(get(urlPathEqualTo("/test-key"))
                     .willReturn(aResponse()
                                     .withStatus(200)
@@ -165,5 +209,8 @@ class PresignedUrlChecksumValidationWiremockTest {
                                                           .join();
 
         assertThat(result.asUtf8String()).isEqualTo(BODY);
+        assertThat(checksumValidationStatus.get())
+            .isEqualTo(ChecksumValidation.FORCE_SKIP);
+
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlChecksumValidationWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlChecksumValidationWiremockTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.presignedurl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+
+/**
+ * WireMock test verifying checksum validation behavior for presigned URL downloads.
+ */
+@WireMockTest
+class PresignedUrlChecksumValidationWiremockTest {
+
+    private static final String BODY = "test-content-for-checksum";
+    // Correct CRC32 of "test-content-for-checksum" encoded as base64
+    private static final String CORRECT_CRC32 = "HUUjuQ=="; // CRC32 of "test-content-for-checksum"
+    private static final String INCORRECT_CRC32 = "AAAAAAAA==";
+
+    private S3AsyncClient s3Client;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmInfo) {
+        s3Client = S3AsyncClient.builder()
+                                .endpointOverride(java.net.URI.create(wmInfo.getHttpBaseUrl()))
+                                .region(software.amazon.awssdk.regions.Region.US_EAST_1)
+                                .credentialsProvider(software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider.create())
+                                .forcePathStyle(true)
+                                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (s3Client != null) {
+            s3Client.close();
+        }
+    }
+
+    @Test
+    void getObject_withMatchingChecksum_shouldSucceed(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/test-key"))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withHeader("x-amz-checksum-crc32", CORRECT_CRC32)
+                                    .withHeader("x-amz-checksum-type", "FULL_OBJECT")
+                                    .withBody(BODY)));
+
+        URL presignedUrl = new URL(wmInfo.getHttpBaseUrl() + "/test-key?" +
+                                   "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                   "X-Amz-SignedHeaders=host%3Bx-amz-checksum-mode&" +
+                                   "X-Amz-Signature=fake&" +
+                                   "X-Amz-Expires=600");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+                                                          .getObject(
+                                                              PresignedUrlDownloadRequest.builder().presignedUrl(presignedUrl).build(),
+                                                              AsyncResponseTransformer.toBytes())
+                                                          .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+    }
+
+    @Test
+    void getObject_withMismatchingChecksum_shouldThrow(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/test-key"))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withHeader("x-amz-checksum-crc32", INCORRECT_CRC32)
+                                    .withHeader("x-amz-checksum-type", "FULL_OBJECT")
+                                    .withBody(BODY)));
+
+        URL presignedUrl = new URL(wmInfo.getHttpBaseUrl() + "/test-key?" +
+                                   "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                   "X-Amz-SignedHeaders=host%3Bx-amz-checksum-mode&" +
+                                   "X-Amz-Signature=fake&" +
+                                   "X-Amz-Expires=600");
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> future = s3Client.presignedUrlExtension()
+                                                                             .getObject(
+                                                                                 PresignedUrlDownloadRequest.builder().presignedUrl(presignedUrl).build(),
+                                                                                 AsyncResponseTransformer.toBytes());
+
+        assertThatThrownBy(future::join)
+            .hasCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("checksum");
+    }
+
+    @Test
+    void getObject_withNoChecksumHeader_shouldSucceedWithoutValidation(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/test-key"))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withBody(BODY)));
+
+        URL presignedUrl = new URL(wmInfo.getHttpBaseUrl() + "/test-key?" +
+                                   "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                   "X-Amz-SignedHeaders=host&" +
+                                   "X-Amz-Signature=fake&" +
+                                   "X-Amz-Expires=600");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+                                                          .getObject(
+                                                              PresignedUrlDownloadRequest.builder().presignedUrl(presignedUrl).build(),
+                                                              AsyncResponseTransformer.toBytes())
+                                                          .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+    }
+
+    @Test
+    void getObject_withCompositeChecksum_shouldSkipValidationAndSucceed(WireMockRuntimeInfo wmInfo) throws Exception {
+        // COMPOSITE checksum (suffix -3 indicates 3 parts) — cannot be validated by raw byte CRC
+        stubFor(get(urlPathEqualTo("/test-key"))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withHeader("x-amz-checksum-crc32", "i0T6cA==-3")
+                                    .withHeader("x-amz-checksum-type", "COMPOSITE")
+                                    .withBody(BODY)));
+
+        URL presignedUrl = new URL(wmInfo.getHttpBaseUrl() + "/test-key?" +
+                                   "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                   "X-Amz-SignedHeaders=host%3Bx-amz-checksum-mode&" +
+                                   "X-Amz-Signature=fake&" +
+                                   "X-Amz-Expires=600");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+                                                          .getObject(
+                                                              PresignedUrlDownloadRequest.builder().presignedUrl(presignedUrl).build(),
+                                                              AsyncResponseTransformer.toBytes())
+                                                          .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
@@ -159,6 +159,69 @@ class PresignedUrlDownloadRequestMarshallerTest {
     }
 
     @Test
+    void marshall_withChecksumModeInSignedHeaders_shouldAddChecksumHeader() throws Exception {
+        URL urlWithChecksum = new URL("https://test-bucket.s3.us-east-1.amazonaws.com/test-key?" +
+                                      "X-Amz-Algorithm=AWS4-HMAC-SHA256&" +
+                                      "X-Amz-SignedHeaders=host%3Bx-amz-checksum-mode&" +
+                                      "X-Amz-Signature=abc123&" +
+                                      "X-Amz-Expires=600");
+
+        SdkHttpFullRequest baseRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .protocol("https")
+                                                           .host("example.com")
+                                                           .build();
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
+            .thenReturn(baseRequest);
+
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
+                                                                                         .url(urlWithChecksum)
+                                                                                         .build();
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.headers()).containsKey("x-amz-checksum-mode");
+        assertThat(result.firstMatchingHeader("x-amz-checksum-mode")).hasValue("ENABLED");
+    }
+
+    @Test
+    void marshall_withoutChecksumModeInSignedHeaders_shouldNotAddChecksumHeader() throws Exception {
+        SdkHttpFullRequest baseRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .protocol("https")
+                                                           .host("example.com")
+                                                           .build();
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
+            .thenReturn(baseRequest);
+
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
+                                                                                         .url(testUrl)
+                                                                                         .build();
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.headers()).doesNotContainKey("x-amz-checksum-mode");
+    }
+
+    @Test
+    void marshall_withNoQueryString_shouldNotAddChecksumHeader() throws Exception {
+        URL urlNoQuery = new URL("https://test-bucket.s3.us-east-1.amazonaws.com/test-key");
+
+        SdkHttpFullRequest baseRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .protocol("https")
+                                                           .host("example.com")
+                                                           .build();
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
+            .thenReturn(baseRequest);
+
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
+                                                                                         .url(urlNoQuery)
+                                                                                         .build();
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.headers()).doesNotContainKey("x-amz-checksum-mode");
+    }
+
+    @Test
     void marshall_withMalformedUrl_shouldThrowSdkClientException() throws Exception {
         // Setup the mock marshaller to return a properly configured request
         SdkHttpFullRequest baseRequest = SdkHttpFullRequest.builder()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
S3 returns checksum headers (x-amz-checksum-crc32, x-amz-checksum-crc64nvme, etc.) only when the request includes x-amz-checksum-mode: ENABLED as an HTTP header. For presigned URL downloads, this header was not being sent because:
1. The checksum interceptors (`HttpChecksumValidationInterceptor`) check request instanceof GetObjectRequest, but presigned URL downloads use `PresignedUrlDownloadRequestWrapper` — a different type — so the interceptor short-circuits.
2. The presigned URL path skips normal request marshalling — the URL IS the pre-marshalled request, and the SDK just sends a GET without adding SDK-level headers.
3. The header is signed into the URL at presigning time (listed in X-Amz-SignedHeaders), but the download path didn't detect this and send the required header.
This meant S3 never returned checksums for presigned URL downloads, making data integrity validation impossible.

## Modifications
This change adds checksum header auto-detection in the request marshaller and enables response checksum validation through the existing SDK interceptor pipeline.

- **Marshaller** (`PresignedUrlDownloadRequestMarshaller`):
  - Parses X-Amz-SignedHeaders from the presigned URL. If it contains x-amz-checksum-mode, adds the x-amz-checksum-mode: ENABLED header to the outgoing request.
  - No user configuration required — the SDK detects and handles this transparently.
- **Execution attributes** (`DefaultAsyncPresignedUrlExtension`):
  - Sets HTTP_CHECKSUM execution attribute with requestValidationMode("ENABLED") and the full response algorithms list (matching the codegen-produced GetObject operation).
  - Enables `HttpChecksumValidationInterceptor` to validate response checksums. On mismatch, throws `SdkClientException`.
- **Javadocs:**
  - `AsyncPresignedUrlExtension` (interface-level): Documents checksum validation behavior and limitations.
  - `S3Presigner.presignGetObject()`: Documents that enabling checksum mode makes the URL non-browser-executable.

## Testing

- Unit tests (`PresignedUrlDownloadRequestMarshallerTest`): Verifies header is added when x-amz-checksum-mode is in SignedHeaders, and not added otherwise.
- WireMock tests (`PresignedUrlChecksumValidationWiremockTest`): Verifies matching checksum succeeds, mismatching checksum throws SdkClientException, and missing checksum skips validation.
- Mock tests (`DefaultAsyncPresignedUrlExtensionTest`): Verifies download completes successfully when checksum headers are present.
- Integration tests (`AsyncPresignedUrlExtensionTestSuite`): Verifies against live S3 that checksums are returned when checksum mode is enabled and not returned otherwise.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
