### PR TITLE
feat(aws-crt-client): add tlsNegotiationTimeout configuration

### DIFF
--- a/.changes/next-release/feature-AWSCommonRuntimeHTTPClient-a093e97.json
+++ b/.changes/next-release/feature-AWSCommonRuntimeHTTPClient-a093e97.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS Common Runtime HTTP Client",
+    "contributor": "",
+    "description": "Added tlsNegotiationTimeout(Duration) configuration to AwsCrtAsyncHttpClient and AwsCrtHttpClient builders, mirroring the option on the Netty client. Configures the maximum amount of time a TLS handshake may take, from CLIENT HELLO through key exchange. Defaults to 10 seconds, matching the underlying CRT runtime's native default."
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -195,6 +195,17 @@ public final class AwsCrtAsyncHttpClient extends AwsCrtHttpClientBase implements
         AwsCrtAsyncHttpClient.Builder connectionAcquisitionTimeout(Duration connectionAcquisitionTimeout);
 
         /**
+         * Configure the maximum amount of time that a TLS handshake is allowed to take from the time the CLIENT HELLO
+         * message is sent to the time the client and server have fully negotiated ciphers and exchanged keys.
+         *
+         * <p>By default, it's 10 seconds.
+         *
+         * @param tlsNegotiationTimeout the timeout duration; must be positive
+         * @return this builder for method chaining.
+         */
+        AwsCrtAsyncHttpClient.Builder tlsNegotiationTimeout(Duration tlsNegotiationTimeout);
+
+        /**
          * Configure whether to enable {@code tcpKeepAlive} and relevant configuration for all connections established by this
          * client.
          *
@@ -267,6 +278,7 @@ public final class AwsCrtAsyncHttpClient extends AwsCrtHttpClientBase implements
         @Override
         public SdkAsyncHttpClient build() {
             return new AwsCrtAsyncHttpClient(this, getAttributeMap().build()
+                                                                      .merge(AwsCrtHttpClientBase.AWS_CRT_HTTP_DEFAULTS)
                                                                       .merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
         }
 
@@ -274,6 +286,7 @@ public final class AwsCrtAsyncHttpClient extends AwsCrtHttpClientBase implements
         public SdkAsyncHttpClient buildWithDefaults(AttributeMap serviceDefaults) {
             return new AwsCrtAsyncHttpClient(this, getAttributeMap().build()
                                                                     .merge(serviceDefaults)
+                                                                    .merge(AwsCrtHttpClientBase.AWS_CRT_HTTP_DEFAULTS)
                                                                     .merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
         }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
@@ -247,6 +247,17 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
         AwsCrtHttpClient.Builder connectionAcquisitionTimeout(Duration connectionAcquisitionTimeout);
 
         /**
+         * Configure the maximum amount of time that a TLS handshake is allowed to take from the time the CLIENT HELLO
+         * message is sent to the time the client and server have fully negotiated ciphers and exchanged keys.
+         *
+         * <p>By default, it's 10 seconds.
+         *
+         * @param tlsNegotiationTimeout the timeout duration; must be positive
+         * @return this builder for method chaining.
+         */
+        AwsCrtHttpClient.Builder tlsNegotiationTimeout(Duration tlsNegotiationTimeout);
+
+        /**
          * Configure whether to enable {@code tcpKeepAlive} and relevant configuration for all connections established by this
          * client.
          *
@@ -305,6 +316,7 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
         @Override
         public AwsCrtHttpClient build() {
             return new AwsCrtHttpClient(this, getAttributeMap().build()
+                                                         .merge(AwsCrtHttpClientBase.AWS_CRT_HTTP_DEFAULTS)
                                                          .merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
         }
 
@@ -312,6 +324,7 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
         public AwsCrtHttpClient buildWithDefaults(AttributeMap serviceDefaults) {
             return new AwsCrtHttpClient(this, getAttributeMap().build()
                                                          .merge(serviceDefaults)
+                                                         .merge(AwsCrtHttpClientBase.AWS_CRT_HTTP_DEFAULTS)
                                                          .merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
         }
     }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
@@ -78,7 +78,6 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
     private final ClientBootstrap bootstrap;
     private final SocketOptions socketOptions;
     private final TlsContext tlsContext;
-    private final TlsConnectionOptions tlsConnectionOptions;
     private final HttpProxyOptions proxyOptions;
     private final HttpMonitoringOptions monitoringOptions;
     private final long maxConnectionIdleInMilliseconds;
@@ -108,8 +107,6 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
         this.socketOptions = registerOwnedResource(clientSocketOptions);
         this.tlsContext = registerOwnedResource(clientTlsContext);
         this.tlsNegotiationTimeout = config.get(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT);
-        this.tlsConnectionOptions = registerOwnedResource(
-            buildTlsConnectionOptions(clientTlsContext, tlsNegotiationTimeout));
         this.readBufferSize = builder.getReadBufferSizeInBytes() == null ?
                               DEFAULT_STREAM_WINDOW_SIZE : builder.getReadBufferSizeInBytes();
         this.maxStreamsPerEndpoint = config.get(SdkHttpConfigurationOption.MAX_CONNECTIONS);
@@ -150,7 +147,11 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
                                     uri, maxStreamsPerEndpoint, maxStreamsPerEndpoint));
 
         boolean isHttps = "https".equalsIgnoreCase(uri.getScheme());
-        TlsConnectionOptions poolTlsConnectionOptions = isHttps ? tlsConnectionOptions : null;
+        TlsConnectionOptions poolTlsConnectionOptions = null;
+        if (isHttps) {
+            poolTlsConnectionOptions = registerOwnedResource(
+                buildTlsConnectionOptions(tlsContext, tlsNegotiationTimeout, uri.getHost()));
+        }
 
         HttpClientConnectionManagerOptions h1Options = new HttpClientConnectionManagerOptions()
                 .withClientBootstrap(bootstrap)

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
@@ -19,14 +19,17 @@ import static software.amazon.awssdk.crtcore.CrtConfigurationUtils.resolveHttpMo
 import static software.amazon.awssdk.crtcore.CrtConfigurationUtils.resolveProxy;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.PROTOCOL;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.buildSocketOptions;
+import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.buildTlsConnectionOptions;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.resolveCipherPreference;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.http.Http2StreamManagerOptions;
 import software.amazon.awssdk.crt.http.HttpClientConnectionManagerOptions;
@@ -37,6 +40,7 @@ import software.amazon.awssdk.crt.http.HttpStreamManagerOptions;
 import software.amazon.awssdk.crt.http.HttpVersion;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsConnectionOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.http.Protocol;
@@ -54,6 +58,14 @@ import software.amazon.awssdk.utils.uri.SdkUri;
  */
 @SdkProtectedApi
 abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
+    // TLS_NEGOTIATION_TIMEOUT diverges from the SDK global default (5s) for backwards compatibility:
+    // the underlying CRT has always applied a 10s handshake timeout, so adopting the 5s global would silently tighten the
+    // effective handshake timeout for existing CRT customers.
+    static final AttributeMap AWS_CRT_HTTP_DEFAULTS =
+        AttributeMap.builder()
+                    .put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, Duration.ofSeconds(10))
+                    .build();
+
     private static final Logger log = Logger.loggerFor(AwsCrtHttpClientBase.class);
 
     private static final String AWS_COMMON_RUNTIME = "AwsCommonRuntime";
@@ -66,12 +78,14 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
     private final ClientBootstrap bootstrap;
     private final SocketOptions socketOptions;
     private final TlsContext tlsContext;
+    private final TlsConnectionOptions tlsConnectionOptions;
     private final HttpProxyOptions proxyOptions;
     private final HttpMonitoringOptions monitoringOptions;
     private final long maxConnectionIdleInMilliseconds;
     private final int maxStreamsPerEndpoint;
     private final long connectionAcquisitionTimeout;
     private final TlsContextOptions tlsContextOptions;
+    private final Duration tlsNegotiationTimeout;
     private boolean isClosed = false;
 
     AwsCrtHttpClientBase(AwsCrtClientBuilderBase builder, AttributeMap config) {
@@ -93,6 +107,9 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
         this.bootstrap = registerOwnedResource(clientBootstrap);
         this.socketOptions = registerOwnedResource(clientSocketOptions);
         this.tlsContext = registerOwnedResource(clientTlsContext);
+        this.tlsNegotiationTimeout = config.get(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT);
+        this.tlsConnectionOptions = registerOwnedResource(
+            buildTlsConnectionOptions(clientTlsContext, tlsNegotiationTimeout));
         this.readBufferSize = builder.getReadBufferSizeInBytes() == null ?
                               DEFAULT_STREAM_WINDOW_SIZE : builder.getReadBufferSizeInBytes();
         this.maxStreamsPerEndpoint = config.get(SdkHttpConfigurationOption.MAX_CONNECTIONS);
@@ -122,18 +139,23 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
         return AWS_COMMON_RUNTIME;
     }
 
+    @SdkTestInternalApi
+    Duration resolvedTlsNegotiationTimeout() {
+        return tlsNegotiationTimeout;
+    }
+
     private HttpStreamManager createConnectionPool(URI uri) {
         log.debug(() ->
                       String.format("Creating ConnectionPool for: URI:%s, MaxConns: %d, MaxStreams: %d",
                                     uri, maxStreamsPerEndpoint, maxStreamsPerEndpoint));
 
         boolean isHttps = "https".equalsIgnoreCase(uri.getScheme());
-        TlsContext poolTlsContext = isHttps ? tlsContext : null;
+        TlsConnectionOptions poolTlsConnectionOptions = isHttps ? tlsConnectionOptions : null;
 
         HttpClientConnectionManagerOptions h1Options = new HttpClientConnectionManagerOptions()
                 .withClientBootstrap(bootstrap)
                 .withSocketOptions(socketOptions)
-                .withTlsContext(poolTlsContext)
+                .withTlsConnectionOptions(poolTlsConnectionOptions)
                 .withUri(uri)
                 .withWindowSize(readBufferSize)
                 .withMaxConnections(maxStreamsPerEndpoint)

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtClientBuilderBase.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtClientBuilderBase.java
@@ -106,6 +106,16 @@ public class AwsCrtClientBuilderBase<BuilderT> {
         return thisBuilder();
     }
 
+    public BuilderT tlsNegotiationTimeout(Duration tlsNegotiationTimeout) {
+        Validate.isPositive(tlsNegotiationTimeout, "tlsNegotiationTimeout");
+        standardOptions.put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, tlsNegotiationTimeout);
+        return thisBuilder();
+    }
+
+    public void setTlsNegotiationTimeout(Duration tlsNegotiationTimeout) {
+        tlsNegotiationTimeout(tlsNegotiationTimeout);
+    }
+
     public BuilderT tcpKeepAliveConfiguration(TcpKeepAliveConfiguration tcpKeepAliveConfiguration) {
         this.tcpKeepAliveConfiguration = tcpKeepAliveConfiguration;
         return thisBuilder();

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
@@ -55,10 +55,14 @@ public final class AwsCrtConfigurationUtils {
         return clientSocketOptions;
     }
 
-    public static TlsConnectionOptions buildTlsConnectionOptions(TlsContext tlsContext, Duration tlsNegotiationTimeout) {
+    public static TlsConnectionOptions buildTlsConnectionOptions(TlsContext tlsContext, Duration tlsNegotiationTimeout,
+                                                                 String serverName) {
         TlsConnectionOptions tlsConnectionOptions = new TlsConnectionOptions(tlsContext);
         if (tlsNegotiationTimeout != null) {
             tlsConnectionOptions.withTimeoutMs(NumericUtils.saturatedCast(tlsNegotiationTimeout.toMillis()));
+        }
+        if (serverName != null) {
+            tlsConnectionOptions.withServerName(serverName);
         }
         return tlsConnectionOptions;
     }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
@@ -20,6 +20,8 @@ import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
+import software.amazon.awssdk.crt.io.TlsConnectionOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.http.crt.TcpKeepAliveConfiguration;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.NumericUtils;
@@ -51,6 +53,14 @@ public final class AwsCrtConfigurationUtils {
         }
 
         return clientSocketOptions;
+    }
+
+    public static TlsConnectionOptions buildTlsConnectionOptions(TlsContext tlsContext, Duration tlsNegotiationTimeout) {
+        TlsConnectionOptions tlsConnectionOptions = new TlsConnectionOptions(tlsContext);
+        if (tlsNegotiationTimeout != null) {
+            tlsConnectionOptions.withTimeoutMs(NumericUtils.saturatedCast(tlsNegotiationTimeout.toMillis()));
+        }
+        return tlsConnectionOptions;
     }
 
     public static TlsCipherPreference resolveCipherPreference(Boolean postQuantumTlsEnabled) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientTest.java
@@ -19,24 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.utils.AttributeMap;
 
-
-public class AwsCrtHttpClientTest extends AwsCrtHttpClientTestBase {
-
-    @Test
-    public void negativeConnectionAcquisitionTimeout_shouldFail() {
-        assertThatThrownBy(() -> {
-            SdkHttpClient client = AwsCrtHttpClient.builder()
-                    .connectionAcquisitionTimeout(Duration.ofSeconds(-1))
-                    .build();
-            client.close();
-        }).hasMessage("connectionAcquisitionTimeout must be positive");
-    }
+class AwsCrtAsyncHttpClientTest extends AwsCrtHttpClientTestBase {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("invalidTlsNegotiationTimeouts")
@@ -47,31 +39,31 @@ public class AwsCrtHttpClientTest extends AwsCrtHttpClientTestBase {
             .hasMessageContaining(expectedMessageFragment);
     }
 
-    @Test
-    void syncBuilder_buildWithDefaults_serviceDefaultsLacksTlsNegotiationTimeout_resolvesToCrtDefault10s() {
-        try (SdkHttpClient client = AwsCrtHttpClient.builder().buildWithDefaults(AttributeMap.empty())) {
-            assertThat(((AwsCrtHttpClient) client).resolvedTlsNegotiationTimeout()).isEqualTo(CRT_DEFAULT);
-        }
-    }
-
-
-    @ParameterizedTest(name = "[sync] {0}")
+    @ParameterizedTest(name = "[async] {0}")
     @MethodSource("resolutionMatrix")
-    void syncBuilder_resolvedTlsNegotiationTimeout_matchesPathBPrecedence(String description, Duration customer,
-                                                                          Duration serviceDefault, Duration expected) {
-        AwsCrtHttpClient.Builder builder = AwsCrtHttpClient.builder();
+    void asyncBuilder_resolvedTlsNegotiationTimeout_matchesPathBPrecedence(String description, Duration customer,
+                                                                           Duration serviceDefault, Duration expected) {
+        AwsCrtAsyncHttpClient.Builder builder = AwsCrtAsyncHttpClient.builder();
         if (customer != null) {
             builder.tlsNegotiationTimeout(customer);
         }
 
-        try (SdkHttpClient client = buildSync(builder, serviceDefault)) {
-            assertThat(((AwsCrtHttpClient) client).resolvedTlsNegotiationTimeout()).isEqualTo(expected);
+        try (SdkAsyncHttpClient client = buildAsync(builder, serviceDefault)) {
+            assertThat(((AwsCrtAsyncHttpClient) client).resolvedTlsNegotiationTimeout()).isEqualTo(expected);
         }
     }
 
-    private static SdkHttpClient buildSync(AwsCrtHttpClient.Builder builder, Duration serviceDefault) {
+    @Test
+    void asyncBuilder_buildWithDefaults_serviceDefaultsLacksTlsNegotiationTimeout_resolvesToCrtDefault10s() {
+        try (SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.builder().buildWithDefaults(AttributeMap.empty())) {
+            assertThat(((AwsCrtAsyncHttpClient) client).resolvedTlsNegotiationTimeout()).isEqualTo(CRT_DEFAULT);
+        }
+    }
+
+    private static SdkAsyncHttpClient buildAsync(AwsCrtAsyncHttpClient.Builder builder, Duration serviceDefault) {
         return serviceDefault == null
                ? builder.build()
                : builder.buildWithDefaults(serviceDefaultsMap(serviceDefault));
     }
+
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientWireMockTest.java
@@ -29,6 +29,7 @@ import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createReque
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -39,6 +40,7 @@ import software.amazon.awssdk.crt.Log;
 import software.amazon.awssdk.http.HttpMetric;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.RecordingResponseHandler;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -48,7 +50,8 @@ import software.amazon.awssdk.utils.AttributeMap;
 public class AwsCrtAsyncHttpClientWireMockTest {
     @Rule
     public WireMockRule mockServer = new WireMockRule(wireMockConfig()
-                                                          .dynamicPort());
+                                                          .dynamicPort()
+                                                          .dynamicHttpsPort());
 
     @BeforeClass
     public static void setup() {
@@ -88,6 +91,31 @@ public class AwsCrtAsyncHttpClientWireMockTest {
         try (SdkAsyncHttpClient anotherClient = AwsCrtAsyncHttpClient.create()) {
             makeSimpleRequest(anotherClient);
         }
+    }
+
+    @Test
+    public void tlsNegotiationTimeout_customValue_clientStartsSuccessfully() throws Exception {
+        AttributeMap defaults = AttributeMap.builder().put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true).build();
+        try (SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.builder()
+                                                              .tlsNegotiationTimeout(Duration.ofSeconds(3))
+                                                              .buildWithDefaults(defaults)) {
+            makeSimpleHttpsRequest(client);
+        }
+    }
+
+    private RecordingResponseHandler makeSimpleHttpsRequest(SdkAsyncHttpClient client) throws Exception {
+        String body = randomAlphabetic(10);
+        URI uri = URI.create("https://localhost:" + mockServer.httpsPort());
+        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withBody(body)));
+        SdkHttpRequest request = createRequest(uri);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+        client.execute(AsyncExecuteRequest.builder()
+                                          .request(request)
+                                          .requestContentPublisher(createProvider(""))
+                                          .responseHandler(recorder)
+                                          .build());
+        recorder.completeFuture().get(5, TimeUnit.SECONDS);
+        return recorder;
     }
 
     /**

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientTest.java
@@ -42,7 +42,7 @@ public class AwsCrtHttpClientTest extends AwsCrtHttpClientTestBase {
     @MethodSource("invalidTlsNegotiationTimeouts")
     void tlsNegotiationTimeout_invalidDuration_shouldThrowException(String description, Duration input,
                                                                     String expectedMessageFragment) {
-        assertThatThrownBy(() -> AwsCrtAsyncHttpClient.builder().tlsNegotiationTimeout(input).build())
+        assertThatThrownBy(() -> AwsCrtHttpClient.builder().tlsNegotiationTimeout(input).build())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(expectedMessageFragment);
     }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientTestBase.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientTestBase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.utils.AttributeMap;
+
+
+public class AwsCrtHttpClientTestBase {
+    static final Duration CRT_DEFAULT = Duration.ofSeconds(10);
+    static final Duration CUSTOMER = Duration.ofSeconds(3);
+    static final Duration SERVICE_DEFAULT = Duration.ofSeconds(7);
+
+    static Stream<Arguments> invalidTlsNegotiationTimeouts() {
+        return Stream.of(
+            Arguments.of("null duration -> rejected by paramNotNull", null, "tlsNegotiationTimeout"),
+            Arguments.of("zero duration -> rejected by isPositive", Duration.ZERO, "must be positive"),
+            Arguments.of("negative duration -> rejected by isPositive", Duration.ofSeconds(-1), "must be positive")
+        );
+    }
+
+
+    static Stream<Arguments> resolutionMatrix() {
+        return Stream.of(
+            Arguments.of("customer unset, no service default -> CRT default (10s) beats GLOBAL (5s)",
+                         null, null, CRT_DEFAULT),
+            Arguments.of("customer unset, service default 7s -> service default beats CRT default",
+                         null, SERVICE_DEFAULT, SERVICE_DEFAULT),
+            Arguments.of("customer set 3s, no service default -> customer wins",
+                         CUSTOMER, null, CUSTOMER),
+            Arguments.of("customer set 3s, service default 7s -> customer beats service default",
+                         CUSTOMER, SERVICE_DEFAULT, CUSTOMER)
+        );
+    }
+
+
+    static AttributeMap serviceDefaultsMap(Duration tlsNegotiationTimeout) {
+        return AttributeMap.builder()
+                           .put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, tlsNegotiationTimeout)
+                           .build();
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
@@ -24,20 +24,20 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.PROTOCOL;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
 import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createRequest;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.Log;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteRequest;
@@ -45,15 +45,14 @@ import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.HttpMetric;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpClientTestSuite;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.utils.AttributeMap;
 
-public class AwsCrtHttpClientWireMockTest {
-    @Rule
-    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
-                                                          .dynamicPort());
+public class AwsCrtHttpClientWireMockTest extends SdkHttpClientTestSuite  {
 
     private static ScheduledExecutorService executorService;
 
@@ -114,6 +113,26 @@ public class AwsCrtHttpClientWireMockTest {
     }
 
     @Test
+    public void tlsNegotiationTimeout_customValue_clientStartsSuccessfully() throws Exception {
+        AttributeMap defaults = AttributeMap.builder().put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true).build();
+        try (SdkHttpClient client = AwsCrtHttpClient.builder()
+                                                    .tlsNegotiationTimeout(Duration.ofSeconds(3))
+                                                    .buildWithDefaults(defaults)) {
+            String body = randomAlphabetic(10);
+            URI uri = URI.create("https://localhost:" + mockServer.httpsPort());
+            stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withBody(body)));
+            SdkHttpRequest request = createRequest(uri);
+
+            HttpExecuteRequest.Builder executeRequestBuilder = HttpExecuteRequest.builder();
+            executeRequestBuilder.request(request)
+                                 .contentStreamProvider(() -> new ByteArrayInputStream(new byte[0]));
+            ExecutableHttpRequest executableRequest = client.prepareRequest(executeRequestBuilder.build());
+            HttpExecuteResponse response = executableRequest.call();
+            assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+        }
+    }
+
+    @Test
     public void abortRequest_shouldFailTheExceptionWithIOException() throws Exception {
         try (SdkHttpClient client = AwsCrtHttpClient.create()) {
             String body = randomAlphabetic(10);
@@ -150,5 +169,26 @@ public class AwsCrtHttpClientWireMockTest {
                              .metricCollector(metricCollector);
         ExecutableHttpRequest executableRequest = client.prepareRequest(executeRequestBuilder.build());
         return executableRequest.call();
+    }
+
+    /**
+     * default value of connectionAcquisitionTimeout of 10 will fail validatesHttpsCertificateIssuer() test
+     * */
+    @Override
+    protected SdkHttpClient createSdkHttpClient(SdkHttpClientOptions options) {
+        boolean trustAllCerts = options.trustAll();
+        return AwsCrtHttpClient.builder()
+                               .connectionAcquisitionTimeout(Duration.ofSeconds(40))
+                               .buildWithDefaults(AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, trustAllCerts).build());
+    }
+
+    // Empty test; behavior not supported when using custom factory
+    @Override
+    public void testCustomTlsTrustManagerAndTrustAllFails() {
+    }
+
+    // Empty test; behavior not supported when using custom factory
+    @Override
+    public void testCustomTlsTrustManager() {
     }
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtTlsHandshakeTimeoutTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtTlsHandshakeTimeoutTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.http.HttpTestUtils.createProvider;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
+import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.crt.http.HttpException;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.RecordingResponseHandler;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.utils.AttributeMap;
+
+/**
+ * Functional test that exercises the CRT runtime's TLS-handshake-timeout machinery end-to-end. Stands up a raw
+ * {@link ServerSocket} (NOT an {@code SSLServerSocket}) on loopback that accepts the TCP connection, drains a
+ * little of the ClientHello into a discard buffer, and never writes a ServerHello. The CRT TLS-negotiation timer
+ * fires before the connectionTimeout, completing the request future exceptionally.
+ */
+class AwsCrtTlsHandshakeTimeoutTest {
+
+    private static final Duration CONNECTION_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration ASSERTION_UPPER_BOUND = Duration.ofSeconds(10);
+
+    private TlsStallingServer stallingServer;
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("aws.crt.debugnative", "true");
+        Log.initLoggingToStdout(Log.LogLevel.Warn);
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        stallingServer = new TlsStallingServer();
+        stallingServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (stallingServer != null) {
+            stallingServer.stop();
+        }
+    }
+
+    @Test
+    void asyncClient_serverWithholdsServerHello_failsWithTlsNegotiationTimeoutDrivenByConfiguredValue() throws Exception {
+        Duration configuredTimeout = Duration.ofSeconds(3);
+        Duration elapsedFloor = Duration.ofMillis(1500);
+
+        AttributeMap defaults = AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, true).build();
+        try (SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.builder()
+                                                              .tlsNegotiationTimeout(configuredTimeout)
+                                                              .connectionTimeout(CONNECTION_TIMEOUT)
+                                                              .buildWithDefaults(defaults)) {
+
+            URI uri = URI.create("https://localhost:" + stallingServer.port());
+            SdkHttpRequest request = createRequest(uri);
+            RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+            long start = System.nanoTime();
+            client.execute(AsyncExecuteRequest.builder()
+                                              .request(request)
+                                              .requestContentPublisher(createProvider(""))
+                                              .responseHandler(recorder)
+                                              .build());
+
+            assertCompletedWithTlsNegotiationTimeout(recorder.completeFuture(), ASSERTION_UPPER_BOUND);
+            Duration elapsed = Duration.ofNanos(System.nanoTime() - start);
+            assertThat(elapsed).as("configured timeout %s should drive the deadline (elapsed=%s)", configuredTimeout, elapsed)
+                               .isGreaterThanOrEqualTo(elapsedFloor);
+        }
+    }
+
+    @Test
+    void syncClient_serverWithholdsServerHello_failsWithTlsNegotiationTimeoutDrivenByConfiguredValue() {
+        Duration configuredTimeout = Duration.ofSeconds(3);
+        Duration elapsedFloor = Duration.ofMillis(1500);
+
+        AttributeMap defaults = AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, true).build();
+        try (SdkHttpClient client = AwsCrtHttpClient.builder()
+                                                    .tlsNegotiationTimeout(configuredTimeout)
+                                                    .connectionTimeout(CONNECTION_TIMEOUT)
+                                                    .buildWithDefaults(defaults)) {
+
+            URI uri = URI.create("https://localhost:" + stallingServer.port());
+            SdkHttpRequest request = createRequest(uri);
+            HttpExecuteRequest httpExecuteRequest = HttpExecuteRequest.builder()
+                                                                     .request(request)
+                                                                     .contentStreamProvider(() -> new ByteArrayInputStream(new byte[0]))
+                                                                     .build();
+            ExecutableHttpRequest executableRequest = client.prepareRequest(httpExecuteRequest);
+
+            long start = System.nanoTime();
+            assertThatThrownBy(executableRequest::call)
+                .isInstanceOf(IOException.class)
+                .hasCauseInstanceOf(HttpException.class)
+                .hasMessageContaining("tls negotiation timeout");
+            Duration elapsed = Duration.ofNanos(System.nanoTime() - start);
+            assertThat(elapsed).as("configured timeout %s should drive the deadline (elapsed=%s)", configuredTimeout, elapsed)
+                               .isBetween(elapsedFloor, ASSERTION_UPPER_BOUND);
+        }
+    }
+
+    private static void assertCompletedWithTlsNegotiationTimeout(CompletableFuture<?> future, Duration upperBound) throws Exception {
+        try {
+            future.get(upperBound.toMillis(), TimeUnit.MILLISECONDS);
+            throw new AssertionError("Expected TLS-negotiation-timeout failure but the future completed successfully");
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new AssertionError("Future did not complete within " + upperBound + " - the TLS-handshake-timeout timer "
+                                     + "did not fire (or the SDK did not surface it).", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            assertThat(cause).isInstanceOf(IOException.class);
+            assertThat(cause).hasCauseInstanceOf(HttpException.class);
+            assertThat(cause).hasMessageContaining("tls negotiation timeout");
+        }
+    }
+
+    /**
+     * Raw {@link ServerSocket} on loopback that accepts TCP connections and never completes the TLS handshake.
+     * For each accepted client, a short-lived reader drains up to one buffer's worth of bytes (typically the
+     * ClientHello) so the kernel send buffer doesn't back-pressure the client into a write block, then the socket
+     * is held open until {@link #stop()} closes the listener. The client's TLS handshake timer fires while waiting
+     * for a ServerHello that never arrives.
+     */
+    private static final class TlsStallingServer {
+        private ServerSocket serverSocket;
+        private Thread listenerThread;
+        private volatile boolean running;
+
+        void start() throws IOException {
+            serverSocket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+            running = true;
+            listenerThread = new Thread(this::acceptLoop, "AwsCrtTlsHandshakeTimeoutTest-StallingServer");
+            listenerThread.setDaemon(true);
+            listenerThread.start();
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        void stop() {
+            running = false;
+            try {
+                serverSocket.close();
+            } catch (IOException ignored) {
+                // best-effort
+            }
+            if (listenerThread != null) {
+                listenerThread.interrupt();
+                try {
+                    listenerThread.join(TimeUnit.SECONDS.toMillis(2));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        private void acceptLoop() {
+            while (running && !Thread.currentThread().isInterrupted()) {
+                Socket client;
+                try {
+                    client = serverSocket.accept();
+                } catch (IOException e) {
+                    return;
+                }
+                Thread worker = new Thread(() -> drainAndStall(client),
+                                           "AwsCrtTlsHandshakeTimeoutTest-StallingClient");
+                worker.setDaemon(true);
+                worker.start();
+            }
+        }
+
+        private void drainAndStall(Socket client) {
+            try (InputStream in = client.getInputStream()) {
+                byte[] discard = new byte[4096];
+                client.setSoTimeout(200);
+                try {
+                    in.read(discard);
+                } catch (IOException ignored) {
+                    // expected: read times out or the client side closes when the TLS-negotiation timer fires.
+                }
+                while (running) {
+                    Thread.sleep(50);
+                }
+            } catch (IOException | InterruptedException ignored) {
+                // teardown path
+            } finally {
+                try {
+                    client.close();
+                } catch (IOException ignored) {
+                    // best-effort
+                }
+            }
+        }
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/H2BehaviorTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/H2BehaviorTest.java
@@ -49,6 +49,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,10 +86,24 @@ public class H2BehaviorTest {
         crt = null;
     }
 
+
     @Test
     public void sendH2Request_overTls() throws Exception {
         CompletableFuture<?> request = sendGetRequest(server.port(), crt);
         request.join();
+    }
+
+    @Test
+    public void buildH2HttpsClient_withCustomTlsNegotiationTimeout_doesNotNpeAndRequestSucceeds() throws Exception {
+        try (SdkAsyncHttpClient h2Client = AwsCrtAsyncHttpClient.builder()
+                                                                .tlsNegotiationTimeout(Duration.ofSeconds(3))
+                                                                .buildWithDefaults(AttributeMap.builder()
+                                                                                               .put(TRUST_ALL_CERTIFICATES, true)
+                                                                                               .put(PROTOCOL, Protocol.HTTP2)
+                                                                                               .build())) {
+            CompletableFuture<?> request = sendGetRequest(server.port(), h2Client);
+            request.join();
+        }
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <rxjava3.version>3.1.5</rxjava3.version>
         <commons-codec.verion>1.17.1</commons-codec.verion>
         <jmh.version>1.37</jmh.version>
-        <awscrt.version>0.46.1</awscrt.version>
+        <awscrt.version>0.47.2</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.10.3</junit5.version>


### PR DESCRIPTION


## Motivation and Context

Add tlsNegotiationTimeout(Duration) to AwsCrtAsyncHttpClient.Builder and AwsCrtHttpClient.Builder, mirroring the Netty client. Configures the maximum TLS handshake duration (CLIENT HELLO through key exchange). Defaults to 10 seconds, matching the underlying CRT runtime's native default (AWS_DEFAULT_TLS_TIMEOUT_MS).

## Modifications

### Public API (additive)

New methods on both CRT builders, with identical signatures and Javadoc:

```java
AwsCrtAsyncHttpClient.Builder tlsNegotiationTimeout(Duration tlsNegotiationTimeout);
AwsCrtHttpClient.Builder       tlsNegotiationTimeout(Duration tlsNegotiationTimeout);
```

A matching bean-style `setTlsNegotiationTimeout(Duration)` is also exposed on each `DefaultBuilder`/`DefaultAsyncBuilder` for `SdkBuilder` reflective access (mirroring the Netty client). Input is validated with `Validate.isPositive`; null and non-positive durations are rejected.

No new SPI option, no new public types. Strictly additive.

### Default resolution

The 10-second default is applied through a new `AWS_CRT_HTTP_DEFAULTS` `AttributeMap` declared on `AwsCrtHttpClientBase`, inserted between `serviceDefaults` and `GLOBAL_HTTP_DEFAULTS` in the four build sites (`build()` / `buildWithDefaults(...)` on each of the sync and async builders). This mirrors the existing `NETTY_HTTP_DEFAULTS` idiom in `NettyNioAsyncHttpClient`. With `AttributeMap.merge`'s "this > argument" semantics, the resulting precedence is:

```
customer-set > service-default > AWS_CRT_HTTP_DEFAULTS (10s) > GLOBAL_HTTP_DEFAULTS (5s)
```

The 10-second default is deliberate: the underlying CRT runtime (`aws-c-io`) has always applied a 10-second handshake timeout (`AWS_DEFAULT_TLS_TIMEOUT_MS = 10000`), so adopting the SDK's 5-second global default would silently tighten the effective handshake timeout for existing CRT customers. The SPI's 5-second default is unchanged; this is a CRT-client-local divergence, documented at the `AWS_CRT_HTTP_DEFAULTS` declaration.

### Construction path

`AwsCrtHttpClientBase` now builds a single `TlsConnectionOptions` from the shared `TlsContext` via a new helper `AwsCrtConfigurationUtils.buildTlsConnectionOptions(TlsContext, Duration)` and registers it as an owned `CrtResource`. `createConnectionPool(URI)` calls `withTlsConnectionOptions(...)` for HTTPS pools (replacing the previous `withTlsContext(...)`); HTTP pools pass null as before. The `Duration` is mapped to `int timeoutMs` via `NumericUtils.saturatedCast(toMillis())`, matching the saturation pattern already used for `connectTimeoutMs`.


## Testing
Added new tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds  <!-- Only the aws-crt-client module was built; no full-repo mvn install was run. -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed  <!-- In the aws-crt-client module on awscrt 0.46.1; H2-over-HTTPS tests temporarily @Disabled per the Release gating section. -->
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [[LaunchC](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)