### PR TITLE
Accept PresignedGetObjectRequest to prevent signed header override

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionSignedHeadersIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionSignedHeadersIntegrationTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.presignedurl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+import software.amazon.awssdk.services.s3.utils.S3TestUtils;
+import software.amazon.awssdk.testutils.service.S3BucketUtils;
+
+/**
+ * Integration test verifying SDK doesn't override presigner-set headers.
+ */
+class AsyncPresignedUrlExtensionSignedHeadersIntegrationTest extends S3IntegrationTestBase {
+
+    private static final long PART_SIZE = 8 * 1024 * 1024L;
+    private static final String FAKE_ETAG = "\"d41d8cd98f00b204e9800998ecf8427e\"";
+
+    private static S3Presigner presigner;
+    private static String testBucket;
+    private static String testKey;
+
+    @BeforeAll
+    static void setUpFixture() throws Exception {
+        setUp();
+        presigner = S3Presigner.builder()
+                               .region(DEFAULT_REGION)
+                               .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                               .build();
+
+        testBucket = S3BucketUtils.temporaryBucketName("signed-headers-test");
+        createBucket(testBucket);
+
+        // Upload object > 8MB to test multipart
+        testKey = "signed-headers-test-object";
+        byte[] largeContent = RandomStringUtils.randomAscii(12 * 1024 * 1024).getBytes(StandardCharsets.UTF_8);
+        s3Async.putObject(
+            PutObjectRequest.builder().bucket(testBucket).key(testKey).build(),
+            AsyncRequestBody.fromBytes(largeContent)
+        ).join();
+
+        S3TestUtils.addCleanupTask(AsyncPresignedUrlExtensionSignedHeadersIntegrationTest.class, () -> {
+            s3.deleteObject(DeleteObjectRequest.builder().bucket(testBucket).key(testKey).build());
+            deleteBucketAndAllContents(testBucket);
+        });
+    }
+
+    @AfterAll
+    static void tearDownFixture() {
+        presigner.close();
+        S3TestUtils.runCleanupTasks(AsyncPresignedUrlExtensionSignedHeadersIntegrationTest.class);
+    }
+
+    @Test
+    void getObject_withPresignedRangeAndMultipartClient_shouldUseSinglePart() {
+        PresignedGetObjectRequest presigned = presign(r -> r.range("bytes=0-1023"));
+
+        DownloadResult result = download(presigned, true);
+
+        assertThat(result.bytes).hasSize(1024);
+        assertThat(result.statusCode).isEqualTo(206);
+        assertThat(result.apiCallCount).isEqualTo(1);
+    }
+
+    @Test
+    void getObject_withPresignedIfMatchAndMultipartClient_shouldMultipartSucceed() {
+        String realEtag = getRealEtag();
+        PresignedGetObjectRequest presigned = presign(r -> r.ifMatch(realEtag));
+
+        DownloadResult result = download(presigned, true);
+
+        assertThat(result.bytes.length).isGreaterThan((int) PART_SIZE);
+        assertThat(result.apiCallCount).isGreaterThan(1);
+    }
+
+    @Test
+    void getObject_withNoSignedRange_shouldMultipartSucceed() {
+        PresignedGetObjectRequest presigned = presign(r -> {});
+
+        DownloadResult result = download(presigned, true);
+
+        assertThat(result.bytes.length).isGreaterThan((int) PART_SIZE);
+        assertThat(result.apiCallCount).isGreaterThan(1);
+    }
+
+    @Test
+    void getObject_withPresignedFakeIfMatch_shouldThrowS3Exception() {
+        PresignedGetObjectRequest presigned = presign(r -> r.ifMatch(FAKE_ETAG));
+
+        assertThatThrownBy(() -> download(presigned, false))
+            .hasCauseInstanceOf(S3Exception.class);
+    }
+
+    @Test
+    void build_withPresignedUrlHavingSignedRange_shouldThrow() {
+        PresignedGetObjectRequest presigned = presign(r -> r.range("bytes=0-1023"));
+
+        assertThatThrownBy(() ->
+                               PresignedUrlDownloadRequest.builder()
+                                                          .presignedUrl(presigned.url())
+                                                          .build()
+        ).isInstanceOf(IllegalArgumentException.class)
+         .hasMessageContaining("presignedGetObjectRequest()");
+    }
+
+    @Test
+    void build_withConflictingRange_shouldThrow() {
+        PresignedGetObjectRequest presigned = presign(r -> r.range("bytes=0-1023"));
+
+        assertThatThrownBy(() ->
+                               PresignedUrlDownloadRequest.builder()
+                                                          .presignedGetObjectRequest(presigned)
+                                                          .range("bytes=500-999")
+                                                          .build()
+        ).isInstanceOf(IllegalArgumentException.class)
+         .hasMessageContaining("conflicts with signed value");
+    }
+
+    // --- Helpers ---
+
+    private PresignedGetObjectRequest presign(
+        java.util.function.Consumer<software.amazon.awssdk.services.s3.model.GetObjectRequest.Builder> customizer) {
+        return presigner.presignGetObject(
+            GetObjectPresignRequest.builder()
+                                   .signatureDuration(Duration.ofMinutes(10))
+                                   .getObjectRequest(r -> {
+                                       r.bucket(testBucket).key(testKey);
+                                       customizer.accept(r);
+                                   })
+                                   .build());
+    }
+
+    private String getRealEtag() {
+        PresignedGetObjectRequest presigned = presign(r -> {});
+        return download(presigned, false).response.eTag();
+    }
+
+    private DownloadResult download(PresignedGetObjectRequest presigned, boolean multipart) {
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedGetObjectRequest(presigned)
+                                                                         .build();
+        return executeDownload(request, multipart);
+    }
+
+    private DownloadResult executeDownload(PresignedUrlDownloadRequest request, boolean multipart) {
+        List<MetricCollection> metrics = new ArrayList<>();
+        S3AsyncClientBuilder clientBuilder = S3AsyncClient.builder()
+                                                          .region(DEFAULT_REGION)
+                                                          .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                                          .overrideConfiguration(c -> c.addMetricPublisher(new MetricPublisher() {
+                                                              @Override
+                                                              public void publish(MetricCollection metricCollection) {
+                                                                  metrics.add(metricCollection);
+                                                              }
+
+                                                              @Override
+                                                              public void close() {
+                                                              }
+                                                          }));
+
+        if (multipart) {
+            clientBuilder.multipartEnabled(true)
+                         .multipartConfiguration(c -> c.minimumPartSizeInBytes(PART_SIZE));
+        }
+
+        S3AsyncClient client = clientBuilder.build();
+        try {
+            ResponseBytes<GetObjectResponse> result = client.presignedUrlExtension()
+                                                            .getObject(request, AsyncResponseTransformer.toBytes())
+                                                            .join();
+
+            return new DownloadResult(
+                result.asByteArray(),
+                result.response().sdkHttpResponse().statusCode(),
+                metrics.size(),
+                result.response());
+        } finally {
+            client.close();
+        }
+    }
+
+    private static class DownloadResult {
+        final byte[] bytes;
+        final int statusCode;
+        final int apiCallCount;
+        final GetObjectResponse response;
+
+        DownloadResult(byte[] bytes, int statusCode, int apiCallCount, GetObjectResponse response) {
+            this.bytes = bytes;
+            this.statusCode = statusCode;
+            this.apiCallCount = apiCallCount;
+            this.response = response;
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
@@ -63,6 +63,11 @@ public class PresignedUrlDownloadHelper {
             return asyncPresignedUrlExtension.getObject(presignedRequest, asyncResponseTransformer);
         }
 
+        if (hasSignedRange(presignedRequest)) {
+            log.debug(() -> "Using single part download because presigned URL has Range in signedHeaders");
+            return asyncPresignedUrlExtension.getObject(presignedRequest, asyncResponseTransformer);
+        }
+
         CompletableFuture<T> resultFuture = new CompletableFuture<>();
         doMultipartDownload(presignedRequest, asyncResponseTransformer)
             .whenComplete((result, error) -> {
@@ -228,6 +233,17 @@ public class PresignedUrlDownloadHelper {
             builder.ifMatch(eTag);
         }
         return builder.build();
+    }
+
+    /**
+     * Returns true if the request has Range in its signedHeaders.
+     * If so, multipart must not add its own Range values.
+     */
+    private static boolean hasSignedRange(PresignedUrlDownloadRequest request) {
+        if (request.signedHeaders() != null) {
+            return request.signedHeaders().containsKey("range");
+        }
+        return false;
     }
 
     /**

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
@@ -106,6 +106,10 @@ public final class DefaultAsyncPresignedUrlExtension implements AsyncPresignedUr
                 .url(presignedUrlDownloadRequest.presignedUrl())
                 .range(presignedUrlDownloadRequest.range())
                 .ifMatch(presignedUrlDownloadRequest.ifMatch())
+                .ifNoneMatch(presignedUrlDownloadRequest.ifNoneMatch())
+                .ifModifiedSince(presignedUrlDownloadRequest.ifModifiedSince())
+                .ifUnmodifiedSince(presignedUrlDownloadRequest.ifUnmodifiedSince())
+                .signedHeaders(presignedUrlDownloadRequest.signedHeaders())
                 .build();
 
         MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ?

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.services.s3.internal.presignedurl;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
@@ -68,13 +70,34 @@ public class PresignedUrlDownloadRequestMarshaller implements Marshaller<Presign
                 .toBuilder()
                 .uri(presignedUri);
 
+            addSignedHeaders(requestBuilder, presignedUrlDownloadRequestWrapper);
             addChecksumModeHeaderIfSignedInUrl(requestBuilder, presignedUri);
 
             return requestBuilder.build();
         } catch (Exception e) {
             throw SdkClientException.builder()
-                    .message("Unable to marshall pre-signed URL Request: " + e.getMessage())
-                    .cause(e).build();
+                                    .message("Unable to marshall pre-signed URL Request: " + e.getMessage())
+                                    .cause(e).build();
+        }
+    }
+
+    /**
+     * Adds all signed headers from the presigned request to the HTTP request.
+     * Skips "host" as it's derived from the URL itself.
+     */
+    private void addSignedHeaders(SdkHttpFullRequest.Builder requestBuilder,
+                                  PresignedUrlDownloadRequestWrapper wrapper) {
+        if (wrapper.signedHeaders() == null) {
+            return;
+        }
+        for (Map.Entry<String, List<String>> entry : wrapper.signedHeaders().entrySet()) {
+            if ("host".equals(entry.getKey())) {
+                continue;
+            }
+            java.util.List<String> values = entry.getValue();
+            if (values != null && !values.isEmpty()) {
+                requestBuilder.putHeader(entry.getKey(), values.get(0));
+            }
         }
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapper.java
@@ -55,20 +55,49 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
         .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("If-Match")
                              .unmarshallLocationName("If-Match").build()).build();
 
+    private static final SdkField<String> IF_NONE_MATCH_FIELD = SdkField
+        .<String>builder(MarshallingType.STRING)
+        .memberName("IfNoneMatch")
+        .getter(getter(PresignedUrlDownloadRequestWrapper::ifNoneMatch))
+        .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("If-None-Match")
+                             .unmarshallLocationName("If-None-Match").build()).build();
+
+    private static final SdkField<String> IF_MODIFIED_SINCE_FIELD = SdkField
+        .<String>builder(MarshallingType.STRING)
+        .memberName("IfModifiedSince")
+        .getter(getter(PresignedUrlDownloadRequestWrapper::ifModifiedSince))
+        .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("If-Modified-Since")
+                             .unmarshallLocationName("If-Modified-Since").build()).build();
+
+    private static final SdkField<String> IF_UNMODIFIED_SINCE_FIELD = SdkField
+        .<String>builder(MarshallingType.STRING)
+        .memberName("IfUnmodifiedSince")
+        .getter(getter(PresignedUrlDownloadRequestWrapper::ifUnmodifiedSince))
+        .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("If-Unmodified-Since")
+                             .unmarshallLocationName("If-Unmodified-Since").build()).build();
+
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(
-        Arrays.asList(RANGE_FIELD, IF_MATCH_FIELD));
+        Arrays.asList(RANGE_FIELD, IF_MATCH_FIELD, IF_NONE_MATCH_FIELD, IF_MODIFIED_SINCE_FIELD, IF_UNMODIFIED_SINCE_FIELD));
 
     private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
 
     private final URL url;
     private final String range;
     private final String ifMatch;
+    private final String ifNoneMatch;
+    private final String ifModifiedSince;
+    private final String ifUnmodifiedSince;
+    private final Map<String, List<String>> signedHeaders;
 
     private PresignedUrlDownloadRequestWrapper(Builder builder) {
         super(builder);
         this.url = builder.url;
         this.range = builder.range;
         this.ifMatch = builder.ifMatch;
+        this.ifNoneMatch = builder.ifNoneMatch;
+        this.ifModifiedSince = builder.ifModifiedSince;
+        this.ifUnmodifiedSince = builder.ifUnmodifiedSince;
+        this.signedHeaders = builder.signedHeaders;
     }
 
     public URL url() {
@@ -81,6 +110,22 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
 
     public String ifMatch() {
         return ifMatch;
+    }
+
+    public String ifNoneMatch() {
+        return ifNoneMatch;
+    }
+
+    public String ifModifiedSince() {
+        return ifModifiedSince;
+    }
+
+    public String ifUnmodifiedSince() {
+        return ifUnmodifiedSince;
+    }
+
+    public Map<String, List<String>> signedHeaders() {
+        return signedHeaders;
     }
 
     @Override
@@ -101,6 +146,9 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
         Map<String, SdkField<?>> map = new HashMap<>();
         map.put("Range", RANGE_FIELD);
         map.put("IfMatch", IF_MATCH_FIELD);
+        map.put("IfNoneMatch", IF_NONE_MATCH_FIELD);
+        map.put("IfModifiedSince", IF_MODIFIED_SINCE_FIELD);
+        map.put("IfUnmodifiedSince", IF_UNMODIFIED_SINCE_FIELD);
         return Collections.unmodifiableMap(map);
     }
 
@@ -125,7 +173,13 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
             return false;
         }
         PresignedUrlDownloadRequestWrapper that = (PresignedUrlDownloadRequestWrapper) obj;
-        return Objects.equals(url, that.url) && Objects.equals(range, that.range) && Objects.equals(ifMatch, that.ifMatch);
+        return Objects.equals(url, that.url)
+               && Objects.equals(range, that.range)
+               && Objects.equals(ifMatch, that.ifMatch)
+               && Objects.equals(ifNoneMatch, that.ifNoneMatch)
+               && Objects.equals(ifModifiedSince, that.ifModifiedSince)
+               && Objects.equals(ifUnmodifiedSince, that.ifUnmodifiedSince)
+               && Objects.equals(signedHeaders, that.signedHeaders);
     }
 
     @Override
@@ -134,6 +188,10 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
         result = 31 * result + Objects.hashCode(url);
         result = 31 * result + Objects.hashCode(range);
         result = 31 * result + Objects.hashCode(ifMatch);
+        result = 31 * result + Objects.hashCode(ifNoneMatch);
+        result = 31 * result + Objects.hashCode(ifModifiedSince);
+        result = 31 * result + Objects.hashCode(ifUnmodifiedSince);
+        result = 31 * result + Objects.hashCode(signedHeaders);
         return result;
     }
 
@@ -141,6 +199,10 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
         private URL url;
         private String range;
         private String ifMatch;
+        private String ifNoneMatch;
+        private String ifModifiedSince;
+        private String ifUnmodifiedSince;
+        private Map<String, List<String>> signedHeaders;
 
         public Builder() {
         }
@@ -150,6 +212,10 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
             this.url = request.url();
             this.range = request.range();
             this.ifMatch = request.ifMatch();
+            this.ifNoneMatch = request.ifNoneMatch();
+            this.ifModifiedSince = request.ifModifiedSince();
+            this.ifUnmodifiedSince = request.ifUnmodifiedSince();
+            this.signedHeaders = request.signedHeaders();
         }
 
         public Builder url(URL url) {
@@ -164,6 +230,26 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
 
         public Builder ifMatch(String ifMatch) {
             this.ifMatch = ifMatch;
+            return this;
+        }
+
+        public Builder ifNoneMatch(String ifNoneMatch) {
+            this.ifNoneMatch = ifNoneMatch;
+            return this;
+        }
+
+        public Builder ifModifiedSince(String ifModifiedSince) {
+            this.ifModifiedSince = ifModifiedSince;
+            return this;
+        }
+
+        public Builder ifUnmodifiedSince(String ifUnmodifiedSince) {
+            this.ifUnmodifiedSince = ifUnmodifiedSince;
+            return this;
+        }
+
+        public Builder signedHeaders(Map<String, List<String>> signedHeaders) {
+            this.signedHeaders = signedHeaders;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequest.java
@@ -16,8 +16,11 @@
 package software.amazon.awssdk.services.s3.presignedurl.model;
 
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -25,18 +28,36 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * Request object for performing download operations using a presigned URL.
+ *
+ * <p>There are two ways to construct this request:</p>
+ * <ul>
+ *   <li>{@link Builder#presignedGetObjectRequest(PresignedGetObjectRequest)} — Recommended when the URL was generated
+ *       using the SDK presigner, especially if headers like Range or If-Match were set at presign time. The SDK
+ *       automatically extracts the URL and signed header values.</li>
+ *   <li>{@link Builder#presignedUrl(URL)} — For URLs where no additional headers (such as Range or If-Match)
+ *       were signed at presign time, i.e., only {@code host} is in {@code X-Amz-SignedHeaders}.</li>
+ * </ul>
  */
 @SdkPublicApi
 public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<PresignedUrlDownloadRequest.Builder,
     PresignedUrlDownloadRequest> {
+
+    private final PresignedGetObjectRequest presignedGetObjectRequest;
     private final URL presignedUrl;
     private final String range;
     private final String ifMatch;
+    private final String ifNoneMatch;
+    private final String ifModifiedSince;
+    private final String ifUnmodifiedSince;
 
     private PresignedUrlDownloadRequest(BuilderImpl builder) {
+        this.presignedGetObjectRequest = builder.presignedGetObjectRequest;
         this.presignedUrl = builder.presignedUrl;
         this.range = builder.range;
         this.ifMatch = builder.ifMatch;
+        this.ifNoneMatch = builder.ifNoneMatch;
+        this.ifModifiedSince = builder.ifModifiedSince;
+        this.ifUnmodifiedSince = builder.ifUnmodifiedSince;
     }
 
     /**
@@ -50,7 +71,14 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
      * @return The presigned URL for the S3 object
      */
     public URL presignedUrl() {
-        return presignedUrl;
+        return presignedGetObjectRequest != null ? presignedGetObjectRequest.url() : presignedUrl;
+    }
+
+    /**
+     * The presigned request object from the SDK presigner, or null if a raw URL was provided.
+     */
+    public PresignedGetObjectRequest presignedGetObjectRequest() {
+        return presignedGetObjectRequest;
     }
 
     /**
@@ -79,6 +107,50 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
         return ifMatch;
     }
 
+    /**
+     * <p>
+     * Return the object only if its entity tag (ETag) is different from the one specified in this header,
+     * otherwise return a 304 (not modified) response.
+     * </p>
+     *
+     * @return The If-None-Match header value, or null if not specified.
+     */
+    public String ifNoneMatch() {
+        return ifNoneMatch;
+    }
+
+    /**
+     * <p>
+     * Return the object only if it has been modified since the specified time,
+     * otherwise return a 304 (not modified) response.
+     * </p>
+     *
+     * @return The If-Modified-Since header value in RFC 7231 format, or null if not specified.
+     */
+    public String ifModifiedSince() {
+        return ifModifiedSince;
+    }
+
+    /**
+     * <p>
+     * Return the object only if it has not been modified since the specified time,
+     * otherwise return a 412 (precondition failed) error.
+     * </p>
+     *
+     * @return The If-Unmodified-Since header value in RFC 7231 format, or null if not specified.
+     */
+    public String ifUnmodifiedSince() {
+        return ifUnmodifiedSince;
+    }
+
+    /**
+     * The signed headers map from the presigned request, or null if a raw URL was provided.
+     * Used internally by the SDK to send correct header values at download time.
+     */
+    public Map<String, List<String>> signedHeaders() {
+        return presignedGetObjectRequest != null ? presignedGetObjectRequest.signedHeaders() : null;
+    }
+
     @Override
     public Builder toBuilder() {
         return new BuilderImpl(this);
@@ -95,9 +167,13 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
     @Override
     public int hashCode() {
         int hashCode = 1;
-        hashCode = 31 * hashCode + Objects.hashCode(presignedUrl());
+        hashCode = 31 * hashCode + Objects.hashCode(presignedGetObjectRequest);
+        hashCode = 31 * hashCode + Objects.hashCode(presignedUrl);
         hashCode = 31 * hashCode + Objects.hashCode(range());
         hashCode = 31 * hashCode + Objects.hashCode(ifMatch());
+        hashCode = 31 * hashCode + Objects.hashCode(ifNoneMatch());
+        hashCode = 31 * hashCode + Objects.hashCode(ifModifiedSince());
+        hashCode = 31 * hashCode + Objects.hashCode(ifUnmodifiedSince());
         return hashCode;
     }
 
@@ -110,9 +186,13 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
             return false;
         }
         PresignedUrlDownloadRequest other = (PresignedUrlDownloadRequest) obj;
-        return Objects.equals(presignedUrl(), other.presignedUrl()) &&
-               Objects.equals(range(), other.range()) &&
-               Objects.equals(ifMatch(), other.ifMatch());
+        return Objects.equals(presignedGetObjectRequest, other.presignedGetObjectRequest)
+               && Objects.equals(presignedUrl, other.presignedUrl)
+               && Objects.equals(range(), other.range())
+               && Objects.equals(ifMatch(), other.ifMatch())
+               && Objects.equals(ifNoneMatch(), other.ifNoneMatch())
+               && Objects.equals(ifModifiedSince(), other.ifModifiedSince())
+               && Objects.equals(ifUnmodifiedSince(), other.ifUnmodifiedSince());
     }
 
     @Override
@@ -121,49 +201,93 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
                        .add("PresignedUrl", presignedUrl())
                        .add("Range", range())
                        .add("IfMatch", ifMatch())
+                       .add("IfNoneMatch", ifNoneMatch())
+                       .add("IfModifiedSince", ifModifiedSince())
+                       .add("IfUnmodifiedSince", ifUnmodifiedSince())
                        .build();
     }
 
     public interface Builder extends CopyableBuilder<Builder, PresignedUrlDownloadRequest> {
         /**
-         * Sets the presigned URL for the S3 object.
-         * @param presignedUrl
-         * @return Returns a reference to this object so that method calls can be chained together.
+         * Sets the presigned URL for the S3 object. Use this for raw URLs from external sources.
+         *
+         * <p>Mutually exclusive with {@link #presignedGetObjectRequest(PresignedGetObjectRequest)}.
+         * If the URL was generated using the SDK presigner with headers like Range or If-Match,
+         * use {@link #presignedGetObjectRequest(PresignedGetObjectRequest)} instead.</p>
          */
         Builder presignedUrl(URL presignedUrl);
 
         /**
-         * Specifies the byte range of an object.
-         * @param range The HTTP Range header value (e.g., "bytes=0-1023")
-         * @return Returns a reference to this object so that method calls can be chained together.
+         * Sets the presigned request object from the SDK presigner. The SDK extracts the URL and signed
+         * header values automatically.
+         *
+         * <p>Recommended when the URL was generated using the SDK presigner, especially if headers like
+         * Range or If-Match were set at presign time.</p>
+         *
+         * <p>Mutually exclusive with {@link #presignedUrl(URL)}.</p>
+         */
+        Builder presignedGetObjectRequest(PresignedGetObjectRequest presignedGetObjectRequest);
+
+        /**
+         * Specifies the byte range of an object (e.g., "bytes=0-1023").
          */
         Builder range(String range);
 
         /**
-         * Return the object only if its entity tag (ETag) is the same as the one specified in this header.
-         * @param ifMatch The If-Match header value (ETag)
-         * @return Returns a reference to this object so that method calls can be chained together.
+         * Return the object only if its ETag matches this value.
          */
         Builder ifMatch(String ifMatch);
+
+        /**
+         * Return the object only if its ETag does NOT match this value.
+         */
+        Builder ifNoneMatch(String ifNoneMatch);
+
+        /**
+         * Return the object only if it has been modified since this date.
+         * Value should be in RFC 7231 format (e.g., "Wed, 17 Jun 2026 17:46:28 GMT").
+         */
+        Builder ifModifiedSince(String ifModifiedSince);
+
+        /**
+         * Return the object only if it has NOT been modified since this date.
+         * Value should be in RFC 7231 format (e.g., "Wed, 17 Jun 2026 17:46:28 GMT").
+         */
+        Builder ifUnmodifiedSince(String ifUnmodifiedSince);
     }
 
     static final class BuilderImpl implements Builder {
+        private PresignedGetObjectRequest presignedGetObjectRequest;
         private URL presignedUrl;
         private String range;
         private String ifMatch;
+        private String ifNoneMatch;
+        private String ifModifiedSince;
+        private String ifUnmodifiedSince;
 
         private BuilderImpl() {
         }
 
-        private BuilderImpl(PresignedUrlDownloadRequest presignedUrlDownloadRequest) {
-            presignedUrl(presignedUrlDownloadRequest.presignedUrl());
-            range(presignedUrlDownloadRequest.range());
-            ifMatch(presignedUrlDownloadRequest.ifMatch());
+        private BuilderImpl(PresignedUrlDownloadRequest request) {
+            this.presignedGetObjectRequest = request.presignedGetObjectRequest;
+            this.presignedUrl = request.presignedUrl;
+            this.range = request.range();
+            this.ifMatch = request.ifMatch();
+            this.ifNoneMatch = request.ifNoneMatch();
+            this.ifModifiedSince = request.ifModifiedSince();
+            this.ifUnmodifiedSince = request.ifUnmodifiedSince();
         }
 
         @Override
         public Builder presignedUrl(URL presignedUrl) {
             this.presignedUrl = presignedUrl;
+            return this;
+        }
+
+        @Override
+        public Builder presignedGetObjectRequest(PresignedGetObjectRequest presignedGetObjectRequest) {
+            Validate.paramNotNull(presignedGetObjectRequest, "presignedGetObjectRequest");
+            this.presignedGetObjectRequest = presignedGetObjectRequest;
             return this;
         }
 
@@ -180,9 +304,104 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
         }
 
         @Override
+        public Builder ifNoneMatch(String ifNoneMatch) {
+            this.ifNoneMatch = ifNoneMatch;
+            return this;
+        }
+
+        @Override
+        public Builder ifModifiedSince(String ifModifiedSince) {
+            this.ifModifiedSince = ifModifiedSince;
+            return this;
+        }
+
+        @Override
+        public Builder ifUnmodifiedSince(String ifUnmodifiedSince) {
+            this.ifUnmodifiedSince = ifUnmodifiedSince;
+            return this;
+        }
+
+        @Override
         public PresignedUrlDownloadRequest build() {
-            Validate.paramNotNull(presignedUrl, "presignedUrl");
+            validateMutualExclusion();
+            Validate.paramNotNull(resolveUrl(), "presignedUrl or presignedGetObjectRequest");
+            validateSignedHeadersAvailable();
+            validateNoConflicts();
             return new PresignedUrlDownloadRequest(this);
+        }
+
+        private URL resolveUrl() {
+            return presignedGetObjectRequest != null ? presignedGetObjectRequest.url() : presignedUrl;
+        }
+
+        private Map<String, List<String>> resolveSignedHeaders() {
+            return presignedGetObjectRequest != null ? presignedGetObjectRequest.signedHeaders() : null;
+        }
+
+        private void validateMutualExclusion() {
+            if (presignedUrl != null && presignedGetObjectRequest != null) {
+                throw new IllegalArgumentException(
+                    "Cannot set both presignedUrl() and presignedGetObjectRequest(). Use one or the other.");
+            }
+        }
+
+        private void validateSignedHeadersAvailable() {
+            if (presignedGetObjectRequest != null || presignedUrl == null) {
+                return;
+            }
+            String query = presignedUrl.getQuery();
+            if (query == null) {
+                return;
+            }
+            for (String param : query.split("&")) {
+                if (param.startsWith("X-Amz-SignedHeaders=")) {
+                    String signed = param.substring("X-Amz-SignedHeaders=".length());
+                    StringBuilder conflicting = new StringBuilder();
+                    for (String header : new String[]{"range", "if-match", "if-none-match",
+                                                      "if-modified-since", "if-unmodified-since"}) {
+                        if (signed.contains(header)) {
+                            if (conflicting.length() > 0) {
+                                conflicting.append(", ");
+                            }
+                            conflicting.append(header);
+                        }
+                    }
+                    if (conflicting.length() > 0) {
+                        throw new IllegalArgumentException(
+                            "The presigned URL has [" + conflicting + "] in its SignedHeaders, but the "
+                            + "values cannot be recovered from the URL alone. Use "
+                            + "presignedGetObjectRequest() instead of presignedUrl() to ensure "
+                            + "correct header values are sent at download time.");
+                    }
+                    break;
+                }
+            }
+        }
+
+        private void validateNoConflicts() {
+            Map<String, List<String>> signedHeaders = resolveSignedHeaders();
+            if (signedHeaders == null) {
+                return;
+            }
+            validateHeaderNotConflicting(signedHeaders, "range", range);
+            validateHeaderNotConflicting(signedHeaders, "if-match", ifMatch);
+            validateHeaderNotConflicting(signedHeaders, "if-none-match", ifNoneMatch);
+            validateHeaderNotConflicting(signedHeaders, "if-modified-since", ifModifiedSince);
+            validateHeaderNotConflicting(signedHeaders, "if-unmodified-since", ifUnmodifiedSince);
+        }
+
+        private static void validateHeaderNotConflicting(Map<String, List<String>> signedHeaders,
+                                                         String headerName, String explicitValue) {
+            if (explicitValue == null) {
+                return;
+            }
+            List<String> signedValues = signedHeaders.get(headerName);
+            if (signedValues != null && !signedValues.isEmpty()
+                && !explicitValue.equals(signedValues.get(0))) {
+                throw new IllegalArgumentException(
+                    headerName + " value '" + explicitValue + "' conflicts with signed value '"
+                    + signedValues.get(0) + "'. Do not set a different value when signedHeaders contains it.");
+            }
         }
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
@@ -21,6 +21,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -234,11 +238,87 @@ class PresignedUrlDownloadRequestMarshallerTest {
 
         URL malformedUrl = new URL("https", "test-bucket.s3.us-east-1.amazonaws.com", -1, "/test key with spaces");
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
-                                                                                         .url(malformedUrl)
-                                                                                         .build();
+                                                                                       .url(malformedUrl)
+                                                                                       .build();
 
         assertThatThrownBy(() -> marshaller.marshall(request))
             .isInstanceOf(SdkClientException.class)
             .hasMessageContaining("Unable to marshall pre-signed URL Request");
+    }
+
+    @Test
+    void marshall_withSignedHeaders_shouldAddAllHeadersExceptHost() throws Exception {
+        Map<String, List<String>> signedHeaders = new HashMap<>();
+        signedHeaders.put("host", Arrays.asList("bucket.s3.amazonaws.com"));
+        signedHeaders.put("range", Arrays.asList("bytes=0-1023"));
+        signedHeaders.put("if-match", Arrays.asList("\"etag123\""));
+        signedHeaders.put("if-none-match", Arrays.asList("\"old-etag\""));
+
+        SdkHttpFullRequest baseRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .protocol("https")
+                                                           .host("example.com")
+                                                           .build();
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
+            .thenReturn(baseRequest);
+
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
+                                                                                       .url(testUrl)
+                                                                                       .signedHeaders(signedHeaders)
+                                                                                       .build();
+
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.firstMatchingHeader("range")).hasValue("bytes=0-1023");
+        assertThat(result.firstMatchingHeader("if-match")).hasValue("\"etag123\"");
+        assertThat(result.firstMatchingHeader("if-none-match")).hasValue("\"old-etag\"");
+        assertThat(result.headers()).doesNotContainKey("host");
+    }
+
+    @Test
+    void marshall_withNullSignedHeaders_shouldNotAddExtraHeaders() throws Exception {
+        SdkHttpFullRequest baseRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .protocol("https")
+                                                           .host("example.com")
+                                                           .build();
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
+            .thenReturn(baseRequest);
+
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
+                                                                                       .url(testUrl)
+                                                                                       .build();
+
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.headers()).doesNotContainKey("range");
+        assertThat(result.headers()).doesNotContainKey("if-match");
+    }
+
+    @Test
+    void marshall_withSignedHeadersAndSdkFieldRange_shouldUseSignedHeadersValue() throws Exception {
+        Map<String, List<String>> signedHeaders = new HashMap<>();
+        signedHeaders.put("host", Arrays.asList("bucket.s3.amazonaws.com"));
+        signedHeaders.put("range", Arrays.asList("bytes=0-1023"));
+
+        // SdkField marshalling would have set Range from the wrapper's range field
+        SdkHttpFullRequest baseRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .protocol("https")
+                                                           .host("example.com")
+                                                           .putHeader("Range", "bytes=0-8388607")
+                                                           .build();
+        when(mockProtocolMarshaller.marshall(any(PresignedUrlDownloadRequestWrapper.class)))
+            .thenReturn(baseRequest);
+
+        PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
+                                                                                       .url(testUrl)
+                                                                                       .range("bytes=0-8388607")
+                                                                                       .signedHeaders(signedHeaders)
+                                                                                       .build();
+
+        SdkHttpFullRequest result = marshaller.marshall(request);
+
+        assertThat(result.firstMatchingHeader("range")).hasValue("bytes=0-1023");
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapperTest.java
@@ -56,9 +56,9 @@ class PresignedUrlDownloadRequestWrapperTest {
 
         List<SdkField<?>> fields = request.sdkFields();
 
-        assertThat(fields).hasSize(2);
+        assertThat(fields).hasSize(5);
         assertThat(fields).extracting(SdkField::memberName)
-                          .containsExactlyInAnyOrder("Range", "IfMatch");
+                          .containsExactlyInAnyOrder("Range", "IfMatch", "IfNoneMatch", "IfModifiedSince", "IfUnmodifiedSince");
         assertThat(fields).allMatch(field -> field.location() == MarshallLocation.HEADER);
         SdkField<?> rangeField = fields.stream()
                                        .filter(f -> "Range".equals(f.memberName()))
@@ -72,14 +72,14 @@ class PresignedUrlDownloadRequestWrapperTest {
     @Test
     void sdkFieldNameToField_shouldReturnExpectedMapping() throws Exception {
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
-                                                                                         .url(new URL("https://example.com"))
-                                                                                         .build();
+                                                                                       .url(new URL("https://example.com"))
+                                                                                       .build();
 
         Map<String, SdkField<?>> fieldMap = request.sdkFieldNameToField();
 
         assertThat(fieldMap)
-            .hasSize(2)
-            .containsKeys("Range", "IfMatch");
+            .hasSize(5)
+            .containsKeys("Range", "IfMatch", "IfNoneMatch", "IfModifiedSince", "IfUnmodifiedSince");
         assertThat(fieldMap.get("Range").memberName()).isEqualTo("Range");
         assertThat(fieldMap.get("IfMatch").memberName()).isEqualTo("IfMatch");
     }
@@ -87,9 +87,9 @@ class PresignedUrlDownloadRequestWrapperTest {
     @Test
     void rangeField_shouldMarshalCorrectly() throws Exception {
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
-                                                                                         .url(new URL("https://example.com"))
-                                                                                         .range("bytes=0-1023")
-                                                                                         .build();
+                                                                                       .url(new URL("https://example.com"))
+                                                                                       .range("bytes=0-1023")
+                                                                                       .build();
 
         SdkField<?> rangeField = request.sdkFields().stream()
                                         .filter(f -> "Range".equals(f.memberName()))

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequestTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequestTest.java
@@ -16,10 +16,19 @@
 package software.amazon.awssdk.services.s3.presignedurl.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URL;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 class PresignedUrlDownloadRequestTest {
 
@@ -30,7 +39,7 @@ class PresignedUrlDownloadRequestTest {
     }
 
     @Test
-    void builder_shouldCreateRequestWithAllFields() throws Exception {
+    void build_withAllFields_shouldCreateRequest() throws Exception {
         URL url = new URL("https://example.com");
         PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(url)
@@ -42,7 +51,7 @@ class PresignedUrlDownloadRequestTest {
     }
 
     @Test
-    void builder_shouldCreateRequestWithOnlyRequiredFields() throws Exception {
+    void build_withOnlyRequiredFields_shouldHaveNullOptionals() throws Exception {
         URL url = new URL("https://example.com");
         PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(url)
@@ -53,32 +62,40 @@ class PresignedUrlDownloadRequestTest {
     }
 
     @Test
-    void toBuilder_shouldCreateBuilderFromExistingRequest() throws Exception {
+    void toBuilder_withAllFields_shouldPreserveValues() throws Exception {
         URL url = new URL("https://example.com");
         PresignedUrlDownloadRequest original = PresignedUrlDownloadRequest.builder()
-                                                                            .presignedUrl(url)
-                                                                            .range("bytes=0-100")
-                                                                            .build();
+                                                                          .presignedUrl(url)
+                                                                          .range("bytes=0-100")
+                                                                          .ifMatch("\"etag\"")
+                                                                          .ifNoneMatch("\"other\"")
+                                                                          .ifModifiedSince("Wed, 17 Jun 2026 17:46:28 GMT")
+                                                                          .ifUnmodifiedSince("Wed, 17 Jun 2026 17:46:28 GMT")
+                                                                          .build();
 
         PresignedUrlDownloadRequest copy = original.toBuilder().build();
 
         assertThat(copy.presignedUrl()).isEqualTo(original.presignedUrl());
         assertThat(copy.range()).isEqualTo(original.range());
+        assertThat(copy.ifMatch()).isEqualTo("\"etag\"");
+        assertThat(copy.ifNoneMatch()).isEqualTo("\"other\"");
+        assertThat(copy.ifModifiedSince()).isEqualTo("Wed, 17 Jun 2026 17:46:28 GMT");
+        assertThat(copy.ifUnmodifiedSince()).isEqualTo("Wed, 17 Jun 2026 17:46:28 GMT");
     }
 
     @Test
-    void toBuilder_shouldAllowModification() throws Exception {
+    void toBuilder_withModification_shouldNotAffectOriginal() throws Exception {
         URL url1 = new URL("https://example.com");
         URL url2 = new URL("https://other.com");
         PresignedUrlDownloadRequest original = PresignedUrlDownloadRequest.builder()
-                                                                            .presignedUrl(url1)
-                                                                            .range("bytes=0-100")
-                                                                            .build();
+                                                                          .presignedUrl(url1)
+                                                                          .range("bytes=0-100")
+                                                                          .build();
 
         PresignedUrlDownloadRequest modified = original.toBuilder()
-                                                        .presignedUrl(url2)
-                                                        .range("bytes=200-300")
-                                                        .build();
+                                                       .presignedUrl(url2)
+                                                       .range("bytes=200-300")
+                                                       .build();
 
         assertThat(modified.presignedUrl()).isEqualTo(url2);
         assertThat(modified.range()).isEqualTo("bytes=200-300");
@@ -88,7 +105,7 @@ class PresignedUrlDownloadRequestTest {
     }
 
     @Test
-    void toString_shouldContainActualFieldValues() throws Exception {
+    void toString_shouldContainFieldValues() throws Exception {
         URL url = new URL("https://example.com");
         String range = "bytes=0-100";
 
@@ -97,19 +114,105 @@ class PresignedUrlDownloadRequestTest {
                                                                            .range(range)
                                                                            .build();
 
-        String result = request.toString();
-
-        assertThat(result)
-            .isNotNull()
-            .isNotEmpty()
-            .contains(request.presignedUrl().toString())
-            .contains(request.range());
-
+        assertThat(request.toString())
+            .contains(url.toString())
+            .contains("bytes=0-100");
     }
 
     @Test
-    void serializableBuilderClass_shouldReturnCorrectClass() {
+    void serializableBuilderClass_shouldReturnBuilderImpl() {
         assertThat(PresignedUrlDownloadRequest.serializableBuilderClass())
             .isEqualTo(PresignedUrlDownloadRequest.BuilderImpl.class);
+    }
+
+    @Test
+    void build_withPresignedUrlHavingRangeInSignedHeaders_shouldThrow() throws Exception {
+        URL url = new URL("https://bucket.s3.us-east-2.amazonaws.com/key"
+                          + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                          + "&X-Amz-SignedHeaders=host%3Brange"
+                          + "&X-Amz-Signature=abc123");
+
+        assertThatThrownBy(() -> PresignedUrlDownloadRequest.builder().presignedUrl(url).build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("range")
+            .hasMessageContaining("presignedGetObjectRequest()");
+    }
+
+    @Test
+    void build_withPresignedUrlHavingIfMatchInSignedHeaders_shouldThrow() throws Exception {
+        URL url = new URL("https://bucket.s3.us-east-2.amazonaws.com/key"
+                          + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                          + "&X-Amz-SignedHeaders=host%3Bif-match"
+                          + "&X-Amz-Signature=abc123");
+
+        assertThatThrownBy(() -> PresignedUrlDownloadRequest.builder().presignedUrl(url).build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("if-match")
+            .hasMessageContaining("presignedGetObjectRequest()");
+    }
+
+    @Test
+    void build_withConflictingRange_shouldThrow() throws Exception {
+        PresignedGetObjectRequest presigned = createPresignedGetObjectRequest(
+            mapOf("host", "bucket.s3.amazonaws.com", "range", "bytes=0-1023"));
+
+        assertThatThrownBy(() ->
+                               PresignedUrlDownloadRequest.builder()
+                                                          .presignedGetObjectRequest(presigned)
+                                                          .range("bytes=500-999")
+                                                          .build()
+        ).isInstanceOf(IllegalArgumentException.class)
+         .hasMessageContaining("conflicts with signed value");
+    }
+
+    @Test
+    void build_withBothPresignedUrlAndPresignedGetObjectRequest_shouldThrow() throws Exception {
+        PresignedGetObjectRequest presigned = createPresignedGetObjectRequest(
+            mapOf("host", "bucket.s3.amazonaws.com"));
+
+        assertThatThrownBy(() ->
+                               PresignedUrlDownloadRequest.builder()
+                                                          .presignedGetObjectRequest(presigned)
+                                                          .presignedUrl(new URL("https://bucket.s3.amazonaws.com/key"))
+                                                          .build()
+        ).isInstanceOf(IllegalArgumentException.class)
+         .hasMessageContaining("Cannot set both");
+    }
+
+    @Test
+    void build_withPresignedGetObjectRequest_shouldExtractUrlAndSignedHeaders() throws Exception {
+        Map<String, List<String>> headers = mapOf("host", "bucket.s3.amazonaws.com", "range", "bytes=0-1023");
+        PresignedGetObjectRequest presigned = createPresignedGetObjectRequest(headers);
+
+        PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
+                                                                         .presignedGetObjectRequest(presigned)
+                                                                         .build();
+
+        assertThat(request.presignedUrl()).isEqualTo(presigned.url());
+        assertThat(request.signedHeaders()).containsKey("range");
+        assertThat(request.signedHeaders().get("range")).containsExactly("bytes=0-1023");
+    }
+
+    private static PresignedGetObjectRequest createPresignedGetObjectRequest(
+        Map<String, List<String>> signedHeaders) throws Exception {
+        return PresignedGetObjectRequest.builder()
+                                        .expiration(Instant.now().plusSeconds(600))
+                                        .isBrowserExecutable(false)
+                                        .signedHeaders(signedHeaders)
+                                        .httpRequest(SdkHttpFullRequest.builder()
+                                                                       .method(SdkHttpMethod.GET)
+                                                                       .protocol("https")
+                                                                       .host("bucket.s3.amazonaws.com")
+                                                                       .encodedPath("/key")
+                                                                       .build())
+                                        .build();
+    }
+
+    private static Map<String, List<String>> mapOf(String... keyValues) {
+        Map<String, List<String>> map = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put(keyValues[i], Arrays.asList(keyValues[i + 1]));
+        }
+        return map;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When a URL is presigned with headers like Range or If-Match, those header values are signed into the signature but not stored in the URL itself — only their names appear in X-Amz-SignedHeaders. This causes two problems:
1. The SDK's multipart download path adds its own Range and If-Match headers that conflict with the signed values → S3 returns 403 signature mismatch.
2. A user passing only the URL to the downloader cannot recover the signed header values to send them correctly.

## Modifications
- `PresignedUrlDownloadRequest` — new presignedGetObjectRequest(PresignedGetObjectRequest) builder method. SDK extracts URL + signed header values automatically. Mutually exclusive with presignedUrl(URL).
- `PresignedUrlDownloadRequestMarshaller` — generic addSignedHeaders() sends all signed headers from the map (skipping host).
- `PresignedUrlDownloadHelper` — hasSignedRange() skips multipart when Range is in signedHeaders.
- `PresignedUrlDownloadRequestWrapper` — carries signedHeaders + new header fields through to marshaller.
- `DefaultAsyncPresignedUrlExtension` — passes signedHeaders to wrapper.
- New fields: ifNoneMatch, ifModifiedSince, ifUnmodifiedSince on download request and wrapper.


## Testing
- Unit: `PresignedUrlDownloadRequestTest` (validation logic, builder extraction)
- Unit: `PresignedUrlDownloadRequestMarshallerTest` (signed headers sent correctly)
- Unit: `PresignedUrlDownloadRequestWrapperTest` (updated field count)
- Integration: `AsyncPresignedUrlExtensionSignedHeadersIntegrationTest` (real S3 — multipart skip, If-Match multipart, conflict validation)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
