### PR TITLE
Part [2/2] -Refactor Enhanced Client to use createX methods instead of builder

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/EnumAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/EnumAttributeConverter.java
@@ -94,7 +94,7 @@ public final class EnumAttributeConverter<T extends Enum<T>> implements Attribut
      */
     @Override
     public AttributeValue transformFrom(T input) {
-        return AttributeValue.builder().s(keyExtractor.apply(input)).build();
+        return AttributeValue.createS(keyExtractor.apply(input));
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/AttributeValues.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/AttributeValues.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  */
 @SdkInternalApi
 public final class AttributeValues {
-    private static final AttributeValue NULL_ATTRIBUTE_VALUE = AttributeValue.builder().nul(true).build();
+    private static final AttributeValue NULL_ATTRIBUTE_VALUE = AttributeValue.createNul(true);
 
     private AttributeValues() {
     }
@@ -47,7 +47,7 @@ public final class AttributeValues {
      * @return An {@link AttributeValue} of type S that represents the string literal.
      */
     public static AttributeValue stringValue(String value) {
-        return AttributeValue.builder().s(value).build();
+        return AttributeValue.createS(value);
     }
 
     /**
@@ -56,7 +56,7 @@ public final class AttributeValues {
      * @return An {@link AttributeValue} of type n that represents the numeric literal.
      */
     public static AttributeValue numberValue(Number value) {
-        return AttributeValue.builder().n(value.toString()).build();
+        return AttributeValue.createN(value.toString());
     }
 
     /**
@@ -65,6 +65,6 @@ public final class AttributeValues {
      * @return An {@link AttributeValue} of type B that represents the binary literal.
      */
     public static AttributeValue binaryValue(SdkBytes value) {
-        return AttributeValue.builder().b(value).build();
+        return AttributeValue.createB(value);
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicBooleanAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicBooleanAttributeConverter.java
@@ -62,7 +62,7 @@ public final class AtomicBooleanAttributeConverter implements AttributeConverter
 
     @Override
     public AttributeValue transformFrom(AtomicBoolean input) {
-        return AttributeValue.builder().bool(input.get()).build();
+        return AttributeValue.createBool(input.get());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicIntegerAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicIntegerAttributeConverter.java
@@ -72,7 +72,7 @@ public final class AtomicIntegerAttributeConverter implements AttributeConverter
 
     @Override
     public AttributeValue transformFrom(AtomicInteger input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicLongAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicLongAttributeConverter.java
@@ -72,7 +72,7 @@ public final class AtomicLongAttributeConverter implements AttributeConverter<At
 
     @Override
     public AttributeValue transformFrom(AtomicLong input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BigDecimalAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BigDecimalAttributeConverter.java
@@ -69,7 +69,7 @@ public final class BigDecimalAttributeConverter implements AttributeConverter<Bi
 
     @Override
     public AttributeValue transformFrom(BigDecimal input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BigIntegerAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BigIntegerAttributeConverter.java
@@ -70,7 +70,7 @@ public final class BigIntegerAttributeConverter implements AttributeConverter<Bi
 
     @Override
     public AttributeValue transformFrom(BigInteger input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BooleanAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BooleanAttributeConverter.java
@@ -66,7 +66,7 @@ public final class BooleanAttributeConverter implements AttributeConverter<Boole
 
     @Override
     public AttributeValue transformFrom(Boolean input) {
-        return AttributeValue.builder().bool(input).build();
+        return AttributeValue.createBool(input);
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ByteArrayAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ByteArrayAttributeConverter.java
@@ -63,7 +63,7 @@ public final class ByteArrayAttributeConverter implements AttributeConverter<byt
 
     @Override
     public AttributeValue transformFrom(byte[] input) {
-        return AttributeValue.builder().b(SdkBytes.fromByteArray(input)).build();
+        return AttributeValue.createB(SdkBytes.fromByteArray(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ByteAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ByteAttributeConverter.java
@@ -55,7 +55,7 @@ public final class ByteAttributeConverter implements AttributeConverter<Byte>, P
 
     @Override
     public AttributeValue transformFrom(Byte input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ByteBufferAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ByteBufferAttributeConverter.java
@@ -65,7 +65,7 @@ public final class ByteBufferAttributeConverter implements AttributeConverter<By
 
     @Override
     public AttributeValue transformFrom(ByteBuffer input) {
-        return AttributeValue.builder().b(SdkBytes.fromByteBuffer(input)).build();
+        return AttributeValue.createB(SdkBytes.fromByteBuffer(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/CharSequenceAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/CharSequenceAttributeConverter.java
@@ -63,7 +63,7 @@ public final class CharSequenceAttributeConverter implements AttributeConverter<
 
     @Override
     public AttributeValue transformFrom(CharSequence input) {
-        return AttributeValue.builder().s(CHAR_SEQUENCE_STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(CHAR_SEQUENCE_STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/CharacterArrayAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/CharacterArrayAttributeConverter.java
@@ -63,7 +63,7 @@ public final class CharacterArrayAttributeConverter implements AttributeConverte
 
     @Override
     public AttributeValue transformFrom(char[] input) {
-        return AttributeValue.builder().s(CHAR_ARRAY_STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(CHAR_ARRAY_STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/CharacterAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/CharacterAttributeConverter.java
@@ -65,7 +65,7 @@ public final class CharacterAttributeConverter implements AttributeConverter<Cha
 
     @Override
     public AttributeValue transformFrom(Character input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DocumentAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DocumentAttributeConverter.java
@@ -54,7 +54,7 @@ public class DocumentAttributeConverter<T> implements AttributeConverter<T> {
 
     @Override
     public AttributeValue transformFrom(T input) {
-        return AttributeValue.builder().m(tableSchema.itemToMap(input, ignoreNulls)).build();
+        return AttributeValue.createM(tableSchema.itemToMap(input, ignoreNulls));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DoubleAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DoubleAttributeConverter.java
@@ -72,7 +72,7 @@ public final class DoubleAttributeConverter implements AttributeConverter<Double
     @Override
     public AttributeValue transformFrom(Double input) {
         ConverterUtils.validateDouble(input);
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DurationAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/DurationAttributeConverter.java
@@ -79,10 +79,8 @@ public final class DurationAttributeConverter implements AttributeConverter<Dura
 
     @Override
     public AttributeValue transformFrom(Duration input) {
-        return AttributeValue.builder()
-                             .n(input.getSeconds() +
-                                (input.getNano() == 0 ? "" : "." + padLeft(9, input.getNano())))
-                             .build();
+        return AttributeValue.createN(input.getSeconds() +
+                                (input.getNano() == 0 ? "" : "." + padLeft(9, input.getNano())));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/EnhancedAttributeValue.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/EnhancedAttributeValue.java
@@ -93,7 +93,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for the null DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().nul(true).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createNul(true))}
      *
      * <p>
      * This call should never fail with an {@link Exception}.
@@ -106,7 +106,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a map (m) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().m(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createM(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided map is null or has null keys.
@@ -121,7 +121,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a string (s) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().s(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createS(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
@@ -139,7 +139,7 @@ public final class EnhancedAttributeValue {
      * This is a String, because it matches the underlying DynamoDB representation.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().n(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createN(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
@@ -154,7 +154,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a bytes (b) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().b(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createB(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
@@ -170,7 +170,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a boolean (bool) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().bool(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createBool(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
@@ -185,7 +185,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-strings (ss) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ss(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createSs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -201,7 +201,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-strings (ss) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ss(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createSs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -217,7 +217,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-strings (ss) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ss(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createSs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -234,7 +234,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-numbers (ns) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ns(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createNs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -250,7 +250,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-numbers (ns) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ns(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createNs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -266,7 +266,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-numbers (ns) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ns(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createNs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -283,7 +283,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-bytes (bs) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().bs(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createBs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -299,7 +299,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-bytes (bs) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().bs(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createBs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -315,7 +315,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a set-of-bytes (bs) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().bs(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createBs(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -332,7 +332,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a list-of-attributes (l) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().l(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createL(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -347,7 +347,7 @@ public final class EnhancedAttributeValue {
      * Create an {@link EnhancedAttributeValue} for a list-of-attributes (l) DynamoDB type.
      *
      * <p>
-     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().l(...).build())}
+     * Equivalent to: {@code EnhancedAttributeValue.fromGeneratedAttributeValue(AttributeValue.createL(...))}
      *
      * <p>
      * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
@@ -748,52 +748,52 @@ public final class EnhancedAttributeValue {
 
         @Override
         public AttributeValue convertNull() {
-            return AttributeValue.builder().nul(true).build();
+            return AttributeValue.createNul(true);
         }
 
         @Override
         public AttributeValue convertMap(Map<String, AttributeValue> value) {
-            return AttributeValue.builder().m(value).build();
+            return AttributeValue.createM(value);
         }
 
         @Override
         public AttributeValue convertString(String value) {
-            return AttributeValue.builder().s(value).build();
+            return AttributeValue.createS(value);
         }
 
         @Override
         public AttributeValue convertNumber(String value) {
-            return AttributeValue.builder().n(value).build();
+            return AttributeValue.createN(value);
         }
 
         @Override
         public AttributeValue convertBytes(SdkBytes value) {
-            return AttributeValue.builder().b(value).build();
+            return AttributeValue.createB(value);
         }
 
         @Override
         public AttributeValue convertBoolean(Boolean value) {
-            return AttributeValue.builder().bool(value).build();
+            return AttributeValue.createBool(value);
         }
 
         @Override
         public AttributeValue convertSetOfStrings(List<String> value) {
-            return AttributeValue.builder().ss(value).build();
+            return AttributeValue.createSs(value);
         }
 
         @Override
         public AttributeValue convertSetOfNumbers(List<String> value) {
-            return AttributeValue.builder().ns(value).build();
+            return AttributeValue.createNs(value);
         }
 
         @Override
         public AttributeValue convertSetOfBytes(List<SdkBytes> value) {
-            return AttributeValue.builder().bs(value).build();
+            return AttributeValue.createBs(value);
         }
 
         @Override
         public AttributeValue convertListOfAttributeValues(List<AttributeValue> value) {
-            return AttributeValue.builder().l(value).build();
+            return AttributeValue.createL(value);
         }
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/FloatAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/FloatAttributeConverter.java
@@ -72,7 +72,7 @@ public final class FloatAttributeConverter implements AttributeConverter<Float>,
     @Override
     public AttributeValue transformFrom(Float input) {
         ConverterUtils.validateFloat(input);
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/InstantAsStringAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/InstantAsStringAttributeConverter.java
@@ -87,7 +87,7 @@ public final class InstantAsStringAttributeConverter implements AttributeConvert
 
     @Override
     public AttributeValue transformFrom(Instant input) {
-        return AttributeValue.builder().s(input.toString()).build();
+        return AttributeValue.createS(input.toString());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/IntegerAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/IntegerAttributeConverter.java
@@ -69,7 +69,7 @@ public final class IntegerAttributeConverter implements AttributeConverter<Integ
 
     @Override
     public AttributeValue transformFrom(Integer input) {
-        return AttributeValue.builder().n(INTEGER_STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(INTEGER_STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/JsonNodeToAttributeValueMapConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/JsonNodeToAttributeValueMapConverter.java
@@ -43,35 +43,33 @@ public class JsonNodeToAttributeValueMapConverter implements JsonNodeVisitor<Att
 
     @Override
     public AttributeValue visitBoolean(boolean bool) {
-        return AttributeValue.builder().bool(bool).build();
+        return AttributeValue.createBool(bool);
     }
 
     @Override
     public AttributeValue visitNumber(String number) {
-        return AttributeValue.builder().n(number).build();
+        return AttributeValue.createN(number);
     }
 
     @Override
     public AttributeValue visitString(String string) {
-        return AttributeValue.builder().s(string).build();
+        return AttributeValue.createS(string);
     }
 
     @Override
     public AttributeValue visitArray(List<JsonNode> array) {
-        return AttributeValue.builder().l(array.stream()
+        return AttributeValue.createL(array.stream()
                                                .map(node -> node.visit(this))
-                                               .collect(Collectors.toList()))
-                             .build();
+                                               .collect(Collectors.toList()));
     }
 
     @Override
     public AttributeValue visitObject(Map<String, JsonNode> object) {
-        return AttributeValue.builder().m(object.entrySet().stream()
+        return AttributeValue.createM(object.entrySet().stream()
                                                 .collect(Collectors.toMap(
                                                     Map.Entry::getKey,
                                                     entry -> entry.getValue().visit(this),
-                                                    (left, right) -> left, LinkedHashMap::new)))
-                             .build();
+                                                    (left, right) -> left, LinkedHashMap::new)));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ListAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ListAttributeConverter.java
@@ -156,17 +156,17 @@ public class ListAttributeConverter<T extends Collection<?>> implements Attribut
                                          .convert(new TypeConvertingVisitor<T>(type.rawClass(), ListAttributeConverter.class) {
                                              @Override
                                              public T convertSetOfStrings(List<String> value) {
-                                                 return convertCollection(value, v -> AttributeValue.builder().s(v).build());
+                                                 return convertCollection(value, v -> AttributeValue.createS(v));
                                              }
 
                                              @Override
                                              public T convertSetOfNumbers(List<String> value) {
-                                                 return convertCollection(value, v -> AttributeValue.builder().n(v).build());
+                                                 return convertCollection(value, v -> AttributeValue.createN(v));
                                              }
 
                                              @Override
                                              public T convertSetOfBytes(List<SdkBytes> value) {
-                                                 return convertCollection(value, v -> AttributeValue.builder().b(v).build());
+                                                 return convertCollection(value, v -> AttributeValue.createB(v));
                                              }
 
                                              @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocalDateAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocalDateAttributeConverter.java
@@ -84,7 +84,7 @@ public final class LocalDateAttributeConverter implements AttributeConverter<Loc
 
     @Override
     public AttributeValue transformFrom(LocalDate input) {
-        return AttributeValue.builder().s(input.toString()).build();
+        return AttributeValue.createS(input.toString());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocalDateTimeAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocalDateTimeAttributeConverter.java
@@ -100,7 +100,7 @@ public final class LocalDateTimeAttributeConverter implements AttributeConverter
 
     @Override
     public AttributeValue transformFrom(LocalDateTime input) {
-        return AttributeValue.builder().s(input.toString()).build();
+        return AttributeValue.createS(input.toString());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocalTimeAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocalTimeAttributeConverter.java
@@ -81,7 +81,7 @@ public final class LocalTimeAttributeConverter implements AttributeConverter<Loc
 
     @Override
     public AttributeValue transformFrom(LocalTime input) {
-        return AttributeValue.builder().s(input.toString()).build();
+        return AttributeValue.createS(input.toString());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocaleAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LocaleAttributeConverter.java
@@ -55,7 +55,7 @@ public final class LocaleAttributeConverter implements AttributeConverter<Locale
 
     @Override
     public AttributeValue transformFrom(Locale input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LongAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/LongAttributeConverter.java
@@ -69,7 +69,7 @@ public final class LongAttributeConverter implements AttributeConverter<Long>, P
 
     @Override
     public AttributeValue transformFrom(Long input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/MonthDayAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/MonthDayAttributeConverter.java
@@ -77,7 +77,7 @@ public final class MonthDayAttributeConverter implements AttributeConverter<Mont
 
     @Override
     public AttributeValue transformFrom(MonthDay input) {
-        return AttributeValue.builder().s(input.toString()).build();
+        return AttributeValue.createS(input.toString());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OffsetDateTimeAsStringAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OffsetDateTimeAsStringAttributeConverter.java
@@ -90,7 +90,7 @@ public final class OffsetDateTimeAsStringAttributeConverter implements Attribute
 
     @Override
     public AttributeValue transformFrom(OffsetDateTime input) {
-        return AttributeValue.builder().s(input.toString()).build();
+        return AttributeValue.createS(input.toString());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OptionalDoubleAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OptionalDoubleAttributeConverter.java
@@ -79,7 +79,7 @@ public final class OptionalDoubleAttributeConverter implements AttributeConverte
     public AttributeValue transformFrom(OptionalDouble input) {
         if (input.isPresent()) {
             ConverterUtils.validateDouble(input.getAsDouble());
-            return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+            return AttributeValue.createN(STRING_CONVERTER.toString(input));
         } else {
             return AttributeValues.nullAttributeValue();
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OptionalIntAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OptionalIntAttributeConverter.java
@@ -76,7 +76,7 @@ public final class OptionalIntAttributeConverter implements AttributeConverter<O
     @Override
     public AttributeValue transformFrom(OptionalInt input) {
         if (input.isPresent()) {
-            return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+            return AttributeValue.createN(STRING_CONVERTER.toString(input));
         } else {
             return AttributeValues.nullAttributeValue();
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OptionalLongAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/OptionalLongAttributeConverter.java
@@ -76,7 +76,7 @@ public final class OptionalLongAttributeConverter implements AttributeConverter<
     @Override
     public AttributeValue transformFrom(OptionalLong input) {
         if (input.isPresent()) {
-            return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+            return AttributeValue.createN(STRING_CONVERTER.toString(input));
         } else {
             return AttributeValues.nullAttributeValue();
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/PeriodAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/PeriodAttributeConverter.java
@@ -62,7 +62,7 @@ public final class PeriodAttributeConverter implements AttributeConverter<Period
 
     @Override
     public AttributeValue transformFrom(Period input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/SdkBytesAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/SdkBytesAttributeConverter.java
@@ -63,7 +63,7 @@ public final class SdkBytesAttributeConverter implements AttributeConverter<SdkB
 
     @Override
     public AttributeValue transformFrom(SdkBytes input) {
-        return AttributeValue.builder().b(input).build();
+        return AttributeValue.createB(input);
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/SdkNumberAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/SdkNumberAttributeConverter.java
@@ -64,7 +64,7 @@ public final class SdkNumberAttributeConverter implements AttributeConverter<Sdk
 
     @Override
     public AttributeValue transformFrom(SdkNumber input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/SetAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/SetAttributeConverter.java
@@ -159,17 +159,17 @@ public class SetAttributeConverter<T extends Collection<?>> implements Attribute
                                          .convert(new TypeConvertingVisitor<T>(type.rawClass(), SetAttributeConverter.class) {
                                              @Override
                                              public T convertSetOfStrings(List<String> value) {
-                                                 return convertCollection(value, v -> AttributeValue.builder().s(v).build());
+                                                 return convertCollection(value, v -> AttributeValue.createS(v));
                                              }
 
                                              @Override
                                              public T convertSetOfNumbers(List<String> value) {
-                                                 return convertCollection(value, v -> AttributeValue.builder().n(v).build());
+                                                 return convertCollection(value, v -> AttributeValue.createN(v));
                                              }
 
                                              @Override
                                              public T convertSetOfBytes(List<SdkBytes> value) {
-                                                 return convertCollection(value, v -> AttributeValue.builder().b(v).build());
+                                                 return convertCollection(value, v -> AttributeValue.createB(v));
                                              }
 
                                              @Override
@@ -219,29 +219,23 @@ public class SetAttributeConverter<T extends Collection<?>> implements Attribute
 
             switch (attributeValueType) {
                 case NS:
-                    return AttributeValue.builder()
-                                         .ns(listOfAttributeValues.stream()
+                    return AttributeValue.createNs(listOfAttributeValues.stream()
                                                                   .peek(av -> Validate.isTrue(av.n() != null,
                                                                                               "Attribute value must be N."))
                                                                   .map(AttributeValue::n)
-                                                                  .collect(Collectors.toList()))
-                                         .build();
+                                                                  .collect(Collectors.toList()));
                 case SS:
-                    return AttributeValue.builder()
-                                         .ss(listOfAttributeValues.stream()
+                    return AttributeValue.createSs(listOfAttributeValues.stream()
                                                                   .peek(av -> Validate.isTrue(av.s() != null,
                                                                                               "Attribute value must be S."))
                                                                   .map(AttributeValue::s)
-                                                                  .collect(Collectors.toList()))
-                                         .build();
+                                                                  .collect(Collectors.toList()));
                 case BS:
-                    return AttributeValue.builder()
-                                         .bs(listOfAttributeValues.stream()
+                    return AttributeValue.createBs(listOfAttributeValues.stream()
                                                                   .peek(av -> Validate.isTrue(av.b() != null,
                                                                                               "Attribute value must be B."))
                                                                   .map(AttributeValue::b)
-                                                                  .collect(Collectors.toList()))
-                                         .build();
+                                                                  .collect(Collectors.toList()));
                 default:
                     throw new IllegalStateException("Unsupported set attribute value type: " + attributeValueType);
             }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ShortAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ShortAttributeConverter.java
@@ -64,7 +64,7 @@ public final class ShortAttributeConverter implements AttributeConverter<Short>,
 
     @Override
     public AttributeValue transformFrom(Short input) {
-        return AttributeValue.builder().n(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createN(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/StringAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/StringAttributeConverter.java
@@ -65,7 +65,7 @@ public final class StringAttributeConverter implements AttributeConverter<String
 
     @Override
     public AttributeValue transformFrom(String input) {
-        return input == null ? AttributeValues.nullAttributeValue() : AttributeValue.builder().s(input).build();
+        return input == null ? AttributeValues.nullAttributeValue() : AttributeValue.createS(input);
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/UriAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/UriAttributeConverter.java
@@ -55,7 +55,7 @@ public final class UriAttributeConverter implements AttributeConverter<URI> {
 
     @Override
     public AttributeValue transformFrom(URI input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/UrlAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/UrlAttributeConverter.java
@@ -55,7 +55,7 @@ public final class UrlAttributeConverter implements AttributeConverter<URL> {
 
     @Override
     public AttributeValue transformFrom(URL input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/UuidAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/UuidAttributeConverter.java
@@ -54,7 +54,7 @@ public final class UuidAttributeConverter implements AttributeConverter<UUID> {
 
     @Override
     public AttributeValue transformFrom(UUID input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ZoneIdAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ZoneIdAttributeConverter.java
@@ -57,7 +57,7 @@ public final class ZoneIdAttributeConverter implements AttributeConverter<ZoneId
 
     @Override
     public AttributeValue transformFrom(ZoneId input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ZoneOffsetAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ZoneOffsetAttributeConverter.java
@@ -58,7 +58,7 @@ public final class ZoneOffsetAttributeConverter implements AttributeConverter<Zo
 
     @Override
     public AttributeValue transformFrom(ZoneOffset input) {
-        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+        return AttributeValue.createS(STRING_CONVERTER.toString(input));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ZonedDateTimeAsStringAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ZonedDateTimeAsStringAttributeConverter.java
@@ -84,7 +84,7 @@ public final class ZonedDateTimeAsStringAttributeConverter implements AttributeC
 
     @Override
     public AttributeValue transformFrom(ZonedDateTime input) {
-        return AttributeValue.builder().s(input.toString()).build();
+        return AttributeValue.createS(input.toString());
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticImmutableTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticImmutableTableSchema.java
@@ -188,7 +188,7 @@ public final class StaticImmutableTableSchema<T, B> implements TableSchema<T> {
                             "[Attribute name: " + key + "]");
                     }
                     if (!ignoreNulls || value != null) {
-                        result.put(key, AttributeValue.builder().s(value).build());
+                        result.put(key, AttributeValue.createS(value));
                     }
                 });
             }


### PR DESCRIPTION
Continuation of https://github.com/aws/aws-sdk-java-v2/pull/7039

The previous PR did most of the work:
Introduced a new customization config flag that conditionally generates an alternative "direct" codepath for unions - specifically DDB's AttributeValue to avoid using the builder pattern, and instead use a factory methods which uses less memory allocations. 

This PR wires those factories into the Enhanced Client's write paths. It replaces `AttributeValue.builder().x(v).build()` with `AttributeValue.createX(v)` across all attribute converters, the `EnhancedAttributeValuevisitor`, and `StaticImmutableTableSchema`.



