### PR TITLE
Include mime.types in sdk-core native image resources

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-75d93e4.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-75d93e4.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Include the sdk-core mime.types resource in the native-image resource configuration so default MIME type detection works in GraalVM native images. Fixes [#7063](https://github.com/aws/aws-sdk-java-v2/issues/7063)",
+    "contributor": "sjh9714"
+}

--- a/core/sdk-core/src/main/resources/META-INF/native-image/software.amazon.awssdk/sdk-core/resource-config.json
+++ b/core/sdk-core/src/main/resources/META-INF/native-image/software.amazon.awssdk/sdk-core/resource-config.json
@@ -3,6 +3,9 @@
     "includes": [
       {
         "pattern": "software/amazon/awssdk/services/\\w+/execution.interceptors"
+      },
+      {
+        "pattern": "\\Qsoftware/amazon/awssdk/core/util/mime.types\\E"
       }]
   }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/MimetypeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/MimetypeTest.java
@@ -19,11 +19,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.utils.IoUtils;
 
 public class MimetypeTest {
+
+    private static final String MIME_TYPES_RESOURCE = "software/amazon/awssdk/core/util/mime.types";
+    private static final String NATIVE_IMAGE_RESOURCE_CONFIG =
+        "META-INF/native-image/software.amazon.awssdk/sdk-core/resource-config.json";
 
     private static Mimetype mimetype;
 
@@ -57,5 +64,15 @@ public class MimetypeTest {
         Path mockPath = mock(Path.class);
         when(mockPath.getFileName()).thenReturn(null);
         assertThat(mimetype.getMimetype(mockPath)).isEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
+    }
+
+    @Test
+    public void nativeImageResourceConfig_includesMimeTypes() throws IOException {
+        try (InputStream resourceConfig = Mimetype.class.getClassLoader().getResourceAsStream(NATIVE_IMAGE_RESOURCE_CONFIG)) {
+            assertThat(resourceConfig).isNotNull();
+
+            String resourceConfigContents = IoUtils.toUtf8String(resourceConfig);
+            assertThat(resourceConfigContents).contains(MIME_TYPES_RESOURCE);
+        }
     }
 }


### PR DESCRIPTION
## Motivation and Context
Fixes #7063.

`sdk-core` loads `software/amazon/awssdk/core/util/mime.types` for default MIME type detection, but the native-image resource configuration did not include that resource. In GraalVM native images, known file extensions can then fall back to `application/octet-stream` because the MIME table is unavailable.

This submission was generated by AI tools and reviewed by sjh9714.

## Modifications
- Add the sdk-core `mime.types` resource to `resource-config.json` for native-image builds.
- Add a focused `MimetypeTest` assertion that the native-image resource config includes the MIME table resource.
- Add the required next-release changelog entry.

## Testing
- Red check before the resource-config fix: `./mvnw -q -pl :sdk-core -am -Dtest=MimetypeTest#nativeImageResourceConfig_includesMimeTypes -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -Dspotbugs.skip=true -Dcheckstyle.skip=true test`
- Green check after the fix: `./mvnw -q -pl :sdk-core -am -Dtest=MimetypeTest#nativeImageResourceConfig_includesMimeTypes -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -Dspotbugs.skip=true -Dcheckstyle.skip=true test`
- `./mvnw -q -pl :sdk-core -am -Dtest=MimetypeTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -Dspotbugs.skip=true -Dcheckstyle.skip=true test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -q -pl :sdk-core -am -Dtest=MimetypeTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test`

Note: I also tried the Java 21 targeted reactor without skipping SpotBugs, but SpotBugs failed before reaching `sdk-core` with `DirectoryNotEmptyException` for `core/annotations/target/classes`. The Java 17 command above uses the repository's Java-17 profile, which skips SpotBugs and runs the focused test class successfully.

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
