### PR TITLE
[Credential Cache Pr 3/3] Standardize refresh window configuration across all credential providers

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -334,7 +334,8 @@ public final class ContainerCredentialsProvider
          * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
          * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
          *
-         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         * <p>This value must be less than or equal to {@link #prefetchTime(Duration)}. Setting this equal to
+         * {@code prefetchTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 1 minute.
          *
@@ -352,7 +353,8 @@ public final class ContainerCredentialsProvider
          * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
          * the refresh while other callers receive the current cached credentials.
          *
-         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         * <p>This value must be greater than or equal to {@link #staleTime(Duration)}. Setting this equal to
+         * {@code staleTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 5 minutes.
          *

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -25,6 +25,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -44,7 +45,6 @@ import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.core.util.SdkUserAgent;
 import software.amazon.awssdk.regions.util.ResourcesEndpointProvider;
 import software.amazon.awssdk.regions.util.ResourcesEndpointRetryPolicy;
-import software.amazon.awssdk.utils.ComparableUtils;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
@@ -86,6 +86,9 @@ public final class ContainerCredentialsProvider
     private static final List<String> VALID_LOOP_BACK_IPV4 = Arrays.asList(ECS_CONTAINER_HOST, EKS_CONTAINER_HOST_IPV4);
     private static final List<String> VALID_LOOP_BACK_IPV6 = Arrays.asList(EKS_CONTAINER_HOST_IPV6);
 
+    private static final Duration DEFAULT_STALE_TIME = Duration.ofMinutes(1);
+    private static final Duration DEFAULT_PREFETCH_TIME = Duration.ofMinutes(5);
+
     private final String endpoint;
     private final HttpCredentialsLoader httpCredentialsLoader;
     private final CachedSupplier<AwsCredentials> credentialsCache;
@@ -95,6 +98,8 @@ public final class ContainerCredentialsProvider
     private final String asyncThreadName;
     private final String sourceChain;
     private final String providerName;
+    private final Duration staleTime;
+    private final Duration prefetchTime;
 
     /**
      * @see #builder()
@@ -108,6 +113,10 @@ public final class ContainerCredentialsProvider
             ? PROVIDER_NAME 
             : builder.sourceChain + "," + PROVIDER_NAME;
         this.httpCredentialsLoader = HttpCredentialsLoader.create(this.providerName);
+        this.staleTime = Optional.ofNullable(builder.staleTime).orElse(DEFAULT_STALE_TIME);
+        this.prefetchTime = Optional.ofNullable(builder.prefetchTime).orElse(DEFAULT_PREFETCH_TIME);
+        Validate.isTrue(this.staleTime.compareTo(this.prefetchTime) <= 0,
+                        "staleTime (%s) must be less than or equal to prefetchTime (%s).", this.staleTime, this.prefetchTime);
 
         if (Boolean.TRUE.equals(builder.asyncCredentialUpdateEnabled)) {
             Validate.paramNotBlank(builder.asyncThreadName, "asyncThreadName");
@@ -156,19 +165,14 @@ public final class ContainerCredentialsProvider
             return null;
         }
 
-        return expiration.minus(1, ChronoUnit.MINUTES);
+        return expiration.minus(staleTime);
     }
 
     private Instant prefetchTime(Instant expiration) {
-        Instant oneHourFromNow = Instant.now().plus(1, ChronoUnit.HOURS);
-
         if (expiration == null) {
-            return oneHourFromNow;
+            return Instant.now().plus(1, ChronoUnit.HOURS);
         }
-
-        Instant fifteenMinutesBeforeExpiration = expiration.minus(15, ChronoUnit.MINUTES);
-
-        return ComparableUtils.minimum(oneHourFromNow, fifteenMinutesBeforeExpiration);
+        return expiration.minus(prefetchTime);
     }
 
     @Override
@@ -323,6 +327,38 @@ public final class ContainerCredentialsProvider
      */
     public interface Builder extends HttpCredentialsProvider.Builder<ContainerCredentialsProvider, Builder>,
                                      CopyableBuilder<Builder, ContainerCredentialsProvider> {
+
+        /**
+         * Configure the amount of time, relative to credential expiration, that defines the mandatory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
+         * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         *
+         * <p>By default, this is 1 minute.
+         *
+         * @param staleTime the duration before expiration that triggers mandatory (blocking) refresh
+         */
+        Builder staleTime(Duration staleTime);
+
+        /**
+         * Configure the amount of time, relative to credential expiration, that defines the advisory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will attempt to refresh them proactively. If the refresh fails, the provider returns the existing cached
+         * credentials without error and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>When {@link #asyncCredentialUpdateEnabled(Boolean)} is true, advisory refreshes happen in a background thread
+         * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
+         * the refresh while other callers receive the current cached credentials.
+         *
+         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         *
+         * <p>By default, this is 5 minutes.
+         *
+         * @param prefetchTime the duration before expiration that triggers advisory (proactive) refresh
+         */
+        Builder prefetchTime(Duration prefetchTime);
     }
 
     private static final class BuilderImpl implements Builder {
@@ -330,6 +366,8 @@ public final class ContainerCredentialsProvider
         private Boolean asyncCredentialUpdateEnabled;
         private String asyncThreadName;
         private String sourceChain;
+        private Duration staleTime;
+        private Duration prefetchTime;
 
         private BuilderImpl() {
             asyncThreadName("container-credentials-provider");
@@ -340,6 +378,8 @@ public final class ContainerCredentialsProvider
             this.asyncCredentialUpdateEnabled = credentialsProvider.asyncCredentialUpdateEnabled;
             this.asyncThreadName = credentialsProvider.asyncThreadName;
             this.sourceChain = credentialsProvider.sourceChain;
+            this.staleTime = credentialsProvider.staleTime;
+            this.prefetchTime = credentialsProvider.prefetchTime;
         }
 
         @Override
@@ -370,6 +410,26 @@ public final class ContainerCredentialsProvider
 
         public void setAsyncThreadName(String asyncThreadName) {
             asyncThreadName(asyncThreadName);
+        }
+
+        @Override
+        public Builder staleTime(Duration staleTime) {
+            this.staleTime = staleTime;
+            return this;
+        }
+
+        public void setStaleTime(Duration staleTime) {
+            staleTime(staleTime);
+        }
+
+        @Override
+        public Builder prefetchTime(Duration prefetchTime) {
+            this.prefetchTime = prefetchTime;
+            return this;
+        }
+
+        public void setPrefetchTime(Duration prefetchTime) {
+            prefetchTime(prefetchTime);
         }
 
         /**

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/HttpCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/HttpCredentialsProvider.java
@@ -28,9 +28,9 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
 public interface HttpCredentialsProvider extends AwsCredentialsProvider, SdkAutoCloseable {
     interface Builder<TypeToBuildT extends HttpCredentialsProvider, BuilderT extends Builder<?, ?>> {
         /**
-         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true,
-         * threads are less likely to block when credentials are loaded, but additional resources are used to maintain
-         * the provider.
+         * Configure whether the provider should fetch credentials asynchronously in the background. When enabled, a
+         * dedicated thread performs credential refreshes during the advisory refresh window, so that callers are less
+         * likely to block waiting for credentials. Additional resources (a thread) are used to maintain the provider.
          *
          * <p>By default, this is disabled.</p>
          */

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -369,7 +369,8 @@ public final class InstanceProfileCredentialsProvider
          * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
          * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
          *
-         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         * <p>This value must be less than or equal to {@link #prefetchTime(Duration)}. Setting this equal to
+         * {@code prefetchTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 1 minute.
          *
@@ -387,7 +388,8 @@ public final class InstanceProfileCredentialsProvider
          * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
          * the refresh while other callers receive the current cached credentials.
          *
-         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         * <p>This value must be greater than or equal to {@link #staleTime(Duration)}. Setting this equal to
+         * {@code staleTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 5 minutes.
          *

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.auth.credentials;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
-import static software.amazon.awssdk.utils.ComparableUtils.maximum;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 import static software.amazon.awssdk.utils.cache.CachedSupplier.StaleValueBehavior.ALLOW;
 
@@ -93,6 +92,8 @@ public final class InstanceProfileCredentialsProvider
 
     private final Duration staleTime;
 
+    private final Duration prefetchTime;
+
     private final String sourceChain;
     private final String providerName;
 
@@ -120,7 +121,10 @@ public final class InstanceProfileCredentialsProvider
                                      .profileName(profileName)
                                      .build();
 
-        this.staleTime = Validate.getOrDefault(builder.staleTime, () -> Duration.ofSeconds(1));
+        this.staleTime = Validate.getOrDefault(builder.staleTime, () -> Duration.ofMinutes(1));
+        this.prefetchTime = Validate.getOrDefault(builder.prefetchTime, () -> Duration.ofMinutes(5));
+        Validate.isTrue(this.staleTime.compareTo(this.prefetchTime) <= 0,
+                        "staleTime (%s) must be less than or equal to prefetchTime (%s).", this.staleTime, this.prefetchTime);
 
         if (Boolean.TRUE.equals(builder.asyncCredentialUpdateEnabled)) {
             Validate.paramNotBlank(builder.asyncThreadName, "asyncThreadName");
@@ -204,7 +208,12 @@ public final class InstanceProfileCredentialsProvider
             return null;
         }
 
-        return now.plus(maximum(timeUntilExpiration.dividedBy(2), Duration.ofMinutes(5)));
+        // Advisory refresh window: use configured prefetchTime before expiry.
+        // If remaining lifetime < prefetchTime, refresh immediately.
+        if (timeUntilExpiration.compareTo(prefetchTime) < 0) {
+            return now;
+        }
+        return expiration.minus(prefetchTime);
     }
 
     @Override
@@ -355,16 +364,36 @@ public final class InstanceProfileCredentialsProvider
         Builder profileName(String profileName);
 
         /**
-         * Configure the amount of time before the moment of expiration of credentials for which to consider the credentials to
-         * be stale. A higher value can lead to a higher rate of request being made to the Amazon EC2 Instance Metadata Service.
-         * The default is 1 sec.
-         * <p>Increasing this value to a higher value (10s or more) may help with situations where a higher load on the instance
-         * metadata service causes it to return 503s error, for which the SDK may not be able to recover fast enough and
-         * returns expired credentials.
+         * Configure the amount of time, relative to credential expiration, that defines the mandatory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
+         * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
          *
-         * @param duration the amount of time before expiration for when to consider the credentials to be stale and need refresh
+         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         *
+         * <p>By default, this is 1 minute.
+         *
+         * @param duration the duration before expiration that triggers mandatory (blocking) refresh
          */
         Builder staleTime(Duration duration);
+
+        /**
+         * Configure the amount of time, relative to credential expiration, that defines the advisory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will attempt to refresh them proactively. If the refresh fails, the provider returns the existing cached
+         * credentials without error and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>When {@link #asyncCredentialUpdateEnabled(Boolean)} is true, advisory refreshes happen in a background thread
+         * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
+         * the refresh while other callers receive the current cached credentials.
+         *
+         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         *
+         * <p>By default, this is 5 minutes.
+         *
+         * @param duration the duration before expiration that triggers advisory (proactive) refresh
+         */
+        Builder prefetchTime(Duration duration);
 
         /**
          * Build a {@link InstanceProfileCredentialsProvider} from the provided configuration.
@@ -382,6 +411,7 @@ public final class InstanceProfileCredentialsProvider
         private Supplier<ProfileFile> profileFile;
         private String profileName;
         private Duration staleTime;
+        private Duration prefetchTime;
         private String sourceChain;
 
         private BuilderImpl() {
@@ -396,6 +426,7 @@ public final class InstanceProfileCredentialsProvider
             this.profileFile = provider.profileFile;
             this.profileName = provider.profileName;
             this.staleTime = provider.staleTime;
+            this.prefetchTime = provider.prefetchTime;
             this.sourceChain = provider.sourceChain;
         }
 
@@ -473,6 +504,16 @@ public final class InstanceProfileCredentialsProvider
 
         public void setStaleTime(Duration duration) {
             staleTime(duration);
+        }
+
+        @Override
+        public Builder prefetchTime(Duration duration) {
+            this.prefetchTime = duration;
+            return this;
+        }
+
+        public void setPrefetchTime(Duration duration) {
+            prefetchTime(duration);
         }
 
         /**

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
@@ -44,21 +45,33 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
 /**
  * A credentials provider that can load credentials from an external process. This is used to support the credential_process
  * setting in the profile credentials file. See
- * <a href="https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes">sourcing credentials
- * from external processes</a> for more information.
+ * <a href="https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes">sourcing
+ * credentials from external processes</a> for more information.
  *
- * <p>
- * This class can be initialized using {@link #builder()}.
+ * <p>This provider caches credentials returned by the external process and refreshes them before they expire. If a refresh
+ * attempt fails after credentials have entered the mandatory refresh window, the provider raises an exception to the caller
+ * (unlike other credential providers that return cached credentials on failure).
  *
- * <p>
- * Available settings:
+ * <p>This class can be initialized using {@link #builder()}.
+ *
+ * <h2>Available settings:</h2>
  * <ul>
- *     <li>Command - The command that should be executed to retrieve credentials.</li>
- *     <li>CredentialRefreshThreshold - The amount of time between when the credentials expire and when the credentials should
- *     start to be refreshed. This allows the credentials to be refreshed *before* they are reported to expire. Default: 15
- *     seconds.</li>
- *     <li>ProcessOutputLimit - The maximum amount of data that can be returned by the external process before an exception is
- *     raised. Default: 64000 bytes (64KB).</li>
+ *     <li><b>Command</b> - The command that should be executed to retrieve credentials. Can be specified as a single string
+ *     (deprecated) or as a list of strings.</li>
+ *     <li><b>StaleTime</b> - The amount of time before credential expiration that defines the mandatory refresh window. When
+ *     credentials are within this window, all callers block until a refresh attempt completes. If the refresh fails, an
+ *     exception is raised. Default: 1 minute.</li>
+ *     <li><b>PrefetchTime</b> - The amount of time before credential expiration that defines the advisory refresh window. When
+ *     credentials are within this window, the provider proactively attempts to refresh them. If the refresh fails during the
+ *     advisory window, the existing cached credentials are returned without error. This replaces the deprecated
+ *     {@code credentialRefreshThreshold} setting; if that setting was explicitly configured, its value is honored as the
+ *     prefetch time for backward compatibility. Default: 5 minutes.</li>
+ *     <li><b>AsyncCredentialUpdateEnabled</b> - Whether to refresh credentials asynchronously in a background thread during
+ *     the advisory refresh window, so that callers are less likely to block. Default: disabled.</li>
+ *     <li><b>ProcessOutputLimit</b> - The maximum amount of data that can be returned by the external process before an
+ *     exception is raised. Default: 64000 bytes (64KB).</li>
+ *     <li><b>CredentialRefreshThreshold</b> - <b>Deprecated.</b> Use {@code prefetchTime} instead. If explicitly set, the
+ *     value is honored as the prefetch time for backward compatibility.</li>
  * </ul>
  */
 @SdkPublicApi
@@ -71,9 +84,10 @@ public final class ProcessCredentialsProvider
     private static final JsonNodeParser PARSER = JsonNodeParser.builder()
                                                                .removeErrorLocations(true)
                                                                .build();
+    private static final Duration DEFAULT_STALE_TIME = Duration.ofMinutes(1);
+    private static final Duration DEFAULT_PREFETCH_TIME = Duration.ofMinutes(5);
 
     private final List<String> executableCommand;
-    private final Duration credentialRefreshThreshold;
     private final long processOutputLimit;
     private final String staticAccountId;
 
@@ -87,6 +101,8 @@ public final class ProcessCredentialsProvider
 
     private final String sourceChain;
     private final String providerName;
+    private final Duration staleTime;
+    private final Duration prefetchTime;
 
     /**
      * @see #builder()
@@ -94,7 +110,6 @@ public final class ProcessCredentialsProvider
     private ProcessCredentialsProvider(Builder builder) {
         this.executableCommand = executableCommand(builder);
         this.processOutputLimit = Validate.isPositive(builder.processOutputLimit, "processOutputLimit");
-        this.credentialRefreshThreshold = Validate.isPositive(builder.credentialRefreshThreshold, "expirationBuffer");
         this.commandFromBuilder = builder.command;
         this.commandAsListOfStringsFromBuilder = builder.commandAsListOfStrings;
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
@@ -103,6 +118,10 @@ public final class ProcessCredentialsProvider
         this.providerName = StringUtils.isEmpty(builder.sourceChain)
             ? PROVIDER_NAME 
             : builder.sourceChain + "," + PROVIDER_NAME;
+        this.staleTime = Optional.ofNullable(builder.staleTime).orElse(DEFAULT_STALE_TIME);
+        this.prefetchTime = Optional.ofNullable(builder.prefetchTime).orElse(DEFAULT_PREFETCH_TIME);
+        Validate.isTrue(this.staleTime.compareTo(this.prefetchTime) <= 0,
+                        "staleTime (%s) must be less than or equal to prefetchTime (%s).", this.staleTime, this.prefetchTime);
 
         CachedSupplier.Builder<AwsCredentials> cacheBuilder = CachedSupplier.builder(this::refreshCredentials)
                                                                             .cachedValueName(toString());
@@ -154,14 +173,28 @@ public final class ProcessCredentialsProvider
             Instant credentialExpirationTime = credentialExpirationTime(credentialsJson);
 
             return RefreshResult.builder(credentials)
-                                .staleTime(credentialExpirationTime)
-                                .prefetchTime(credentialExpirationTime.minusMillis(credentialRefreshThreshold.toMillis()))
+                                .staleTime(staleTime(credentialExpirationTime))
+                                .prefetchTime(prefetchTime(credentialExpirationTime))
                                 .build();
         } catch (InterruptedException e) {
             throw new IllegalStateException("Process-based credential refreshing has been interrupted.", e);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to refresh process-based credentials.", e);
         }
+    }
+
+    private Instant staleTime(Instant expiration) {
+        if (expiration == null || expiration.equals(Instant.MAX)) {
+            return Instant.MAX;
+        }
+        return expiration.minus(staleTime);
+    }
+
+    private Instant prefetchTime(Instant expiration) {
+        if (expiration == null || expiration.equals(Instant.MAX)) {
+            return Instant.MAX;
+        }
+        return expiration.minus(prefetchTime);
     }
 
     /**
@@ -277,10 +310,11 @@ public final class ProcessCredentialsProvider
         private Boolean asyncCredentialUpdateEnabled = false;
         private String command;
         private List<String> commandAsListOfStrings;
-        private Duration credentialRefreshThreshold = Duration.ofSeconds(15);
         private long processOutputLimit = 64000;
         private String staticAccountId;
         private String sourceChain;
+        private Duration staleTime;
+        private Duration prefetchTime;
 
         /**
          * @see #builder()
@@ -292,22 +326,66 @@ public final class ProcessCredentialsProvider
             this.asyncCredentialUpdateEnabled = provider.asyncCredentialUpdateEnabled;
             this.command = provider.commandFromBuilder;
             this.commandAsListOfStrings = provider.commandAsListOfStringsFromBuilder;
-            this.credentialRefreshThreshold = provider.credentialRefreshThreshold;
             this.processOutputLimit = provider.processOutputLimit;
             this.staticAccountId = provider.staticAccountId;
             this.sourceChain = provider.sourceChain;
+            this.staleTime = provider.staleTime;
+            this.prefetchTime = provider.prefetchTime;
         }
 
         /**
-         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true,
-         * threads are less likely to block when credentials are loaded, but additional resources are used to maintain
-         * the provider.
+         * Configure whether the provider should fetch credentials asynchronously in the background. When enabled, a
+         * dedicated thread performs credential refreshes during the advisory refresh window (defined by
+         * {@link #prefetchTime(Duration)}), so that callers are less likely to block waiting for credentials. Additional
+         * resources (a thread) are used to maintain the provider.
+         *
+         * <p>Regardless of this setting, callers will block if credentials enter the mandatory refresh window (defined by
+         * {@link #staleTime(Duration)}).
          *
          * <p>By default, this is disabled.</p>
          */
         @SuppressWarnings("unchecked")
         public Builder asyncCredentialUpdateEnabled(Boolean asyncCredentialUpdateEnabled) {
             this.asyncCredentialUpdateEnabled = asyncCredentialUpdateEnabled;
+            return this;
+        }
+
+        /**
+         * Configure the amount of time, relative to credential expiration, that defines the mandatory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
+         * raises an exception to the caller.
+         *
+         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         *
+         * <p>By default, this is 1 minute.</p>
+         *
+         * @param staleTime the duration before expiration that triggers mandatory (blocking) refresh
+         */
+        public Builder staleTime(Duration staleTime) {
+            this.staleTime = staleTime;
+            return this;
+        }
+
+        /**
+         * Configure the amount of time, relative to credential expiration, that defines the advisory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will attempt to refresh them proactively. If the refresh fails during the advisory window, the provider
+         * returns the existing cached credentials. If the refresh fails after credentials have entered the mandatory refresh
+         * window (defined by {@link #staleTime(Duration)}), the provider raises an exception.
+         *
+         * <p>When {@link #asyncCredentialUpdateEnabled(Boolean)} is true, advisory refreshes happen in a background thread
+         * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
+         * the refresh while other callers receive the current cached credentials.
+         *
+         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         *
+         * <p>By default, this is 5 minutes.</p>
+         *
+         * @param prefetchTime the duration before expiration that triggers advisory (proactive) refresh
+         */
+        public Builder prefetchTime(Duration prefetchTime) {
+            this.prefetchTime = prefetchTime;
             return this;
         }
 
@@ -338,10 +416,13 @@ public final class ProcessCredentialsProvider
          * Configure the amount of time between when the credentials expire and when the credentials should start to be
          * refreshed. This allows the credentials to be refreshed *before* they are reported to expire.
          *
-         * <p>Default: 15 seconds.</p>
+         * @deprecated Use {@link #prefetchTime(Duration)} instead. This method has been deprecated for consistency
+         * with other credential providers. Calls to this method are equivalent to calling
+         * {@code prefetchTime(credentialRefreshThreshold)}.
          */
+        @Deprecated
         public Builder credentialRefreshThreshold(Duration credentialRefreshThreshold) {
-            this.credentialRefreshThreshold = credentialRefreshThreshold;
+            this.prefetchTime = credentialRefreshThreshold;
             return this;
         }
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
@@ -356,7 +356,8 @@ public final class ProcessCredentialsProvider
          * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
          * raises an exception to the caller.
          *
-         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         * <p>This value must be less than or equal to {@link #prefetchTime(Duration)}. Setting this equal to
+         * {@code prefetchTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 1 minute.</p>
          *
@@ -378,7 +379,8 @@ public final class ProcessCredentialsProvider
          * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
          * the refresh while other callers receive the current cached credentials.
          *
-         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         * <p>This value must be greater than or equal to {@link #staleTime(Duration)}. Setting this equal to
+         * {@code staleTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 5 minutes.</p>
          *

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
@@ -189,21 +189,34 @@ public class WebIdentityTokenFileCredentialsProvider
         Builder asyncCredentialUpdateEnabled(Boolean asyncCredentialUpdateEnabled);
 
         /**
-         * Configure the amount of time, relative to STS token expiration, that the cached credentials are considered close to
-         * stale and should be updated.
+         * Configure the amount of time, relative to credential expiration, that defines the advisory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will attempt to refresh them proactively. If the refresh fails, the provider returns the existing cached
+         * credentials without error and will not attempt another refresh until a backoff period has elapsed.
          *
-         * <p>Prefetch updates will occur between the specified time and the stale time of the provider. Prefetch
-         * updates may be asynchronous. See {@link #asyncCredentialUpdateEnabled}.
+         * <p>When {@link #asyncCredentialUpdateEnabled(Boolean)} is true, advisory refreshes happen in a background thread
+         * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
+         * the refresh while other callers receive the current cached credentials.
+         *
+         * <p>This value must be greater than {@link #staleTime(Duration)}.
          *
          * <p>By default, this is 5 minutes.
+         *
+         * @param prefetchTime the duration before expiration that triggers advisory (proactive) refresh
          */
         Builder prefetchTime(Duration prefetchTime);
 
         /**
-         * Configure the amount of time, relative to STS token expiration, that the cached credentials are considered stale and
-         * must be updated. All threads will block until the value is updated.
+         * Configure the amount of time, relative to credential expiration, that defines the mandatory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
+         * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>This value must be less than {@link #prefetchTime(Duration)}.
          *
          * <p>By default, this is 1 minute.
+         *
+         * @param staleTime the duration before expiration that triggers mandatory (blocking) refresh
          */
         Builder staleTime(Duration staleTime);
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
@@ -198,7 +198,8 @@ public class WebIdentityTokenFileCredentialsProvider
          * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
          * the refresh while other callers receive the current cached credentials.
          *
-         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         * <p>This value must be greater than or equal to {@link #staleTime(Duration)}. Setting this equal to
+         * {@code staleTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 5 minutes.
          *
@@ -212,7 +213,8 @@ public class WebIdentityTokenFileCredentialsProvider
          * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
          * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
          *
-         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         * <p>This value must be less than or equal to {@link #prefetchTime(Duration)}. Setting this equal to
+         * {@code prefetchTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 1 minute.
          *

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderTest.java
@@ -574,39 +574,79 @@ public class InstanceProfileCredentialsProviderTest {
     }
 
     @Test
+    void resolveCredentials_immediateRefreshWhenRemainingLifetimeLessThan5Minutes() {
+        // When IMDS returns credentials with less than 5 minutes of remaining lifetime,
+        // the prefetchTime should be set to 'now', triggering a refresh soon after.
+        // Advance the clock by 2 minutes to account for jitter on the prefetch time.
+        AdjustableClock clock = new AdjustableClock();
+        AwsCredentialsProvider credentialsProvider = credentialsProviderWithClock(clock);
+        Instant now = Instant.now();
+        // Credentials that expire in 3 minutes (less than the 5 minute advisory window)
+        Instant shortExpiration = now.plus(3, MINUTES);
+        String shortLivedCredentialsResponse =
+            "{"
+            + "\"AccessKeyId\":\"ACCESS_KEY_ID\","
+            + "\"SecretAccessKey\":\"SECRET_ACCESS_KEY\","
+            + "\"Expiration\":\"" + DateUtils.formatIso8601Date(shortExpiration) + '"'
+            + "}";
+
+        String refreshedCredentialsResponse =
+            "{"
+            + "\"AccessKeyId\":\"ACCESS_KEY_ID2\","
+            + "\"SecretAccessKey\":\"SECRET_ACCESS_KEY2\","
+            + "\"Expiration\":\"" + DateUtils.formatIso8601Date(now.plus(6, HOURS)) + '"'
+            + "}";
+
+        // Prime cache with short-lived credentials
+        clock.time = now;
+        stubSecureCredentialsResponse(aResponse().withBody(shortLivedCredentialsResponse));
+        AwsCredentials firstCredentials = credentialsProvider.resolveCredentials();
+        assertThat(firstCredentials.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY");
+
+        // Advance past any jitter on the prefetch time (which was set to 'now').
+        // The staleTime is shortExpiration - 1min = now + 2min.
+        // The jitter window is at most 1 minute (between prefetchTime and 1min before staleTime).
+        // So advancing by 2 minutes guarantees we are past the jittered prefetch time, triggering refresh.
+        clock.time = now.plus(2, MINUTES);
+        stubSecureCredentialsResponse(aResponse().withBody(refreshedCredentialsResponse));
+        AwsCredentials secondCredentials = credentialsProvider.resolveCredentials();
+        assertThat(secondCredentials.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY2");
+    }
+
+    @Test
     void imdsCallFrequencyIsLimited() {
-        // Requires running the test multiple times to account for refresh jitter
-        for (int i = 0; i < 10; i++) {
-            AdjustableClock clock = new AdjustableClock();
-            AwsCredentialsProvider credentialsProvider = credentialsProviderWithClock(clock);
-            Instant now = Instant.now();
-            String successfulCredentialsResponse1 =
-                "{"
-                + "\"AccessKeyId\":\"ACCESS_KEY_ID\","
-                + "\"SecretAccessKey\":\"SECRET_ACCESS_KEY\","
-                + "\"Expiration\":\"" + DateUtils.formatIso8601Date(now) + '"'
-                + "}";
+        // Verify that IMDS is not called again if we haven't reached the prefetch window
+        AdjustableClock clock = new AdjustableClock();
+        AwsCredentialsProvider credentialsProvider = credentialsProviderWithClock(clock);
+        Instant now = Instant.now();
+        Instant expiration = now.plus(6, HOURS);
+        String successfulCredentialsResponse1 =
+            "{"
+            + "\"AccessKeyId\":\"ACCESS_KEY_ID\","
+            + "\"SecretAccessKey\":\"SECRET_ACCESS_KEY\","
+            + "\"Expiration\":\"" + DateUtils.formatIso8601Date(expiration) + '"'
+            + "}";
 
-            String successfulCredentialsResponse2 =
-                "{"
-                + "\"AccessKeyId\":\"ACCESS_KEY_ID2\","
-                + "\"SecretAccessKey\":\"SECRET_ACCESS_KEY2\","
-                + "\"Expiration\":\"" + DateUtils.formatIso8601Date(now.plus(6, HOURS)) + '"'
-                + "}";
+        String successfulCredentialsResponse2 =
+            "{"
+            + "\"AccessKeyId\":\"ACCESS_KEY_ID2\","
+            + "\"SecretAccessKey\":\"SECRET_ACCESS_KEY2\","
+            + "\"Expiration\":\"" + DateUtils.formatIso8601Date(expiration.plus(6, HOURS)) + '"'
+            + "}";
 
-            // Set the time to 5 minutes before expiration and call IMDS
-            clock.time = now.minus(5, MINUTES);
-            stubSecureCredentialsResponse(aResponse().withBody(successfulCredentialsResponse1));
-            AwsCredentials credentials5MinutesAgo = credentialsProvider.resolveCredentials();
+        // Prime the cache at the current time
+        clock.time = now;
+        stubSecureCredentialsResponse(aResponse().withBody(successfulCredentialsResponse1));
+        AwsCredentials credentialsAtStart = credentialsProvider.resolveCredentials();
 
-            // Set the time to 2 seconds before expiration, and verify that do not call IMDS because it hasn't been 5 minutes yet
-            clock.time = now.minus(2, SECONDS);
-            stubSecureCredentialsResponse(aResponse().withBody(successfulCredentialsResponse2));
-            AwsCredentials credentials2SecondsAgo = credentialsProvider.resolveCredentials();
+        // Move time forward but still before the prefetch window (5 min before expiry).
+        // Since prefetchTime = expiration - 5min = now + 5h55m, anything before that should not trigger refresh.
+        clock.time = now.plus(5, HOURS);
+        stubSecureCredentialsResponse(aResponse().withBody(successfulCredentialsResponse2));
+        AwsCredentials credentials5HoursLater = credentialsProvider.resolveCredentials();
 
-            assertThat(credentials2SecondsAgo).isEqualTo(credentials5MinutesAgo);
-            assertThat(credentials5MinutesAgo.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY");
-        }
+        assertThat(credentials5HoursLater).isEqualTo(credentialsAtStart);
+        assertThat(credentialsAtStart.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY");
     }
 
     @Test
@@ -632,7 +672,7 @@ public class InstanceProfileCredentialsProviderTest {
 
 
         Duration staleTime = Duration.ofMinutes(5);
-        AwsCredentialsProvider provider = credentialsProviderWithClock(clock, staleTime);
+        AwsCredentialsProvider provider = credentialsProviderWithClock(clock, staleTime, Duration.ofMinutes(10));
 
         // cache expiration with expiration = 6 hours
         clock.time = now;
@@ -704,10 +744,15 @@ public class InstanceProfileCredentialsProviderTest {
     }
 
     private AwsCredentialsProvider credentialsProviderWithClock(Clock clock, Duration staleTime) {
+        return credentialsProviderWithClock(clock, staleTime, Duration.ofMinutes(5));
+    }
+
+    private AwsCredentialsProvider credentialsProviderWithClock(Clock clock, Duration staleTime, Duration prefetchTime) {
         InstanceProfileCredentialsProvider.BuilderImpl builder =
             (InstanceProfileCredentialsProvider.BuilderImpl) InstanceProfileCredentialsProvider.builder();
         builder.clock(clock);
         builder.staleTime(staleTime);
+        builder.prefetchTime(prefetchTime);
         return builder.build();
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
@@ -161,7 +161,8 @@ public class ProcessCredentialsProviderTest {
                                           .command(String.format("%s %s %s token=%s exp=%s",
                                                                  scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY,
                                                                  SESSION_TOKEN, expiration))
-                                          .credentialRefreshThreshold(Duration.ofSeconds(1))
+                                          .staleTime(Duration.ofMillis(500))
+                                          .prefetchTime(Duration.ofSeconds(1))
                                           .build();
 
         AwsCredentials credentials = credentialsProvider.resolveCredentials();
@@ -176,7 +177,8 @@ public class ProcessCredentialsProviderTest {
             ProcessCredentialsProvider.builder()
                                       .command(String.format("%s %s %s token=sessionToken exp=%s acctid=%s",
                                                              scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY, expiration, ACCOUNT_ID))
-                                      .credentialRefreshThreshold(Duration.ofSeconds(1))
+                                      .staleTime(Duration.ofMillis(500))
+                                      .prefetchTime(Duration.ofSeconds(1))
                                       .build();
 
         AwsCredentials credentials = credentialsProvider.resolveCredentials();
@@ -191,7 +193,8 @@ public class ProcessCredentialsProviderTest {
             ProcessCredentialsProvider.builder()
                                       .command(String.format("%s %s %s token=sessionToken exp=%s",
                                                              scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY, expiration))
-                                      .credentialRefreshThreshold(Duration.ofSeconds(1))
+                                      .staleTime(Duration.ofMillis(500))
+                                      .prefetchTime(Duration.ofSeconds(1))
                                       .staticAccountId("staticAccountId")
                                       .sourceChain("v")
                                       .build();
@@ -225,7 +228,7 @@ public class ProcessCredentialsProviderTest {
             ProcessCredentialsProvider.builder()
                                       .command(String.format("%s %s %s token=%s exp=%s",
                                                              scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY, SESSION_TOKEN,
-                                                             DateUtils.formatIso8601Date(Instant.now().plusSeconds(20))))
+                                                             DateUtils.formatIso8601Date(Instant.now().plus(Duration.ofMinutes(30)))))
                                       .build();
 
         AwsCredentials request1 = credentialsProvider.resolveCredentials();
@@ -241,7 +244,8 @@ public class ProcessCredentialsProviderTest {
                                           .command(String.format("%s %s %s token=%s exp=%s",
                                                          scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY, RANDOM_SESSION_TOKEN,
                                                          DateUtils.formatIso8601Date(Instant.now().plusSeconds(20))))
-                                          .credentialRefreshThreshold(Duration.ofSeconds(20))
+                                          .staleTime(Duration.ofSeconds(10))
+                                          .prefetchTime(Duration.ofSeconds(20))
                                           .build();
 
         AwsCredentials request1 = credentialsProvider.resolveCredentials();
@@ -251,11 +255,46 @@ public class ProcessCredentialsProviderTest {
     }
 
     @Test
+    void defaultPrefetchTime_credentialsWithinFiveMinuteWindow_areRefreshed() {
+        // Credentials that expire in 30 seconds: staleTime = now+30s - 1min = now-30s (in the past, stale!)
+        // In STRICT mode, stale credentials force a synchronous refresh on every call
+        ProcessCredentialsProvider credentialsProvider =
+            ProcessCredentialsProvider.builder()
+                                      .command(String.format("%s %s %s token=%s exp=%s",
+                                                             scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY, RANDOM_SESSION_TOKEN,
+                                                             DateUtils.formatIso8601Date(Instant.now().plusSeconds(30))))
+                                      .build();
+
+        AwsCredentials request1 = credentialsProvider.resolveCredentials();
+        AwsCredentials request2 = credentialsProvider.resolveCredentials();
+
+        assertThat(request1).isNotEqualTo(request2);
+    }
+
+    @Test
+    void defaultPrefetchTime_credentialsFarFromExpiry_areCached() {
+        // Credentials that expire in 30 minutes: prefetchTime = now+30min - 5min = now+25min (in the future)
+        // So the cache should NOT refresh
+        ProcessCredentialsProvider credentialsProvider =
+            ProcessCredentialsProvider.builder()
+                                      .command(String.format("%s %s %s token=%s exp=%s",
+                                                             scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY, RANDOM_SESSION_TOKEN,
+                                                             DateUtils.formatIso8601Date(Instant.now().plus(Duration.ofMinutes(30)))))
+                                      .build();
+
+        AwsCredentials request1 = credentialsProvider.resolveCredentials();
+        AwsCredentials request2 = credentialsProvider.resolveCredentials();
+
+        assertThat(request1).isEqualTo(request2);
+    }
+
+    @Test
     void processFailed_shouldContainErrorMessage() {
         ProcessCredentialsProvider credentialsProvider =
             ProcessCredentialsProvider.builder()
                                       .command(errorScriptLocation)
-                                      .credentialRefreshThreshold(Duration.ofSeconds(20))
+                                      .staleTime(Duration.ofSeconds(10))
+                                      .prefetchTime(Duration.ofSeconds(20))
                                       .build();
 
         assertThatThrownBy(credentialsProvider::resolveCredentials)
@@ -269,7 +308,8 @@ public class ProcessCredentialsProviderTest {
             ProcessCredentialsProvider.builder()
                                       .command(String.format("%s %s %s token=%s",
                                                              scriptLocation, ACCESS_KEY_ID, SECRET_ACCESS_KEY, SESSION_TOKEN))
-                                      .credentialRefreshThreshold(Duration.ofSeconds(20))
+                                      .staleTime(Duration.ofSeconds(10))
+                                      .prefetchTime(Duration.ofSeconds(20))
                                       .build();
 
         AwsCredentials request1 = credentialsProvider.resolveCredentials();

--- a/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
+++ b/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
@@ -333,7 +333,8 @@ public final class LoginCredentialsProvider implements
          * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
          * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
          *
-         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         * <p>This value must be less than or equal to {@link #prefetchTime(Duration)}. Setting this equal to
+         * {@code prefetchTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 1 minute.
          *
@@ -351,7 +352,8 @@ public final class LoginCredentialsProvider implements
          * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
          * the refresh while other callers receive the current cached credentials.
          *
-         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         * <p>This value must be greater than or equal to {@link #staleTime(Duration)}. Setting this equal to
+         * {@code staleTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 5 minutes.
          *

--- a/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
+++ b/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginCredentialsProvider.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.services.signin.model.OAuth2ErrorCode;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 import software.amazon.awssdk.utils.cache.CachedSupplier;
@@ -106,6 +107,8 @@ public final class LoginCredentialsProvider implements
 
         this.staleTime = Optional.ofNullable(builder.staleTime).orElse(DEFAULT_STALE_TIME);
         this.prefetchTime = Optional.ofNullable(builder.prefetchTime).orElse(DEFAULT_PREFETCH_TIME);
+        Validate.isTrue(this.staleTime.compareTo(this.prefetchTime) <= 0,
+                        "staleTime (%s) must be less than or equal to prefetchTime (%s).", this.staleTime, this.prefetchTime);
         this.sourceChain = builder.sourceChain;
 
         this.providerName = StringUtils.isEmpty(builder.sourceChain)
@@ -254,16 +257,16 @@ public final class LoginCredentialsProvider implements
     }
 
     /**
-     * The amount of time, relative to session token expiration, that the cached credentials are considered stale and should no
-     * longer be used. All threads will block until the value is updated.
+     * The amount of time, relative to credential expiration, that defines the mandatory refresh window. When credentials are
+     * within this window, all threads will block until the credentials are updated.
      */
     public Duration staleTime() {
         return staleTime;
     }
 
     /**
-     * The amount of time, relative to session token expiration, that the cached credentials are considered close to stale and
-     * should be updated.
+     * The amount of time, relative to credential expiration, that defines the advisory refresh window. When credentials are
+     * within this window, the provider proactively attempts to refresh them.
      */
     public Duration prefetchTime() {
         return prefetchTime;
@@ -312,29 +315,47 @@ public final class LoginCredentialsProvider implements
         Builder signinClient(SigninClient signinClient);
 
         /**
-         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true, threads are
-         * less likely to block when credentials are loaded, but additional resources are used to maintain the provider.
+         * Configure whether the provider should fetch credentials asynchronously in the background. When enabled, a
+         * dedicated thread performs credential refreshes during the advisory refresh window (defined by
+         * {@link #prefetchTime(Duration)}), so that callers are less likely to block waiting for credentials. Additional
+         * resources (a thread) are used to maintain the provider.
+         *
+         * <p>Regardless of this setting, callers will block if credentials enter the mandatory refresh window (defined by
+         * {@link #staleTime(Duration)}).
          *
          * <p>By default, this is enabled.
          */
         Builder asyncCredentialUpdateEnabled(Boolean asyncCredentialUpdateEnabled);
 
         /**
-         * Configure the amount of time, relative to login token expiration, that the cached credentials are considered stale and
-         * should no longer be used. All threads will block until the value is updated.
+         * Configure the amount of time, relative to credential expiration, that defines the mandatory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
+         * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>This value must be less than {@link #prefetchTime(Duration)}.
          *
          * <p>By default, this is 1 minute.
+         *
+         * @param staleTime the duration before expiration that triggers mandatory (blocking) refresh
          */
         Builder staleTime(Duration staleTime);
 
         /**
-         * Configure the amount of time, relative to signin token expiration, that the cached credentials are considered close to
-         * stale and should be updated.
-         * <p>
-         * Prefetch updates will occur between the specified time and the stale time of the provider. Prefetch updates may be
-         * asynchronous. See {@link #asyncCredentialUpdateEnabled}.
+         * Configure the amount of time, relative to credential expiration, that defines the advisory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will attempt to refresh them proactively. If the refresh fails, the provider returns the existing cached
+         * credentials without error and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>When {@link #asyncCredentialUpdateEnabled(Boolean)} is true, advisory refreshes happen in a background thread
+         * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
+         * the refresh while other callers receive the current cached credentials.
+         *
+         * <p>This value must be greater than {@link #staleTime(Duration)}.
          *
          * <p>By default, this is 5 minutes.
+         *
+         * @param prefetchTime the duration before expiration that triggers advisory (proactive) refresh
          */
         Builder prefetchTime(Duration prefetchTime);
 

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.sso.auth;
 
+import static software.amazon.awssdk.utils.Validate.isTrue;
 import static software.amazon.awssdk.utils.Validate.notNull;
 import static software.amazon.awssdk.utils.cache.CachedSupplier.StaleValueBehavior.ALLOW;
 
@@ -83,6 +84,8 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
 
         this.staleTime = Optional.ofNullable(builder.staleTime).orElse(DEFAULT_STALE_TIME);
         this.prefetchTime = Optional.ofNullable(builder.prefetchTime).orElse(DEFAULT_PREFETCH_TIME);
+        isTrue(this.staleTime.compareTo(this.prefetchTime) <= 0,
+               "staleTime (%s) must be less than or equal to prefetchTime (%s).", this.staleTime, this.prefetchTime);
         this.sourceChain = builder.sourceChain;
 
         this.providerName = StringUtils.isEmpty(builder.sourceChain)
@@ -133,16 +136,16 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
     }
 
     /**
-     * The amount of time, relative to session token expiration, that the cached credentials are considered stale and
-     * should no longer be used. All threads will block until the value is updated.
+     * The amount of time, relative to credential expiration, that defines the mandatory refresh window. When credentials are
+     * within this window, all threads will block until the credentials are updated.
      */
     public Duration staleTime() {
         return staleTime;
     }
 
     /**
-     * The amount of time, relative to session token expiration, that the cached credentials are considered close to stale
-     * and should be updated.
+     * The amount of time, relative to credential expiration, that defines the advisory refresh window. When credentials are
+     * within this window, the provider proactively attempts to refresh them.
      */
     public Duration prefetchTime() {
         return prefetchTime;
@@ -182,30 +185,47 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
         Builder ssoClient(SsoClient ssoclient);
 
         /**
-         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true,
-         * threads are less likely to block when credentials are loaded, but addtiional resources are used to maintian
-         * the provider.
+         * Configure whether the provider should fetch credentials asynchronously in the background. When enabled, a
+         * dedicated thread performs credential refreshes during the advisory refresh window (defined by
+         * {@link #prefetchTime(Duration)}), so that callers are less likely to block waiting for credentials. Additional
+         * resources (a thread) are used to maintain the provider.
+         *
+         * <p>Regardless of this setting, callers will block if credentials enter the mandatory refresh window (defined by
+         * {@link #staleTime(Duration)}).
          *
          * <p>By default, this is disabled.</p>
          */
         Builder asyncCredentialUpdateEnabled(Boolean asyncCredentialUpdateEnabled);
 
         /**
-         * Configure the amount of time, relative to SSO session token expiration, that the cached credentials are considered
-         * stale and should no longer be used. All threads will block until the value is updated.
+         * Configure the amount of time, relative to credential expiration, that defines the mandatory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
+         * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>This value must be less than {@link #prefetchTime(Duration)}.
          *
          * <p>By default, this is 1 minute.</p>
+         *
+         * @param staleTime the duration before expiration that triggers mandatory (blocking) refresh
          */
         Builder staleTime(Duration staleTime);
 
         /**
-         * Configure the amount of time, relative to SSO session token expiration, that the cached credentials are considered
-         * close to stale and should be updated.
+         * Configure the amount of time, relative to credential expiration, that defines the advisory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will attempt to refresh them proactively. If the refresh fails, the provider returns the existing cached
+         * credentials without error and will not attempt another refresh until a backoff period has elapsed.
          *
-         * Prefetch updates will occur between the specified time and the stale time of the provider. Prefetch updates may be
-         * asynchronous. See {@link #asyncCredentialUpdateEnabled}.
+         * <p>When {@link #asyncCredentialUpdateEnabled(Boolean)} is true, advisory refreshes happen in a background thread
+         * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
+         * the refresh while other callers receive the current cached credentials.
+         *
+         * <p>This value must be greater than {@link #staleTime(Duration)}.
          *
          * <p>By default, this is 5 minutes.</p>
+         *
+         * @param prefetchTime the duration before expiration that triggers advisory (proactive) refresh
          */
         Builder prefetchTime(Duration prefetchTime);
 

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -203,7 +203,8 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
          * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
          * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
          *
-         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         * <p>This value must be less than or equal to {@link #prefetchTime(Duration)}. Setting this equal to
+         * {@code prefetchTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 1 minute.</p>
          *
@@ -221,7 +222,8 @@ public final class SsoCredentialsProvider implements AwsCredentialsProvider, Sdk
          * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
          * the refresh while other callers receive the current cached credentials.
          *
-         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         * <p>This value must be greater than or equal to {@link #staleTime(Duration)}. Setting this equal to
+         * {@code staleTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 5 minutes.</p>
          *

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
@@ -208,7 +208,8 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
          * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
          * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
          *
-         * <p>This value must be less than {@link #prefetchTime(Duration)}.
+         * <p>This value must be less than or equal to {@link #prefetchTime(Duration)}. Setting this equal to
+         * {@code prefetchTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 1 minute.</p>
          *
@@ -230,7 +231,8 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
          * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
          * the refresh while other callers receive the current cached credentials.
          *
-         * <p>This value must be greater than {@link #staleTime(Duration)}.
+         * <p>This value must be greater than or equal to {@link #staleTime(Duration)}. Setting this equal to
+         * {@code staleTime} effectively disables prefetch, causing all refreshes to be mandatory (blocking).
          *
          * <p>By default, this is 5 minutes.</p>
          *

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
@@ -74,6 +74,8 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
 
         this.staleTime = Optional.ofNullable(builder.staleTime).orElse(DEFAULT_STALE_TIME);
         this.prefetchTime = Optional.ofNullable(builder.prefetchTime).orElse(DEFAULT_PREFETCH_TIME);
+        Validate.isTrue(this.staleTime.compareTo(this.prefetchTime) <= 0,
+                        "staleTime (%s) must be less than or equal to prefetchTime (%s).", this.staleTime, this.prefetchTime);
 
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
         CachedSupplier.Builder<AwsSessionCredentials> cacheBuilder =
@@ -117,16 +119,16 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
     }
 
     /**
-     * The amount of time, relative to STS token expiration, that the cached credentials are considered stale and
-     * should no longer be used. All threads will block until the value is updated.
+     * The amount of time, relative to credential expiration, that defines the mandatory refresh window. When credentials are
+     * within this window, all threads will block until the credentials are updated.
      */
     public Duration staleTime() {
         return staleTime;
     }
 
     /**
-     * The amount of time, relative to STS token expiration, that the cached credentials are considered close to stale
-     * and should be updated.
+     * The amount of time, relative to credential expiration, that defines the advisory refresh window. When credentials are
+     * within this window, the provider proactively attempts to refresh them.
      */
     public Duration prefetchTime() {
         return prefetchTime;
@@ -184,9 +186,13 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
         }
 
         /**
-         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true,
-         * threads are less likely to block when credentials are loaded, but additional resources are used to maintain
-         * the provider.
+         * Configure whether the provider should fetch credentials asynchronously in the background. When enabled, a
+         * dedicated thread performs credential refreshes during the advisory refresh window (defined by
+         * {@link #prefetchTime(Duration)}), so that callers are less likely to block waiting for credentials. Additional
+         * resources (a thread) are used to maintain the provider.
+         *
+         * <p>Regardless of this setting, callers will block if credentials enter the mandatory refresh window (defined by
+         * {@link #staleTime(Duration)}).
          *
          * <p>By default, this is disabled.</p>
          */
@@ -197,10 +203,16 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
         }
 
         /**
-         * Configure the amount of time, relative to STS token expiration, that the cached credentials are considered
-         * stale and must be updated. All threads will block until the value is updated.
+         * Configure the amount of time, relative to credential expiration, that defines the mandatory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will block all callers until a refresh attempt completes. If the refresh attempt fails, the provider
+         * returns the cached credentials and will not attempt another refresh until a backoff period has elapsed.
+         *
+         * <p>This value must be less than {@link #prefetchTime(Duration)}.
          *
          * <p>By default, this is 1 minute.</p>
+         *
+         * @param staleTime the duration before expiration that triggers mandatory (blocking) refresh
          */
         @SuppressWarnings("unchecked")
         public B staleTime(Duration staleTime) {
@@ -209,13 +221,20 @@ public abstract class StsCredentialsProvider implements AwsCredentialsProvider, 
         }
 
         /**
-         * Configure the amount of time, relative to STS token expiration, that the cached credentials are considered
-         * close to stale and should be updated.
+         * Configure the amount of time, relative to credential expiration, that defines the advisory refresh window. When
+         * the cached credentials are within this window (i.e., their remaining lifetime is less than this duration), the
+         * provider will attempt to refresh them proactively. If the refresh fails, the provider returns the existing cached
+         * credentials without error and will not attempt another refresh until a backoff period has elapsed.
          *
-         * Prefetch updates will occur between the specified time and the stale time of the provider. Prefetch updates may be
-         * asynchronous. See {@link #asyncCredentialUpdateEnabled}.
+         * <p>When {@link #asyncCredentialUpdateEnabled(Boolean)} is true, advisory refreshes happen in a background thread
+         * and callers immediately receive the current cached credentials. When it is false, one caller will block to perform
+         * the refresh while other callers receive the current cached credentials.
+         *
+         * <p>This value must be greater than {@link #staleTime(Duration)}.
          *
          * <p>By default, this is 5 minutes.</p>
+         *
+         * @param prefetchTime the duration before expiration that triggers advisory (proactive) refresh
          */
         @SuppressWarnings("unchecked")
         public B prefetchTime(Duration prefetchTime) {

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityCredentialsProviderFactoryTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityCredentialsProviderFactoryTest.java
@@ -39,8 +39,8 @@ class StsWebIdentityCredentialsProviderFactoryTest {
         AwsCredentialsProvider provider = factory.create(
             WebIdentityTokenCredentialProperties.builder()
                                                 .asyncCredentialUpdateEnabled(true)
-                                                .prefetchTime(Duration.ofMinutes(5))
-                                                .staleTime(Duration.ofMinutes(15))
+                                                .prefetchTime(Duration.ofMinutes(15))
+                                                .staleTime(Duration.ofMinutes(5))
                                                 .roleArn("role-arn")
                                                 .webIdentityTokenFile(Paths.get("/path/to/file"))
                                                 .roleSessionName("session-name")


### PR DESCRIPTION
**This PR merges to feature/master/credential_cache, NOT to master**
[Credential Cache Pr 3/3].

Standardize refresh window configuration across all credential providers


## Motivation and Context

This is part 3 of 3 implementing the Credential Refresh Behavior spec. With static stability enabled (PRs 1-2), this PR standardizes the refresh timing defaults and adds consistent builder configuration across all credential providers.

The SEP mandates 1-minute mandatory (stale) and 5-minute advisory (prefetch) refresh windows. Several providers previously used different values (IMDS: 1s stale; Container: 15min prefetch; Process: 15s prefetch). This PR aligns them all and exposes `staleTime(Duration)` / `prefetchTime(Duration)` builder methods for customer override.

**PR chain**: [PR 1: CachedSupplier ALLOW engine](https://github.com/aws/aws-sdk-java-v2/pull/7028) → [PR 2: Enable static stability for STS, Container, SSO, and Login credential providers](https://github.com/aws/aws-sdk-java-v2/pull/7031) → PR3 (this)

**Depends on**:  https://github.com/aws/aws-sdk-java-v2/pull/7028 and https://github.com/aws/aws-sdk-java-v2/pull/7031

## Modifications

- **`InstanceProfileCredentialsProvider`**: Changed default staleTime from 1 second to 1 minute. Changed prefetchTime from `max(timeUntilExpiry/2, 5min)` to flat 5 minutes before expiry. Added `prefetchTime(Duration)` builder method. Added `staleTime <= prefetchTime` validation.

- **`ContainerCredentialsProvider`**: Changed prefetchTime from `min(1hr, 15min-before-expiry)` to flat 5 minutes before expiry. Added `staleTime(Duration)` and `prefetchTime(Duration)` builder methods. Added validation.

- **`ProcessCredentialsProvider`**: Added `staleTime(Duration)` and `prefetchTime(Duration)` builder methods. Changed default staleTime from 0 (at-expiration) to 1 minute. Changed default prefetchTime from 15 seconds to 5 minutes. Deprecated `credentialRefreshThreshold` (it now sets prefetchTime under the hood for backward compatibility). Added validation.

- **`WebIdentityTokenFileCredentialsProvider`**: Added `staleTime(Duration)` and `prefetchTime(Duration)` builder methods that pass through to the underlying STS provider.

- **`StsCredentialsProvider` / `SsoCredentialsProvider` / `LoginCredentialsProvider`**: Added `staleTime <= prefetchTime` validation at construction. Updated Javadoc for `staleTime`, `prefetchTime`, and `asyncCredentialUpdateEnabled` to use consistent terminology (mandatory refresh window / advisory refresh window).

- **`HttpCredentialsProvider`**: Updated `asyncCredentialUpdateEnabled` Javadoc for clarity.

- **Tests**: Updated IMDS timing tests for new defaults, added Process provider timing tests, updated WebIdentity factory test for new builder params.

## Testing
New and existing tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
