### PR TITLE
Add support for generating endpoint tests with integer parameter values.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2Codegen-25804b2.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2Codegen-25804b2.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2 Codegen\"",
+    "contributor": "",
+    "description": "Add support for generating endpoint tests with integer parameter values."
+}

--- a/.changes/next-release/bugfix-AWSSDKforJavav2Codegen-25804b2.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2Codegen-25804b2.json
@@ -1,6 +1,6 @@
 {
     "type": "bugfix",
-    "category": "AWS SDK for Java v2 Codegen\"",
+    "category": "AWS SDK for Java v2 Codegen",
     "contributor": "",
     "description": "Add support for generating endpoint tests with integer parameter values."
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -193,6 +193,9 @@ public class EndpointRulesSpecUtils {
             case VALUE_NUMBER_INT:
                 b.add("$L", Validate.isInstanceOf(JrsNumber.class, treeNode, "Expected number").getValue().intValue());
                 break;
+            case VALUE_NUMBER_FLOAT:
+                b.add("$L", Validate.isInstanceOf(JrsNumber.class, treeNode, "Expected number").getValue().doubleValue());
+                break;
             case START_ARRAY:
                 handleArrayDefaultValue(b, "stringarray",
                                         Validate.isInstanceOf(JrsArray.class, treeNode, "Expected string array"));

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.codegen.poet.rules;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.jr.stree.JrsArray;
 import com.fasterxml.jackson.jr.stree.JrsBoolean;
+import com.fasterxml.jackson.jr.stree.JrsNumber;
 import com.fasterxml.jackson.jr.stree.JrsString;
 import com.fasterxml.jackson.jr.stree.JrsValue;
 import com.squareup.javapoet.ClassName;
@@ -188,6 +189,9 @@ public class EndpointRulesSpecUtils {
             case VALUE_TRUE:
             case VALUE_FALSE:
                 b.add("$L", Validate.isInstanceOf(JrsBoolean.class, treeNode, "Expected boolean").booleanValue());
+                break;
+            case VALUE_NUMBER_INT:
+                b.add("$L", Validate.isInstanceOf(JrsNumber.class, treeNode, "Expected number").getValue().intValue());
                 break;
             case START_ARRAY:
                 handleArrayDefaultValue(b, "stringarray",

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-tests.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-tests.json
@@ -184,6 +184,26 @@
             ]
         },
         {
+            "documentation": "Has integer operation input",
+            "expect": {
+                "endpoint": {
+                    "url": "https://myservice.aws"
+                }
+            },
+            "params": {
+                "region": "us-east-1"
+            },
+            "operationInputs": [
+                {
+                    "operationName": "OperationWithContextParam",
+                    "operationParams": {
+                        "StringMember": "this is a test",
+                        "IntegerMember": 42
+                    }
+                }
+            ]
+        },
+        {
             "documentation": "Has has undeclared input parameter",
             "expect": {
                 "error": "Missing info"

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-tests.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-tests.json
@@ -204,6 +204,26 @@
             ]
         },
         {
+            "documentation": "Has double operation input",
+            "expect": {
+                "endpoint": {
+                    "url": "https://myservice.aws"
+                }
+            },
+            "params": {
+                "region": "us-east-1"
+            },
+            "operationInputs": [
+                {
+                    "operationName": "OperationWithContextParam",
+                    "operationParams": {
+                        "StringMember": "this is a test",
+                        "DoubleMember": 3.14
+                    }
+                }
+            ]
+        },
+        {
             "documentation": "Has has undeclared input parameter",
             "expect": {
                 "error": "Missing info"

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
@@ -216,6 +216,9 @@
             "name": "operationContextParam"
           }
         },
+        "IntegerMember": {
+          "shape": "Integer"
+        },
         "NestedMember": {
           "shape": "ChecksumStructure"
         }
@@ -453,6 +456,7 @@
       "payload":"Body"
     },
     "String":{"type":"string"},
+    "Integer":{"type":"integer"},
     "BearerAuthOperationRequest": {
       "type": "structure",
       "members": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
@@ -219,6 +219,9 @@
         "IntegerMember": {
           "shape": "Integer"
         },
+        "DoubleMember": {
+          "shape": "Double"
+        },
         "NestedMember": {
           "shape": "ChecksumStructure"
         }
@@ -457,6 +460,7 @@
     },
     "String":{"type":"string"},
     "Integer":{"type":"integer"},
+    "Double":{"type":"double"},
     "BearerAuthOperationRequest": {
       "type": "structure",
       "members": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
@@ -127,6 +127,16 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
                                                                                            .stringMember("this is a test").integerMember(42).build();
                 builder.build().operationWithContextParam(request);
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()),
+            new SyncTestCase("Has double operation input", () -> {
+                QueryClientBuilder builder = QueryClient.builder();
+                builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
+                builder.httpClient(getSyncHttpClient());
+                builder.region(Region.of("us-east-1"));
+                OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
+                                                                                           .stringMember("this is a test").doubleMember(3.14).build();
+                builder.build().operationWithContextParam(request);
             }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()));
     }
 
@@ -208,6 +218,16 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 builder.region(Region.of("us-east-1"));
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
                                                                                            .stringMember("this is a test").integerMember(42).build();
+                return builder.build().operationWithContextParam(request);
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()),
+            new AsyncTestCase("Has double operation input", () -> {
+                QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
+                builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
+                builder.httpClient(getAsyncHttpClient());
+                builder.region(Region.of("us-east-1"));
+                OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
+                                                                                           .stringMember("this is a test").doubleMember(3.14).build();
                 return builder.build().operationWithContextParam(request);
             }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()));
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
@@ -117,7 +117,17 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
                                                                                            .nestedMember(ChecksumStructure.builder().checksumMode("foo").build()).build();
                 builder.build().operationWithContextParam(request);
-            }, Expect.builder().error("Missing info").build()));
+            }, Expect.builder().error("Missing info").build()),
+            new SyncTestCase("Has integer operation input", () -> {
+                QueryClientBuilder builder = QueryClient.builder();
+                builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
+                builder.httpClient(getSyncHttpClient());
+                builder.region(Region.of("us-east-1"));
+                OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
+                                                                                           .stringMember("this is a test").integerMember(42).build();
+                builder.build().operationWithContextParam(request);
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()));
     }
 
     private static List<AsyncTestCase> asyncTestCases() {
@@ -189,6 +199,16 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
                                                                                            .nestedMember(ChecksumStructure.builder().checksumMode("foo").build()).build();
                 return builder.build().operationWithContextParam(request);
-            }, Expect.builder().error("Missing info").build()));
+            }, Expect.builder().error("Missing info").build()),
+            new AsyncTestCase("Has integer operation input", () -> {
+                QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
+                builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
+                builder.httpClient(getAsyncHttpClient());
+                builder.region(Region.of("us-east-1"));
+                OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
+                                                                                           .stringMember("this is a test").integerMember(42).build();
+                return builder.build().operationWithContextParam(request);
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()));
     }
 }


### PR DESCRIPTION
Add support for generating endpoint tests with integer parameter values.

## Motivation and Context

`EndpointRulesSpecUtils.treeNodeToLiteral()` handles `VALUE_STRING`, `VALUE_TRUE`/`VALUE_FALSE`, and `START_ARRAY` token types but does not handle `VALUE_NUMBER_INT`. Any service model that introduces an integer operation parameter in endpoint tests will hit this codegen failure.

## Modifications
- **`EndpointRulesSpecUtils.java`**: Added a `VALUE_NUMBER_INT` case to the `treeNodeToLiteral` switch statement, using `JrsNumber.getValue().intValue()` to emit the integer literal. This follows the same pattern already used in `RuleSetCreationSpec.java`.

## Testing
Added new tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] 
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.


## License
- [x] I confirm that this pull request can be released under the Apache 2 license