### PR TITLE
 Remove ServiceMetadata usage from AwsClientEndpointProvider in generated client builders

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -30,6 +30,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,6 +50,7 @@ import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.BuiltInParameter;
 import software.amazon.awssdk.codegen.model.service.ClientContextParam;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
@@ -86,7 +88,6 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.StringUtils;
@@ -514,21 +515,53 @@ public class BaseClientBuilderClass implements ClassSpec {
         String serviceNameForSystemProperty = model.getNamingStrategy().getServiceNameForSystemProperties();
         String serviceNameForProfileFile = model.getNamingStrategy().getServiceNameForProfileFile();
 
-        builder.addCode("builder.lazyOptionIfAbsent($T.CLIENT_ENDPOINT_PROVIDER, c ->", SdkClientOption.class)
-               .addCode("  $T.builder()", AwsClientEndpointProvider.class)
-               .addCode("    .serviceEndpointOverrideEnvironmentVariable($S)", "AWS_ENDPOINT_URL_" + serviceNameForEnvVar)
-               .addCode("    .serviceEndpointOverrideSystemProperty($S)", "aws.endpointUrl" + serviceNameForSystemProperty)
-               .addCode("    .serviceProfileProperty($S)", serviceNameForProfileFile)
-               .addCode("    .serviceEndpointPrefix(serviceEndpointPrefix())")
-               .addCode("    .defaultProtocol($S)", "https")
-               .addCode("    .region(c.get($T.AWS_REGION))", AwsClientOption.class)
-               .addCode("    .profileFile(c.get($T.PROFILE_FILE_SUPPLIER))", SdkClientOption.class)
-               .addCode("    .profileName(c.get($T.PROFILE_NAME))", SdkClientOption.class)
-               .addCode("    .putAdvancedOption($T.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,", ServiceMetadataAdvancedOption.class)
-               .addCode("        c.get($T.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))", ServiceMetadataAdvancedOption.class)
-               .addCode("    .dualstackEnabled(c.get($T.DUALSTACK_ENDPOINT_ENABLED))", AwsClientOption.class)
-               .addCode("    .fipsEnabled(c.get($T.FIPS_ENDPOINT_ENABLED))", AwsClientOption.class)
-               .addCode("    .build());");
+        builder.addCode("builder.lazyOptionIfAbsent($T.CLIENT_ENDPOINT_PROVIDER, c -> {\n", SdkClientOption.class)
+               .addCode("  $T<$T> endpointFromOverrides = $T.builder()\n",
+                        Optional.class, ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"),
+                        AwsClientEndpointProvider.class)
+               .addCode("    .serviceEndpointOverrideEnvironmentVariable($S)\n", "AWS_ENDPOINT_URL_" + serviceNameForEnvVar)
+               .addCode("    .serviceEndpointOverrideSystemProperty($S)\n", "aws.endpointUrl" + serviceNameForSystemProperty)
+               .addCode("    .serviceProfileProperty($S)\n", serviceNameForProfileFile)
+               .addCode("    .profileFile(c.get($T.PROFILE_FILE_SUPPLIER))\n", SdkClientOption.class)
+               .addCode("    .profileName(c.get($T.PROFILE_NAME))\n", SdkClientOption.class)
+               .addCode("    .buildIfOverridePresent();\n")
+               .addCode("  if (endpointFromOverrides.isPresent()) {\n")
+               .addCode("    return endpointFromOverrides.get();\n")
+               .addCode("  }\n")
+               .addCode("  $T clientEndpointUri = null;\n", URI.class)
+               .addCode("  try {\n")
+               .addCode("    $T endpointParams = $T.builder()\n",
+                        endpointRulesSpecUtils.parametersClassName(), endpointRulesSpecUtils.parametersClassName())
+               .addCode("      .region(c.get($T.AWS_REGION))\n", AwsClientOption.class);
+
+        if (hasBuiltIn(BuiltInParameter.AWS_USE_DUAL_STACK)) {
+            builder.addCode("      .useDualStack(c.get($T.DUALSTACK_ENDPOINT_ENABLED))\n", AwsClientOption.class);
+        }
+        if (hasBuiltIn(BuiltInParameter.AWS_USE_FIPS)) {
+            builder.addCode("      .useFips(c.get($T.FIPS_ENDPOINT_ENABLED))\n", AwsClientOption.class);
+        }
+
+        builder.addCode("      .build();\n")
+               .addCode("    $T endpoint = $T.joinLikeSync(defaultEndpointProvider().resolveEndpoint(endpointParams));\n",
+                        ClassName.get("software.amazon.awssdk.endpoints", "Endpoint"),
+                        ClassName.get("software.amazon.awssdk.utils", "CompletableFutureUtils"))
+               .addCode("    clientEndpointUri = endpoint.url();\n")
+               .addCode("  } catch (Exception e) {\n")
+               .addCode("    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.\n")
+               .addCode("    return $T.create($T.create($S), false);\n",
+                        ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"),
+                        URI.class, "https://localhost")
+               .addCode("  }\n")
+               .addCode("  if (clientEndpointUri.getHost() == null) {\n")
+               .addCode("    throw $T.create(\"Configured region (\" + c.get($T.AWS_REGION)\n",
+                        ClassName.get("software.amazon.awssdk.core.exception", "SdkClientException"),
+                        AwsClientOption.class)
+               .addCode("      + \") resulted in an invalid URI: \" + clientEndpointUri\n")
+               .addCode("      + \". This is usually caused by an invalid region configuration.\");\n")
+               .addCode("  }\n")
+               .addCode("  return $T.create(clientEndpointUri, false);\n",
+                        ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"))
+               .addCode("});\n");
 
         if (model.getMetadata().isJsonProtocol()) {
             builder.addStatement("builder.option($1T.ENABLE_FAST_UNMARSHALLER, true)",
@@ -1049,6 +1082,11 @@ public class BaseClientBuilderClass implements ClassSpec {
     private boolean hasClientContextParams() {
         Map<String, ClientContextParam> clientContextParams = model.getClientContextParams();
         return clientContextParams != null && !clientContextParams.isEmpty();
+    }
+
+    private boolean hasBuiltIn(BuiltInParameter builtIn) {
+        return model.getEndpointRuleSetModel().getParameters().values().stream()
+                    .anyMatch(p -> builtIn.equals(p.getBuiltInEnum()));
     }
 
     private boolean hasSdkClientContextParams() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -516,17 +516,18 @@ public class BaseClientBuilderClass implements ClassSpec {
         String serviceNameForProfileFile = model.getNamingStrategy().getServiceNameForProfileFile();
 
         builder.addCode("builder.lazyOptionIfAbsent($T.CLIENT_ENDPOINT_PROVIDER, c -> {\n", SdkClientOption.class)
-               .addCode("  $T<$T> endpointFromOverrides = $T.builder()\n",
-                        Optional.class, ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"),
+               .addCode("  $T<$T> overrideEndpoint = $T.builder()\n",
+                        Optional.class, URI.class,
                         AwsClientEndpointProvider.class)
                .addCode("    .serviceEndpointOverrideEnvironmentVariable($S)\n", "AWS_ENDPOINT_URL_" + serviceNameForEnvVar)
                .addCode("    .serviceEndpointOverrideSystemProperty($S)\n", "aws.endpointUrl" + serviceNameForSystemProperty)
                .addCode("    .serviceProfileProperty($S)\n", serviceNameForProfileFile)
                .addCode("    .profileFile(c.get($T.PROFILE_FILE_SUPPLIER))\n", SdkClientOption.class)
                .addCode("    .profileName(c.get($T.PROFILE_NAME))\n", SdkClientOption.class)
-               .addCode("    .buildIfOverridePresent();\n")
-               .addCode("  if (endpointFromOverrides.isPresent()) {\n")
-               .addCode("    return endpointFromOverrides.get();\n")
+               .addCode("    .resolveFromOverrides();\n")
+               .addCode("  if (overrideEndpoint.isPresent()) {\n")
+               .addCode("    return $T.create(overrideEndpoint.get(), true);\n",
+                        ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"))
                .addCode("  }\n")
                .addCode("  $T clientEndpointUri = null;\n", URI.class)
                .addCode("  $T region = c.get($T.AWS_REGION);\n",
@@ -549,10 +550,9 @@ public class BaseClientBuilderClass implements ClassSpec {
                         ClassName.get("software.amazon.awssdk.endpoints", "Endpoint"),
                         ClassName.get("software.amazon.awssdk.utils", "CompletableFutureUtils"))
                .addCode("    clientEndpointUri = endpoint.url();\n")
-               .addCode("  } catch ($T e) {\n",
-                        ClassName.get("software.amazon.awssdk.core.exception", "SdkClientException"))
-               .addCode("    // Endpoint resolution failed. This is expected for services that require request-bound\n")
-               .addCode("    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.\n")
+               .addCode("  } catch (Exception e) {\n")
+               .addCode("    // Endpoint resolution failed. This is expected for services with required parameters\n")
+               .addCode("    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.\n")
                .addCode("    return $T.create($T.create($S), false);\n",
                         ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"),
                         URI.class, "https://localhost")

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -529,10 +529,13 @@ public class BaseClientBuilderClass implements ClassSpec {
                .addCode("    return endpointFromOverrides.get();\n")
                .addCode("  }\n")
                .addCode("  $T clientEndpointUri = null;\n", URI.class)
+               .addCode("  $T region = c.get($T.AWS_REGION);\n",
+                        ClassName.get("software.amazon.awssdk.regions", "Region"),
+                        AwsClientOption.class)
                .addCode("  try {\n")
                .addCode("    $T endpointParams = $T.builder()\n",
                         endpointRulesSpecUtils.parametersClassName(), endpointRulesSpecUtils.parametersClassName())
-               .addCode("      .region(c.get($T.AWS_REGION))\n", AwsClientOption.class);
+               .addCode("      .region(region)\n");
 
         if (hasBuiltIn(BuiltInParameter.AWS_USE_DUAL_STACK)) {
             builder.addCode("      .useDualStack(c.get($T.DUALSTACK_ENDPOINT_ENABLED))\n", AwsClientOption.class);
@@ -546,16 +549,17 @@ public class BaseClientBuilderClass implements ClassSpec {
                         ClassName.get("software.amazon.awssdk.endpoints", "Endpoint"),
                         ClassName.get("software.amazon.awssdk.utils", "CompletableFutureUtils"))
                .addCode("    clientEndpointUri = endpoint.url();\n")
-               .addCode("  } catch (Exception e) {\n")
-               .addCode("    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.\n")
+               .addCode("  } catch ($T e) {\n",
+                        ClassName.get("software.amazon.awssdk.core.exception", "SdkClientException"))
+               .addCode("    // Endpoint resolution failed. This is expected for services that require request-bound\n")
+               .addCode("    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.\n")
                .addCode("    return $T.create($T.create($S), false);\n",
                         ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"),
                         URI.class, "https://localhost")
                .addCode("  }\n")
                .addCode("  if (clientEndpointUri.getHost() == null) {\n")
-               .addCode("    throw $T.create(\"Configured region (\" + c.get($T.AWS_REGION)\n",
-                        ClassName.get("software.amazon.awssdk.core.exception", "SdkClientException"),
-                        AwsClientOption.class)
+               .addCode("    throw $T.create(\"Configured region (\" + region\n",
+                        ClassName.get("software.amazon.awssdk.core.exception", "SdkClientException"))
                .addCode("      + \") resulted in an invalid URI: \" + clientEndpointUri\n")
                .addCode("      + \". This is usually caused by an invalid region configuration.\");\n")
                .addCode("  }\n")

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.json;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -15,13 +17,16 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.scheme.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
@@ -29,15 +34,16 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.services.json.internal.JsonServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -96,20 +102,33 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson")
-                .serviceProfileProperty("json_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
+                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
+                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
@@ -112,20 +113,20 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
-                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -104,13 +104,13 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
                                                                                                   .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -119,9 +119,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -1,9 +1,11 @@
 package software.amazon.awssdk.services.json;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.MyServiceHttpConfig;
 import software.amazon.MyServiceRetryPolicy;
@@ -19,6 +21,7 @@ import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.codegen.poet.plugins.InternalTestPlugin1;
 import software.amazon.awssdk.codegen.poet.plugins.InternalTestPlugin2;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculationResolver;
@@ -27,9 +30,11 @@ import software.amazon.awssdk.core.checksums.ResponseChecksumValidationResolver;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.scheme.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
@@ -38,17 +43,18 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
 import software.amazon.awssdk.services.json.endpoints.JsonClientContextParams;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.services.json.internal.JsonServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -192,20 +198,33 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson")
-                .serviceProfileProperty("json_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
+                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
+                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         SdkClientConfiguration clientConfig = config;
         builder.lazyOption(SdkClientOption.REQUEST_CHECKSUM_CALCULATION, c -> resolveRequestChecksumCalculation(clientConfig));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
@@ -208,20 +209,20 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
-                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -200,13 +200,13 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
                                                                                                   .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -215,9 +215,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -119,13 +119,13 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
                                                                                                   .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -136,9 +136,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.query;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -17,6 +19,7 @@ import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointMode;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointModeResolver;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculationResolver;
@@ -25,9 +28,11 @@ import software.amazon.awssdk.core.checksums.ResponseChecksumValidationResolver;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
@@ -37,16 +42,17 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
 import software.amazon.awssdk.services.query.auth.scheme.internal.QueryAuthSchemeInterceptor;
 import software.amazon.awssdk.services.query.endpoints.QueryClientContextParams;
+import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryResolveEndpointInterceptor;
 import software.amazon.awssdk.services.query.internal.QueryServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -111,20 +117,35 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         builder.option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
-                .serviceProfileProperty("query_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
+                                                                                                  .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    QueryEndpointParams endpointParams = QueryEndpointParams.builder()
+                                                                            .region(c.get(AwsClientOption.AWS_REGION))
+                                                                            .useDualStack(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
+                                                                            .useFips(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         SdkClientConfiguration clientConfig = config;
         builder.lazyOption(SdkClientOption.REQUEST_CHECKSUM_CALCULATION, c -> resolveRequestChecksumCalculation(clientConfig));
         builder.lazyOption(SdkClientOption.RESPONSE_CHECKSUM_VALIDATION, c -> resolveResponseChecksumValidation(clientConfig));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
 import software.amazon.awssdk.services.query.auth.scheme.internal.QueryAuthSchemeInterceptor;
@@ -127,22 +128,22 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    QueryEndpointParams endpointParams = QueryEndpointParams.builder()
-                                                                            .region(c.get(AwsClientOption.AWS_REGION))
+                    QueryEndpointParams endpointParams = QueryEndpointParams.builder().region(region)
                                                                             .useDualStack(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
                                                                             .useFips(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.json;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -13,28 +15,32 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.services.json.internal.JsonServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Internal base class for {@link DefaultJsonClientBuilder} and {@link DefaultJsonAsyncClientBuilder}.
@@ -98,20 +104,33 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson")
-                .serviceProfileProperty("json_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
+                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
+                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -106,13 +106,13 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
                                                                                                   .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -121,9 +121,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
@@ -114,20 +115,20 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
-                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
@@ -123,13 +123,13 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
                                                                                                   .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -138,9 +138,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.json;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -15,6 +17,7 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculationResolver;
@@ -23,9 +26,11 @@ import software.amazon.awssdk.core.checksums.ResponseChecksumValidationResolver;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.scheme.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
@@ -34,16 +39,17 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
 import software.amazon.awssdk.services.json.endpoints.JsonClientContextParams;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.services.json.internal.JsonServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -115,20 +121,33 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.option(SdkClientOption.SERVICE_CONFIGURATION, finalServiceConfig);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson")
-                .serviceProfileProperty("json_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
+                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
+                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         SdkClientConfiguration clientConfig = config;
         builder.lazyOption(SdkClientOption.REQUEST_CHECKSUM_CALCULATION, c -> resolveRequestChecksumCalculation(clientConfig));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
@@ -131,20 +132,20 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
-                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
@@ -128,20 +129,20 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
-                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
@@ -1,5 +1,6 @@
 package software.amazon.awssdk.services.json;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,15 +18,18 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.scheme.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
@@ -33,16 +37,17 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.auth.scheme.internal.JsonAuthSchemeInterceptor;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.services.json.internal.EnvironmentTokenSystemSettings;
 import software.amazon.awssdk.services.json.internal.JsonServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -113,20 +118,33 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson")
-                .serviceProfileProperty("json_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
+                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder()
+                                                                          .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
@@ -120,13 +120,13 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
                                                                                                   .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -135,9 +135,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
@@ -101,13 +101,13 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_H2_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlH2").serviceProfileProperty("h2_service")
                                                                                                   .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -116,9 +116,9 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.h2.auth.scheme.H2AuthSchemeProvider;
 import software.amazon.awssdk.services.h2.auth.scheme.internal.H2AuthSchemeInterceptor;
@@ -109,20 +110,20 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(c.get(AwsClientOption.AWS_REGION))
-                                                                      .build();
+                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.h2;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -13,13 +15,16 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.ProtocolNegotiation;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
@@ -29,16 +34,17 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.h2.auth.scheme.H2AuthSchemeProvider;
 import software.amazon.awssdk.services.h2.auth.scheme.internal.H2AuthSchemeInterceptor;
+import software.amazon.awssdk.services.h2.endpoints.H2EndpointParams;
 import software.amazon.awssdk.services.h2.endpoints.H2EndpointProvider;
 import software.amazon.awssdk.services.h2.endpoints.internal.H2RequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.h2.endpoints.internal.H2ResolveEndpointInterceptor;
 import software.amazon.awssdk.services.h2.internal.H2ServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Internal base class for {@link DefaultH2ClientBuilder} and {@link DefaultH2AsyncClientBuilder}.
@@ -93,20 +99,33 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_H2_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlH2")
-                .serviceProfileProperty("h2_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_H2_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlH2").serviceProfileProperty("h2_service")
+                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(c.get(AwsClientOption.AWS_REGION))
+                                                                      .build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.h2.auth.scheme.H2AuthSchemeProvider;
 import software.amazon.awssdk.services.h2.auth.scheme.internal.H2AuthSchemeInterceptor;
@@ -108,20 +109,20 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(c.get(AwsClientOption.AWS_REGION))
-                                                                      .build();
+                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.h2;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -13,13 +15,16 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
@@ -28,16 +33,17 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.h2.auth.scheme.H2AuthSchemeProvider;
 import software.amazon.awssdk.services.h2.auth.scheme.internal.H2AuthSchemeInterceptor;
+import software.amazon.awssdk.services.h2.endpoints.H2EndpointParams;
 import software.amazon.awssdk.services.h2.endpoints.H2EndpointProvider;
 import software.amazon.awssdk.services.h2.endpoints.internal.H2RequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.h2.endpoints.internal.H2ResolveEndpointInterceptor;
 import software.amazon.awssdk.services.h2.internal.H2ServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Internal base class for {@link DefaultH2ClientBuilder} and {@link DefaultH2AsyncClientBuilder}.
@@ -92,20 +98,33 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_H2_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlH2")
-                .serviceProfileProperty("h2_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_H2_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlH2").serviceProfileProperty("h2_service")
+                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(c.get(AwsClientOption.AWS_REGION))
+                                                                      .build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
@@ -100,13 +100,13 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_H2_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlH2").serviceProfileProperty("h2_service")
                                                                                                   .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -115,9 +115,9 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.database;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -13,13 +15,16 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4aAuthScheme;
 import software.amazon.awssdk.http.auth.aws.signer.RegionSet;
@@ -28,15 +33,16 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.auth.scheme.internal.DatabaseAuthSchemeInterceptor;
+import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointParams;
 import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointProvider;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseResolveEndpointInterceptor;
 import software.amazon.awssdk.services.database.internal.DatabaseServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Internal base class for {@link DefaultDatabaseClientBuilder} and {@link DefaultDatabaseAsyncClientBuilder}.
@@ -92,20 +98,33 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
-                .serviceProfileProperty("database_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
+                                                                                                  .serviceProfileProperty("database_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder()
+                                                                                  .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
@@ -100,13 +100,13 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
                                                                                                   .serviceProfileProperty("database_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -115,9 +115,9 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.auth.scheme.internal.DatabaseAuthSchemeInterceptor;
@@ -108,20 +109,20 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder()
-                                                                                  .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
@@ -110,13 +110,13 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
                                                                                                   .serviceProfileProperty("database_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -125,9 +125,9 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.database;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -15,13 +17,16 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.scheme.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
@@ -30,15 +35,16 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.auth.scheme.internal.DatabaseAuthSchemeInterceptor;
+import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointParams;
 import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointProvider;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseResolveEndpointInterceptor;
 import software.amazon.awssdk.services.database.internal.DatabaseServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -102,20 +108,33 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
-                .serviceProfileProperty("database_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
+                                                                                                  .serviceProfileProperty("database_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder()
+                                                                                  .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.auth.scheme.internal.DatabaseAuthSchemeInterceptor;
@@ -118,20 +119,20 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder()
-                                                                                  .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.database;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -13,26 +15,30 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.auth.scheme.internal.DatabaseAuthSchemeInterceptor;
+import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointParams;
 import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointProvider;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseResolveEndpointInterceptor;
 import software.amazon.awssdk.services.database.internal.DatabaseServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Internal base class for {@link DefaultDatabaseClientBuilder} and {@link DefaultDatabaseAsyncClientBuilder}.
@@ -84,20 +90,33 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         builder.option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors);
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
-                .serviceProfileProperty("database_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
+                                                                                                  .serviceProfileProperty("database_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder()
+                                                                                  .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
@@ -92,13 +92,13 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_DATABASE_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlDatabase")
                                                                                                   .serviceProfileProperty("database_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -107,9 +107,9 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.SdkClientJsonProtocolAdvancedOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.auth.scheme.internal.DatabaseAuthSchemeInterceptor;
@@ -100,20 +101,20 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder()
-                                                                                  .region(c.get(AwsClientOption.AWS_REGION)).build();
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder().region(region).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -1,10 +1,12 @@
 package software.amazon.awssdk.services.query;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -17,6 +19,7 @@ import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointMode;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointModeResolver;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculationResolver;
@@ -25,9 +28,11 @@ import software.amazon.awssdk.core.checksums.ResponseChecksumValidationResolver;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.scheme.BearerAuthScheme;
 import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
@@ -35,16 +40,17 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
-import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
 import software.amazon.awssdk.services.query.auth.scheme.internal.QueryAuthSchemeInterceptor;
 import software.amazon.awssdk.services.query.endpoints.QueryClientContextParams;
+import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryResolveEndpointInterceptor;
 import software.amazon.awssdk.services.query.internal.QueryServiceClientConfigurationBuilder;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -109,20 +115,35 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         builder.option(AwsClientOption.ACCOUNT_ID_ENDPOINT_MODE, resolveAccountIdEndpointMode(config));
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-            c -> AwsClientEndpointProvider
-                .builder()
-                .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
-                .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
-                .serviceProfileProperty("query_service")
-                .serviceEndpointPrefix(serviceEndpointPrefix())
-                .defaultProtocol("https")
-                .region(c.get(AwsClientOption.AWS_REGION))
-                .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                .profileName(c.get(SdkClientOption.PROFILE_NAME))
-                .putAdvancedOption(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT,
-                                   c.get(ServiceMetadataAdvancedOption.DEFAULT_S3_US_EAST_1_REGIONAL_ENDPOINT))
-                .dualstackEnabled(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
-                .fipsEnabled(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build());
+            c -> {
+                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
+                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
+                                                                                                  .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
+                if (endpointFromOverrides.isPresent()) {
+                    return endpointFromOverrides.get();
+                }
+                URI clientEndpointUri = null;
+                try {
+                    QueryEndpointParams endpointParams = QueryEndpointParams.builder()
+                                                                            .region(c.get(AwsClientOption.AWS_REGION))
+                                                                            .useDualStack(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
+                                                                            .useFips(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    clientEndpointUri = endpoint.url();
+                } catch (Exception e) {
+                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                    return ClientEndpointProvider.create(URI.create("https://localhost"), false);
+                }
+                if (clientEndpointUri.getHost() == null) {
+                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
+                                                    + ") resulted in an invalid URI: " + clientEndpointUri
+                                                    + ". This is usually caused by an invalid region configuration.");
+                }
+                return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
         SdkClientConfiguration clientConfig = config;
         builder.lazyOption(SdkClientOption.REQUEST_CHECKSUM_CALCULATION, c -> resolveRequestChecksumCalculation(clientConfig));
         builder.lazyOption(SdkClientOption.RESPONSE_CHECKSUM_VALIDATION, c -> resolveResponseChecksumValidation(clientConfig));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.identity.spi.TokenIdentity;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
 import software.amazon.awssdk.services.query.auth.scheme.internal.QueryAuthSchemeInterceptor;
@@ -125,22 +126,22 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                     return endpointFromOverrides.get();
                 }
                 URI clientEndpointUri = null;
+                Region region = c.get(AwsClientOption.AWS_REGION);
                 try {
-                    QueryEndpointParams endpointParams = QueryEndpointParams.builder()
-                                                                            .region(c.get(AwsClientOption.AWS_REGION))
+                    QueryEndpointParams endpointParams = QueryEndpointParams.builder().region(region)
                                                                             .useDualStack(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
                                                                             .useFips(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build();
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (Exception e) {
-                    // Resolution requires request-bound params; fallback to placeholder, resolved at request time.
+                } catch (SdkClientException e) {
+                    // Endpoint resolution failed. This is expected for services that require request-bound
+                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {
-                    throw SdkClientException.create("Configured region (" + c.get(AwsClientOption.AWS_REGION)
-                                                    + ") resulted in an invalid URI: " + clientEndpointUri
-                                                    + ". This is usually caused by an invalid region configuration.");
+                    throw SdkClientException.create("Configured region (" + region + ") resulted in an invalid URI: "
+                                                    + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -117,13 +117,13 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         builder.lazyOptionIfAbsent(
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
-                Optional<ClientEndpointProvider> endpointFromOverrides = AwsClientEndpointProvider.builder()
+                Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                                                   .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
                                                                                                   .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
                                                                                                   .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).buildIfOverridePresent();
-                if (endpointFromOverrides.isPresent()) {
-                    return endpointFromOverrides.get();
+                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                if (overrideEndpoint.isPresent()) {
+                    return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
                 URI clientEndpointUri = null;
                 Region region = c.get(AwsClientOption.AWS_REGION);
@@ -134,9 +134,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                     Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
                         endpointParams));
                     clientEndpointUri = endpoint.url();
-                } catch (SdkClientException e) {
-                    // Endpoint resolution failed. This is expected for services that require request-bound
-                    // params (e.g., S3 bucket). Use a placeholder that will be resolved at request time.
+                } catch (Exception e) {
+                    // Endpoint resolution failed. This is expected for services with required parameters
+                    // beyond region, dualstack, and FIPS. Use a placeholder that will be replaced at request time.
                     return ClientEndpointProvider.create(URI.create("https://localhost"), false);
                 }
                 if (clientEndpointUri.getHost() == null) {

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProvider.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProvider.java
@@ -74,10 +74,6 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         this.clientEndpoint = new Lazy<>(() -> resolveClientEndpoint(new Builder(builder)));
     }
 
-    private AwsClientEndpointProvider(Builder builder, boolean overridesOnly) {
-        this.clientEndpoint = new Lazy<>(() -> resolveFromOverridesAndEnvironment(new Builder(builder)));
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -99,19 +95,12 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         return clientEndpoint.getValue().isEndpointOverridden;
     }
 
-    // TODO: Remove once all callers are migrated to use resolveFromOverridesAndEnvironment
-    private ClientEndpoint resolveClientEndpoint(Builder builder) {
+    // TODO: Remove once all callers are migrated to use resolveFromOverrides
+    private static ClientEndpoint resolveClientEndpoint(Builder builder) {
         return OptionalUtils.firstPresent(clientEndpointFromClientOverride(builder),
                                           () -> clientEndpointFromEnvironment(builder),
                                           () -> clientEndpointFromServiceMetadata(builder))
                             .orElseThrow(AwsClientEndpointProvider::failToLoadEndpointException);
-    }
-
-    private ClientEndpoint resolveFromOverridesAndEnvironment(Builder builder) {
-        initializeProfileFileDefaults(builder);
-        return OptionalUtils.firstPresent(clientEndpointFromClientOverride(builder),
-                                          () -> clientEndpointFromEnvironment(builder))
-                            .orElse(null);
     }
 
     private static SdkClientException failToLoadEndpointException() {
@@ -119,14 +108,14 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
                                          AwsClientEndpointProvider.class.getName() + " for more information.");
     }
 
-    private Optional<ClientEndpoint> clientEndpointFromClientOverride(Builder builder) {
+    private static Optional<ClientEndpoint> clientEndpointFromClientOverride(Builder builder) {
         Optional<ClientEndpoint> result = Optional.ofNullable(builder.clientEndpointOverride)
                                                   .map(uri -> new ClientEndpoint(uri, true));
         result.ifPresent(e -> log.trace(() -> "Client was configured with endpoint override: " + e.clientEndpoint));
         return result;
     }
 
-    private Optional<ClientEndpoint> clientEndpointFromEnvironment(Builder builder) {
+    private static Optional<ClientEndpoint> clientEndpointFromEnvironment(Builder builder) {
         if (builder.serviceEndpointOverrideEnvironmentVariable == null ||
             builder.serviceEndpointOverrideSystemProperty == null ||
             builder.serviceProfileProperty == null) {
@@ -159,19 +148,19 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
                             .map(uri -> new ClientEndpoint(uri, true));
     }
 
-    private Optional<URI> systemProperty(String systemProperty) {
+    private static Optional<URI> systemProperty(String systemProperty) {
         // CHECKSTYLE:OFF - We have to read system properties directly here to match the load order of the other SDKs
         return createUri("system property " + systemProperty,
                          Optional.ofNullable(System.getProperty(systemProperty)));
         // CHECKSTYLE:ON
     }
 
-    private Optional<URI> environmentVariable(String environmentVariable) {
+    private static Optional<URI> environmentVariable(String environmentVariable) {
         return createUri("environment variable " + environmentVariable,
                          SystemSettingUtils.resolveEnvironmentVariable(environmentVariable));
     }
 
-    private Optional<URI> profileProperty(Builder builder, String profileProperty) {
+    private static Optional<URI> profileProperty(Builder builder, String profileProperty) {
         initializeProfileFileDefaults(builder);
         return createUri("profile property " + profileProperty,
                          Optional.ofNullable(builder.profileFile.get())
@@ -179,7 +168,7 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
                                  .flatMap(p -> p.property(profileProperty)));
     }
 
-    private Optional<URI> servicesProperty(Builder builder) {
+    private static Optional<URI> servicesProperty(Builder builder) {
         Optional<ProfileFile> profileFile = Optional.ofNullable(builder.profileFile.get());
         Optional<String> servicesSectionName = profileFile
             .flatMap(pf -> pf.profile(builder.profileName))
@@ -193,7 +182,7 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         return createUri("services section property", serviceEndpoint);
     }
 
-    private Optional<ClientEndpoint> clientEndpointFromServiceMetadata(Builder builder) {
+    private static Optional<ClientEndpoint> clientEndpointFromServiceMetadata(Builder builder) {
         // This value is generally overridden after endpoints 2.0. It seems to exist for backwards-compatibility
         // with older client versions or interceptors.
 
@@ -270,7 +259,7 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         return Optional.of(new ClientEndpoint(endpoint, false));
     }
 
-    private Optional<URI> createUri(String source, Optional<String> uri) {
+    private static Optional<URI> createUri(String source, Optional<String> uri) {
         return uri.map(u -> {
             try {
                 URI parsedUri = SdkUri.getInstance().newUri(uri.get());
@@ -282,7 +271,7 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         });
     }
 
-    private void initializeProfileFileDefaults(Builder builder) {
+    private static void initializeProfileFileDefaults(Builder builder) {
         if (builder.profileFile == null) {
             builder.profileFile = new Lazy<>(ProfileFile::defaultProfileFile)::getValue;
         }
@@ -496,15 +485,17 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         }
 
         /**
-         * Build a {@link ClientEndpointProvider} if an endpoint override or environment-based endpoint is configured.
-         * Returns {@link Optional#empty()} if no override is found, allowing callers to provide their own fallback.
+         * Resolve an endpoint from overrides and environment configuration.
+         * Checks client override, system properties, environment variables, and profile configuration.
+         * Returns {@link Optional#empty()} if no override is configured, allowing callers to provide
+         * their own fallback.
          */
-        public Optional<ClientEndpointProvider> buildIfOverridePresent() {
-            AwsClientEndpointProvider provider = new AwsClientEndpointProvider(this, true);
-            if (provider.clientEndpoint.getValue() == null) {
-                return Optional.empty();
-            }
-            return Optional.of(provider);
+        public Optional<URI> resolveFromOverrides() {
+            Builder copy = new Builder(this);
+            initializeProfileFileDefaults(copy);
+            return OptionalUtils.firstPresent(clientEndpointFromClientOverride(copy),
+                                              () -> clientEndpointFromEnvironment(copy))
+                                .map(endpoint -> endpoint.clientEndpoint);
         }
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProvider.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProvider.java
@@ -74,6 +74,10 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         this.clientEndpoint = new Lazy<>(() -> resolveClientEndpoint(new Builder(builder)));
     }
 
+    private AwsClientEndpointProvider(Builder builder, boolean overridesOnly) {
+        this.clientEndpoint = new Lazy<>(() -> resolveFromOverridesAndEnvironment(new Builder(builder)));
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -95,11 +99,19 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         return clientEndpoint.getValue().isEndpointOverridden;
     }
 
+    // TODO: Remove once all callers are migrated to use resolveFromOverridesAndEnvironment
     private ClientEndpoint resolveClientEndpoint(Builder builder) {
         return OptionalUtils.firstPresent(clientEndpointFromClientOverride(builder),
                                           () -> clientEndpointFromEnvironment(builder),
                                           () -> clientEndpointFromServiceMetadata(builder))
                             .orElseThrow(AwsClientEndpointProvider::failToLoadEndpointException);
+    }
+
+    private ClientEndpoint resolveFromOverridesAndEnvironment(Builder builder) {
+        initializeProfileFileDefaults(builder);
+        return OptionalUtils.firstPresent(clientEndpointFromClientOverride(builder),
+                                          () -> clientEndpointFromEnvironment(builder))
+                            .orElse(null);
     }
 
     private static SdkClientException failToLoadEndpointException() {
@@ -488,16 +500,11 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
          * Returns {@link Optional#empty()} if no override is found, allowing callers to provide their own fallback.
          */
         public Optional<ClientEndpointProvider> buildIfOverridePresent() {
-            this.serviceEndpointPrefix = null;
-            this.region = null;
-            this.protocol = null;
-            AwsClientEndpointProvider provider = new AwsClientEndpointProvider(this);
-            try {
-                provider.clientEndpoint();
-                return Optional.of(provider);
-            } catch (SdkClientException e) {
+            AwsClientEndpointProvider provider = new AwsClientEndpointProvider(this, true);
+            if (provider.clientEndpoint.getValue() == null) {
                 return Optional.empty();
             }
+            return Optional.of(provider);
         }
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProvider.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProvider.java
@@ -482,5 +482,22 @@ public final class AwsClientEndpointProvider implements ClientEndpointProvider {
         public AwsClientEndpointProvider build() {
             return new AwsClientEndpointProvider(this);
         }
+
+        /**
+         * Build a {@link ClientEndpointProvider} if an endpoint override or environment-based endpoint is configured.
+         * Returns {@link Optional#empty()} if no override is found, allowing callers to provide their own fallback.
+         */
+        public Optional<ClientEndpointProvider> buildIfOverridePresent() {
+            this.serviceEndpointPrefix = null;
+            this.region = null;
+            this.protocol = null;
+            AwsClientEndpointProvider provider = new AwsClientEndpointProvider(this);
+            try {
+                provider.clientEndpoint();
+                return Optional.of(provider);
+            } catch (SdkClientException e) {
+                return Optional.empty();
+            }
+        }
     }
 }

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProviderBuildIfOverridePresentTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProviderBuildIfOverridePresentTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ClientEndpointProvider;
+
+class AwsClientEndpointProviderBuildIfOverridePresentTest {
+
+    private static final String TEST_SYSTEM_PROPERTY = "aws.endpointUrlTestService";
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty(TEST_SYSTEM_PROPERTY);
+    }
+
+    @Test
+    void buildIfOverridePresent_withClientEndpointOverride_returnsProviderWithOverride() {
+        URI override = URI.create("https://custom-endpoint.example.com");
+
+        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+            .clientEndpointOverride(override)
+            .buildIfOverridePresent();
+
+        assertThat(result).isPresent();
+        assertThat(result.get().clientEndpoint()).isEqualTo(override);
+        assertThat(result.get().isEndpointOverridden()).isTrue();
+    }
+
+    @Test
+    void buildIfOverridePresent_withSystemPropertyEndpoint_returnsProviderWithEndpoint() {
+        System.setProperty(TEST_SYSTEM_PROPERTY, "https://sys-prop-endpoint.example.com");
+
+        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+            .serviceEndpointOverrideSystemProperty(TEST_SYSTEM_PROPERTY)
+            .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_TEST_SERVICE")
+            .serviceProfileProperty("testservice")
+            .buildIfOverridePresent();
+
+        assertThat(result).isPresent();
+        assertThat(result.get().clientEndpoint())
+            .isEqualTo(URI.create("https://sys-prop-endpoint.example.com"));
+        assertThat(result.get().isEndpointOverridden()).isTrue();
+    }
+
+    @Test
+    void buildIfOverridePresent_withNoOverrideOrEnvironment_returnsEmpty() {
+        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+            .serviceEndpointOverrideSystemProperty("aws.endpointUrlNonExistent")
+            .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_NON_EXISTENT")
+            .serviceProfileProperty("nonexistent")
+            .buildIfOverridePresent();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void buildIfOverridePresent_withNoParamsConfigured_returnsEmpty() {
+        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+            .buildIfOverridePresent();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void buildIfOverridePresent_withoutServiceMetadataParams_returnsProviderWithOverride() {
+        URI override = URI.create("https://override.example.com");
+
+        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+            .clientEndpointOverride(override)
+            .buildIfOverridePresent();
+
+        assertThat(result).isPresent();
+        assertThat(result.get().clientEndpoint()).isEqualTo(override);
+    }
+}

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProviderResolveFromOverridesTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/endpoint/AwsClientEndpointProviderResolveFromOverridesTest.java
@@ -21,9 +21,8 @@ import java.net.URI;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.core.ClientEndpointProvider;
 
-class AwsClientEndpointProviderBuildIfOverridePresentTest {
+class AwsClientEndpointProviderResolveFromOverridesTest {
 
     private static final String TEST_SYSTEM_PROPERTY = "aws.endpointUrlTestService";
 
@@ -33,62 +32,48 @@ class AwsClientEndpointProviderBuildIfOverridePresentTest {
     }
 
     @Test
-    void buildIfOverridePresent_withClientEndpointOverride_returnsProviderWithOverride() {
+    void resolveFromOverrides_withClientEndpointOverride_returnsOverrideUri() {
         URI override = URI.create("https://custom-endpoint.example.com");
 
-        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+        Optional<URI> result = AwsClientEndpointProvider.builder()
             .clientEndpointOverride(override)
-            .buildIfOverridePresent();
+            .resolveFromOverrides();
 
         assertThat(result).isPresent();
-        assertThat(result.get().clientEndpoint()).isEqualTo(override);
-        assertThat(result.get().isEndpointOverridden()).isTrue();
+        assertThat(result.get()).isEqualTo(override);
     }
 
     @Test
-    void buildIfOverridePresent_withSystemPropertyEndpoint_returnsProviderWithEndpoint() {
+    void resolveFromOverrides_withSystemPropertyEndpoint_returnsEndpointUri() {
         System.setProperty(TEST_SYSTEM_PROPERTY, "https://sys-prop-endpoint.example.com");
 
-        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+        Optional<URI> result = AwsClientEndpointProvider.builder()
             .serviceEndpointOverrideSystemProperty(TEST_SYSTEM_PROPERTY)
             .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_TEST_SERVICE")
             .serviceProfileProperty("testservice")
-            .buildIfOverridePresent();
+            .resolveFromOverrides();
 
         assertThat(result).isPresent();
-        assertThat(result.get().clientEndpoint())
-            .isEqualTo(URI.create("https://sys-prop-endpoint.example.com"));
-        assertThat(result.get().isEndpointOverridden()).isTrue();
+        assertThat(result.get()).isEqualTo(URI.create("https://sys-prop-endpoint.example.com"));
     }
 
     @Test
-    void buildIfOverridePresent_withNoOverrideOrEnvironment_returnsEmpty() {
-        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
+    void resolveFromOverrides_withNoOverrideOrEnvironment_returnsEmpty() {
+        Optional<URI> result = AwsClientEndpointProvider.builder()
             .serviceEndpointOverrideSystemProperty("aws.endpointUrlNonExistent")
             .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_NON_EXISTENT")
             .serviceProfileProperty("nonexistent")
-            .buildIfOverridePresent();
+            .resolveFromOverrides();
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    void buildIfOverridePresent_withNoParamsConfigured_returnsEmpty() {
-        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
-            .buildIfOverridePresent();
+    void resolveFromOverrides_withNoParamsConfigured_returnsEmpty() {
+        Optional<URI> result = AwsClientEndpointProvider.builder()
+            .resolveFromOverrides();
 
         assertThat(result).isEmpty();
     }
 
-    @Test
-    void buildIfOverridePresent_withoutServiceMetadataParams_returnsProviderWithOverride() {
-        URI override = URI.create("https://override.example.com");
-
-        Optional<ClientEndpointProvider> result = AwsClientEndpointProvider.builder()
-            .clientEndpointOverride(override)
-            .buildIfOverridePresent();
-
-        assertThat(result).isPresent();
-        assertThat(result.get().clientEndpoint()).isEqualTo(override);
-    }
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/ClientEndpointResolutionTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/ClientEndpointResolutionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.endpointproviders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.EndpointCapturingInterceptor;
+import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersClient;
+
+/**
+ * Tests that the generated client builder resolves a default endpoint when no override is configured,
+ * and correctly uses endpoint overrides from client configuration, system properties, and environment sources.
+ */
+public class ClientEndpointResolutionTest {
+
+    private static final String SERVICE_SYSTEM_PROPERTY = "aws.endpointUrlRestJsonEndpointProviders";
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty(SERVICE_SYSTEM_PROPERTY);
+    }
+
+    @Test
+    void clientBuild_withRegionOnly_resolvesEndpointViaEndpoints2() {
+        EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+
+        RestJsonEndpointProvidersClient client = RestJsonEndpointProvidersClient.builder()
+            .region(Region.US_WEST_2)
+            .credentialsProvider(AnonymousCredentialsProvider.create())
+            .overrideConfiguration(c -> c.addExecutionInterceptor(interceptor))
+            .build();
+
+        try {
+            client.operationWithNoInputOrOutput(r -> {});
+        } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+            // Expected
+        }
+
+        assertThat(interceptor.endpoints())
+            .singleElement()
+            .asString()
+            .contains("us-west-2")
+            .contains("amazonaws.com");
+    }
+
+    @Test
+    void clientBuild_withSystemPropertyOverride_usesOverrideEndpoint() {
+        System.setProperty(SERVICE_SYSTEM_PROPERTY, "https://custom-override.example.com");
+
+        EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+
+        RestJsonEndpointProvidersClient client = RestJsonEndpointProvidersClient.builder()
+            .region(Region.US_WEST_2)
+            .credentialsProvider(AnonymousCredentialsProvider.create())
+            .overrideConfiguration(c -> c.addExecutionInterceptor(interceptor))
+            .build();
+
+        try {
+            client.operationWithNoInputOrOutput(r -> {});
+        } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+            // Expected
+        }
+
+        assertThat(interceptor.endpoints())
+            .singleElement()
+            .asString()
+            .startsWith("https://custom-override.example.com");
+    }
+
+    @Test
+    void clientBuild_withEndpointOverride_usesClientOverride() {
+        EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+
+        RestJsonEndpointProvidersClient client = RestJsonEndpointProvidersClient.builder()
+            .region(Region.US_WEST_2)
+            .endpointOverride(URI.create("https://my-override.example.com"))
+            .credentialsProvider(AnonymousCredentialsProvider.create())
+            .overrideConfiguration(c -> c.addExecutionInterceptor(interceptor))
+            .build();
+
+        try {
+            client.operationWithNoInputOrOutput(r -> {});
+        } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+            // Expected
+        }
+
+        assertThat(interceptor.endpoints())
+            .singleElement()
+            .asString()
+            .startsWith("https://my-override.example.com");
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When creating any AWS service client (e.g., DynamoDbClient.builder().region(...).build()), the SDK resolves a default client endpoint by calling ServiceMetadata.of(servicePrefix). This triggers the static initialization of GeneratedServiceMetadataProvider, which eagerly instantiates all 310 service metadata classes — even though only one is needed. This adds 350-500ms of cold start latency, significantly impacting Lambda and other latency-sensitive
applications.

The endpoint resolved by ServiceMetadata is ultimately replaced by Endpoints 2.0 at request time anyway, making this initialization cost entirely wasted.

## Modifications

AwsClientEndpointProvider.java

   - Added buildIfOverridePresent() method to the Builder. This checks only endpoint overrides and environment sources (system properties, env vars, profile config) and returns Optional.empty() if none are configured, without ever touching ServiceMetadata.
   - Added resolveFromOverridesAndEnvironment() — same resolution chain as existing resolveClientEndpoint() but without the ServiceMetadata fallback.

   BaseClientBuilderClass.java (codegen template)

   - Changed the generated finalizeServiceConfiguration() method to use a three-step approach:
     1. Call buildIfOverridePresent() — if the user configured an override or environment endpoint, use it directly.
     2. Best-effort resolve using the service's own Endpoints 2.0 provider with client-config params (region, fips, dualstack). This succeeds for 95%+ of services and produces a real, debuggable endpoint.
     3. If Endpoints 2.0 resolution fails (e.g., S3 requires request-bound params like bucket, forcePathStyle), fall back to a https://localhost placeholder that gets replaced at request time.

   - Added host validation after successful resolution to preserve fail-fast behavior for invalid regions (e.g., US_EAST_1 with underscores).
   - useDualStack/useFips params are only set conditionally based on whether the service's endpoint rules model declares those built-ins.

## Testing
- Added unit tests for buildIfOverridePresent() covering override path, environment path, and empty result when no override is configured.
- Verified existing endpoint resolution and invalid region validation tests continue to pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
