### PR TITLE
fix: allow IPv6 EKS Pod Identity host regardless of IMDS endpoint mode

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -307,11 +307,7 @@ public final class ContainerCredentialsProvider
         }
 
         public boolean isMetadataServiceEndpoint(String host) {
-            String mode = SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE.getStringValueOrThrow();
-            if ("IPV6".equalsIgnoreCase(mode)) {
-                return VALID_LOOP_BACK_IPV6.contains(host);
-            }
-            return VALID_LOOP_BACK_IPV4.contains(host);
+            return VALID_LOOP_BACK_IPV4.contains(host) || VALID_LOOP_BACK_IPV6.contains(host);
         }
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsEndpointProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsEndpointProviderTest.java
@@ -164,6 +164,20 @@ public class ContainerCredentialsEndpointProviderTest {
                                                .headers(new HashMap<>())
                                                .build())),
 
+            // EKS Pod Identity sets the IPv6 container URI but does NOT set
+            // AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE (that controls IMDS, not the
+            // container credentials endpoint). The IPv6 host must be allowed with the
+            // mode left at its IPv4 default.
+            Arguments.of("http link-local EKS URI with IPv6, default endpoint mode",
+                         Collections.singletonList(Pair.of(FULL_URI_ENV, EKS_CONTAINER_HOST_IPV6 + "/credentials")),
+                         EKS_CONTAINER_HOST_IPV6 + "/credentials",
+                         new Result().type("success").sdkRequest(
+                             SdkHttpFullRequest.builder()
+                                               .uri(URI.create(EKS_CONTAINER_HOST_IPV6 + "/credentials"))
+                                               .method(SdkHttpMethod.GET)
+                                               .headers(new HashMap<>())
+                                               .build())),
+
             Arguments.of("complex full URI",
                          Collections.singletonList(Pair.of(FULL_URI_ENV, COMPLEX_URI)),
                          COMPLEX_URI,


### PR DESCRIPTION
ContainerCredentialsProvider rejects the EKS Pod Identity IPv6 endpoint (http://[fd00:ec2::23]/v1/credentials) unless AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE was explicitly set to IPV6. That variable configures the EC2 IMDS endpoint (169.254.169.254 vs [fd00:ec2::254]) which is (I believe?) a separate subsystem from the container credentials endpoint and EKS Pod Identity never sets it, so it defaults to the IPv4 allowlist. This behavior rejects valid IPv6 loopback hosts.

While users can technically set `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6`, but that env var also redirects the SDK's IMDS calls to [fd00:ec2::254] which may not be desired.

This change aligns the Java SDK with the C++, Python (botocore), Go v2, and JS v3 SDKs, all of which allow the EKS IPv6 host unconditionally.

Related issue: aws/containers-roadmap#2683.


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
