### PR TITLE
Add bug label to documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -2,7 +2,7 @@
 name: "📕 Documentation Issue"
 description: Report an issue in the API Reference documentation or Developer Guide
 title: "(short issue description)"
-labels: [documentation, needs-triage]
+labels: [documentation, needs-triage, bug]
 assignees: []
 body:
   - type: textarea


### PR DESCRIPTION
## Motivation and Context
Documentation issues require a `bug` or `feature-request` label for proper classification in repository metrics. Adding `bug` as the default label to align with other AWS SDK repositories.

## Modifications
Added `bug` to the labels list in `.github/ISSUE_TEMPLATE/documentation.yml`.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] I confirm that this pull request can be released under the Apache 2 license