### PR TITLE
Test add regression tests for syncclientclass

### DIFF
--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/SyncClientClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/SyncClientClassTest.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.codegen.poet.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.awsQueryCompatibleJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.cborServiceModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.customContentTypeModels;
@@ -29,10 +31,16 @@ import static software.amazon.awssdk.codegen.poet.ClientTestModels.rpcv2ServiceM
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.xmlServiceModels;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
+import java.io.IOException;
 import org.junit.Test;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.Protocol;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.PoetExtension;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.codegen.poet.client.specs.Ec2ProtocolSpec;
+import software.amazon.awssdk.codegen.poet.client.specs.ProtocolSpec;
 
 public class SyncClientClassTest {
     @Test
@@ -103,6 +111,48 @@ public class SyncClientClassTest {
     public void syncClientClassWithUnsignedPayload() {
         SyncClientClass syncClientClass = createSyncClientClass(opsWithSigv4a());
         assertThat(syncClientClass, generatesTo("test-unsigned-payload-trait-sync-client-class.java"));
+    }
+
+    @Test
+    public void syncClientEndpointDiscovery_whenRequiredEndpointDiscoveryAllowsEndpointOverride_generatesFallbackAndWarning()
+        throws IOException {
+        IntermediateModel model = endpointDiscoveryModels();
+        model.getCustomizationConfig().setAllowEndpointOverrideForEndpointDiscoveryRequiredOperations(true);
+
+        String generatedClient = generateClass(createSyncClientClass(model));
+
+        String requiredOperationOverrideFallback =
+            "if (endpointOverridden) {\n"
+            + "      endpointDiscoveryEnabled = false;\n"
+            + "    } else if (!endpointDiscoveryEnabled) {\n"
+            + "      throw new IllegalStateException(\"This operation requires endpoint discovery to be enabled, or for "
+            + "you to specify an endpoint override when the client is created.\");\n"
+            + "    }";
+        String constructorWarning =
+            "if (clientConfiguration.option(SdkClientOption.CLIENT_ENDPOINT_PROVIDER).isEndpointOverridden()) {\n"
+            + "        log.warn(() -> \"Endpoint discovery is enabled for this client, and an endpoint override was also "
+            + "specified. This will disable endpoint discovery for methods that require it, instead using the specified "
+            + "endpoint override. This may or may not be what you intended.\");\n"
+            + "      }";
+
+        assertThat(generatedClient, containsString(requiredOperationOverrideFallback));
+        assertThat(generatedClient, containsString(constructorWarning));
+    }
+
+    @Test
+    public void getProtocolSpecs_withEc2Protocol_returnsEc2ProtocolSpec() {
+        IntermediateModel model = queryServiceModels();
+        model.getMetadata().setProtocol(Protocol.EC2);
+
+        ProtocolSpec protocolSpec = SyncClientClass.getProtocolSpecs(new PoetExtension(model), model);
+
+        assertThat(protocolSpec, instanceOf(Ec2ProtocolSpec.class));
+    }
+
+    private String generateClass(ClassSpec spec) throws IOException {
+        StringBuilder output = new StringBuilder();
+        PoetUtils.buildJavaFile(spec).writeTo(output);
+        return output.toString();
     }
 
 }


### PR DESCRIPTION
# test: add regression tests for SyncClientClass

## Motivation and Context

Hey 👋

I added two regression tests for `SyncClientClass` around sync client generation behavior.

While looking through the generation logic, I noticed the endpoint-discovery override path and EC2 protocol selection were not directly covered by the existing test suite.

## Modifications

* Added `syncClientEndpointDiscovery_whenRequiredEndpointDiscoveryAllowsEndpointOverride_generatesFallbackAndWarning`.
* Added `getProtocolSpecs_withEc2Protocol_returnsEc2ProtocolSpec`.

## Testing

These tests check that endpoint overrides generate the expected fallback and warning behavior for required endpoint discovery, and that EC2 models use the EC2 protocol spec.

Impact on coverage:

* Covers endpoint-discovery override handling, including [covered lines](https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java#L214-L221) for endpoint override warnings and [covered lines](https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java#L261-L282) for required endpoint-discovery fallback generation.
* Covers EC2 protocol selection, including [covered lines](https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java#L388-L396).
* This adds about 3% line coverage and 12% branch coverage for `SyncClientClass`. 

Targeted tests pass locally.

## Screenshots (if appropriate)

Not applicable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

I hope you find these tests useful. Please let me know if you have any questions or concerns.

Thanks,