### PR TITLE
Remove ServiceMetadata usage from RDS/Neptune/DocDB presigning interceptors

### DIFF
--- a/services/docdb/src/main/java/software/amazon/awssdk/services/docdb/internal/RdsPresignInterceptor.java
+++ b/services/docdb/src/main/java/software/amazon/awssdk/services/docdb/internal/RdsPresignInterceptor.java
@@ -25,9 +25,7 @@ import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
-import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.core.ClientEndpointProvider;
-import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -35,7 +33,6 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -48,6 +45,7 @@ import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.docdb.endpoints.DocDbEndpointProvider;
 import software.amazon.awssdk.services.docdb.model.DocDbRequest;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 
@@ -72,7 +70,6 @@ public abstract class RdsPresignInterceptor<T extends DocDbRequest> implements E
                                                    .build())
         .build();
 
-    private static final String SERVICE_NAME = "rds";
     private static final String PARAM_SOURCE_REGION = "SourceRegion";
     private static final String PARAM_DESTINATION_REGION = "DestinationRegion";
     private static final String PARAM_PRESIGNED_URL = "PreSignedUrl";
@@ -109,7 +106,7 @@ public abstract class RdsPresignInterceptor<T extends DocDbRequest> implements E
         SelectedAuthScheme<?> selectedAuthScheme = executionAttributes.getAttribute(SELECTED_AUTH_SCHEME);
         String sourceRegion = presignableRequest.getSourceRegion();
         String destinationRegion = selectedAuthScheme.authSchemeOption().signerProperty(AwsV4HttpSigner.REGION_NAME);
-        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME, executionAttributes);
+        URI endpoint = createEndpoint(sourceRegion, executionAttributes);
         SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall().toBuilder().uri(endpoint);
 
         SdkHttpFullRequest requestToPresign =
@@ -218,17 +215,14 @@ public abstract class RdsPresignInterceptor<T extends DocDbRequest> implements E
                                  .build();
     }
 
-    private URI createEndpoint(String regionName, String serviceName, ExecutionAttributes attributes) {
-        return AwsClientEndpointProvider.builder()
-                                        .serviceEndpointPrefix(SERVICE_NAME)
-                                        .defaultProtocol(Protocol.HTTPS.toString())
-                                        .region(Region.of(regionName))
-                                        .profileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE_SUPPLIER))
-                                        .profileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
-                                        .dualstackEnabled(
-                                            attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
-                                        .fipsEnabled(attributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED))
-                                        .build()
-                                        .clientEndpoint();
+    private URI createEndpoint(String regionName, ExecutionAttributes attributes) {
+        return CompletableFutureUtils.joinLikeSync(
+            DocDbEndpointProvider.defaultProvider()
+                                 .resolveEndpoint(p -> p.region(Region.of(regionName))
+                                                        .useDualStack(attributes.getAttribute(
+                                                            AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+                                                        .useFips(attributes.getAttribute(
+                                                            AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED)))
+        ).url();
     }
 }

--- a/services/neptune/src/main/java/software/amazon/awssdk/services/neptune/internal/RdsPresignInterceptor.java
+++ b/services/neptune/src/main/java/software/amazon/awssdk/services/neptune/internal/RdsPresignInterceptor.java
@@ -25,9 +25,7 @@ import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
-import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.core.ClientEndpointProvider;
-import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -35,7 +33,6 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -48,6 +45,7 @@ import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.neptune.endpoints.NeptuneEndpointProvider;
 import software.amazon.awssdk.services.neptune.model.NeptuneRequest;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 
@@ -73,7 +71,6 @@ public abstract class RdsPresignInterceptor<T extends NeptuneRequest> implements
                                                    .build())
         .build();
 
-    private static final String SERVICE_NAME = "rds";
     private static final String PARAM_SOURCE_REGION = "SourceRegion";
     private static final String PARAM_DESTINATION_REGION = "DestinationRegion";
     private static final String PARAM_PRESIGNED_URL = "PreSignedUrl";
@@ -110,7 +107,7 @@ public abstract class RdsPresignInterceptor<T extends NeptuneRequest> implements
         SelectedAuthScheme<?> selectedAuthScheme = executionAttributes.getAttribute(SELECTED_AUTH_SCHEME);
         String sourceRegion = presignableRequest.getSourceRegion();
         String destinationRegion = selectedAuthScheme.authSchemeOption().signerProperty(AwsV4HttpSigner.REGION_NAME);
-        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME, executionAttributes);
+        URI endpoint = createEndpoint(sourceRegion, executionAttributes);
         SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall().toBuilder().uri(endpoint);
 
         SdkHttpFullRequest requestToPresign =
@@ -219,17 +216,14 @@ public abstract class RdsPresignInterceptor<T extends NeptuneRequest> implements
                                  .build();
     }
 
-    private URI createEndpoint(String regionName, String serviceName, ExecutionAttributes attributes) {
-        return AwsClientEndpointProvider.builder()
-                                        .serviceEndpointPrefix(SERVICE_NAME)
-                                        .defaultProtocol(Protocol.HTTPS.toString())
-                                        .region(Region.of(regionName))
-                                        .profileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE_SUPPLIER))
-                                        .profileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
-                                        .dualstackEnabled(
-                                            attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
-                                        .fipsEnabled(attributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED))
-                                        .build()
-                                        .clientEndpoint();
+    private URI createEndpoint(String regionName, ExecutionAttributes attributes) {
+        return CompletableFutureUtils.joinLikeSync(
+            NeptuneEndpointProvider.defaultProvider()
+                                   .resolveEndpoint(p -> p.region(Region.of(regionName))
+                                                          .useDualStack(attributes.getAttribute(
+                                                              AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+                                                          .useFips(attributes.getAttribute(
+                                                              AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED)))
+        ).url();
     }
 }

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
@@ -25,9 +25,7 @@ import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
-import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.core.ClientEndpointProvider;
-import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -35,7 +33,6 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -48,6 +45,7 @@ import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.Identity;
 import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.endpoints.RdsEndpointProvider;
 import software.amazon.awssdk.services.rds.model.RdsRequest;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 
@@ -72,7 +70,6 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
                                                    .build())
         .build();
 
-    private static final String SERVICE_NAME = "rds";
     private static final String PARAM_SOURCE_REGION = "SourceRegion";
     private static final String PARAM_DESTINATION_REGION = "DestinationRegion";
     private static final String PARAM_PRESIGNED_URL = "PreSignedUrl";
@@ -109,7 +106,7 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
         SelectedAuthScheme<?> selectedAuthScheme = executionAttributes.getAttribute(SELECTED_AUTH_SCHEME);
         String sourceRegion = presignableRequest.getSourceRegion();
         String destinationRegion = selectedAuthScheme.authSchemeOption().signerProperty(AwsV4HttpSigner.REGION_NAME);
-        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME, executionAttributes);
+        URI endpoint = createEndpoint(sourceRegion, executionAttributes);
         SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall().toBuilder().uri(endpoint);
 
         SdkHttpFullRequest requestToPresign =
@@ -217,17 +214,14 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
                                  .build();
     }
 
-    private URI createEndpoint(String regionName, String serviceName, ExecutionAttributes attributes) {
-        return AwsClientEndpointProvider.builder()
-                                        .serviceEndpointPrefix(SERVICE_NAME)
-                                        .defaultProtocol(Protocol.HTTPS.toString())
-                                        .region(Region.of(regionName))
-                                        .profileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE_SUPPLIER))
-                                        .profileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
-                                        .dualstackEnabled(
-                                            attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
-                                        .fipsEnabled(attributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED))
-                                        .build()
-                                        .clientEndpoint();
+    private URI createEndpoint(String regionName, ExecutionAttributes attributes) {
+        return CompletableFutureUtils.joinLikeSync(
+            RdsEndpointProvider.defaultProvider()
+                               .resolveEndpoint(p -> p.region(Region.of(regionName))
+                                                      .useDualStack(attributes.getAttribute(
+                                                          AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+                                                      .useFips(attributes.getAttribute(
+                                                          AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED)))
+        ).url();
     }
 }

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
@@ -100,6 +100,9 @@ class PresignRequestHandlerTest {
             if (testCase.expectedUri != null) {
                 assertEquals(normalize(URI.create(testCase.expectedUri)), normalize(presignedUrlAsUri));
             }
+            if (testCase.expectedPresignedUrlHost != null) {
+                assertEquals(testCase.expectedPresignedUrlHost, presignedUrlAsUri.getHost());
+            }
         } else {
             assertFalse(rawQueryParameters.containsKey("PreSignedUrl"));
         }
@@ -169,6 +172,24 @@ class PresignRequestHandlerTest {
             builder("StartDBInstanceAutomatedBackupsReplication Without SourceRegion Does NOT Send PresignedUrl")
                 .clientConsumer(c -> c.startDBInstanceAutomatedBackupsReplication(r -> r.kmsKeyId(TEST_KMS_KEY_ID)))
                 .shouldContainPreSignedUrl(false)
+                .build(),
+
+            builder("CopyDbClusterSnapshot - With FIPS enabled resolves to fips endpoint")
+                .clientConfigure(c -> c.region(Region.US_EAST_1).fipsEnabled(true))
+                .clientConsumer(c -> c.copyDBClusterSnapshot(makeTestRequestBuilder()
+                                                                 .sourceRegion("us-west-2")
+                                                                 .build()))
+                .shouldContainPreSignedUrl(true)
+                .expectedPresignedUrlHost("rds-fips.us-west-2.amazonaws.com")
+                .build(),
+
+            builder("CopyDbClusterSnapshot - With dualstack enabled resolves to dualstack endpoint")
+                .clientConfigure(c -> c.region(Region.US_EAST_1).dualstackEnabled(true))
+                .clientConsumer(c -> c.copyDBClusterSnapshot(makeTestRequestBuilder()
+                                                                 .sourceRegion("us-west-2")
+                                                                 .build()))
+                .shouldContainPreSignedUrl(true)
+                .expectedPresignedUrlHost("rds.us-west-2.api.aws")
                 .build()
         );
     }
@@ -296,6 +317,7 @@ class PresignRequestHandlerTest {
         private final String expectedDestinationRegion;
         private final Clock signingClockOverride;
         private final String expectedUri;
+        private final String expectedPresignedUrlHost;
 
         TestCase(TestCaseBuilder builder) {
             this.name = Validate.notNull(builder.name, "name");
@@ -305,6 +327,7 @@ class PresignRequestHandlerTest {
             this.expectedDestinationRegion = builder.expectedDestinationRegion;
             this.signingClockOverride = builder.signingClockOverride;
             this.expectedUri = builder.expectedUri;
+            this.expectedPresignedUrlHost = builder.expectedPresignedUrlHost;
         }
     }
 
@@ -316,6 +339,7 @@ class PresignRequestHandlerTest {
         private String expectedDestinationRegion;
         private Clock signingClockOverride;
         private String expectedUri;
+        private String expectedPresignedUrlHost;
 
         private TestCaseBuilder name(String name) {
             this.name = name;
@@ -349,6 +373,11 @@ class PresignRequestHandlerTest {
 
         public TestCaseBuilder expectedUri(String expectedUri) {
             this.expectedUri = expectedUri;
+            return this;
+        }
+
+        public TestCaseBuilder expectedPresignedUrlHost(String expectedPresignedUrlHost) {
+            this.expectedPresignedUrlHost = expectedPresignedUrlHost;
             return this;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This is part of the ServiceMetadata removal effort to eliminate 350-500ms cold start latency caused by GeneratedServiceMetadataProvider initialization.

RDS, Neptune, and DocDB each have a RdsPresignInterceptor that generates presigned URLs for cross-region operations (e.g., CopyDBClusterSnapshot, CreateDBCluster). These interceptors call AwsClientEndpointProvider with serviceEndpointPrefix("rds") to resolve the endpoint for the source region. This triggers ServiceMetadata.of("rds"), which eagerly loads all 310 service metadata classes — adding 350-500ms of unnecessary initialization on every presigning call path.

This PR replaces that ServiceMetadata-based resolution with each service's Endpoints 2.0 provider, which resolves the same endpoint without triggering the expensive static initialization.

The endpoint resolved here is used as the host in the final presigned URL that gets sent to the service. The service validates this host when processing the presigned URL, so it must be the correct regional RDS endpoint, not a placeholder.

## Modifications

- Replaced AwsClientEndpointProvider usage in createEndpoint() with direct calls to each service's Endpoints 2.0 provider:

   - RDS → RdsEndpointProvider.defaultProvider().resolveEndpoint(...)
   - Neptune → NeptuneEndpointProvider.defaultProvider().resolveEndpoint(...)
   - DocDB → DocDbEndpointProvider.defaultProvider().resolveEndpoint(...)

- The endpoint params passed are region, useDualStack, and useFips — the same inputs the old code used. Null values for dualstack/fips are handled by the generated endpoint provider (treated as false, the declared default in the endpoint rule set).

- Removed unused imports (AwsClientEndpointProvider, Protocol, SdkExecutionAttribute) and the SERVICE_NAME constant.

## Testing

   - Existing PresignRequestHandlerTest (RDS, Neptune, DocDB) validates the full presigning flow, including asserting the exact presigned URL host (https://rds.us-east-1.amazonaws.com) and signature.
   - Existing PresignRequestWireMockTest (Neptune, DocDB) validates presigned URLs in wire-level integration tests.
   - All existing tests pass without modification, confirming behavioral equivalence.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
