### PR TITLE
test: prefab AttributeValue in DescribeTableEnhancedResponseTest

### DIFF
--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/DescribeTableEnhancedResponseTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/DescribeTableEnhancedResponseTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DescribeTableEnhancedResponseTest {
 
@@ -33,6 +34,9 @@ public class DescribeTableEnhancedResponseTest {
     public void equalsHashcode() {
         EqualsVerifier.forClass(DescribeTableEnhancedResponse.class)
                       .withNonnullFields("response")
+                      .withPrefabValues(AttributeValue.class,
+                                        AttributeValue.builder().s("one").build(),
+                                        AttributeValue.builder().s("two").build())
                       .verify();
     }
 }


### PR DESCRIPTION
## Motivation and Context

`DescribeTableEnhancedResponseTest.equalsHashcode` uses EqualsVerifier on the `DescribeTableEnhancedResponse` wrapper, which delegates `equals`/`hashCode` to the low-level `DescribeTableResponse`. EqualsVerifier walks the full reachable type graph from `DescribeTableResponse` to synthesise representative values for every nested type.

If the low-level model gains a shape reachable from `DescribeTableResponse` that transitively exposes a `Map<String, AttributeValue>` or `List<AttributeValue>`, the graph becomes recursive: `AttributeValue` itself contains a `Map<String, AttributeValue>` (its `M` member) and a `List<AttributeValue>` (its `L` member). EqualsVerifier 3.15.1 detects the cycle and aborts the test with:

```
Recursive datastructure.
Add prefab values for one of the following types: ... AttributeValue.
```

Other tests in the same module already handle this exact issue by supplying `AttributeValue` prefab values to EqualsVerifier (see `EqualsAndHashCodeTest`, `BatchWriteResultTest`, `TransactWriteItemsEnhancedResponseTest`). This change applies the same idiom to `DescribeTableEnhancedResponseTest` so the test remains correct as the low-level model evolves.

## Modifications
Updated test to add prefab values

## Testing

Updated tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

(Neither: this is a test-only robustness change with no customer-visible effect.)

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds (only the affected `dynamodb-enhanced` module was built; full-repo `mvn install` was not run)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes (the change IS to a test; no new behaviour to cover)
- [x] All new and existing tests passed
- [ ] I have added a changelog entry (test-only change with no customer-facing impact; per the contribution guidelines, no changelog is required)
- [ ] My change is to implement 1.11 parity feature

## License

- [x] I confirm that this pull request can be released under the Apache 2 license