### PR TITLE
use class-based temporaryBucketName for s3 stability test buckets

### DIFF
--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3AsyncWithCrtAsyncHttpClientStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3AsyncWithCrtAsyncHttpClientStabilityTest.java
@@ -1,5 +1,7 @@
 package software.amazon.awssdk.stability.tests.s3;
 
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,7 +17,7 @@ import software.amazon.awssdk.testutils.retry.RetryableTest;
  */
 public class S3AsyncWithCrtAsyncHttpClientStabilityTest extends S3AsyncBaseStabilityTest {
 
-    private static String bucketName = "s3withcrtasyncclientstabilitytests" + System.currentTimeMillis();
+    private static String bucketName = temporaryBucketName(S3AsyncWithCrtAsyncHttpClientStabilityTest.class);
 
     private static S3AsyncClient s3CrtClient;
 

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3CrtAsyncClientStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3CrtAsyncClientStabilityTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.stability.tests.s3;
 
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import software.amazon.awssdk.crt.CrtResource;
@@ -26,7 +28,7 @@ import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
  * Stability tests for {@link S3CrtAsyncClient}
  */
 public class S3CrtAsyncClientStabilityTest extends S3AsyncBaseStabilityTest {
-    private static final String BUCKET_NAME = String.format("s3crtasyncclinetstabilitytests%d", System.currentTimeMillis());
+    private static final String BUCKET_NAME = temporaryBucketName(S3CrtAsyncClientStabilityTest.class);
     private static final S3AsyncClient s3CrtAsyncClient;
 
     static {

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3CrtClientStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3CrtClientStabilityTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.stability.tests.s3;
 
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -32,7 +34,7 @@ import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
  * Stability tests for S3 sync client using {@link AwsCrtHttpClient}.
  */
 public class S3CrtClientStabilityTest extends S3BaseStabilityTest {
-    private static final String BUCKET_NAME = String.format("s3crthttpclientstabilitytests%d", System.currentTimeMillis());
+    private static final String BUCKET_NAME = temporaryBucketName(S3CrtClientStabilityTest.class);
 
     private static final int CRT_CLIENT_THREAD_COUNT;
 

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MultipartJavaBasedStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3MultipartJavaBasedStabilityTest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.stability.tests.s3;
 
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,7 +25,7 @@ import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class S3MultipartJavaBasedStabilityTest extends S3AsyncBaseStabilityTest {
-    private static final String BUCKET_NAME = String.format("s3multipartjavabasedstabilitytest%d", System.currentTimeMillis());
+    private static final String BUCKET_NAME = temporaryBucketName(S3MultipartJavaBasedStabilityTest.class);
     private static final S3AsyncClient multipartJavaBasedClient;
 
     static {

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3NettyAsyncStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3NettyAsyncStabilityTest.java
@@ -1,5 +1,7 @@
 package software.amazon.awssdk.stability.tests.s3;
 
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
@@ -12,7 +14,7 @@ import java.time.Duration;
 
 public class S3NettyAsyncStabilityTest extends S3AsyncBaseStabilityTest {
 
-    private static String bucketName = "s3nettyasyncstabilitytests" + System.currentTimeMillis();
+    private static String bucketName = temporaryBucketName(S3NettyAsyncStabilityTest.class);
 
     private static S3AsyncClient s3NettyClient;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The S3 CRT stability tests hardcode their bucket names via `String.format(...)`
instead of using the shared `S3BucketUtils.temporaryBucketName(...)` helper. As a
result their bucket prefixes don't correspond to the test class name (also there is
a typo: `s3crtasyncclinet...` for `S3CrtAsyncClientStabilityTest`).

## Modifications
Switched the bucket names in the S3 stability tests from hardcoded strings to
`temporaryBucketName(<TestClass>.class)`, so each bucket prefix is derived from its
test class name (consistent with the other S3 integration tests):

- `S3CrtAsyncClientStabilityTest` (also fixes the `clinet` typo)
- `S3CrtClientStabilityTest`
- `S3MultipartJavaBasedStabilityTest`
- `S3NettyAsyncStabilityTest`
- `S3AsyncWithCrtAsyncHttpClientStabilityTest`

`S3MockWithAsyncClientStabilityTest` is left unchanged — it uses a mock HTTP client
and never creates a real bucket.

The module already depends on `service-test-utils`, so no new dependency was needed.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
