### PR TITLE
Fix Bedrock AgentCore memory ARN handling

### DIFF
--- a/services/bedrockagentcore/src/main/java/software/amazon/awssdk/services/bedrockagentcore/internal/BedrockAgentCoreArnInterceptor.java
+++ b/services/bedrockagentcore/src/main/java/software/amazon/awssdk/services/bedrockagentcore/internal/BedrockAgentCoreArnInterceptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.bedrockagentcore.internal;
+
+import java.lang.reflect.Method;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+
+/**
+ * Interceptor that intercepts BedrockAgentCore requests and extracts the short memory ID from
+ * a full ARN if passed in the `memoryId` parameter.
+ */
+@SdkInternalApi
+public final class BedrockAgentCoreArnInterceptor implements ExecutionInterceptor {
+
+    @Override
+    public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
+        SdkRequest request = context.request();
+        try {
+            Method getMemoryIdMethod = request.getClass().getMethod("memoryId");
+            String memoryId = (String) getMemoryIdMethod.invoke(request);
+            if (memoryId != null && memoryId.startsWith("arn:")) {
+                String shortMemoryId = extractMemoryId(memoryId);
+                if (!memoryId.equals(shortMemoryId)) {
+                    Method toBuilderMethod = request.getClass().getMethod("toBuilder");
+                    Object builder = toBuilderMethod.invoke(request);
+                    Method builderMemoryIdMethod = builder.getClass().getMethod("memoryId", String.class);
+                    builderMemoryIdMethod.invoke(builder, shortMemoryId);
+                    Method buildMethod = builder.getClass().getMethod("build");
+                    return (SdkRequest) buildMethod.invoke(builder);
+                }
+            }
+        } catch (NoSuchMethodException e) {
+            // Request doesn't have a memoryId field (expected for some requests)
+        } catch (Exception e) {
+            // Safe fall-through on unexpected reflection exceptions to avoid blocking request execution
+        }
+        return request;
+    }
+
+    private String extractMemoryId(String memoryId) {
+        if (memoryId == null) {
+            return null;
+        }
+        if (memoryId.startsWith("arn:")) {
+            // Format: arn:partition:service:region:account-id:resource
+            int colonCount = 0;
+            int index = -1;
+            while (colonCount < 5) {
+                index = memoryId.indexOf(':', index + 1);
+                if (index == -1) {
+                    break;
+                }
+                colonCount++;
+            }
+            if (index != -1 && index < memoryId.length() - 1) {
+                String resourcePart = memoryId.substring(index + 1);
+                // resourcePart is e.g. "memory/my-memory-store-AbCdEf"
+                int slashIndex = resourcePart.indexOf('/');
+                if (slashIndex != -1 && slashIndex < resourcePart.length() - 1) {
+                    return resourcePart.substring(slashIndex + 1);
+                }
+                return resourcePart;
+            }
+        }
+        return memoryId;
+    }
+}

--- a/services/bedrockagentcore/src/main/resources/codegen-resources/customization.config
+++ b/services/bedrockagentcore/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,5 @@
+{
+    "interceptors": [
+        "software.amazon.awssdk.services.bedrockagentcore.internal.BedrockAgentCoreArnInterceptor"
+    ]
+}

--- a/services/bedrockagentcore/src/test/java/software/amazon/awssdk/services/bedrockagentcore/internal/BedrockAgentCoreArnInterceptorTest.java
+++ b/services/bedrockagentcore/src/test/java/software/amazon/awssdk/services/bedrockagentcore/internal/BedrockAgentCoreArnInterceptorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.bedrockagentcore.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.services.bedrockagentcore.model.CreateEventRequest;
+
+public class BedrockAgentCoreArnInterceptorTest {
+
+    private final BedrockAgentCoreArnInterceptor interceptor = new BedrockAgentCoreArnInterceptor();
+
+    @Test
+    public void modifyRequest_withFullArn_extractsShortMemoryId() {
+        CreateEventRequest request = CreateEventRequest.builder()
+                .memoryId("arn:aws:bedrock-agentcore:us-west-2:111122223333:memory/my-memory-store-AbCdEf")
+                .build();
+
+        Context.ModifyRequest context = () -> request;
+        SdkRequest modified = interceptor.modifyRequest(context, new ExecutionAttributes());
+
+        assertEquals(CreateEventRequest.class, modified.getClass());
+        CreateEventRequest modifiedRequest = (CreateEventRequest) modified;
+        assertEquals("my-memory-store-AbCdEf", modifiedRequest.memoryId());
+    }
+
+    @Test
+    public void modifyRequest_withShortMemoryId_leavesUnchanged() {
+        CreateEventRequest request = CreateEventRequest.builder()
+                .memoryId("my-memory-store-AbCdEf")
+                .build();
+
+        Context.ModifyRequest context = () -> request;
+        SdkRequest modified = interceptor.modifyRequest(context, new ExecutionAttributes());
+
+        assertSame(request, modified);
+    }
+
+    @Test
+    public void modifyRequest_withNullMemoryId_leavesUnchanged() {
+        CreateEventRequest request = CreateEventRequest.builder().build();
+
+        Context.ModifyRequest context = () -> request;
+        SdkRequest modified = interceptor.modifyRequest(context, new ExecutionAttributes());
+
+        assertSame(request, modified);
+    }
+
+    @Test
+    public void modifyRequest_withMalformedArn_leavesUnchanged() {
+        CreateEventRequest request = CreateEventRequest.builder()
+                .memoryId("arn:aws:bedrock-agentcore:us-west-2")
+                .build();
+
+        Context.ModifyRequest context = () -> request;
+        SdkRequest modified = interceptor.modifyRequest(context, new ExecutionAttributes());
+
+        assertSame(request, modified);
+    }
+}


### PR DESCRIPTION
Normalize Bedrock AgentCore memory ARNs passed as memoryId values to the short memory store ID before request marshalling.

This prevents CreateEvent, ListMemoryRecords, and RetrieveMemoryRecords from silently using the full ARN in memory paths, which can cause memory extraction and record retrieval to appear successful while returning no records.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixes #7036.

Bedrock AgentCore memory APIs may accept a full memory ARN as `memoryId`, but using that ARN directly in memory request paths can cause operations to appear successful while memory extraction or retrieval does not return expected records. This change normalizes full memory ARNs to the short memory store ID used by the service.

## Modifications
Added a Bedrock AgentCore execution interceptor that checks requests with a `memoryId` value and extracts the short memory store ID when a full memory ARN is provided.

Registered the interceptor through the service customization configuration.

Added unit tests covering full ARN normalization and unchanged handling for short, null, and malformed memory IDs.

## Testing
Attempted to run:

`mvn -q -DskipITs -Dtest=BedrockAgentCoreArnInterceptorTest test`

The test run could not complete because the local workspace could not resolve `software.amazon.awssdk:bom-internal:pom:2.46.16-SNAPSHOT`, which also left several parent-managed dependency versions unresolved.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
