### PR TITLE
Deprecate IS_DISCOVERED_ENDPOINT, add SKIP_ENDPOINT_RESOLUTION attribute

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -172,8 +172,8 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         String providerVar = "provider";
 
         b.addStatement("$T result = context.request()", SdkRequest.class);
-        // We skip resolution if the source of the endpoint is the endpoint discovery call
-        b.beginControlFlow("if ($1T.endpointIsDiscovered(executionAttributes))",
+        // We skip resolution if endpoint resolution should be skipped (e.g., endpoint discovery or pre-signed URLs)
+        b.beginControlFlow("if ($1T.skipEndpointResolution(executionAttributes))",
                            endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"));
         b.addStatement("return result");
         b.endControlFlow();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -172,7 +172,6 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         String providerVar = "provider";
 
         b.addStatement("$T result = context.request()", SdkRequest.class);
-        // We skip resolution if endpoint resolution should be skipped (e.g., endpoint discovery or pre-signed URLs)
         b.beginControlFlow("if ($1T.skipEndpointResolution(executionAttributes))",
                            endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"));
         b.addStatement("return result");

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RequestEndpointInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RequestEndpointInterceptorSpec.java
@@ -64,8 +64,8 @@ public class RequestEndpointInterceptorSpec implements ClassSpec {
                                          .addParameter(ExecutionAttributes.class, "executionAttributes");
 
 
-        // We skip setting the endpoint here if the source of the endpoint is the endpoint discovery call
-        b.beginControlFlow("if ($1T.endpointIsDiscovered(executionAttributes))",
+        // We skip setting the endpoint here if endpoint resolution should be skipped
+        b.beginControlFlow("if ($1T.skipEndpointResolution(executionAttributes))",
                            endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"))
          .addStatement("return context.httpRequest()")
          .endControlFlow().build();

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
@@ -66,9 +66,22 @@ public final class AwsEndpointProviderUtils {
     /**
      * True if the the {@link SdkInternalExecutionAttribute#IS_DISCOVERED_ENDPOINT} attribute is present and its value
      * is {@code true}, {@code false} otherwise.
+     *
+     * @deprecated Use {@link #skipEndpointResolution(ExecutionAttributes)} instead.
      */
+    @Deprecated
     public static boolean endpointIsDiscovered(ExecutionAttributes attrs) {
         return attrs.getOptionalAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT).orElse(false);
+    }
+
+    /**
+     * True if endpoint resolution should be skipped for the current request. This returns {@code true} if either
+     * {@link SdkInternalExecutionAttribute#SKIP_ENDPOINT_RESOLUTION} or
+     * {@link SdkInternalExecutionAttribute#IS_DISCOVERED_ENDPOINT} is set to {@code true}.
+     */
+    public static boolean skipEndpointResolution(ExecutionAttributes attrs) {
+        return attrs.getOptionalAttribute(SdkInternalExecutionAttribute.SKIP_ENDPOINT_RESOLUTION).orElse(false)
+               || attrs.getOptionalAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT).orElse(false);
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-preSra.java
@@ -62,7 +62,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         SdkRequest result = context.request();
-        if (AwsEndpointProviderUtils.endpointIsDiscovered(executionAttributes)) {
+        if (AwsEndpointProviderUtils.skipEndpointResolution(executionAttributes)) {
             return result;
         }
         QueryEndpointProvider provider = (QueryEndpointProvider) executionAttributes

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-endpointsbasedauth.java
@@ -50,7 +50,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         SdkRequest result = context.request();
-        if (AwsEndpointProviderUtils.endpointIsDiscovered(executionAttributes)) {
+        if (AwsEndpointProviderUtils.skipEndpointResolution(executionAttributes)) {
             return result;
         }
         QueryEndpointProvider provider = (QueryEndpointProvider) executionAttributes

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-multiauthsigv4a.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-multiauthsigv4a.java
@@ -39,7 +39,7 @@ public final class DatabaseResolveEndpointInterceptor implements ExecutionInterc
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         SdkRequest result = context.request();
-        if (AwsEndpointProviderUtils.endpointIsDiscovered(executionAttributes)) {
+        if (AwsEndpointProviderUtils.skipEndpointResolution(executionAttributes)) {
             return result;
         }
         DatabaseEndpointProvider provider = (DatabaseEndpointProvider) executionAttributes

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-stringarray.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor-with-stringarray.java
@@ -41,7 +41,7 @@ public final class SampleSvcResolveEndpointInterceptor implements ExecutionInter
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         SdkRequest result = context.request();
-        if (AwsEndpointProviderUtils.endpointIsDiscovered(executionAttributes)) {
+        if (AwsEndpointProviderUtils.skipEndpointResolution(executionAttributes)) {
             return result;
         }
         SampleSvcEndpointProvider provider = (SampleSvcEndpointProvider) executionAttributes

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -50,7 +50,7 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         SdkRequest result = context.request();
-        if (AwsEndpointProviderUtils.endpointIsDiscovered(executionAttributes)) {
+        if (AwsEndpointProviderUtils.skipEndpointResolution(executionAttributes)) {
             return result;
         }
         QueryEndpointProvider provider = (QueryEndpointProvider) executionAttributes

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/request-set-endpoint-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/request-set-endpoint-interceptor.java
@@ -14,7 +14,7 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 public final class QueryRequestSetEndpointInterceptor implements ExecutionInterceptor {
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
-        if (AwsEndpointProviderUtils.endpointIsDiscovered(executionAttributes)) {
+        if (AwsEndpointProviderUtils.skipEndpointResolution(executionAttributes)) {
             return context.httpRequest();
         }
         Endpoint endpoint = executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -125,9 +125,21 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
 
     /**
      * Whether the endpoint on the request is the result of Endpoint Discovery.
+     *
+     * @deprecated This attribute is specific to the endpoint discovery feature and should not be used to skip endpoint
+     * resolution; use {@link #SKIP_ENDPOINT_RESOLUTION} instead.
      */
+    @Deprecated
     public static final ExecutionAttribute<Boolean> IS_DISCOVERED_ENDPOINT =
         new ExecutionAttribute<>("IsDiscoveredEndpoint");
+
+    /**
+     * Whether endpoint resolution should be skipped for the current request. When set to {@code true}, the SDK will not
+     * invoke the endpoint provider and will use the endpoint already set on the request. This is used for pre-signed URL
+     * operations and other scenarios where the endpoint is already fully resolved.
+     */
+    public static final ExecutionAttribute<Boolean> SKIP_ENDPOINT_RESOLUTION =
+        new ExecutionAttribute<>("SkipEndpointResolution");
 
     /**
      * The nano time that the current API call attempt began.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -97,6 +97,8 @@ public abstract class BaseClientHandler {
         if (executionParams.discoveredEndpoint() != null) {
             URI discoveredEndpoint = executionParams.discoveredEndpoint();
             executionParams.putExecutionAttribute(SdkInternalExecutionAttribute.SKIP_ENDPOINT_RESOLUTION, true);
+            // Keep deprecated attribute for cross-module compatibility with older generated service clients
+            executionParams.putExecutionAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT, true);
             return originalRequest.toBuilder().host(discoveredEndpoint.getHost()).port(discoveredEndpoint.getPort()).build();
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -96,7 +96,7 @@ public abstract class BaseClientHandler {
                                                                  ClientExecutionParams executionParams) {
         if (executionParams.discoveredEndpoint() != null) {
             URI discoveredEndpoint = executionParams.discoveredEndpoint();
-            executionParams.putExecutionAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT, true);
+            executionParams.putExecutionAttribute(SdkInternalExecutionAttribute.SKIP_ENDPOINT_RESOLUTION, true);
             return originalRequest.toBuilder().host(discoveredEndpoint.getHost()).port(discoveredEndpoint.getPort()).build();
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
@@ -135,8 +135,7 @@ public final class DefaultAsyncPresignedUrlExtension implements AsyncPresignedUr
                             .withRequestConfiguration(clientConfiguration)
                             .withInput(internalRequest)
                             .withMetricCollector(apiCallMetricCollector)
-                            // TODO: Deprecate IS_DISCOVERED_ENDPOINT, use new SKIP_ENDPOINT_RESOLUTION for better semantics
-                            .putExecutionAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT, true)
+                            .putExecutionAttribute(SdkInternalExecutionAttribute.SKIP_ENDPOINT_RESOLUTION, true)
                             .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM,
                                           checksumConfigForUrl(presignedUrlDownloadRequest.presignedUrl()))
                             .withMarshaller(new PresignedUrlDownloadRequestMarshaller(protocolFactory)),

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AwsEndpointProviderUtilsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AwsEndpointProviderUtilsTest.java
@@ -74,6 +74,12 @@ public class AwsEndpointProviderUtilsTest {
     }
 
     @Test
+    public void skipEndpointResolution_attrsAbsent_returnsFalse() {
+        ExecutionAttributes attrs = new ExecutionAttributes();
+        assertThat(AwsEndpointProviderUtils.skipEndpointResolution(attrs)).isFalse();
+    }
+
+    @Test
     public void disableHostPrefixInjection_attrIsFalse_returnsFalse() {
         ExecutionAttributes attrs = new ExecutionAttributes();
         attrs.putAttribute(SdkInternalExecutionAttribute.DISABLE_HOST_PREFIX_INJECTION, false);

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AwsEndpointProviderUtilsTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/AwsEndpointProviderUtilsTest.java
@@ -67,6 +67,13 @@ public class AwsEndpointProviderUtilsTest {
     }
 
     @Test
+    public void skipEndpointResolution_skipAttrIsTrue_returnsTrue() {
+        ExecutionAttributes attrs = new ExecutionAttributes();
+        attrs.putAttribute(SdkInternalExecutionAttribute.SKIP_ENDPOINT_RESOLUTION, true);
+        assertThat(AwsEndpointProviderUtils.skipEndpointResolution(attrs)).isTrue();
+    }
+
+    @Test
     public void disableHostPrefixInjection_attrIsFalse_returnsFalse() {
         ExecutionAttributes attrs = new ExecutionAttributes();
         attrs.putAttribute(SdkInternalExecutionAttribute.DISABLE_HOST_PREFIX_INJECTION, false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The pre-signed URL GET feature needs to skip endpoint resolution for requests where the URL is already fully resolved. The existing SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT was being reused for this purpose, but its semantics are tied to the endpoint discovery feature (cellular routing for services like DynamoDB). Using it for pre-signed URLs is semantically incorrect and confusing.

## Modifications
Added SKIP_ENDPOINT_RESOLUTION execution attribute with proper semantics for skipping endpoint resolution, deprecated IS_DISCOVERED_ENDPOINT, and migrated all internal usages to use the new attribute while maintaining backward compatibility via OR fallback.
- SdkInternalExecutionAttribute — Deprecated IS_DISCOVERED_ENDPOINT, added SKIP_ENDPOINT_RESOLUTION with clear semantics: "do not invoke the endpoint provider, use the endpoint already set on the request."
- BaseClientHandler — Migrated endpoint discovery path to set SKIP_ENDPOINT_RESOLUTION instead of IS_DISCOVERED_ENDPOINT.
- AwsEndpointProviderUtils.java.resource (codegen template) — Deprecated endpointIsDiscovered(), added skipEndpointResolution() which checks both SKIP_ENDPOINT_RESOLUTION and IS_DISCOVERED_ENDPOINT (OR logic for backward compatibility with any external consumer still setting the old attribute).
- EndpointResolverInterceptorSpec / RequestEndpointInterceptorSpec — Updated codegen to generate calls to skipEndpointResolution() instead of endpointIsDiscovered().
- DefaultAsyncPresignedUrlExtension — Replaced IS_DISCOVERED_ENDPOINT with SKIP_ENDPOINT_RESOLUTION, removed TODO.
- 6 codegen golden test files — Updated to match new generated interceptor code.
- AwsEndpointProviderUtilsTest — Added test for skipEndpointResolution().

## Testing
- sdk-core — all tests pass
- codegen — all tests pass (including golden file comparisons for interceptor specs)
- codegen-generated-classes-test — all tests pass including new skipEndpointResolution test
- s3 — all tests pass

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
