### PR TITLE
Fix DurationAttributeConverter negative fractional durations

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDB-1db6c7e.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-1db6c7e.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB",
+    "description": "Fixed DurationAttributeConverter negative fractional duration serialization and parsing. Values like Duration.ofMillis(-1) now serialize as -0.001000000 and round trip correctly. Fixes [#7060](https://github.com/aws/aws-sdk-java-v2/issues/7060).",
+    "contributor": "Arnab Nandy"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DurationAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DurationAttributeConverter.java
@@ -79,9 +79,16 @@ public final class DurationAttributeConverter implements AttributeConverter<Dura
 
     @Override
     public AttributeValue transformFrom(Duration input) {
+        long seconds = input.getSeconds();
+        int nanos = input.getNano();
+        String value = seconds + (nanos == 0 ? "" : "." + padLeft(9, nanos));
+
+        if (input.isNegative() && nanos != 0) {
+            value = "-" + Math.abs(seconds + 1) + "." + padLeft(9, 1_000_000_000 - nanos);
+        }
+
         return AttributeValue.builder()
-                             .n(input.getSeconds() +
-                                (input.getNano() == 0 ? "" : "." + padLeft(9, input.getNano())))
+                             .n(value)
                              .build();
     }
 
@@ -103,10 +110,11 @@ public final class DurationAttributeConverter implements AttributeConverter<Dura
         public Duration convertNumber(String value) {
             String[] splitOnDecimal = ConverterUtils.splitNumberOnDecimal(value);
 
+            boolean isNegative = value.startsWith("-");
             long seconds = Long.parseLong(splitOnDecimal[0]);
             int nanoAdjustment = Integer.parseInt(padRight(splitOnDecimal[1]));
 
-            if (seconds < 0) {
+            if (isNegative) {
                 nanoAdjustment = -nanoAdjustment;
             }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DurationAttributeConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DurationAttributeConverterTest.java
@@ -61,6 +61,14 @@ class DurationAttributeConverterTest {
         assertThat(converted).isEqualByComparingTo(expected);
     }
 
+    @ParameterizedTest
+    @MethodSource("roundTripDurations")
+    void roundTrip(Duration duration) {
+        Duration converted = converter.transformTo(converter.transformFrom(duration));
+
+        assertThat(converted).isEqualByComparingTo(duration);
+    }
+
     static Stream<Arguments> noPadding() {
         return Stream.of(
             Arguments.of("0.123456789", Duration.ofNanos(123_456_789)),
@@ -74,7 +82,10 @@ class DurationAttributeConverterTest {
             Arguments.of("0.1",         Duration.ofMillis(100)),
             Arguments.of("0.001", Duration.ofMillis(1)),
             Arguments.of("0.000001", Duration.of(1, MICROS)),
-            Arguments.of("0.001", Duration.ofMillis(1))
+            Arguments.of("0.001", Duration.ofMillis(1)),
+            Arguments.of("-0.1", Duration.ofMillis(-100)),
+            Arguments.of("-0.001", Duration.ofMillis(-1)),
+            Arguments.of("-0.000001", Duration.of(-1, MICROS))
         );
     }
 
@@ -107,7 +118,22 @@ class DurationAttributeConverterTest {
             Arguments.of("9", Duration.ofSeconds(9)),
             Arguments.of("-9", Duration.ofSeconds(-9)),
             Arguments.of("0.001000000", Duration.ofMillis(1)),
-            Arguments.of("0.000000001", Duration.ofNanos(1)));
+            Arguments.of("0.000000001", Duration.ofNanos(1)),
+            Arguments.of("-0.001000000", Duration.ofMillis(-1)),
+            Arguments.of("-0.000000001", Duration.ofNanos(-1)),
+            Arguments.of("-1.234567890", Duration.ofNanos(-1_234_567_890)));
+    }
+
+    static Stream<Duration> roundTripDurations() {
+        return Stream.of(
+            Duration.ZERO,
+            Duration.ofNanos(1),
+            Duration.ofMillis(1),
+            Duration.ofSeconds(1, 234_567_890),
+            Duration.ofSeconds(-9),
+            Duration.ofMillis(-1),
+            Duration.ofNanos(-1),
+            Duration.ofNanos(-1_234_567_890));
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Fixes #7060 

`DurationAttributeConverter` incorrectly serialized negative fractional durations because Java represents them with negative seconds and positive nanos. For example, `Duration.ofMillis(-1)` was serialized as `-1.999000000` instead of `-0.001000000`.


## Modifications
<!--- Describe your changes in detail -->
Updated `DurationAttributeConverter` to correctly serialize negative fractional `Duration` values using their mathematical signed decimal representation.

Also updated parsing logic so number strings like `-0.001000000` are converted back to negative durations instead of positive ones.

Added regression tests for:
- Negative fractional serialization
- Negative fractional parsing
- No-padding negative fractional parsing
- Duration round trips


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran:

```bash
mvn -Dtest=DurationAttributeConverterTest test
```

## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
