### PR TITLE
Replace typed range/ifMatch with generic header map on PresignedUrlDownloadRequest

### DIFF
--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerPresignedUrlDownloadIntegrationTest.java
@@ -128,7 +128,7 @@ public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3Inte
         PresignedUrlDownloadRequest.Builder requestBuilder = PresignedUrlDownloadRequest.builder()
                                                                                         .presignedUrl(createPresignedRequest(key).url());
         if (range != null) {
-            requestBuilder.range(range);
+            requestBuilder.putHeader("Range", range);
         }
 
         PresignedFileDownload download = tm.downloadFileWithPresignedUrl(
@@ -159,7 +159,7 @@ public class S3TransferManagerPresignedUrlDownloadIntegrationTest extends S3Inte
         PresignedUrlDownloadRequest.Builder requestBuilder = PresignedUrlDownloadRequest.builder()
                                                                                         .presignedUrl(createPresignedRequest(key).url());
         if (range != null) {
-            requestBuilder.range(range);
+            requestBuilder.putHeader("Range", range);
         }
 
         Download<ResponseBytes<GetObjectResponse>> download = tm.downloadWithPresignedUrl(

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/GenericS3TransferManager.java
@@ -615,7 +615,7 @@ class GenericS3TransferManager implements S3TransferManager {
         progressUpdater.transferInitiated();
 
         responseTransformer = isS3ClientMultipartEnabled()
-                              && presignedDownloadFileRequest.presignedUrlDownloadRequest().range() == null
+                              && !presignedDownloadFileRequest.presignedUrlDownloadRequest().headers().containsKey("Range")
                               ? progressUpdater.wrapForNonSerialFileDownload(
                                   responseTransformer, GetObjectRequest.builder().build())
                               : progressUpdater.wrapResponseTransformer(responseTransformer);
@@ -651,7 +651,7 @@ class GenericS3TransferManager implements S3TransferManager {
         progressUpdater.transferInitiated();
 
         responseTransformer = isS3ClientMultipartEnabled()
-                              && presignedDownloadRequest.presignedUrlDownloadRequest().range() == null
+                              && !presignedDownloadRequest.presignedUrlDownloadRequest().headers().containsKey("Range")
                               ? progressUpdater.wrapForNonSerialFileDownload(
                                   responseTransformer, GetObjectRequest.builder().build())
                               : progressUpdater.wrapResponseTransformer(responseTransformer);

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlListenerWiremockTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPresignedUrlListenerWiremockTest.java
@@ -119,7 +119,7 @@ public class S3TransferManagerPresignedUrlListenerWiremockTest {
         PresignedUrlDownloadRequest.Builder requestBuilder = PresignedUrlDownloadRequest.builder()
                                                                                        .presignedUrl(presignedUrl);
         if (range != null) {
-            requestBuilder.range(range);
+            requestBuilder.putHeader("Range", range);
         }
 
         if ("toFile".equals(type)) {

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTestSuite.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTestSuite.java
@@ -373,7 +373,7 @@ public abstract class AsyncPresignedUrlExtensionTestSuite extends S3IntegrationT
     private PresignedUrlDownloadRequest createRequestForKey(String key, String range) {
         return PresignedUrlDownloadRequest.builder()
             .presignedUrl(createPresignedUrl(key))
-            .range(range)
+            .putHeader("Range", range)
             .build();
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/ParallelPresignedUrlMultipartDownloaderSubscriber.java
@@ -130,7 +130,8 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
 
     private void sendFirstRequest(AsyncResponseTransformer<GetObjectResponse, GetObjectResponse> transformer) {
         PresignedUrlDownloadRequest partRequest = createRangedGetRequest(0L);
-        log.debug(() -> "Sending first range request with range=" + partRequest.range());
+        log.debug(() -> "Sending first range request with range="
+                        + partRequest.headers().get(PresignedUrlDownloadHelper.RANGE_HEADER));
 
         if (!inFlightPermits.tryAcquire()) {
             throw new IllegalStateException("Failed to acquire permit for first request");
@@ -231,7 +232,8 @@ public class ParallelPresignedUrlMultipartDownloaderSubscriber
         }
 
         PresignedUrlDownloadRequest partRequest = createRangedGetRequest(partIndex);
-        log.debug(() -> "Sending range request for part " + partIndex + " with range=" + partRequest.range());
+        log.debug(() -> "Sending range request for part " + partIndex + " with range="
+                        + partRequest.headers().get(PresignedUrlDownloadHelper.RANGE_HEADER));
 
         CompletableFuture<GetObjectResponse> response =
             s3AsyncClient.presignedUrlExtension().getObject(partRequest, transformer);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelper.java
@@ -32,6 +32,18 @@ import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public class PresignedUrlDownloadHelper {
+    /**
+     * The {@code Range} HTTP header name. Used internally to detect a caller-supplied range (which forces a
+     * single-part download) and to build the SDK's own per-part range requests. Package-private so the
+     * multipart subscribers in this package can share it without exposing it on the public request type.
+     */
+    static final String RANGE_HEADER = "Range";
+
+    /**
+     * The {@code If-Match} HTTP header name, used internally for per-part consistency on multipart downloads.
+     */
+    static final String IF_MATCH_HEADER = "If-Match";
+
     private static final Logger log = Logger.loggerFor(PresignedUrlDownloadHelper.class);
     private static final int DEFAULT_MAX_IN_FLIGHT_PARTS = 10;
 
@@ -57,9 +69,9 @@ public class PresignedUrlDownloadHelper {
         Validate.paramNotNull(presignedRequest, "presignedRequest");
         Validate.paramNotNull(asyncResponseTransformer, "asyncResponseTransformer");
 
-        if (presignedRequest.range() != null) {
-            log.debug(() -> "Using single part download because presigned URL request range is included in the request. range = "
-                            + presignedRequest.range());
+        if (presignedRequest.headers().containsKey(RANGE_HEADER)) {
+            log.debug(() -> "Using single part download because presigned URL request includes a Range header. range = "
+                            + presignedRequest.headers().get(RANGE_HEADER));
             return asyncPresignedUrlExtension.getObject(presignedRequest, asyncResponseTransformer);
         }
 
@@ -222,10 +234,11 @@ public class PresignedUrlDownloadHelper {
         long endByte = totalContentLength != null
                        ? Math.min(startByte + partSizeInBytes - 1, totalContentLength - 1)
                        : startByte + partSizeInBytes - 1;
-        PresignedUrlDownloadRequest.Builder builder = originalRequest.toBuilder()
-                                                                     .range("bytes=" + startByte + "-" + endByte);
+        PresignedUrlDownloadRequest.Builder builder =
+            originalRequest.toBuilder()
+                           .putHeader(RANGE_HEADER, "bytes=" + startByte + "-" + endByte);
         if (partIndex > 0 && eTag != null) {
-            builder.ifMatch(eTag);
+            builder.putHeader(IF_MATCH_HEADER, eTag);
         }
         return builder.build();
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriber.java
@@ -127,7 +127,8 @@ public class PresignedUrlMultipartDownloaderSubscriber
                                   AsyncResponseTransformer<GetObjectResponse,
                                       GetObjectResponse> asyncResponseTransformer) {
         PresignedUrlDownloadRequest partRequest = createRangedGetRequest(partIndex);
-        log.debug(() -> "Sending range request for part " + partIndex + " with range=" + partRequest.range());
+        log.debug(() -> "Sending range request for part " + partIndex + " with range="
+                        + partRequest.headers().get(PresignedUrlDownloadHelper.RANGE_HEADER));
 
         requestsSent.incrementAndGet();
         CompletableFuture<GetObjectResponse> responseFuture = s3AsyncClient.presignedUrlExtension()

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtension.java
@@ -104,8 +104,7 @@ public final class DefaultAsyncPresignedUrlExtension implements AsyncPresignedUr
 
         PresignedUrlDownloadRequestWrapper internalRequest = PresignedUrlDownloadRequestWrapper.builder()
                 .url(presignedUrlDownloadRequest.presignedUrl())
-                .range(presignedUrlDownloadRequest.range())
-                .ifMatch(presignedUrlDownloadRequest.ifMatch())
+                .headers(presignedUrlDownloadRequest.headers())
                 .build();
 
         MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ?

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshaller.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.services.s3.internal.presignedurl;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
@@ -68,6 +70,7 @@ public class PresignedUrlDownloadRequestMarshaller implements Marshaller<Presign
                 .toBuilder()
                 .uri(presignedUri);
 
+            addCustomHeaders(requestBuilder, presignedUrlDownloadRequestWrapper);
             addChecksumModeHeaderIfSignedInUrl(requestBuilder, presignedUri);
 
             return requestBuilder.build();
@@ -75,6 +78,20 @@ public class PresignedUrlDownloadRequestMarshaller implements Marshaller<Presign
             throw SdkClientException.builder()
                     .message("Unable to marshall pre-signed URL Request: " + e.getMessage())
                     .cause(e).build();
+        }
+    }
+
+    /**
+     * Adds the request's headers to the HTTP request builder. These are the signed header values that must be
+     * replayed at download time.
+     */
+    private void addCustomHeaders(SdkHttpFullRequest.Builder requestBuilder,
+                                  PresignedUrlDownloadRequestWrapper wrapper) {
+        if (wrapper.headers() == null || wrapper.headers().isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, List<String>> entry : wrapper.headers().entrySet()) {
+            requestBuilder.putHeader(entry.getKey(), entry.getValue());
         }
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapper.java
@@ -16,71 +16,51 @@
 package software.amazon.awssdk.services.s3.internal.presignedurl.model;
 
 import java.net.URL;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.TreeMap;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
-import software.amazon.awssdk.core.protocol.MarshallLocation;
-import software.amazon.awssdk.core.protocol.MarshallingType;
-import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.services.s3.model.S3Request;
 
 /**
  * Internal request object for presigned URL GetObject operations.
  * <p>
- * This class is used internally by the AWS SDK to process presigned URL requests for S3 GetObject operations. It contains minimal
- * SdkField definitions needed for custom marshalling and is not intended for direct use by SDK users.
+ * This class is used internally by the AWS SDK to process presigned URL requests for S3 GetObject operations. It carries the
+ * presigned URL and the headers that must be replayed at download time (the values that were signed when the URL was
+ * generated). It is not intended for direct use by SDK users.
  * </p>
  * <b>Note:</b> This is an internal implementation class and should not be used
  * directly. Use {@code PresignedUrlDownloadRequest} for public API interactions.
  */
 @SdkInternalApi
 public final class PresignedUrlDownloadRequestWrapper extends S3Request {
-    private static final SdkField<String> RANGE_FIELD = SdkField
-        .<String>builder(MarshallingType.STRING)
-        .memberName("Range")
-        .getter(getter(PresignedUrlDownloadRequestWrapper::range))
-        .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("Range")
-                             .unmarshallLocationName("Range").build()).build();
 
-    private static final SdkField<String> IF_MATCH_FIELD = SdkField
-        .<String>builder(MarshallingType.STRING)
-        .memberName("IfMatch")
-        .getter(getter(PresignedUrlDownloadRequestWrapper::ifMatch))
-        .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("If-Match")
-                             .unmarshallLocationName("If-Match").build()).build();
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.emptyList();
 
-    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(
-        Arrays.asList(RANGE_FIELD, IF_MATCH_FIELD));
-
-    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = memberNameToFieldInitializer();
+    private static final Map<String, SdkField<?>> SDK_NAME_TO_FIELD = Collections.emptyMap();
 
     private final URL url;
-    private final String range;
-    private final String ifMatch;
+    private final Map<String, List<String>> headers;
 
     private PresignedUrlDownloadRequestWrapper(Builder builder) {
         super(builder);
         this.url = builder.url;
-        this.range = builder.range;
-        this.ifMatch = builder.ifMatch;
+        this.headers = Collections.unmodifiableMap(builder.headers);
     }
 
     public URL url() {
         return url;
     }
 
-    public String range() {
-        return range;
-    }
-
-    public String ifMatch() {
-        return ifMatch;
+    /**
+     * Returns the headers to be sent with the download request, using case-insensitive header-name comparison.
+     */
+    public Map<String, List<String>> headers() {
+        return headers;
     }
 
     @Override
@@ -91,17 +71,6 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
     @Override
     public Map<String, SdkField<?>> sdkFieldNameToField() {
         return SDK_NAME_TO_FIELD;
-    }
-
-    private static <T> Function<Object, T> getter(Function<PresignedUrlDownloadRequestWrapper, T> g) {
-        return obj -> g.apply((PresignedUrlDownloadRequestWrapper) obj);
-    }
-
-    private static Map<String, SdkField<?>> memberNameToFieldInitializer() {
-        Map<String, SdkField<?>> map = new HashMap<>();
-        map.put("Range", RANGE_FIELD);
-        map.put("IfMatch", IF_MATCH_FIELD);
-        return Collections.unmodifiableMap(map);
     }
 
     @Override
@@ -125,22 +94,20 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
             return false;
         }
         PresignedUrlDownloadRequestWrapper that = (PresignedUrlDownloadRequestWrapper) obj;
-        return Objects.equals(url, that.url) && Objects.equals(range, that.range) && Objects.equals(ifMatch, that.ifMatch);
+        return Objects.equals(url, that.url) && Objects.equals(headers, that.headers);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hashCode(super.hashCode());
         result = 31 * result + Objects.hashCode(url);
-        result = 31 * result + Objects.hashCode(range);
-        result = 31 * result + Objects.hashCode(ifMatch);
+        result = 31 * result + Objects.hashCode(headers);
         return result;
     }
 
     public static final class Builder extends S3Request.BuilderImpl {
         private URL url;
-        private String range;
-        private String ifMatch;
+        private Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         public Builder() {
         }
@@ -148,8 +115,9 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
         Builder(PresignedUrlDownloadRequestWrapper request) {
             super(request);
             this.url = request.url();
-            this.range = request.range();
-            this.ifMatch = request.ifMatch();
+            if (request.headers() != null) {
+                headers(request.headers());
+            }
         }
 
         public Builder url(URL url) {
@@ -157,13 +125,14 @@ public final class PresignedUrlDownloadRequestWrapper extends S3Request {
             return this;
         }
 
-        public Builder range(String range) {
-            this.range = range;
-            return this;
-        }
-
-        public Builder ifMatch(String ifMatch) {
-            this.ifMatch = ifMatch;
+        public Builder headers(Map<String, List<String>> headers) {
+            Map<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            if (headers != null) {
+                for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                    copy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+                }
+            }
+            this.headers = copy;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequest.java
@@ -16,8 +16,14 @@
 package software.amazon.awssdk.services.s3.presignedurl.model;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -25,24 +31,40 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * Request object for performing download operations using a presigned URL.
+ *
+ * <p>If any fields from the {@code GetObjectRequest} that are marshalled as HTTP headers were signed when
+ * generating the presigned URL using {@link software.amazon.awssdk.services.s3.presigner.S3Presigner#presignGetObject},
+ * their values are not stored in the URL — only their names appear in {@code X-Amz-SignedHeaders}. If any
+ * signed headers are missing from the download request, S3 will return a signature mismatch error.
+ *
+ * <p>Use {@link Builder#putHeader(String, String)} (or {@link Builder#headers(Map)}) to supply the signed
+ * header values at download time, for example:</p>
+ * <pre>{@code
+ * PresignedUrlDownloadRequest.builder()
+ *     .presignedUrl(url)
+ *     .putHeader("Range", "bytes=0-1023")
+ *     .putHeader("If-Match", eTag)
+ *     .build();
+ * }</pre>
+ *
  */
 @SdkPublicApi
 public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<PresignedUrlDownloadRequest.Builder,
     PresignedUrlDownloadRequest> {
+
     private final URL presignedUrl;
-    private final String range;
-    private final String ifMatch;
+    private final Map<String, List<String>> headers;
 
     private PresignedUrlDownloadRequest(BuilderImpl builder) {
         this.presignedUrl = builder.presignedUrl;
-        this.range = builder.range;
-        this.ifMatch = builder.ifMatch;
+        this.headers = CollectionUtils.deepUnmodifiableMap(builder.headers,
+                                                           () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
     }
 
     /**
      * <p>
-     * The presigned URL for the S3 object. This URL contains all necessary authentication information and can be used to download
-     * the object without additional credentials.
+     * The presigned URL for the S3 object. This URL contains all necessary authentication information and can be used
+     * to download the object without additional credentials.
      * </p>
      * <b>Note:</b> Presigned URLs have a limited lifetime and will expire after the
      * specified duration. Ensure the URL is used before expiration.
@@ -54,29 +76,16 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
     }
 
     /**
-     * <p>
-     * Specifies the byte range of an object. For more information about the HTTP Range header, see
-     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-range">
-     * https://www.rfc-editor.org/rfc/rfc9110.html#name-range</a>.
-     * </p>
-     * <b>Note:</b>  Amazon S3 doesn't support retrieving multiple ranges of data per <code>GET</code> request.
+     * Returns the headers to be sent with the download request. These are the headers that were signed when
+     * generating the presigned URL and must be included at download time for the signature to match (for example
+     * {@code Range}, {@code If-Match}, {@code If-None-Match}, or the SSE-C headers).
      *
-     * @return The HTTP Range header value, or null if not specified.
-     */
-    public String range() {
-        return range;
-    }
-
-    /**
-     * <p>
-     * Return the object only if its entity tag (ETag) is the same as the one specified in this header,
-     * otherwise return a 412 (precondition failed) error.
-     * </p>
+     * <p>The returned map uses case-insensitive header-name comparison.</p>
      *
-     * @return The If-Match header value, or null if not specified.
+     * @return An unmodifiable map of header name to values, or an empty map if none set.
      */
-    public String ifMatch() {
-        return ifMatch;
+    public Map<String, List<String>> headers() {
+        return headers;
     }
 
     @Override
@@ -96,8 +105,7 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
     public int hashCode() {
         int hashCode = 1;
         hashCode = 31 * hashCode + Objects.hashCode(presignedUrl());
-        hashCode = 31 * hashCode + Objects.hashCode(range());
-        hashCode = 31 * hashCode + Objects.hashCode(ifMatch());
+        hashCode = 31 * hashCode + Objects.hashCode(headers());
         return hashCode;
     }
 
@@ -111,54 +119,72 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
         }
         PresignedUrlDownloadRequest other = (PresignedUrlDownloadRequest) obj;
         return Objects.equals(presignedUrl(), other.presignedUrl()) &&
-               Objects.equals(range(), other.range()) &&
-               Objects.equals(ifMatch(), other.ifMatch());
+               Objects.equals(headers(), other.headers());
     }
 
     @Override
     public String toString() {
         return ToString.builder("PresignedUrlDownloadRequest")
                        .add("PresignedUrl", presignedUrl())
-                       .add("Range", range())
-                       .add("IfMatch", ifMatch())
+                       .add("Headers", headers())
                        .build();
     }
 
     public interface Builder extends CopyableBuilder<Builder, PresignedUrlDownloadRequest> {
         /**
          * Sets the presigned URL for the S3 object.
-         * @param presignedUrl
+         * @param presignedUrl the presigned URL
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder presignedUrl(URL presignedUrl);
 
         /**
-         * Specifies the byte range of an object.
-         * @param range The HTTP Range header value (e.g., "bytes=0-1023")
+         * Adds a single header to be sent with the download request. Use this to supply any header value that was
+         * signed when generating the presigned URL (for example {@code Range}, {@code If-Match},
+         * {@code If-None-Match}, or the SSE-C headers) and therefore must be present at download time.
+         *
+         * <p>Header names are treated case-insensitively. This overrides any value already configured for the same
+         * header name.</p>
+         *
+         * @param name The header name (e.g., {@code "Range"}, {@code "If-Match"})
+         * @param value The header value (e.g., {@code "bytes=0-1023"})
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder range(String range);
+        default Builder putHeader(String name, String value) {
+            return putHeader(name, Collections.singletonList(value));
+        }
 
         /**
-         * Return the object only if its entity tag (ETag) is the same as the one specified in this header.
-         * @param ifMatch The If-Match header value (ETag)
+         * Adds a single header with multiple values to be sent with the download request.
+         *
+         * <p>Header names are treated case-insensitively. This overrides any values already configured for the same
+         * header name.</p>
+         *
+         * @param name The header name
+         * @param values The header values
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder ifMatch(String ifMatch);
+        Builder putHeader(String name, List<String> values);
+
+        /**
+         * Sets all headers to be sent with the download request, replacing any previously configured headers.
+         *
+         * @param headers A map of header name to values
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder headers(Map<String, List<String>> headers);
     }
 
     static final class BuilderImpl implements Builder {
         private URL presignedUrl;
-        private String range;
-        private String ifMatch;
+        private Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         private BuilderImpl() {
         }
 
-        private BuilderImpl(PresignedUrlDownloadRequest presignedUrlDownloadRequest) {
-            presignedUrl(presignedUrlDownloadRequest.presignedUrl());
-            range(presignedUrlDownloadRequest.range());
-            ifMatch(presignedUrlDownloadRequest.ifMatch());
+        private BuilderImpl(PresignedUrlDownloadRequest request) {
+            presignedUrl(request.presignedUrl());
+            headers(request.headers());
         }
 
         @Override
@@ -168,14 +194,19 @@ public final class PresignedUrlDownloadRequest implements ToCopyableBuilder<Pres
         }
 
         @Override
-        public Builder range(String range) {
-            this.range = range;
+        public Builder putHeader(String name, List<String> values) {
+            Validate.paramNotNull(name, "name");
+            Validate.paramNotNull(values, "values");
+            this.headers.put(name, new ArrayList<>(values));
             return this;
         }
 
         @Override
-        public Builder ifMatch(String ifMatch) {
-            this.ifMatch = ifMatch;
+        public Builder headers(Map<String, List<String>> headers) {
+            Validate.paramNotNull(headers, "headers");
+            Map<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            copy.putAll(CollectionUtils.deepCopyMap(headers));
+            this.headers = copy;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -300,6 +300,11 @@ public interface S3Presigner extends SdkPresigner {
      * {@code x-amz-checksum-mode} header at download time, which the SDK sends automatically).
      * <p/>
      *
+     * <b>Signed headers note:</b> If the {@code GetObjectRequest} includes fields that are marshalled as
+     * HTTP headers (as defined by the service model), these will be signed into the URL's signature but their
+     * <b>values will not be stored in the URL</b> — only their names appear in {@code X-Amz-SignedHeaders}.
+     * If any signed headers are missing from the download request, S3 will return a signature mismatch error.
+     *
      * <b>Example Usage</b>
      * <p/>
      *

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/MultipartS3AsyncClientTest.java
@@ -78,7 +78,7 @@ class MultipartS3AsyncClientTest {
         AsyncResponseTransformer<GetObjectResponse, String> mockTransformer = mock(AsyncResponseTransformer.class);
         PresignedUrlDownloadRequest req = PresignedUrlDownloadRequest.builder()
                                                                      .presignedUrl(new URL("https://s3.amazonaws.com/bucket/key?signature=abc"))
-                                                                     .range("bytes=0-1023")
+                                                                     .putHeader("Range", "bytes=0-1023")
                                                                      .build();
         when(mockDelegate.presignedUrlExtension()).thenReturn(mockDelegateExtension);
         S3AsyncClient s3AsyncClient = MultipartS3AsyncClient.create(mockDelegate, MultipartConfiguration.builder().build(), true);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlDownloadHelperTest.java
@@ -133,8 +133,8 @@ class PresignedUrlDownloadHelperTest {
         PresignedUrlDownloadRequest result = PresignedUrlDownloadHelper.createRangedGetRequest(
             original, 0, 16L, 32L, "\"etag\"");
 
-        assertThat(result.range()).isEqualTo("bytes=0-15");
-        assertThat(result.ifMatch()).isNull();
+        assertThat(result.headers().get("Range")).isEqualTo(java.util.Collections.singletonList("bytes=0-15"));
+        assertThat(result.headers().containsKey("If-Match")).isFalse();
         assertThat(result.presignedUrl()).isEqualTo(url);
     }
 
@@ -148,8 +148,8 @@ class PresignedUrlDownloadHelperTest {
         PresignedUrlDownloadRequest result = PresignedUrlDownloadHelper.createRangedGetRequest(
             original, 1, 16L, 32L, "\"etag\"");
 
-        assertThat(result.range()).isEqualTo("bytes=16-31");
-        assertThat(result.ifMatch()).isEqualTo("\"etag\"");
+        assertThat(result.headers().get("Range")).isEqualTo(java.util.Collections.singletonList("bytes=16-31"));
+        assertThat(result.headers().get("If-Match")).isEqualTo(java.util.Collections.singletonList("\"etag\""));
     }
 
     @Test
@@ -163,7 +163,7 @@ class PresignedUrlDownloadHelperTest {
         PresignedUrlDownloadRequest result = PresignedUrlDownloadHelper.createRangedGetRequest(
             original, 1, 16L, 30L, "\"etag\"");
 
-        assertThat(result.range()).isEqualTo("bytes=16-29");
+        assertThat(result.headers().get("Range")).isEqualTo(java.util.Collections.singletonList("bytes=16-29"));
     }
 
     @Test
@@ -177,6 +177,6 @@ class PresignedUrlDownloadHelperTest {
         PresignedUrlDownloadRequest result = PresignedUrlDownloadHelper.createRangedGetRequest(
             original, 0, 16L, null, null);
 
-        assertThat(result.range()).isEqualTo("bytes=0-15");
+        assertThat(result.headers().get("Range")).isEqualTo(java.util.Collections.singletonList("bytes=0-15"));
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriberWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/PresignedUrlMultipartDownloaderSubscriberWiremockTest.java
@@ -149,7 +149,7 @@ class PresignedUrlMultipartDownloaderSubscriberWiremockTest {
         stubSuccessfulRangeResponse();
         PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                          .presignedUrl(presignedUrl)
-                                                                         .range("bytes=0-10")
+                                                                         .putHeader("Range", "bytes=0-10")
                                                                          .build();
         Object result = executeDownload(request, transformerType).join();
         byte[] expectedPartial = Arrays.copyOfRange(TEST_DATA, 0, 11);
@@ -333,7 +333,7 @@ class PresignedUrlMultipartDownloaderSubscriberWiremockTest {
 
         PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                          .presignedUrl(presignedUrl)
-                                                                         .range("bytes=0-1024")
+                                                                         .putHeader("Range", "bytes=0-1024")
                                                                          .build();
         assertThatThrownBy(() -> executeDownload(request, transformerType).join())
             .hasRootCauseInstanceOf(S3Exception.class);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/DefaultAsyncPresignedUrlExtensionTest.java
@@ -152,7 +152,7 @@ class DefaultAsyncPresignedUrlExtensionTest {
             Arguments.of(
                 "Request with range header",
                 (Consumer<PresignedUrlDownloadRequest.Builder>) builder ->
-                    builder.presignedUrl(createTestUrl()).range("bytes=0-1024"),
+                    builder.presignedUrl(createTestUrl()).putHeader("Range", "bytes=0-1024"),
                 "bytes=0-1024"
             )
         );

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlDownloadRequestMarshallerTest.java
@@ -119,7 +119,9 @@ class PresignedUrlDownloadRequestMarshallerTest {
 
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(testUrl)
-                                                                                         .range(rangeValue)
+                                                                                         .headers(java.util.Collections.singletonMap(
+                                                                                             "Range",
+                                                                                             java.util.Collections.singletonList(rangeValue)))
                                                                                          .build();
 
         SdkHttpFullRequest result = marshaller.marshall(request);
@@ -144,7 +146,6 @@ class PresignedUrlDownloadRequestMarshallerTest {
 
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(testUrl)
-                                                                                         .range(rangeValue)
                                                                                          .build();
         SdkHttpFullRequest result = marshaller.marshall(request);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlSignedHeadersWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/PresignedUrlSignedHeadersWiremockTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.presignedurl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presignedurl.model.PresignedUrlDownloadRequest;
+
+/**
+ * WireMock tests verifying that signed headers supplied via {@link PresignedUrlDownloadRequest#putHeader}
+ * are sent in the HTTP request and that missing signed headers result in a signature mismatch (403).
+ */
+@WireMockTest
+class PresignedUrlSignedHeadersWiremockTest {
+
+    private static final String BODY = "hello-presigned";
+    private static final String KEY_PATH = "/test-key";
+
+    private S3AsyncClient s3Client;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmInfo) {
+        s3Client = S3AsyncClient.builder()
+                                .endpointOverride(java.net.URI.create(wmInfo.getHttpBaseUrl()))
+                                .region(Region.US_EAST_1)
+                                .credentialsProvider(AnonymousCredentialsProvider.create())
+                                .forcePathStyle(true)
+                                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (s3Client != null) {
+            s3Client.close();
+        }
+    }
+
+    @Test
+    void getObject_withRangeHeader_shouldSendRangeInHttpRequest(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubFor(get(urlPathEqualTo(KEY_PATH))
+                    .withHeader("Range", equalTo("bytes=0-1023"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withHeader("Content-Range", "bytes 0-1023/2048")
+                                    .withBody(BODY)));
+
+        URL presignedUrl = presignedUrlWithSignedHeaders(wmInfo, "host%3Brange");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+            .getObject(PresignedUrlDownloadRequest.builder()
+                                                  .presignedUrl(presignedUrl)
+                                                  .putHeader("Range", "bytes=0-1023")
+                                                  .build(),
+                       AsyncResponseTransformer.toBytes())
+            .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+        verify(getRequestedFor(urlPathEqualTo(KEY_PATH))
+                   .withHeader("Range", equalTo("bytes=0-1023")));
+    }
+
+    @Test
+    void getObject_withIfMatchHeader_shouldSendIfMatchInHttpRequest(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubFor(get(urlPathEqualTo(KEY_PATH))
+                    .withHeader("If-Match", equalTo("\"abc123\""))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withBody(BODY)));
+
+        URL presignedUrl = presignedUrlWithSignedHeaders(wmInfo, "host%3Bif-match");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+            .getObject(PresignedUrlDownloadRequest.builder()
+                                                  .presignedUrl(presignedUrl)
+                                                  .putHeader("If-Match", "\"abc123\"")
+                                                  .build(),
+                       AsyncResponseTransformer.toBytes())
+            .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+        verify(getRequestedFor(urlPathEqualTo(KEY_PATH))
+                   .withHeader("If-Match", equalTo("\"abc123\"")));
+    }
+
+    @Test
+    void getObject_withMultipleSignedHeaders_shouldSendAllInHttpRequest(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubFor(get(urlPathEqualTo(KEY_PATH))
+                    .withHeader("Range", equalTo("bytes=0-99"))
+                    .withHeader("If-None-Match", equalTo("\"old-etag\""))
+                    .withHeader("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withHeader("Content-Range", "bytes 0-99/200")
+                                    .withBody(BODY)));
+
+        URL presignedUrl = presignedUrlWithSignedHeaders(wmInfo,
+            "host%3Bif-none-match%3Brange%3Bx-amz-server-side-encryption-customer-algorithm");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+            .getObject(PresignedUrlDownloadRequest.builder()
+                                                  .presignedUrl(presignedUrl)
+                                                  .putHeader("Range", "bytes=0-99")
+                                                  .putHeader("If-None-Match", "\"old-etag\"")
+                                                  .putHeader("x-amz-server-side-encryption-customer-algorithm", "AES256")
+                                                  .build(),
+                       AsyncResponseTransformer.toBytes())
+            .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+        verify(getRequestedFor(urlPathEqualTo(KEY_PATH))
+                   .withHeader("Range", equalTo("bytes=0-99"))
+                   .withHeader("If-None-Match", equalTo("\"old-etag\""))
+                   .withHeader("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256")));
+    }
+
+    @Test
+    void getObject_withMissingSignedHeader_serverReturns403(WireMockRuntimeInfo wmInfo) throws Exception {
+        // Simulate S3 returning 403 SignatureDoesNotMatch when a signed header is missing
+        stubFor(get(urlPathEqualTo(KEY_PATH))
+                    .withHeader("Range", WireMock.absent())
+                    .willReturn(aResponse()
+                                    .withStatus(403)
+                                    .withHeader("Content-Type", "application/xml")
+                                    .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                              + "<Error>"
+                                              + "<Code>SignatureDoesNotMatch</Code>"
+                                              + "<Message>The request signature we calculated does not match "
+                                              + "the signature you provided.</Message>"
+                                              + "</Error>")));
+
+        URL presignedUrl = presignedUrlWithSignedHeaders(wmInfo, "host%3Brange");
+
+        // Caller omits the Range header that was signed into the URL
+        CompletableFuture<ResponseBytes<GetObjectResponse>> future = s3Client.presignedUrlExtension()
+            .getObject(PresignedUrlDownloadRequest.builder()
+                                                  .presignedUrl(presignedUrl)
+                                                  .build(),
+                       AsyncResponseTransformer.toBytes());
+
+        assertThatThrownBy(future::join)
+            .hasCauseInstanceOf(S3Exception.class)
+            .hasMessageContaining("signature");
+    }
+
+    @Test
+    void getObject_withWrongHeaderValue_serverReturns403(WireMockRuntimeInfo wmInfo) throws Exception {
+        // S3 rejects if the header value doesn't match what was signed
+        stubFor(get(urlPathEqualTo(KEY_PATH))
+                    .withHeader("Range", equalTo("bytes=0-1023"))
+                    .willReturn(aResponse()
+                                    .withStatus(206)
+                                    .withHeader("Content-Length", "1024")
+                                    .withHeader("Content-Range", "bytes 0-1023/2048")
+                                    .withBody(BODY)));
+
+        // Any request with a different Range gets 403
+        stubFor(get(urlPathEqualTo(KEY_PATH))
+                    .withHeader("Range", WireMock.notMatching("bytes=0-1023"))
+                    .willReturn(aResponse()
+                                    .withStatus(403)
+                                    .withHeader("Content-Type", "application/xml")
+                                    .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                              + "<Error>"
+                                              + "<Code>SignatureDoesNotMatch</Code>"
+                                              + "<Message>The request signature we calculated does not match "
+                                              + "the signature you provided.</Message>"
+                                              + "</Error>")));
+
+        URL presignedUrl = presignedUrlWithSignedHeaders(wmInfo, "host%3Brange");
+
+        // Caller sends a different Range value than what was signed
+        CompletableFuture<ResponseBytes<GetObjectResponse>> future = s3Client.presignedUrlExtension()
+            .getObject(PresignedUrlDownloadRequest.builder()
+                                                  .presignedUrl(presignedUrl)
+                                                  .putHeader("Range", "bytes=500-999")
+                                                  .build(),
+                       AsyncResponseTransformer.toBytes());
+
+        assertThatThrownBy(future::join)
+            .hasCauseInstanceOf(S3Exception.class)
+            .hasMessageContaining("signature");
+    }
+
+    @Test
+    void getObject_withNoSignedHeaders_shouldSucceedWithoutExtraHeaders(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubFor(get(urlPathEqualTo(KEY_PATH))
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Length", String.valueOf(BODY.length()))
+                                    .withBody(BODY)));
+
+        // URL signed with only "host" — no additional headers needed
+        URL presignedUrl = presignedUrlWithSignedHeaders(wmInfo, "host");
+
+        ResponseBytes<GetObjectResponse> result = s3Client.presignedUrlExtension()
+            .getObject(PresignedUrlDownloadRequest.builder()
+                                                  .presignedUrl(presignedUrl)
+                                                  .build(),
+                       AsyncResponseTransformer.toBytes())
+            .join();
+
+        assertThat(result.asUtf8String()).isEqualTo(BODY);
+    }
+
+    private static URL presignedUrlWithSignedHeaders(WireMockRuntimeInfo wmInfo, String signedHeaders) throws Exception {
+        return new URL(wmInfo.getHttpBaseUrl() + KEY_PATH + "?"
+                       + "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+                       + "X-Amz-SignedHeaders=" + signedHeaders + "&"
+                       + "X-Amz-Signature=fakesig&"
+                       + "X-Amz-Expires=600");
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/presignedurl/model/PresignedUrlDownloadRequestWrapperTest.java
@@ -18,12 +18,13 @@ package software.amazon.awssdk.services.s3.internal.presignedurl.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkField;
-import software.amazon.awssdk.core.protocol.MarshallLocation;
 
 
 class PresignedUrlDownloadRequestWrapperTest {
@@ -36,83 +37,69 @@ class PresignedUrlDownloadRequestWrapperTest {
 
     @Test
     void basicProperties_shouldWork() throws Exception {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.put("Range", Collections.singletonList("bytes=0-100"));
+        headers.put("If-Match", Collections.singletonList("\"etag-123\""));
+
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
-                                                                                         .range("bytes=0-100")
-                                                                                         .ifMatch("\"etag-123\"")
+                                                                                         .headers(headers)
                                                                                          .build();
 
         assertThat(request.url()).isEqualTo(new URL("https://example.com"));
-        assertThat(request.range()).isEqualTo("bytes=0-100");
-        assertThat(request.ifMatch()).isEqualTo("\"etag-123\"");
+        assertThat(request.headers().get("Range")).isEqualTo(Collections.singletonList("bytes=0-100"));
+        assertThat(request.headers().get("If-Match")).isEqualTo(Collections.singletonList("\"etag-123\""));
     }
 
     @Test
-    void sdkFields_shouldReturnExpectedFields() throws Exception {
+    void sdkFields_shouldReturnEmptyList() throws Exception {
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
-                                                                                         .range("bytes=0-100")
+                                                                                         .headers(Collections.emptyMap())
                                                                                          .build();
 
         List<SdkField<?>> fields = request.sdkFields();
 
-        assertThat(fields).hasSize(2);
-        assertThat(fields).extracting(SdkField::memberName)
-                          .containsExactlyInAnyOrder("Range", "IfMatch");
-        assertThat(fields).allMatch(field -> field.location() == MarshallLocation.HEADER);
-        SdkField<?> rangeField = fields.stream()
-                                       .filter(f -> "Range".equals(f.memberName()))
-                                       .findFirst()
-                                       .orElseThrow(() -> new AssertionError("Range field not found"));
-        Object rangeValue = rangeField.getValueOrDefault(request);
-        assertThat(rangeValue).isNotNull();
-        assertThat(rangeValue).isEqualTo("bytes=0-100");
+        assertThat(fields).isEmpty();
     }
 
     @Test
-    void sdkFieldNameToField_shouldReturnExpectedMapping() throws Exception {
+    void sdkFieldNameToField_shouldReturnEmptyMapping() throws Exception {
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
                                                                                          .build();
 
         Map<String, SdkField<?>> fieldMap = request.sdkFieldNameToField();
 
-        assertThat(fieldMap)
-            .hasSize(2)
-            .containsKeys("Range", "IfMatch");
-        assertThat(fieldMap.get("Range").memberName()).isEqualTo("Range");
-        assertThat(fieldMap.get("IfMatch").memberName()).isEqualTo("IfMatch");
+        assertThat(fieldMap).isEmpty();
     }
 
     @Test
-    void rangeField_shouldMarshalCorrectly() throws Exception {
+    void headers_shouldBeCaseInsensitive() throws Exception {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.put("Range", Collections.singletonList("bytes=0-1023"));
+
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
-                                                                                         .range("bytes=0-1023")
+                                                                                         .headers(headers)
                                                                                          .build();
 
-        SdkField<?> rangeField = request.sdkFields().stream()
-                                        .filter(f -> "Range".equals(f.memberName()))
-                                        .findFirst()
-                                        .orElseThrow(() -> new AssertionError("Range field not found"));
-        Object extractedValue = rangeField.getValueOrDefault(request);
-
-        assertThat(extractedValue).isEqualTo("bytes=0-1023");
+        assertThat(request.headers().get("range")).isEqualTo(Collections.singletonList("bytes=0-1023"));
+        assertThat(request.headers().get("RANGE")).isEqualTo(Collections.singletonList("bytes=0-1023"));
     }
 
     @Test
-    void ifMatchField_shouldMarshalCorrectly() throws Exception {
+    void toBuilder_shouldPreserveHeaders() throws Exception {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.put("If-Match", Collections.singletonList("\"etag-value\""));
+
         PresignedUrlDownloadRequestWrapper request = PresignedUrlDownloadRequestWrapper.builder()
                                                                                          .url(new URL("https://example.com"))
-                                                                                         .ifMatch("\"etag-value\"")
+                                                                                         .headers(headers)
                                                                                          .build();
 
-        SdkField<?> ifMatchField = request.sdkFields().stream()
-                                          .filter(f -> "IfMatch".equals(f.memberName()))
-                                          .findFirst()
-                                          .orElseThrow(() -> new AssertionError("IfMatch field not found"));
-        Object extractedValue = ifMatchField.getValueOrDefault(request);
+        PresignedUrlDownloadRequestWrapper copy = request.toBuilder().build();
 
-        assertThat(extractedValue).isEqualTo("\"etag-value\"");
+        assertThat(copy.headers().get("If-Match")).isEqualTo(Collections.singletonList("\"etag-value\""));
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/AsyncPresignedUrlExtensionTest.java
@@ -168,7 +168,7 @@ public class AsyncPresignedUrlExtensionTest {
             URL presignedUrl = createPresignedUrl(wireMockRuntimeInfo, presignedUrlPath);
             PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                                .presignedUrl(presignedUrl)
-                                                                               .range(range)
+                                                                               .putHeader("Range", range)
                                                                                .build();
 
             CompletableFuture<ResponseBytes<GetObjectResponse>> result =

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequestTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/presignedurl/model/PresignedUrlDownloadRequestTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.s3.presignedurl.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
+import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
@@ -34,11 +35,11 @@ class PresignedUrlDownloadRequestTest {
         URL url = new URL("https://example.com");
         PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(url)
-                                                                           .range("bytes=0-100")
+                                                                           .putHeader("Range", "bytes=0-100")
                                                                            .build();
 
         assertThat(request.presignedUrl()).isEqualTo(url);
-        assertThat(request.range()).isEqualTo("bytes=0-100");
+        assertThat(request.headers().get("Range")).isEqualTo(Collections.singletonList("bytes=0-100"));
     }
 
     @Test
@@ -49,7 +50,7 @@ class PresignedUrlDownloadRequestTest {
                                                                            .build();
 
         assertThat(request.presignedUrl()).isEqualTo(url);
-        assertThat(request.range()).isNull();
+        assertThat(request.headers()).isEmpty();
     }
 
     @Test
@@ -57,13 +58,13 @@ class PresignedUrlDownloadRequestTest {
         URL url = new URL("https://example.com");
         PresignedUrlDownloadRequest original = PresignedUrlDownloadRequest.builder()
                                                                             .presignedUrl(url)
-                                                                            .range("bytes=0-100")
+                                                                            .putHeader("Range", "bytes=0-100")
                                                                             .build();
 
         PresignedUrlDownloadRequest copy = original.toBuilder().build();
 
         assertThat(copy.presignedUrl()).isEqualTo(original.presignedUrl());
-        assertThat(copy.range()).isEqualTo(original.range());
+        assertThat(copy.headers()).isEqualTo(original.headers());
     }
 
     @Test
@@ -72,29 +73,28 @@ class PresignedUrlDownloadRequestTest {
         URL url2 = new URL("https://other.com");
         PresignedUrlDownloadRequest original = PresignedUrlDownloadRequest.builder()
                                                                             .presignedUrl(url1)
-                                                                            .range("bytes=0-100")
+                                                                            .putHeader("Range", "bytes=0-100")
                                                                             .build();
 
         PresignedUrlDownloadRequest modified = original.toBuilder()
                                                         .presignedUrl(url2)
-                                                        .range("bytes=200-300")
+                                                        .putHeader("Range", "bytes=200-300")
                                                         .build();
 
         assertThat(modified.presignedUrl()).isEqualTo(url2);
-        assertThat(modified.range()).isEqualTo("bytes=200-300");
+        assertThat(modified.headers().get("Range")).isEqualTo(Collections.singletonList("bytes=200-300"));
         // Original unchanged
         assertThat(original.presignedUrl()).isEqualTo(url1);
-        assertThat(original.range()).isEqualTo("bytes=0-100");
+        assertThat(original.headers().get("Range")).isEqualTo(Collections.singletonList("bytes=0-100"));
     }
 
     @Test
     void toString_shouldContainActualFieldValues() throws Exception {
         URL url = new URL("https://example.com");
-        String range = "bytes=0-100";
 
         PresignedUrlDownloadRequest request = PresignedUrlDownloadRequest.builder()
                                                                            .presignedUrl(url)
-                                                                           .range(range)
+                                                                           .putHeader("Range", "bytes=0-100")
                                                                            .build();
 
         String result = request.toString();
@@ -102,9 +102,7 @@ class PresignedUrlDownloadRequestTest {
         assertThat(result)
             .isNotNull()
             .isNotEmpty()
-            .contains(request.presignedUrl().toString())
-            .contains(request.range());
-
+            .contains(request.presignedUrl().toString());
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Signed header-location fields (Range, If-Match, If-None-Match, SSE-C, etc.) are signed into a presigned URL's signature but their values are not stored in the URL — only their names appear in X-Amz-SignedHeaders. The downloader must replay those exact header values or S3 returns a 403 signature mismatch.
This is the same behavior in [V1](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/PresignedUrlDownloadRequest.html#:~:text=If%20any%20signed%20headers%20or%20parameters%20are%20missing%20from%20the%20request%2C%20a%20Signature%20mismatch%20error%20will%20be%20thrown%20from%20S3.%20Ensure%20you%20set%20all%20the%20custom%20headers/parameters%20that%20are%20used%20for%20creating%20the%20presigned%20url.), the `PresignedUrlDownloadRequest` required the caller to manually set any headers that were signed at URL generation time. If a header was signed but not replayed at download time, S3 rejected the request with SignatureDoesNotMatch. The SDK cannot automatically recover from this because the header values are not stored anywhere in the URL — only the header names are listed in X-Amz-SignedHeaders. The caller must know what values were signed and provide them.
v2 `PresignedUrlDownloadRequest` only exposed range() and ifMatch() [these were also needed  to be set by SDK for the multipart downloads] with no way to supply other signed headers (SSE-C, If-None-Match, etc.).

## Modifications
Added putHeader(String, String) / headers(Map<String, List<String>>) after RequestOverrideConfiguration's header idiom in the V2 SDK. We considered extending `PresignedUrlDownloadRequest` from S3Request or SdkRequest so that overrideConfiguration() would be available, but this was not viable because S3Request.overrideConfiguration() exposes signer, credentials, and endpoint overrides that are incompatible with presigned URL execution (which uses a NoOpSigner and relies solely on the URL's embedded signature). Extending S3Request would pull in sdkFields(), marshalling traits, and the full request pipeline — none of which apply to a presigned URL download.

- PresignedUrlDownloadRequest: Replaced range(String)/ifMatch(String) with putHeader(String, String), putHeader(String, List<String>), and headers(Map<String, List<String>>). Backed by TreeMap(String.CASE_INSENSITIVE_ORDER) using CollectionUtils.deepUnmodifiableMap.
- PresignedUrlDownloadRequestWrapper: Carries the generic header map. sdkFields() returns empty; headers applied directly by marshaller.
- PresignedUrlDownloadRequestMarshaller: Added addCustomHeaders() to put all headers from the map onto the HTTP request.
- DefaultAsyncPresignedUrlExtension: Passes headers() map to wrapper.
- PresignedUrlDownloadHelper: Package-private RANGE_HEADER/IF_MATCH_HEADER constants. Range detection and createRangedGetRequest() use the map.
- Multipart subscribers: Log lines read from the map.
- S3Presigner: Added "Signed headers note" Javadoc to presignGetObject().
- GenericS3TransferManager: Updated range check to use headers().containsKey("Range").

## Testing

- PresignedUrlDownloadRequestTest — putHeader, headers(Map), case-insensitive lookup, toBuilder, EqualsVerifier.
- PresignedUrlDownloadRequestWrapperTest — header map, case-insensitive keys, empty sdkFields, toBuilder.
- PresignedUrlDownloadHelperTest — createRangedGetRequest uses headers map.
- PresignedUrlDownloadRequestMarshallerTest — headers added to HTTP request.
- DefaultAsyncPresignedUrlExtensionTest — end-to-end with putHeader.
- PresignedUrlSignedHeadersWiremockTest — WireMock tests verifying signed headers are sent in HTTP requests and missing/wrong headers cause 403.
- MultipartS3AsyncClientTest, AsyncPresignedUrlExtensionTest, PresignedUrlMultipartDownloaderSubscriberWiremockTest — updated to use putHeader API.
- S3TransferManagerPresignedUrlListenerWiremockTest, S3TransferManagerPresignedUrlDownloadIntegrationTest — updated to use putHeader API.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
