### PR TITLE
Add ObjectAnnotation support for S3 event notifications

### DIFF
--- a/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/internal/DefaultS3EventNotificationReader.java
+++ b/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/internal/DefaultS3EventNotificationReader.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.eventnotifications.s3.model.S3Bucket;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotification;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotificationRecord;
 import software.amazon.awssdk.eventnotifications.s3.model.S3Object;
+import software.amazon.awssdk.eventnotifications.s3.model.S3ObjectAnnotation;
 import software.amazon.awssdk.eventnotifications.s3.model.TransitionEventData;
 import software.amazon.awssdk.eventnotifications.s3.model.UserIdentity;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
@@ -213,7 +214,8 @@ public final class DefaultS3EventNotificationReader implements S3EventNotificati
         S3Bucket bucket = readBucket(s3.get("bucket"));
         S3Object object = readObject(s3.get("object"));
         String s3SchemaVersion = expectStringOrNull(s3, "s3SchemaVersion");
-        return new S3(configurationId, bucket, object, s3SchemaVersion);
+        List<S3ObjectAnnotation> objectAnnotation = readObjectAnnotations(s3.get("objectAnnotation"));
+        return new S3(configurationId, bucket, object, s3SchemaVersion, objectAnnotation);
     }
 
     private S3Object readObject(JsonNode jsonNode) {
@@ -226,7 +228,10 @@ public final class DefaultS3EventNotificationReader implements S3EventNotificati
         String eTag = expectStringOrNull(objectNode, "eTag");
         String versionId = expectStringOrNull(objectNode, "versionId");
         String sequencer = expectStringOrNull(objectNode, "sequencer");
-        return new S3Object(key, size, eTag, versionId, sequencer);
+        JsonNode hasObjectAnnotationNode = objectNode.get("hasObjectAnnotation");
+        Boolean hasObjectAnnotation = isNull(hasObjectAnnotationNode) ? null 
+                                     : expectBoolean(hasObjectAnnotationNode, "hasObjectAnnotation");
+        return new S3Object(key, size, eTag, versionId, sequencer, hasObjectAnnotation);
     }
 
     private S3Bucket readBucket(JsonNode jsonNode) {
@@ -311,5 +316,29 @@ public final class DefaultS3EventNotificationReader implements S3EventNotificati
         }
         Validate.isTrue(node.isNumber(), "expected '%s' to be numeric, but was not", name);
         return Long.parseLong(node.asNumber());
+    }
+
+    private List<S3ObjectAnnotation> readObjectAnnotations(JsonNode jsonNode) {
+        List<JsonNode> annotationArray = expectArrayOrNull(jsonNode, "objectAnnotation");
+        if (annotationArray == null) {
+            return null;
+        }
+        return annotationArray.stream().map(this::readObjectAnnotation).collect(Collectors.toList());
+    }
+
+    private S3ObjectAnnotation readObjectAnnotation(JsonNode jsonNode) {
+        Map<String, JsonNode> node = expectObjectOrNull(jsonNode, "objectAnnotation[]");
+        if (node == null) {
+            return null;
+        }
+        String name = expectStringOrNull(node, "name");
+        Long size = expectLong(node.get("size"), "size");
+        String eTag = expectStringOrNull(node, "eTag");
+        return new S3ObjectAnnotation(name, size, eTag);
+    }
+
+    private Boolean expectBoolean(JsonNode node, String name) {
+        Validate.isTrue(node.isBoolean(), "expected '%s' to be boolean, but was not", name);
+        return node.asBoolean();
     }
 }

--- a/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/internal/DefaultS3EventNotificationWriter.java
+++ b/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/internal/DefaultS3EventNotificationWriter.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.eventnotifications.s3.model.S3Bucket;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotification;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotificationRecord;
 import software.amazon.awssdk.eventnotifications.s3.model.S3Object;
+import software.amazon.awssdk.eventnotifications.s3.model.S3ObjectAnnotation;
 import software.amazon.awssdk.eventnotifications.s3.model.TransitionEventData;
 import software.amazon.awssdk.eventnotifications.s3.model.UserIdentity;
 import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
@@ -185,6 +186,9 @@ public final class DefaultS3EventNotificationWriter implements S3EventNotificati
         writeStringField(writer, "configurationId", s3.getConfigurationId());
         writeS3Bucket(writer, s3.getBucket());
         writeS3Object(writer, s3.getObject());
+        if (s3.getObjectAnnotation() != null) {
+            writeS3ObjectAnnotations(writer, s3.getObjectAnnotation());
+        }
         writer.writeEndObject();
     }
 
@@ -200,6 +204,9 @@ public final class DefaultS3EventNotificationWriter implements S3EventNotificati
         writeStringField(writer, "eTag", s3Object.getETag());
         writeStringField(writer, "versionId", s3Object.getVersionId());
         writeStringField(writer, "sequencer", s3Object.getSequencer());
+        if (s3Object.getHasObjectAnnotation() != null) {
+            writeBooleanField(writer, "hasObjectAnnotation", s3Object.getHasObjectAnnotation());
+        }
         writer.writeEndObject();
     }
 
@@ -273,6 +280,26 @@ public final class DefaultS3EventNotificationWriter implements S3EventNotificati
         } else {
             writer.writeNumber(value.toString());
         }
+    }
+
+    private void writeS3ObjectAnnotations(JsonWriter writer, List<S3ObjectAnnotation> annotations) {
+        writer.writeFieldName("objectAnnotation");
+        writer.writeStartArray();
+        annotations.forEach(a -> writeS3ObjectAnnotation(writer, a));
+        writer.writeEndArray();
+    }
+
+    private void writeS3ObjectAnnotation(JsonWriter writer, S3ObjectAnnotation a) {
+        writer.writeStartObject();
+        writeStringField(writer, "name", a.getName());
+        writeNumericField(writer, "size", a.getSize());
+        writeStringField(writer, "eTag", a.getETag());
+        writer.writeEndObject();
+    }
+
+    private void writeBooleanField(JsonWriter writer, String field, boolean value) {
+        writer.writeFieldName(field);
+        writer.writeValue(value);
     }
 
     @Override

--- a/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/model/S3.java
+++ b/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/model/S3.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.eventnotifications.s3.model;
 
+import java.util.List;
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.ToString;
@@ -31,12 +32,19 @@ public class S3 {
     private final S3Bucket bucket;
     private final S3Object object;
     private final String s3SchemaVersion;
+    private final List<S3ObjectAnnotation> objectAnnotation;
 
     public S3(String configurationId, S3Bucket bucket, S3Object object, String s3SchemaVersion) {
+        this(configurationId, bucket, object, s3SchemaVersion, null);
+    }
+
+    public S3(String configurationId, S3Bucket bucket, S3Object object, String s3SchemaVersion,
+              List<S3ObjectAnnotation> objectAnnotation) {
         this.configurationId = configurationId;
         this.bucket = bucket;
         this.object = object;
         this.s3SchemaVersion = s3SchemaVersion;
+        this.objectAnnotation = objectAnnotation;
     }
 
     /**
@@ -65,6 +73,10 @@ public class S3 {
         return s3SchemaVersion;
     }
 
+    public List<S3ObjectAnnotation> getObjectAnnotation() {
+        return objectAnnotation;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -85,7 +97,10 @@ public class S3 {
         if (!Objects.equals(object, s3.object)) {
             return false;
         }
-        return Objects.equals(s3SchemaVersion, s3.s3SchemaVersion);
+        if (!Objects.equals(s3SchemaVersion, s3.s3SchemaVersion)) {
+            return false;
+        }
+        return Objects.equals(objectAnnotation, s3.objectAnnotation);
     }
 
     @Override
@@ -94,6 +109,7 @@ public class S3 {
         result = 31 * result + (bucket != null ? bucket.hashCode() : 0);
         result = 31 * result + (object != null ? object.hashCode() : 0);
         result = 31 * result + (s3SchemaVersion != null ? s3SchemaVersion.hashCode() : 0);
+        result = 31 * result + (objectAnnotation != null ? objectAnnotation.hashCode() : 0);
         return result;
     }
 
@@ -104,6 +120,7 @@ public class S3 {
                        .add("bucket", bucket)
                        .add("object", object)
                        .add("s3SchemaVersion", s3SchemaVersion)
+                       .add("objectAnnotation", objectAnnotation)
                        .build();
     }
 }

--- a/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/model/S3Object.java
+++ b/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/model/S3Object.java
@@ -33,13 +33,19 @@ public class S3Object {
     private final String eTag;
     private final String versionId;
     private final String sequencer;
+    private final Boolean hasObjectAnnotation;
 
     public S3Object(String key, Long size, String eTag, String versionId, String sequencer) {
+        this(key, size, eTag, versionId, sequencer, null);
+    }
+
+    public S3Object(String key, Long size, String eTag, String versionId, String sequencer, Boolean hasObjectAnnotation) {
         this.key = key;
         this.size = size;
         this.eTag = eTag;
         this.versionId = versionId;
         this.sequencer = sequencer;
+        this.hasObjectAnnotation = hasObjectAnnotation;
     }
 
     /**
@@ -94,6 +100,16 @@ public class S3Object {
         return sequencer;
     }
 
+    /**
+     * This field is only set on CopyObject events. Returns false when no annotations were copied,
+     * true when annotations were copied, or null if not applicable.
+     *
+     * @return Boolean indicating whether object annotations were copied, or null if not applicable
+     */
+    public Boolean getHasObjectAnnotation() {
+        return hasObjectAnnotation;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -117,7 +133,10 @@ public class S3Object {
         if (!Objects.equals(versionId, s3Object.versionId)) {
             return false;
         }
-        return Objects.equals(sequencer, s3Object.sequencer);
+        if (!Objects.equals(sequencer, s3Object.sequencer)) {
+            return false;
+        }
+        return Objects.equals(hasObjectAnnotation, s3Object.hasObjectAnnotation);
     }
 
     @Override
@@ -127,11 +146,22 @@ public class S3Object {
         result = 31 * result + (eTag != null ? eTag.hashCode() : 0);
         result = 31 * result + (versionId != null ? versionId.hashCode() : 0);
         result = 31 * result + (sequencer != null ? sequencer.hashCode() : 0);
+        result = 31 * result + (hasObjectAnnotation != null ? hasObjectAnnotation.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
+        if (hasObjectAnnotation != null) {
+            return ToString.builder("S3Object")
+                           .add("key", key)
+                           .add("size", size)
+                           .add("eTag", eTag)
+                           .add("versionId", versionId)
+                           .add("sequencer", sequencer)
+                           .add("hasObjectAnnotation", hasObjectAnnotation)
+                           .build();
+        }
         return ToString.builder("S3Object")
                        .add("key", key)
                        .add("size", size)

--- a/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/model/S3ObjectAnnotation.java
+++ b/services-custom/s3-event-notifications/src/main/java/software/amazon/awssdk/eventnotifications/s3/model/S3ObjectAnnotation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.eventnotifications.s3.model;
+
+import java.util.Objects;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.ToString;
+
+@SdkPublicApi
+public class S3ObjectAnnotation {
+    private final String name;
+    private final Long size;
+    private final String eTag;
+
+    public S3ObjectAnnotation(String name, Long size, String eTag) {
+        this.name = name;
+        this.size = size;
+        this.eTag = eTag;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getSize() {
+        return size;
+    }
+
+    public String getETag() {
+        return eTag;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        S3ObjectAnnotation that = (S3ObjectAnnotation) o;
+        if (!Objects.equals(name, that.name)) {
+            return false;
+        }
+        if (!Objects.equals(size, that.size)) {
+            return false;
+        }
+        return Objects.equals(eTag, that.eTag);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (size != null ? size.hashCode() : 0);
+        result = 31 * result + (eTag != null ? eTag.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("S3ObjectAnnotation")
+                       .add("name", name)
+                       .add("size", size)
+                       .add("eTag", eTag)
+                       .build();
+    }
+}

--- a/services-custom/s3-event-notifications/src/test/java/software/amazon/awssdk/eventnotifications/s3/model/S3EventNotificationReaderTest.java
+++ b/services-custom/s3-event-notifications/src/test/java/software/amazon/awssdk/eventnotifications/s3/model/S3EventNotificationReaderTest.java
@@ -49,7 +49,7 @@ class S3EventNotificationReaderTest {
                 "ObjectCreated:Put",
                 "aws:s3",
                 "1970-01-01T00:00:00.000Z",
-                "2.1",
+                "2.4",
                 null,
                 new ResponseElements(
                     null, null),
@@ -73,7 +73,7 @@ class S3EventNotificationReaderTest {
         String json = eventNotification.toJsonPretty();
         assertThat(json).isEqualTo("{\n"
                                    + "  \"Records\" : [ {\n"
-                                   + "    \"eventVersion\" : \"2.1\",\n"
+                                   + "    \"eventVersion\" : \"2.4\",\n"
                                    + "    \"eventSource\" : \"aws:s3\",\n"
                                    + "    \"awsRegion\" : \"us-west-2\",\n"
                                    + "    \"eventTime\" : \"1970-01-01T00:00:00Z\",\n"
@@ -115,7 +115,7 @@ class S3EventNotificationReaderTest {
         String eventJson = "{  "
                            + "   \"Records\":[  "
                            + "      {  "
-                           + "         \"eventVersion\":\"2.1\","
+                           + "         \"eventVersion\":\"2.4\","
                            + "         \"eventSource\":\"aws:s3\","
                            + "         \"awsRegion\":\"us-west-2\","
                            + "         \"eventTime\":\"1970-01-01T00:00:00.000Z\","
@@ -163,7 +163,7 @@ class S3EventNotificationReaderTest {
                 "ObjectCreated:Put",
                 "aws:s3",
                 "1970-01-01T00:00:00.000Z",
-                "2.1",
+                "2.4",
                 new RequestParameters("127.0.0.1"),
                 new ResponseElements(
                     "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD", "C3D13FE58DE4C810"),
@@ -192,7 +192,7 @@ class S3EventNotificationReaderTest {
         assertThat(rec.getAwsRegion()).isEqualTo("us-west-2");
         assertThat(rec.getEventName()).isEqualTo("ObjectCreated:Put");
         assertThat(rec.getEventTime()).isEqualTo(Instant.parse("1970-01-01T00:00:00.000Z"));
-        assertThat(rec.getEventVersion()).isEqualTo("2.1");
+        assertThat(rec.getEventVersion()).isEqualTo("2.4");
 
         UserIdentity userIdentity = rec.getUserIdentity();
         assertThat(userIdentity).isNotNull();
@@ -238,7 +238,7 @@ class S3EventNotificationReaderTest {
         String eventJson = "{\n"
                            + "  \"Records\":[\n"
                            + "    {\n"
-                           + "      \"eventVersion\":\"2.1\",\n"
+                           + "      \"eventVersion\":\"2.4\",\n"
                            + "      \"eventSource\":\"aws:s3\",\n"
                            + "      \"awsRegion\":\"us-west-2\",\n"
                            + "      \"eventTime\":\"1970-01-01T00:00:00.000Z\",\n"
@@ -268,8 +268,12 @@ class S3EventNotificationReaderTest {
                            + "          \"size\":1024,\n"
                            + "          \"eTag\":\"d41d8cd98f00b204e9800998ecf8427e\",\n"
                            + "          \"versionId\":\"096fKKXTRTtl3on89fVO.nfljtsv6qko\",\n"
-                           + "          \"sequencer\":\"0055AED6DCD90281E5\"\n"
-                           + "        }\n"
+                           + "          \"sequencer\":\"0055AED6DCD90281E5\",\n"
+                           + "          \"hasObjectAnnotation\":true\n"
+                           + "        },\n"
+                           + "        \"objectAnnotation\":[\n"
+                           + "          {\"name\":\"anno1\",\"size\":50,\"eTag\":\"etag1\"}\n"
+                           + "        ]\n"
                            + "      },\n"
                            + "      \"glacierEventData\": {\n"
                            + "        \"restoreEventData\": {\n"
@@ -309,7 +313,7 @@ class S3EventNotificationReaderTest {
                 "ObjectCreated:Put",
                 "aws:s3",
                 "1970-01-01T00:00:00.000Z",
-                "2.1",
+                "2.4",
                 new RequestParameters("127.0.0.1"),
                 new ResponseElements(
                     "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD", "C3D13FE58DE4C810"),
@@ -324,8 +328,12 @@ class S3EventNotificationReaderTest {
                         1024L,
                         "d41d8cd98f00b204e9800998ecf8427e",
                         "096fKKXTRTtl3on89fVO.nfljtsv6qko",
-                        "0055AED6DCD90281E5"),
-                    "1.0"
+                        "0055AED6DCD90281E5",
+                        true),
+                    "1.0",
+                    Arrays.asList(
+                        new S3ObjectAnnotation("anno1", 50L, "etag1")
+                    )
                 ),
                 new UserIdentity("AIDAJDPLRKLG7UEXAMPLE"),
                 new GlacierEventData(new RestoreEventData("1970-02-02T00:00:00.000Z", "testStorageClass")),
@@ -372,6 +380,15 @@ class S3EventNotificationReaderTest {
         assertThat(replication.getFailureReason()).isEqualTo("failureReasonTest");
         assertThat(replication.getThreshold()).isEqualTo("thresholdTest");
         assertThat(replication.getS3Operation()).isEqualTo("s3OperationTest");
+
+        S3 s3 = rec.getS3();
+        assertThat(s3.getObjectAnnotation()).hasSize(1);
+        assertThat(s3.getObjectAnnotation().get(0).getName()).isEqualTo("anno1");
+        assertThat(s3.getObjectAnnotation().get(0).getSize()).isEqualTo(50L);
+        assertThat(s3.getObjectAnnotation().get(0).getETag()).isEqualTo("etag1");
+
+        S3Object s3Object = s3.getObject();
+        assertThat(s3Object.getHasObjectAnnotation()).isTrue();
     }
 
     @Test
@@ -402,7 +419,7 @@ class S3EventNotificationReaderTest {
     void missingField_shouldBeNull() {
         String json = "{\n"
                       + "  \"Records\" : [ {\n"
-                      + "    \"eventVersion\" : \"2.1\",\n"
+                      + "    \"eventVersion\" : \"2.4\",\n"
                       + "    \"eventSource\" : \"aws:s3\",\n"
                       + "    \"awsRegion\" : \"us-west-2\",\n"
                       + "    \"eventTime\" : \"1970-01-01T01:01:01.001Z\",\n"
@@ -446,7 +463,7 @@ class S3EventNotificationReaderTest {
     void eventTimeIsNullWhenEventNamePresent_shouldSucceed() {
         String json = "{\n"
                       + "  \"Records\" : [ {\n"
-                      + "    \"eventVersion\" : \"2.1\",\n"
+                      + "    \"eventVersion\" : \"2.4\",\n"
                       + "    \"eventSource\" : \"aws:s3\",\n"
                       + "    \"awsRegion\" : \"us-west-2\",\n"
                       // missing eventTime
@@ -508,7 +525,7 @@ class S3EventNotificationReaderTest {
         String eventJson = "{  "
                            + "   \"Records\":[  "
                            + "      {  "
-                           + "         \"eventVersion\":\"2.1\","
+                           + "         \"eventVersion\":\"2.4\","
                            + "         \"eventSource\":\"aws:s3\","
                            + "         \"awsRegion\":\"us-west-2\","
                            + "         \"eventTime\":\"1970-01-01T00:00:00.000Z\","
@@ -538,8 +555,10 @@ class S3EventNotificationReaderTest {
                            + "               \"size\":1024,"
                            + "               \"eTag\":\"d41d8cd98f00b204e9800998ecf8427e\","
                            + "               \"versionId\":\"096fKKXTRTtl3on89fVO.nfljtsv6qko\","
-                           + "               \"sequencer\":\"0055AED6DCD90281E5\""
-                           + "            }"
+                           + "               \"sequencer\":\"0055AED6DCD90281E5\","
+                           + "               \"hasObjectAnnotation\":true"
+                           + "            },"
+                           + "            \"objectAnnotation\":[{\"name\":\"anno1\",\"size\":50,\"eTag\":\"etag1\"}]"
                            + "         }"
                            + "      }"
                            + "   ]"
@@ -556,7 +575,7 @@ class S3EventNotificationReaderTest {
                 "ObjectCreated:Put",
                 "aws:s3",
                 "1970-01-01T00:00:00.000Z",
-                "2.1",
+                "2.4",
                 new RequestParameters("127.0.0.1"),
                 new ResponseElements(
                     "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD", "C3D13FE58DE4C810"),
@@ -571,8 +590,12 @@ class S3EventNotificationReaderTest {
                         1024L,
                         "d41d8cd98f00b204e9800998ecf8427e",
                         "096fKKXTRTtl3on89fVO.nfljtsv6qko",
-                        "0055AED6DCD90281E5"),
-                    "1.0"
+                        "0055AED6DCD90281E5",
+                        true),
+                    "1.0",
+                    Arrays.asList(
+                        new S3ObjectAnnotation("anno1", 50L, "etag1")
+                    )
                 ),
                 new UserIdentity("AIDAJDPLRKLG7UEXAMPLE")
             ))
@@ -585,7 +608,7 @@ class S3EventNotificationReaderTest {
         assertThat(rec.getAwsRegion()).isEqualTo("us-west-2");
         assertThat(rec.getEventName()).isEqualTo("ObjectCreated:Put");
         assertThat(rec.getEventTime()).isEqualTo(Instant.parse("1970-01-01T00:00:00.000Z"));
-        assertThat(rec.getEventVersion()).isEqualTo("2.1");
+        assertThat(rec.getEventVersion()).isEqualTo("2.4");
 
         UserIdentity userIdentity = rec.getUserIdentity();
         assertThat(userIdentity).isNotNull();
@@ -619,6 +642,12 @@ class S3EventNotificationReaderTest {
         assertThat(s3Object.getSizeAsLong()).isEqualTo(1024L);
         assertThat(s3Object.getVersionId()).isEqualTo("096fKKXTRTtl3on89fVO.nfljtsv6qko");
         assertThat(s3Object.getSequencer()).isEqualTo("0055AED6DCD90281E5");
+        assertThat(s3Object.getHasObjectAnnotation()).isTrue();
+
+        assertThat(s3.getObjectAnnotation()).hasSize(1);
+        assertThat(s3.getObjectAnnotation().get(0).getName()).isEqualTo("anno1");
+        assertThat(s3.getObjectAnnotation().get(0).getSize()).isEqualTo(50L);
+        assertThat(s3.getObjectAnnotation().get(0).getETag()).isEqualTo("etag1");
 
         assertThat(rec.getGlacierEventData()).isNull();
         assertThat(rec.getIntelligentTieringEventData()).isNull();

--- a/services-custom/s3-event-notifications/src/test/java/software/amazon/awssdk/eventnotifications/s3/model/S3EventNotificationWriterTest.java
+++ b/services-custom/s3-event-notifications/src/test/java/software/amazon/awssdk/eventnotifications/s3/model/S3EventNotificationWriterTest.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.eventnotifications.s3.model.S3Bucket;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotification;
 import software.amazon.awssdk.eventnotifications.s3.model.S3EventNotificationRecord;
 import software.amazon.awssdk.eventnotifications.s3.model.S3Object;
+import software.amazon.awssdk.eventnotifications.s3.model.S3ObjectAnnotation;
 import software.amazon.awssdk.eventnotifications.s3.model.TransitionEventData;
 import software.amazon.awssdk.eventnotifications.s3.model.UserIdentity;
 
@@ -45,7 +46,7 @@ class S3EventNotificationWriterTest {
                 "ObjectCreated:Get",
                 "aws:s3",
                 "1970-01-01T01:01:01.001Z",
-                "2.1",
+                "2.4",
                 new RequestParameters("127.1.2.3"),
                 new ResponseElements(
                     "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANxid2", "C3D13FE58DE4CRID"),
@@ -69,7 +70,7 @@ class S3EventNotificationWriterTest {
 
         String expected = "{\n"
                            + "  \"Records\" : [ {\n"
-                           + "    \"eventVersion\" : \"2.1\",\n"
+                           + "    \"eventVersion\" : \"2.4\",\n"
                            + "    \"eventSource\" : \"aws:s3\",\n"
                            + "    \"awsRegion\" : \"us-west-2\",\n"
                            + "    \"eventTime\" : \"1970-01-01T01:01:01.001Z\",\n"
@@ -109,7 +110,7 @@ class S3EventNotificationWriterTest {
 
     @Test
     void testToJson_requiredFielsdOnly() {
-        String expected = "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\","
+        String expected = "{\"Records\":[{\"eventVersion\":\"2.4\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\","
                           + "\"eventTime\":\"1970-01-01T01:01:01.001Z\",\"eventName\":\"ObjectCreated:Get\","
                           + "\"userIdentity\":{\"principalId\""
                           + ":\"AIDAJDPLRKLG7UEXAMUID\"},\"requestParameters\":{\"sourceIPAddress\":\"127.1.2.3\"},"
@@ -127,7 +128,7 @@ class S3EventNotificationWriterTest {
                 "ObjectCreated:Get",
                 "aws:s3",
                 "1970-01-01T01:01:01.001Z",
-                "2.1",
+                "2.4",
                 new RequestParameters("127.1.2.3"),
                 new ResponseElements(
                     "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANxid2", "C3D13FE58DE4CRID"),
@@ -155,7 +156,7 @@ class S3EventNotificationWriterTest {
     void testPrettyPrint_allFields() {
         String expected = "{\n"
                           + "  \"Records\" : [ {\n"
-                          + "    \"eventVersion\" : \"2.1\",\n"
+                          + "    \"eventVersion\" : \"2.4\",\n"
                           + "    \"eventSource\" : \"aws:s3\",\n"
                           + "    \"awsRegion\" : \"us-west-2\",\n"
                           + "    \"eventTime\" : \"1970-01-01T01:01:01.001Z\",\n"
@@ -185,8 +186,14 @@ class S3EventNotificationWriterTest {
                           + "        \"size\" : 1024,\n"
                           + "        \"eTag\" : \"d41d8cd98f00b204e9800998ecf8427e\",\n"
                           + "        \"versionId\" : \"096fKKXTRTtl3on89fVO.nfljtsv6qko\",\n"
-                          + "        \"sequencer\" : \"0055AED6DCD90281E5\"\n"
-                          + "      }\n"
+                          + "        \"sequencer\" : \"0055AED6DCD90281E5\",\n"
+                          + "        \"hasObjectAnnotation\" : true\n"
+                          + "      },\n"
+                          + "      \"objectAnnotation\" : [ {\n"
+                          + "        \"name\" : \"anno1\",\n"
+                          + "        \"size\" : 50,\n"
+                          + "        \"eTag\" : \"etag1\"\n"
+                          + "      } ]\n"
                           + "    },\n"
                           + "    \"glacierEventData\" : {\n"
                           + "      \"restoreEventData\" : {\n"
@@ -219,7 +226,7 @@ class S3EventNotificationWriterTest {
                 "ObjectCreated:Put",
                 "aws:s3",
                 "1970-01-01T01:01:01.001Z",
-                "2.1",
+                "2.4",
                 new RequestParameters("127.0.0.1"),
                 new ResponseElements(
                     "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD", "C3D13FE58DE4C810"),
@@ -234,8 +241,12 @@ class S3EventNotificationWriterTest {
                         1024L,
                         "d41d8cd98f00b204e9800998ecf8427e",
                         "096fKKXTRTtl3on89fVO.nfljtsv6qko",
-                        "0055AED6DCD90281E5"),
-                    "1.0"
+                        "0055AED6DCD90281E5",
+                        true),
+                    "1.0",
+                    Arrays.asList(
+                        new S3ObjectAnnotation("anno1", 50L, "etag1")
+                    )
                 ),
                 new UserIdentity("AIDAJDPLRKLG7UEXAMPLE"),
                 new GlacierEventData(new RestoreEventData("1971-02-02T01:01:01.001Z", "testStorageClass")),
@@ -256,7 +267,7 @@ class S3EventNotificationWriterTest {
 
     @Test
     void testToJson_allFields() {
-        String expected = "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":"
+        String expected = "{\"Records\":[{\"eventVersion\":\"2.4\",\"eventSource\":\"aws:s3\",\"awsRegion\":"
                           + "\"us-west-2\",\"eventTime\":\"1970-01-01T01:01:01.001Z\",\"eventName\":\"ObjectCreated:Get\","
                           + "\"userIdentity\":{\"principalId\":\"PRINCIPALIDTEST\"},\"requestParameters\":{\"sourceIPAddress\":"
                           + "\"127.1.2.3\"},\"responseElements\":{\"x-amz-request-id\":\"C3D13FE58DE4CRID\",\"x-amz-id-2\":"
@@ -265,7 +276,8 @@ class S3EventNotificationWriterTest {
                           + "\"ownerIdentity\":{\"principalId\":\"PRINCIPALIDTESTBUCKET\"},\"arn\":\"arn:aws:s3:::mybucket\"},"
                           + "\"object\":{\"key\":\"HappyFace-test.jpg\",\"size\":2048,\"eTag\":"
                           + "\"d41d8cd98f00b204e9800998ecf8etag\",\"versionId\":\"096fKKXTRTtl3on89fVO.nfljtsv6vid\","
-                          + "\"sequencer\":\"0055AED6DCD9028SEQ\"}},\"glacierEventData\":{\"restoreEventData\":"
+                          + "\"sequencer\":\"0055AED6DCD9028SEQ\",\"hasObjectAnnotation\":true},\"objectAnnotation\":[{\"name\":"
+                          + "\"anno1\",\"size\":50,\"eTag\":\"etag1\"}]},\"glacierEventData\":{\"restoreEventData\":"
                           + "{\"lifecycleRestorationExpiryTime\":\"1971-02-02T01:01:01.001Z\",\"lifecycleRestoreStorageClass\":"
                           + "\"testStorageClass\"}},\"replicationEventData\":{\"replicationRuleId\":\"replicationRuleIdTest\","
                           + "\"destinationBucket\":\"destinationBucketTest\",\"s3Operation\":\"s3OperationTest\","
@@ -280,7 +292,7 @@ class S3EventNotificationWriterTest {
                 "ObjectCreated:Get",
                 "aws:s3",
                 "1970-01-01T01:01:01.001Z",
-                "2.1",
+                "2.4",
                 new RequestParameters("127.1.2.3"),
                 new ResponseElements(
                     "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANxid2", "C3D13FE58DE4CRID"),
@@ -295,8 +307,12 @@ class S3EventNotificationWriterTest {
                         2048L,
                         "d41d8cd98f00b204e9800998ecf8etag",
                         "096fKKXTRTtl3on89fVO.nfljtsv6vid",
-                        "0055AED6DCD9028SEQ"),
-                    "1.0"
+                        "0055AED6DCD9028SEQ",
+                        true),
+                    "1.0",
+                    Arrays.asList(
+                        new S3ObjectAnnotation("anno1", 50L, "etag1")
+                    )
                 ),
                 new UserIdentity("PRINCIPALIDTEST"),
                 new GlacierEventData(new RestoreEventData("1971-02-02T01:01:01.001Z", "testStorageClass")),
@@ -372,5 +388,4 @@ class S3EventNotificationWriterTest {
 
         assertThat(event.toJson()).isEqualTo(expected);
     }
-
 }


### PR DESCRIPTION
Motivation:
- Support ObjectAnnotation in S3 event notifications for putObjectAnnotation/deleteObjectAnnotation events, and hasObjectAnnotation on S3Object for CopyObject events.

Modification:
- Add S3ObjectAnnotation model class (name, size, eTag)
- Add objectAnnotation list to S3 model
- Add hasObjectAnnotation boolean to S3Object model
- Update Reader/Writer for serialization/deserialization
- Add round-trip tests for both features

Result:
- S3 event notifications support ObjectAnnotation data and hasObjectAnnotation flag for BYOA functionality.