### PR TITLE
add parity test for smithy migration

### DIFF
--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/Fixtures.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/Fixtures.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.parity;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import software.amazon.awssdk.codegen.C2jModels;
+import software.amazon.awssdk.codegen.IntermediateModelBuilder;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.EndpointTestSuiteModel;
+import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
+import software.amazon.awssdk.codegen.model.service.Paginators;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+import software.amazon.awssdk.codegen.model.service.Waiters;
+import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
+
+/**
+ * Loads a service's codegen resources from
+ * {@code services/<name>/src/main/resources/codegen-resources/} and builds an
+ * {@link IntermediateModel}. Reads files in place — no copying.
+ */
+final class Fixtures {
+
+    private Fixtures() {
+    }
+
+    static IntermediateModel buildFromC2j(String serviceName) {
+        Path dir = servicePath(serviceName);
+        ServiceModel service = ModelLoaderUtils.loadModel(ServiceModel.class,
+                                                          dir.resolve("service-2.json").toFile());
+
+        CustomizationConfig customization = ModelLoaderUtils
+            .loadOptionalModel(CustomizationConfig.class, dir.resolve("customization.config").toFile())
+            .orElseGet(CustomizationConfig::create);
+
+        Paginators paginators = ModelLoaderUtils
+            .loadOptionalModel(Paginators.class, dir.resolve("paginators-1.json").toFile())
+            .orElseGet(Paginators::none);
+
+        Waiters waiters = ModelLoaderUtils
+            .loadOptionalModel(Waiters.class, dir.resolve("waiters-2.json").toFile())
+            .orElseGet(Waiters::none);
+
+        EndpointRuleSetModel endpointRuleSet = ModelLoaderUtils
+            .loadOptionalModel(EndpointRuleSetModel.class, dir.resolve("endpoint-rule-set.json").toFile())
+            .orElse(null);
+
+        EndpointTestSuiteModel endpointTests = ModelLoaderUtils
+            .loadOptionalModel(EndpointTestSuiteModel.class, dir.resolve("endpoint-tests.json").toFile())
+            .orElse(null);
+
+        C2jModels models = C2jModels.builder()
+                                    .serviceModel(service)
+                                    .customizationConfig(customization)
+                                    .paginatorsModel(paginators)
+                                    .waitersModel(waiters)
+                                    .endpointRuleSetModel(endpointRuleSet)
+                                    .endpointTestSuiteModel(endpointTests)
+                                    .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
+    static IntermediateModel buildFromSmithy(String serviceName) {
+        // TODO: swap to SmithyIntermediateModelBuilder once Smithy translation lands.
+        return buildFromC2j(serviceName);
+    }
+
+    private static Path servicePath(String serviceName) {
+        Path dir = Paths.get("..", "services", serviceName, "src", "main", "resources", "codegen-resources");
+        File asFile = dir.toFile();
+        if (!asFile.exists() || !asFile.isDirectory()) {
+            throw new IllegalArgumentException("Codegen resources directory not found: " + asFile.getAbsolutePath());
+        }
+        return dir;
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityChecker.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityChecker.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.parity;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+
+/**
+ * Compares two {@link IntermediateModel}s by serializing both to JSON and
+ * walking the trees. Emits one {@link ParityDiff} per leaf-level mismatch.
+ * Arrays are sorted by content key before comparison so member ordering does
+ * not produce false positives.
+ */
+final class IntermediateModelParityChecker {
+
+    private static final Set<String> GLOBAL_IGNORE_PATHS;
+
+    static {
+        Set<String> g = new LinkedHashSet<>();
+        GLOBAL_IGNORE_PATHS = Collections.unmodifiableSet(g);
+    }
+
+    private static final String[] SORT_KEY_FIELDS = {
+        "c2jName", "exceptionName", "name", "value"
+    };
+
+    private final ObjectMapper mapper;
+    private final List<ParityAllowlistEntry> globalIgnoreEntries;
+
+    IntermediateModelParityChecker() {
+        this.mapper = new ObjectMapper()
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .registerModule(new Jdk8Module());
+        this.globalIgnoreEntries = new ArrayList<>(GLOBAL_IGNORE_PATHS.size());
+        for (String path : GLOBAL_IGNORE_PATHS) {
+            globalIgnoreEntries.add(new ParityAllowlistEntry(path, "global ignore"));
+        }
+    }
+
+    ParityResult compare(String service, IntermediateModel c2j, IntermediateModel smithy) {
+        return compare(service, c2j, smithy, Collections.emptyList());
+    }
+
+    ParityResult compare(String service,
+                         IntermediateModel c2j,
+                         IntermediateModel smithy,
+                         List<ParityAllowlistEntry> serviceAllowlist) {
+        return compareTrees(service, mapper.valueToTree(c2j), mapper.valueToTree(smithy), serviceAllowlist);
+    }
+
+    ParityResult compareTrees(String service,
+                              JsonNode c2jTree,
+                              JsonNode smithyTree,
+                              List<ParityAllowlistEntry> serviceAllowlist) {
+        List<ParityDiff> all = new ArrayList<>();
+        computeDiffs("", c2jTree, smithyTree, all);
+
+        List<ParityAllowlistEntry> combined = new ArrayList<>(globalIgnoreEntries);
+        combined.addAll(serviceAllowlist);
+
+        List<ParityDiff> unexpected = new ArrayList<>(all.size());
+        for (ParityDiff diff : all) {
+            if (!isAllowed(diff, combined)) {
+                unexpected.add(diff);
+            }
+        }
+        return new ParityResult(service, all, unexpected);
+    }
+
+    /**
+     * Load a per-service allowlist from a JSON file.
+     *
+     * <p>Format: a flat JSON object mapping diff path to reason.
+     *
+     * <pre>{@code
+     * {
+     *   "metadata.apiVersion": "Smithy uses compact date format"
+     * }
+     * }</pre>
+     */
+    List<ParityAllowlistEntry> loadAllowlist(InputStream in) throws IOException {
+        if (in == null) {
+            return Collections.emptyList();
+        }
+        Map<String, String> raw = mapper.readValue(in, new TypeReference<LinkedHashMap<String, String>>() { });
+        List<ParityAllowlistEntry> entries = new ArrayList<>(raw.size());
+        for (Map.Entry<String, String> e : raw.entrySet()) {
+            entries.add(new ParityAllowlistEntry(e.getKey(), e.getValue()));
+        }
+        return entries;
+    }
+
+    private static boolean isAllowed(ParityDiff diff, List<ParityAllowlistEntry> allowlist) {
+        for (ParityAllowlistEntry entry : allowlist) {
+            if (entry.matches(diff.path())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void computeDiffs(String path, JsonNode c2j, JsonNode smithy, List<ParityDiff> out) {
+        if (c2j == null && smithy == null) {
+            return;
+        }
+        if (c2j == null || c2j.isNull()) {
+            if (smithy != null && !smithy.isNull()) {
+                out.add(new ParityDiff(path, ParityDiff.Type.ADDED, null, truncate(smithy.toString())));
+            }
+            return;
+        }
+        if (smithy == null || smithy.isNull()) {
+            out.add(new ParityDiff(path, ParityDiff.Type.MISSING, truncate(c2j.toString()), null));
+            return;
+        }
+        if (c2j.getNodeType() != smithy.getNodeType()) {
+            out.add(new ParityDiff(path, ParityDiff.Type.TYPE_MISMATCH,
+                                   c2j.getNodeType().name(),
+                                   smithy.getNodeType().name()));
+            return;
+        }
+
+        if (c2j.isObject()) {
+            compareObjects(path, (ObjectNode) c2j, (ObjectNode) smithy, out);
+        } else if (c2j.isArray()) {
+            compareArrays(path, c2j, smithy, out);
+        } else {
+            if (!c2j.equals(smithy)) {
+                out.add(new ParityDiff(path, ParityDiff.Type.CHANGED,
+                                       truncate(c2j.toString()),
+                                       truncate(smithy.toString())));
+            }
+        }
+    }
+
+    private void compareObjects(String path, ObjectNode c2j, ObjectNode smithy, List<ParityDiff> out) {
+        Set<String> fields = new LinkedHashSet<>();
+        Iterator<String> c2jFields = c2j.fieldNames();
+        while (c2jFields.hasNext()) {
+            fields.add(c2jFields.next());
+        }
+        Iterator<String> smithyFields = smithy.fieldNames();
+        while (smithyFields.hasNext()) {
+            fields.add(smithyFields.next());
+        }
+        for (String field : fields) {
+            String childPath = path.isEmpty() ? field : path + "." + field;
+            computeDiffs(childPath, c2j.get(field), smithy.get(field), out);
+        }
+    }
+
+    private void compareArrays(String path, JsonNode c2j, JsonNode smithy, List<ParityDiff> out) {
+        List<JsonNode> c2jSorted = sortArray(c2j);
+        List<JsonNode> smithySorted = sortArray(smithy);
+        int maxLen = Math.max(c2jSorted.size(), smithySorted.size());
+        for (int i = 0; i < maxLen; i++) {
+            String childPath = path + "[" + i + "]";
+            JsonNode c2jElem = i < c2jSorted.size() ? c2jSorted.get(i) : null;
+            JsonNode smithyElem = i < smithySorted.size() ? smithySorted.get(i) : null;
+            computeDiffs(childPath, c2jElem, smithyElem, out);
+        }
+    }
+
+    private static List<JsonNode> sortArray(JsonNode array) {
+        List<JsonNode> sorted = new ArrayList<>();
+        for (JsonNode element : array) {
+            sorted.add(element);
+        }
+        sorted.sort((a, b) -> sortKey(a).compareTo(sortKey(b)));
+        return sorted;
+    }
+
+    private static String sortKey(JsonNode node) {
+        if (node.isObject()) {
+            for (String field : SORT_KEY_FIELDS) {
+                JsonNode candidate = node.get(field);
+                if (candidate != null && candidate.isTextual()) {
+                    return candidate.asText();
+                }
+            }
+            return node.toString();
+        }
+        return node.asText();
+    }
+
+    private static String truncate(String value) {
+        int max = 120;
+        if (value == null || value.length() <= max) {
+            return value;
+        }
+        return value.substring(0, max) + "...(" + value.length() + " chars)";
+    }
+
+    static Set<String> globalIgnorePathsForTest() {
+        return GLOBAL_IGNORE_PATHS;
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityChecker.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityChecker.java
@@ -41,6 +41,11 @@ import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
  */
 final class IntermediateModelParityChecker {
 
+    /**
+     * Diff paths ignored for every service. Add an entry
+     * only when a diff at that path is verified acceptable across all services;
+     * prefer per-service allowlists for anything narrower.
+     */
     private static final Set<String> GLOBAL_IGNORE_PATHS;
 
     static {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityCheckerTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityCheckerTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.parity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.Metadata;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+
+class IntermediateModelParityCheckerTest {
+
+    private final IntermediateModelParityChecker checker = new IntermediateModelParityChecker();
+
+    @Test
+    void compare_whenModelsIdentical_reportsNoDiffs() {
+        IntermediateModel a = simpleModel("Foo", "1.0");
+        IntermediateModel b = simpleModel("Foo", "1.0");
+
+        ParityResult result = checker.compare("foo", a, b);
+
+        assertThat(result.allDiffs()).isEmpty();
+        assertThat(result.unexpectedDiffs()).isEmpty();
+    }
+
+    @Test
+    void compare_whenMetadataDiffers_reportsChangedDiff() {
+        IntermediateModel a = simpleModel("Foo", "1.0");
+        IntermediateModel b = simpleModel("Foo", "2.0");
+
+        ParityResult result = checker.compare("foo", a, b);
+
+        assertThat(result.unexpectedDiffs())
+            .extracting(ParityDiff::path)
+            .contains("metadata.apiVersion");
+        assertThat(result.unexpectedDiffs())
+            .extracting(ParityDiff::type)
+            .contains(ParityDiff.Type.CHANGED);
+    }
+
+    @Test
+    void compare_whenSameFieldDifferentJsonType_reportsTypeDiff() throws Exception {
+        String c2jJson = "{ \"metadata\": { \"awsQueryCompatible\": {} } }";
+        String smithyJson = "{ \"metadata\": { \"awsQueryCompatible\": \"true\" } }";
+
+        com.fasterxml.jackson.databind.JsonNode c2jTree =
+            new com.fasterxml.jackson.databind.ObjectMapper().readTree(c2jJson);
+        com.fasterxml.jackson.databind.JsonNode smithyTree =
+            new com.fasterxml.jackson.databind.ObjectMapper().readTree(smithyJson);
+
+        ParityResult result = checker.compareTrees("foo", c2jTree, smithyTree, Collections.emptyList());
+
+        assertThat(result.unexpectedDiffs())
+            .anyMatch(d -> d.path().equals("metadata.awsQueryCompatible")
+                           && d.type() == ParityDiff.Type.TYPE_MISMATCH);
+    }
+
+    @Test
+    void compare_whenShapeMissingFromSmithy_reportsMissingDiff() {
+        IntermediateModel a = modelWithShapes("FooShape", "BarShape");
+        IntermediateModel b = modelWithShapes("FooShape");
+
+        ParityResult result = checker.compare("foo", a, b);
+
+        assertThat(result.unexpectedDiffs())
+            .anyMatch(d -> d.path().startsWith("shapes.BarShape")
+                           && d.type() == ParityDiff.Type.MISSING);
+    }
+
+    @Test
+    void compare_whenShapeAddedInSmithy_reportsAddedDiff() {
+        IntermediateModel a = modelWithShapes("FooShape");
+        IntermediateModel b = modelWithShapes("FooShape", "ExtraShape");
+
+        ParityResult result = checker.compare("foo", a, b);
+
+        assertThat(result.unexpectedDiffs())
+            .anyMatch(d -> d.path().startsWith("shapes.ExtraShape")
+                           && d.type() == ParityDiff.Type.ADDED);
+    }
+
+    @Test
+    void compare_whenDiffHasPerServiceAllowlistEntry_ignored() {
+        IntermediateModel a = simpleModel("Foo", "1.0");
+        IntermediateModel b = simpleModel("Foo", "2.0");
+        List<ParityAllowlistEntry> allowlist = Collections.singletonList(
+            new ParityAllowlistEntry("metadata.apiVersion", "Smithy uses compact date"));
+
+        ParityResult result = checker.compare("foo", a, b, allowlist);
+
+        assertThat(result.unexpectedDiffs()).isEmpty();
+        assertThat(result.allDiffs())
+            .extracting(ParityDiff::path)
+            .contains("metadata.apiVersion");
+    }
+
+    @Test
+    void compare_whenAllowlistGlobPatternMatches_ignored() {
+        IntermediateModel a = modelWithShapes("FooShape");
+        IntermediateModel b = modelWithShapes("BarShape");
+
+        List<ParityAllowlistEntry> allowlist = Collections.singletonList(
+            new ParityAllowlistEntry("shapes.**", "all shape diffs allowed for this synthetic test"));
+
+        ParityResult result = checker.compare("foo", a, b, allowlist);
+
+        assertThat(result.unexpectedDiffs()).as(result.summary()).isEmpty();
+        assertThat(result.allDiffs()).as(result.summary()).isNotEmpty();
+    }
+
+    @Test
+    void newAllowlistEntry_whenReasonMissing_throws() {
+        assertThatThrownBy(() -> new ParityAllowlistEntry("some.path", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("reason");
+    }
+
+    @Test
+    void newAllowlistEntry_whenReasonBlank_throws() {
+        assertThatThrownBy(() -> new ParityAllowlistEntry("some.path", "  "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("reason");
+    }
+
+    @Test
+    void newAllowlistEntry_whenPathMissing_throws() {
+        assertThatThrownBy(() -> new ParityAllowlistEntry("", "reason"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("path");
+    }
+
+    @Test
+    void loadAllowlist_whenJsonValid_returnsEntries() throws Exception {
+        String json = "{ \"metadata.apiVersion\": \"Smithy uses compact date\","
+                      + " \"shapes.Foo.documentation\": \"docs rephrased\" }";
+        List<ParityAllowlistEntry> entries =
+            checker.loadAllowlist(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries).extracting(ParityAllowlistEntry::path)
+            .containsExactly("metadata.apiVersion", "shapes.Foo.documentation");
+    }
+
+    @Test
+    void loadAllowlist_whenReasonBlank_throws() {
+        String json = "{ \"a.b\": \"\" }";
+        assertThatThrownBy(() ->
+            checker.loadAllowlist(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))))
+            .hasMessageContaining("reason");
+    }
+
+    @Test
+    void loadAllowlist_whenStreamNull_returnsEmpty() throws Exception {
+        assertThat(checker.loadAllowlist(null)).isEmpty();
+    }
+
+    @Test
+    void compare_whenMapEntriesInDifferentInsertionOrder_reportsNoDiffs() {
+        IntermediateModel a = new IntermediateModel();
+        a.setMetadata(metadata("Foo", "1.0"));
+        Map<String, ShapeModel> aShapes = new HashMap<>();
+        aShapes.put("Zeta", shape("Zeta"));
+        aShapes.put("Alpha", shape("Alpha"));
+        a.setShapes(aShapes);
+        a.setCustomizationConfig(CustomizationConfig.create());
+
+        IntermediateModel b = new IntermediateModel();
+        b.setMetadata(metadata("Foo", "1.0"));
+        Map<String, ShapeModel> bShapes = new HashMap<>();
+        bShapes.put("Alpha", shape("Alpha"));
+        bShapes.put("Zeta", shape("Zeta"));
+        b.setShapes(bShapes);
+        b.setCustomizationConfig(CustomizationConfig.create());
+
+        ParityResult result = checker.compare("foo", a, b);
+
+        assertThat(result.unexpectedDiffs())
+            .as(result.summary())
+            .isEmpty();
+    }
+
+    @Test
+    void compare_whenSelfCompared_reportsNoDiffs() {
+        IntermediateModel model = modelWithShapes("FooShape", "BarShape", "BazShape");
+
+        ParityResult result = checker.compare("foo", model, model);
+
+        assertThat(result.unexpectedDiffs()).as(result.summary()).isEmpty();
+        assertThat(result.allDiffs()).isEmpty();
+    }
+
+    @Test
+    void result_summary_includesServiceAndDiffCount() {
+        IntermediateModel a = simpleModel("Foo", "1.0");
+        IntermediateModel b = simpleModel("Foo", "2.0");
+
+        ParityResult result = checker.compare("foo", a, b);
+
+        assertThat(result.summary())
+            .contains("foo")
+            .contains("unexpected");
+    }
+
+    private static IntermediateModel simpleModel(String serviceName, String apiVersion) {
+        IntermediateModel model = new IntermediateModel();
+        model.setMetadata(metadata(serviceName, apiVersion));
+        model.setShapes(Collections.emptyMap());
+        model.setOperations(Collections.emptyMap());
+        model.setCustomizationConfig(CustomizationConfig.create());
+        return model;
+    }
+
+    private static IntermediateModel modelWithShapes(String... shapeNames) {
+        IntermediateModel model = simpleModel("Foo", "1.0");
+        Map<String, ShapeModel> shapes = new HashMap<>();
+        for (String name : shapeNames) {
+            shapes.put(name, shape(name));
+        }
+        model.setShapes(shapes);
+        return model;
+    }
+
+    private static Metadata metadata(String serviceName, String apiVersion) {
+        Metadata m = new Metadata();
+        m.setServiceName(serviceName);
+        m.setApiVersion(apiVersion);
+        return m;
+    }
+
+    private static ShapeModel shape(String name) {
+        ShapeModel shape = new ShapeModel(name);
+        shape.setShapeName(name);
+        shape.setType("Structure");
+        return shape;
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityCheckerTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityCheckerTest.java
@@ -24,7 +24,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.Metadata;
@@ -78,30 +82,6 @@ class IntermediateModelParityCheckerTest {
     }
 
     @Test
-    void compare_whenShapeMissingFromSmithy_reportsMissingDiff() {
-        IntermediateModel a = modelWithShapes("FooShape", "BarShape");
-        IntermediateModel b = modelWithShapes("FooShape");
-
-        ParityResult result = checker.compare("foo", a, b);
-
-        assertThat(result.unexpectedDiffs())
-            .anyMatch(d -> d.path().startsWith("shapes.BarShape")
-                           && d.type() == ParityDiff.Type.MISSING);
-    }
-
-    @Test
-    void compare_whenShapeAddedInSmithy_reportsAddedDiff() {
-        IntermediateModel a = modelWithShapes("FooShape");
-        IntermediateModel b = modelWithShapes("FooShape", "ExtraShape");
-
-        ParityResult result = checker.compare("foo", a, b);
-
-        assertThat(result.unexpectedDiffs())
-            .anyMatch(d -> d.path().startsWith("shapes.ExtraShape")
-                           && d.type() == ParityDiff.Type.ADDED);
-    }
-
-    @Test
     void compare_whenDiffHasPerServiceAllowlistEntry_ignored() {
         IntermediateModel a = simpleModel("Foo", "1.0");
         IntermediateModel b = simpleModel("Foo", "2.0");
@@ -130,25 +110,20 @@ class IntermediateModelParityCheckerTest {
         assertThat(result.allDiffs()).as(result.summary()).isNotEmpty();
     }
 
-    @Test
-    void newAllowlistEntry_whenReasonMissing_throws() {
-        assertThatThrownBy(() -> new ParityAllowlistEntry("some.path", null))
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidAllowlistEntries")
+    void newAllowlistEntry_whenInputInvalid_throws(String label, String path, String reason, String expectedMessage) {
+        assertThatThrownBy(() -> new ParityAllowlistEntry(path, reason))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("reason");
+            .hasMessageContaining(expectedMessage);
     }
 
-    @Test
-    void newAllowlistEntry_whenReasonBlank_throws() {
-        assertThatThrownBy(() -> new ParityAllowlistEntry("some.path", "  "))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("reason");
-    }
-
-    @Test
-    void newAllowlistEntry_whenPathMissing_throws() {
-        assertThatThrownBy(() -> new ParityAllowlistEntry("", "reason"))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("path");
+    static Stream<Arguments> invalidAllowlistEntries() {
+        return Stream.of(
+            Arguments.of("path missing",  "",             "reason",   "path"),
+            Arguments.of("reason null",   "some.path",    null,       "reason"),
+            Arguments.of("reason blank",  "some.path",    "  ",       "reason")
+        );
     }
 
     @Test
@@ -201,14 +176,44 @@ class IntermediateModelParityCheckerTest {
             .isEmpty();
     }
 
-    @Test
-    void compare_whenSelfCompared_reportsNoDiffs() {
-        IntermediateModel model = modelWithShapes("FooShape", "BarShape", "BazShape");
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("diffCases")
+    void diffEngine_producesExpectedDiff(String label,
+                                         IntermediateModel c2j,
+                                         IntermediateModel smithy,
+                                         ParityDiff.Type expectedType,
+                                         String expectedPath) {
+        ParityResult result = checker.compare("test", c2j, smithy);
 
-        ParityResult result = checker.compare("foo", model, model);
+        assertThat(result.unexpectedDiffs())
+            .as(result.summary())
+            .anyMatch(d -> d.path().equals(expectedPath) && d.type() == expectedType);
+    }
 
-        assertThat(result.unexpectedDiffs()).as(result.summary()).isEmpty();
-        assertThat(result.allDiffs()).isEmpty();
+    static Stream<Arguments> diffCases() {
+        return Stream.of(
+            Arguments.of("apiVersion value changed",
+                         simpleModel("Foo", "1.0"), simpleModel("Foo", "2.0"),
+                         ParityDiff.Type.CHANGED, "metadata.apiVersion"),
+            Arguments.of("shape missing from smithy",
+                         modelWithShapes("FooShape", "BarShape"), modelWithShapes("FooShape"),
+                         ParityDiff.Type.MISSING, "shapes.BarShape"),
+            Arguments.of("shape added in smithy",
+                         modelWithShapes("FooShape"), modelWithShapes("FooShape", "ExtraShape"),
+                         ParityDiff.Type.ADDED, "shapes.ExtraShape"),
+            Arguments.of("shape names differ by case",
+                         modelWithShapes("Foo"), modelWithShapes("foo"),
+                         ParityDiff.Type.MISSING, "shapes.Foo"),
+            Arguments.of("trailing space in value",
+                         simpleModel("Foo", "1.0"), simpleModel("Foo", "1.0 "),
+                         ParityDiff.Type.CHANGED, "metadata.apiVersion"),
+            Arguments.of("internal space in value",
+                         simpleModel("Foo", "1.0"), simpleModel("Foo", "1. 0"),
+                         ParityDiff.Type.CHANGED, "metadata.apiVersion"),
+            Arguments.of("empty string vs non-empty",
+                         simpleModel("Foo", ""), simpleModel("Foo", "1.0"),
+                         ParityDiff.Type.CHANGED, "metadata.apiVersion")
+        );
     }
 
     @Test

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/IntermediateModelParityTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.parity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+
+/**
+ * Runs the parity checker across representative services. Compares the
+ * {@code IntermediateModel} produced by the C2J pipeline against the one
+ * produced by the Smithy pipeline and fails on any unexpected diff.
+ */
+class IntermediateModelParityTest {
+
+    private final IntermediateModelParityChecker checker = new IntermediateModelParityChecker();
+
+    @ParameterizedTest(name = "parity for {0}")
+    @ValueSource(strings = {
+        "lambda",
+        "sqs",
+        "ec2",
+        "route53",
+        "kinesis"
+    })
+    void c2jAndSmithy_produceEqualIntermediateModels(String service) throws IOException {
+        IntermediateModel c2j = Fixtures.buildFromC2j(service);
+        IntermediateModel smithy = Fixtures.buildFromSmithy(service);
+
+        List<ParityAllowlistEntry> allowlist = loadAllowlistFor(service);
+
+        ParityResult result = checker.compare(service, c2j, smithy, allowlist);
+
+        assertThat(result.unexpectedDiffs())
+            .as(result.summary())
+            .isEmpty();
+    }
+
+    private List<ParityAllowlistEntry> loadAllowlistFor(String service) throws IOException {
+        String resource = "/software/amazon/awssdk/codegen/parity/" + service + "-expected-diffs.json";
+        try (InputStream in = getClass().getResourceAsStream(resource)) {
+            if (in == null) {
+                return Collections.emptyList();
+            }
+            return checker.loadAllowlist(in);
+        }
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/ParityAllowlistEntry.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/ParityAllowlistEntry.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.parity;
+
+import java.util.regex.Pattern;
+
+/**
+ * Allowlisted parity diff path with a free-text reason.
+ *
+ * <p>{@code path} is matched against {@link ParityDiff#path()} as a glob where
+ * {@code *} matches one dot-separated segment and {@code **} matches any number
+ * of segments.
+ */
+final class ParityAllowlistEntry {
+
+    private final String path;
+    private final String reason;
+    private final Pattern compiled;
+
+    ParityAllowlistEntry(String path, String reason) {
+        if (path == null || path.trim().isEmpty()) {
+            throw new IllegalArgumentException("allowlist entry: 'path' is required");
+        }
+        if (reason == null || reason.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                "allowlist entry for path '" + path + "': 'reason' is required");
+        }
+        this.path = path;
+        this.reason = reason;
+        this.compiled = compileGlob(path);
+    }
+
+    boolean matches(String diffPath) {
+        return compiled.matcher(diffPath).matches();
+    }
+
+    String path() {
+        return path;
+    }
+
+    String reason() {
+        return reason;
+    }
+
+    private static Pattern compileGlob(String glob) {
+        StringBuilder regex = new StringBuilder("^");
+        int i = 0;
+        while (i < glob.length()) {
+            char c = glob.charAt(i);
+            if (c == '*' && i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                regex.append(".*");
+                i += 2;
+            } else if (c == '*') {
+                regex.append("[^.]+");
+                i++;
+            } else if ("\\.+()[]{}^$|?".indexOf(c) >= 0) {
+                regex.append('\\').append(c);
+                i++;
+            } else {
+                regex.append(c);
+                i++;
+            }
+        }
+        regex.append("$");
+        return Pattern.compile(regex.toString());
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/ParityDiff.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/ParityDiff.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.parity;
+
+import java.util.Objects;
+
+/**
+ * One structural difference between two {@code IntermediateModel}s at a given
+ * JSON path.
+ */
+final class ParityDiff {
+
+    enum Type {
+        /** Present in C2J, absent in Smithy. */
+        MISSING,
+        /** Absent in C2J, present in Smithy. */
+        ADDED,
+        /** Present in both, values differ. */
+        CHANGED,
+        /** Present in both, JSON node types differ (e.g. string vs object). */
+        TYPE_MISMATCH
+    }
+
+    private final String path;
+    private final Type type;
+    private final String c2jValue;
+    private final String smithyValue;
+
+    ParityDiff(String path, Type type, String c2jValue, String smithyValue) {
+        this.path = path;
+        this.type = type;
+        this.c2jValue = c2jValue;
+        this.smithyValue = smithyValue;
+    }
+
+    String path() {
+        return path;
+    }
+
+    Type type() {
+        return type;
+    }
+
+    String c2jValue() {
+        return c2jValue;
+    }
+
+    String smithyValue() {
+        return smithyValue;
+    }
+
+    @Override
+    public String toString() {
+        switch (type) {
+            case MISSING:
+                return String.format("MISSING %s: %s", path, c2jValue);
+            case ADDED:
+                return String.format("ADDED   %s: %s", path, smithyValue);
+            case CHANGED:
+                return String.format("CHANGED %s: c2j=%s, smithy=%s", path, c2jValue, smithyValue);
+            case TYPE_MISMATCH:
+                return String.format("TYPE    %s: c2j=%s, smithy=%s", path, c2jValue, smithyValue);
+            default:
+                throw new IllegalStateException("unknown diff type: " + type);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ParityDiff)) {
+            return false;
+        }
+        ParityDiff other = (ParityDiff) o;
+        return Objects.equals(path, other.path)
+            && type == other.type
+            && Objects.equals(c2jValue, other.c2jValue)
+            && Objects.equals(smithyValue, other.smithyValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, type, c2jValue, smithyValue);
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/parity/ParityResult.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/parity/ParityResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.parity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Result of comparing two {@code IntermediateModel}s. Tests assert against
+ * {@link #unexpectedDiffs()} (diffs not covered by an allowlist entry).
+ */
+final class ParityResult {
+
+    private final String service;
+    private final List<ParityDiff> allDiffs;
+    private final List<ParityDiff> unexpectedDiffs;
+
+    ParityResult(String service, List<ParityDiff> allDiffs, List<ParityDiff> unexpectedDiffs) {
+        this.service = service;
+        this.allDiffs = Collections.unmodifiableList(allDiffs);
+        this.unexpectedDiffs = Collections.unmodifiableList(unexpectedDiffs);
+    }
+
+    String service() {
+        return service;
+    }
+
+    List<ParityDiff> allDiffs() {
+        return allDiffs;
+    }
+
+    List<ParityDiff> unexpectedDiffs() {
+        return unexpectedDiffs;
+    }
+
+    String summary() {
+        int allowed = allDiffs.size() - unexpectedDiffs.size();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Parity result for ").append(service).append(":\n");
+        sb.append("  total diffs: ").append(allDiffs.size())
+          .append(" (").append(allowed).append(" allowlisted, ")
+          .append(unexpectedDiffs.size()).append(" unexpected)\n");
+        if (!unexpectedDiffs.isEmpty()) {
+            sb.append("Unexpected diffs:\n");
+            sb.append(unexpectedDiffs.stream()
+                                     .map(d -> "  " + d.toString())
+                                     .collect(Collectors.joining("\n")));
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Adds a correctness gate for the Smithy migration: a parity checker that compares two `IntermediateModel` instances and reports structural differences by JSON path. Later PRs that add Smithy translation will run against this checker to catch drift before generated code is affected.

## Modifications
<!--- Describe your changes in detail -->

Under `codegen/src/test/java/.../parity/`:

- `IntermediateModelParityChecker` — JSON tree diff engine. Serializes two `IntermediateModel`s and emits one `ParityDiff` per structural mismatch. Sorts arrays by content key so member order is stable.
- `ParityDiff`, `ParityResult`, `ParityAllowlistEntry` — data types.
- `Fixtures` — loads a service's real codegen resources (`services/<name>/src/main/resources/codegen-resources/`) and build an `IntermediateModel`. `buildFromSmithy` currently delegates to C2J until the Smithy pipeline lands.
- `IntermediateModelParityCheckerTest` — self-tests for the diff engine (identical models, missing / added / changed / type-mismatch, glob allowlist, map ordering).
- `IntermediateModelParityTest` — parameterized test running C2J vs Smithy across lambda, sqs, ec2, route53, kinesis. Both sides use C2J in this PR so the checker validates against a known-equal baseline.

We can add Optional per-service allowlist file at `test/resources/.../parity/<service>-expected-diffs.json`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added Unit test for the checker. 
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
