### PR TITLE
fix(crt): fail request on HTTP 200 with error body

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
@@ -212,7 +212,7 @@ public final class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseH
     private void handleServiceError(int responseStatus, HttpHeader[] headers, byte[] errorPayload) {
         SdkHttpResponse.Builder errorResponse = populateSdkHttpResponse(SdkHttpResponse.builder(),
                                                                         responseStatus, headers);
-        if (requestFailedMidwayOfOtherError(responseStatus)) {
+        if (requestFailedMidwayOfOtherError(responseStatus) || isSuccessStatus(responseStatus)) {
             AwsServiceException s3Exception = buildS3Exception(responseStatus, errorPayload, errorResponse);
 
             SdkClientException sdkClientException =
@@ -224,6 +224,10 @@ public final class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseH
             initiateResponseHandling(errorResponse.build());
             onErrorResponseComplete(errorPayload);
         }
+    }
+
+    private static boolean isSuccessStatus(int responseStatus) {
+        return responseStatus >= 200 && responseStatus < 300;
     }
 
     private static AwsServiceException buildS3Exception(int responseStatus,

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
@@ -150,6 +150,21 @@ public class S3CrtResponseHandlerAdapterTest {
     }
 
     @Test
+    public void errorResponseWith200Status_shouldCompleteFutureExceptionally() {
+        int statusCode = 200;
+        responseHandlerAdapter.onResponseHeaders(statusCode, new HttpHeader[0]);
+
+        byte[] errorPayload = "errorResponse".getBytes(StandardCharsets.UTF_8);
+        responseHandlerAdapter.onFinished(stubResponseContext(1, statusCode, errorPayload));
+
+        Throwable actualException = sdkResponseHandler.error;
+        assertThat(actualException).isInstanceOf(S3Exception.class);
+        assertThat(((S3Exception) actualException).statusCode()).isEqualTo(200);
+        assertThat(future).isCompletedExceptionally();
+        verify(s3MetaRequest).close();
+    }
+
+    @Test
     public void requestFailed_shouldCompleteFutureExceptionally() {
 
         responseHandlerAdapter.onFinished(stubResponseContext(1, 0, null));


### PR DESCRIPTION
## Motivation and Context
When using the CRT-backed S3AsyncClient, if an S3-compatible server returns HTTP 200 in the response header but an `<Error>` XML payload in the body (a documented behavior of S3's `CompleteMultipartUpload` API), the client was silently reporting success and completing the future with `null`. This prevented the client from detecting the failure and caused undetectable data loss.

This change ensures that error responses returned with a 2xx success status code are correctly treated as failures, completing the response future exceptionally with an `S3Exception`.

Fixes https://github.com/aws/aws-sdk-java-v2/issues/7068

## Modifications
- **S3CrtResponseHandlerAdapter.java**:
  - Updated `handleServiceError` to fail the response handler and the future exceptionally if `isSuccessStatus(responseStatus)` is true.
  - Added a private helper method `isSuccessStatus(int responseStatus)` to detect 2xx status codes.
- **S3CrtResponseHandlerAdapterTest.java**:
  - Added the `errorResponseWith200Status_shouldCompleteFutureExceptionally` unit test to verify that the future is completed exceptionally when S3 returns an error with HTTP status 200.

## Testing
Tested locally using JUnit 5:
- Ran `S3CrtResponseHandlerAdapterTest` which includes the new test case confirming that HTTP 200 with an error payload throws `S3Exception`.
  Command run: `.\mvnw.cmd test -pl :s3 "-Dtest=S3CrtResponseHandlerAdapterTest" "-Dspotbugs.skip=true" "-Dcheckstyle.skip=true" "-Dfindbugs.skip=true"`
- All 9 unit tests passed successfully.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license