### PR TITLE
Fix CRT connection pool leak / missing concurrency metrics

### DIFF
--- a/.changes/next-release/bugfix-AWSCommonRuntimeHTTPClient-03285eb.json
+++ b/.changes/next-release/bugfix-AWSCommonRuntimeHTTPClient-03285eb.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS Common Runtime HTTP Client",
+    "contributor": "",
+    "description": "Fix CRT connection pool exhaustion/leak when streams are cancelled due to API call timeouts.  Ensure concurrency/HTTP metrics are always published."
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java
@@ -20,9 +20,11 @@ import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapCrtException
 import static software.amazon.awssdk.http.crt.internal.request.CrtRequestAdapter.toAsyncCrtRequest;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.http.HttpRequestBase;
 import software.amazon.awssdk.crt.http.HttpStreamBase;
+import software.amazon.awssdk.crt.http.HttpStreamManager;
 import software.amazon.awssdk.http.SdkCancellationException;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
@@ -58,33 +60,39 @@ public final class CrtAsyncRequestExecutor {
         long acquireStartTime = 0;
 
         if (shouldPublishMetrics) {
-            // go ahead and get acquireStartTime for the concurrency timer as early as possible,
-            // so it's as accurate as possible, but only do it in a branch since clock_gettime()
-            // results in a full sys call barrier (multiple mutexes and a hw interrupt).
             acquireStartTime = System.nanoTime();
         }
 
         HttpRequestBase crtRequest = toAsyncCrtRequest(executionContext);
+        HttpStreamManager streamManager = executionContext.streamManager();
 
         CrtResponseAdapter crtResponseHandler =
             CrtResponseAdapter.toCrtResponseHandler(requestFuture, asyncRequest.responseHandler());
 
         CompletableFuture<HttpStreamBase> streamFuture =
-            executionContext.streamManager().acquireStream(crtRequest, crtResponseHandler);
+            streamManager.acquireStream(crtRequest, crtResponseHandler);
+
+        // Guard to ensure metrics are reported exactly once per request.
+        AtomicBoolean metricsReported = new AtomicBoolean(false);
+
+        long finalAcquireStartTime = acquireStartTime;
 
         // Evict the connection from the pool on failure so it is not reused.
+        // Also report metrics on failure — this ensures concurrency metrics
+        // are available during pool exhaustion timeouts.
         requestFuture.whenComplete((r, t) -> {
             if (t != null) {
+                if (shouldPublishMetrics && metricsReported.compareAndSet(false, true)) {
+                    reportMetrics(streamManager, metricCollector, finalAcquireStartTime);
+                }
                 crtResponseHandler.closeConnection();
             }
         });
 
-        long finalAcquireStartTime = acquireStartTime;
-
         streamFuture.whenComplete((stream, throwable) -> {
             crtResponseHandler.onAcquireStream(stream);
-            if (shouldPublishMetrics) {
-                reportMetrics(executionContext.streamManager(), metricCollector, finalAcquireStartTime);
+            if (shouldPublishMetrics && metricsReported.compareAndSet(false, true)) {
+                reportMetrics(streamManager, metricCollector, finalAcquireStartTime);
             }
 
             if (throwable != null) {

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
@@ -19,9 +19,11 @@ import static software.amazon.awssdk.http.crt.internal.CrtUtils.reportMetrics;
 import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapCrtException;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.crt.http.HttpStreamBase;
+import software.amazon.awssdk.crt.http.HttpStreamManager;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.crt.internal.request.CrtRequestAdapter;
 import software.amazon.awssdk.http.crt.internal.response.InputStreamAdaptingHttpStreamResponseHandler;
@@ -50,9 +52,6 @@ public final class CrtRequestExecutor {
         long acquireStartTime = 0;
 
         if (shouldPublishMetrics) {
-            // go ahead and get acquireStartTime for the concurrency timer as early as possible,
-            // so it's as accurate as possible, but only do it in a branch since clock_gettime()
-            // results in a full sys call barrier (multiple mutexes and a hw interrupt).
             acquireStartTime = System.nanoTime();
         }
 
@@ -60,23 +59,32 @@ public final class CrtRequestExecutor {
             new InputStreamAdaptingHttpStreamResponseHandler(requestFuture);
 
         HttpRequest crtRequest = CrtRequestAdapter.toCrtRequest(executionContext);
+        HttpStreamManager streamManager = executionContext.streamManager();
 
         CompletableFuture<HttpStreamBase> streamFuture =
-            executionContext.streamManager().acquireStream(crtRequest, crtResponseHandler);
+            streamManager.acquireStream(crtRequest, crtResponseHandler);
+
+        // Guard to ensure metrics are reported exactly once per request.
+        AtomicBoolean metricsReported = new AtomicBoolean(false);
+
+        long finalAcquireStartTime = acquireStartTime;
 
         // Evict the connection from the pool on failure so it is not reused.
+        // Also report metrics on failure — this ensures concurrency metrics
+        // are available during pool exhaustion timeouts.
         requestFuture.whenComplete((r, t) -> {
             if (t != null) {
+                if (shouldPublishMetrics && metricsReported.compareAndSet(false, true)) {
+                    reportMetrics(streamManager, metricCollector, finalAcquireStartTime);
+                }
                 crtResponseHandler.closeConnection();
             }
         });
 
-        long finalAcquireStartTime = acquireStartTime;
-
         streamFuture.whenComplete((streamBase, throwable) -> {
             crtResponseHandler.onAcquireStream(streamBase);
-            if (shouldPublishMetrics) {
-                reportMetrics(executionContext.streamManager(), metricCollector, finalAcquireStartTime);
+            if (shouldPublishMetrics && metricsReported.compareAndSet(false, true)) {
+                reportMetrics(streamManager, metricCollector, finalAcquireStartTime);
             }
 
             if (throwable != null) {

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/ResponseHandlerHelper.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/ResponseHandlerHelper.java
@@ -41,11 +41,8 @@ public class ResponseHandlerHelper {
     /**
      * Set the stream reference and activate it as soon as it is acquired from the pool.
      *
-     * <p>Activating immediately ensures that any subsequent {@code closeConnection()} call will
-     * properly trigger {@code onResponseComplete} in the CRT native layer, which is required for
-     * {@code Http1StreamManager} to release the connection slot back to the pool. Without prior
-     * activation, {@code cancel()} + {@code close()} releases the native stream handle without
-     * triggering callbacks, permanently leaking the connection slot.
+     * <p>Activate must be called before any other methods on the stream including
+     * {@code cancel()} or {@code close()}.  Calling it here ensures this is done.
      *
      * <p>{@code activate()} is idempotent per the CRT contract — safe to call even if
      * {@code Http1StreamManager} has already activated the stream.
@@ -56,11 +53,12 @@ public class ResponseHandlerHelper {
                 this.stream = stream;
                 if (this.stream != null) {
                     this.stream.activate();
-                }
-                // closeConnection() was requested before the stream was acquired; close it now.
-                if (streamClosed && this.stream != null) {
-                    this.stream.cancel();
-                    this.stream.close();
+
+                    // closeConnection() was requested before the stream was acquired; close it now.
+                    if (streamClosed) {
+                        this.stream.cancel();
+                        this.stream.close();
+                    }
                 }
             }
         }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/ResponseHandlerHelper.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/ResponseHandlerHelper.java
@@ -39,13 +39,24 @@ public class ResponseHandlerHelper {
     }
 
     /**
-     * Set the stream reference as soon as it is acquired from the pool, so that closeConnection can
-     * cancel it even if onResponseHeaders has not yet fired (e.g. the server is unresponsive).
+     * Set the stream reference and activate it as soon as it is acquired from the pool.
+     *
+     * <p>Activating immediately ensures that any subsequent {@code closeConnection()} call will
+     * properly trigger {@code onResponseComplete} in the CRT native layer, which is required for
+     * {@code Http1StreamManager} to release the connection slot back to the pool. Without prior
+     * activation, {@code cancel()} + {@code close()} releases the native stream handle without
+     * triggering callbacks, permanently leaking the connection slot.
+     *
+     * <p>{@code activate()} is idempotent per the CRT contract — safe to call even if
+     * {@code Http1StreamManager} has already activated the stream.
      */
     public void onAcquireStream(HttpStreamBase stream) {
         synchronized (streamLock) {
             if (this.stream == null) {
                 this.stream = stream;
+                if (this.stream != null) {
+                    this.stream.activate();
+                }
                 // closeConnection() was requested before the stream was acquired; close it now.
                 if (streamClosed && this.stream != null) {
                     this.stream.cancel();
@@ -89,13 +100,19 @@ public class ResponseHandlerHelper {
     /**
      * Cancel and close the stream, forcing the underlying connection to shut down rather than be returned to the
      * connection pool. This should be called on error paths or when the stream is aborted before the response is
-     * fully consumed. {@code cancel()} must be invoked before {@code close()} per the CRT contract.
+     * fully consumed.
+     *
+     * <p>Calls {@code activate()} before {@code cancel()} to ensure the CRT native layer will deliver
+     * {@code onResponseComplete}. This is critical for {@code Http1StreamManager} to release the
+     * connection slot back to the pool. {@code activate()} is idempotent — calling it on an
+     * already-activated stream is safe.
      */
     public void closeConnection() {
         synchronized (streamLock) {
             if (!streamClosed) {
                 streamClosed = true;
                 if (stream != null) {
+                    stream.activate();
                     stream.cancel();
                     stream.close();
                 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientPoolExhaustionTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientPoolExhaustionTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.HttpTestUtils.createProvider;
+import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createRequest;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+/**
+ * Tests that verify the CRT HTTP client's connection pool does not permanently
+ * exhaust when requests are aborted (via timeout or explicit abort), and that
+ * concurrency metrics are reported even on failed/timed-out requests.
+ */
+public class AwsCrtHttpClientPoolExhaustionTest {
+
+    private static final int MAX_CONCURRENCY = 3;
+
+    @RegisterExtension
+    static WireMockExtension mockServer = WireMockExtension.newInstance()
+                                                           .options(wireMockConfig().dynamicPort())
+                                                           .build();
+
+    private static ScheduledExecutorService scheduler;
+
+    @BeforeAll
+    static void setup() {
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        scheduler.shutdown();
+    }
+
+    /**
+     * Verifies that after aborting all pool connections, the pool recovers and
+     * can serve new requests.
+     */
+    @Test
+    void syncClient_poolRecoversAfterRepeatedAborts(WireMockRuntimeInfo wm) throws Exception {
+        URI uri = URI.create("http://localhost:" + wm.getHttpPort());
+
+        try (SdkHttpClient client = AwsCrtHttpClient.builder().maxConcurrency(MAX_CONCURRENCY).build()) {
+            // Phase 1: Abort MAX_CONCURRENCY requests (exhausts all pool slots)
+            stubSlowServer(2000);
+            for (int i = 0; i < MAX_CONCURRENCY; i++) {
+                ExecutableHttpRequest req = client.prepareRequest(syncRequest(uri, null));
+                scheduler.schedule(req::abort, 50, TimeUnit.MILLISECONDS);
+                try {
+                    req.call();
+                } catch (Exception e) {
+                    // expected — aborted
+                }
+            }
+
+            // Wait for cancel callbacks to propagate
+            Thread.sleep(300);
+
+            // Phase 2: Verify pool can serve new requests
+            stubFastServer();
+            int successCount = 0;
+            for (int i = 0; i < MAX_CONCURRENCY; i++) {
+                try {
+                    client.prepareRequest(syncRequest(uri, null)).call();
+                    successCount++;
+                } catch (Exception e) {
+                    // pool exhausted — connection leaked
+                }
+            }
+
+            assertThat(successCount)
+                .as("All %d requests should succeed after pool recovery (was %d)", MAX_CONCURRENCY, successCount)
+                .isEqualTo(MAX_CONCURRENCY);
+        }
+    }
+
+    /**
+     * Verifies that after multiple rounds of aborts (more than maxConcurrency total),
+     * the pool continues to function. This catches progressive leaks where each abort
+     * leaks one slot.
+     */
+    @Test
+    void syncClient_poolDoesNotProgressivelyLeak(WireMockRuntimeInfo wm) throws Exception {
+        URI uri = URI.create("http://localhost:" + wm.getHttpPort());
+        int totalAborts = MAX_CONCURRENCY * 3; // 9 aborts with pool size 3
+
+        try (SdkHttpClient client = AwsCrtHttpClient.builder().maxConcurrency(MAX_CONCURRENCY).build()) {
+            stubSlowServer(2000);
+            for (int i = 0; i < totalAborts; i++) {
+                ExecutableHttpRequest req = client.prepareRequest(syncRequest(uri, null));
+                scheduler.schedule(req::abort, 50, TimeUnit.MILLISECONDS);
+                try {
+                    req.call();
+                } catch (Exception e) {
+                    // expected
+                }
+            }
+
+            Thread.sleep(300);
+
+            // Verify pool still works after 9 aborts (3x the pool size)
+            stubFastServer();
+            int successCount = 0;
+            for (int i = 0; i < MAX_CONCURRENCY; i++) {
+                try {
+                    client.prepareRequest(syncRequest(uri, null)).call();
+                    successCount++;
+                } catch (Exception e) {
+                    // leaked
+                }
+            }
+
+            assertThat(successCount).isEqualTo(MAX_CONCURRENCY);
+        }
+    }
+
+    /**
+     * Verifies that concurrency metrics (AvailableConcurrency, LeasedConcurrency,
+     * MaxConcurrency, PendingConcurrencyAcquires) are reported even when the request
+     * fails due to timeout/abort.
+     */
+    @Test
+    void syncClient_metricsReportedOnAbortedRequest(WireMockRuntimeInfo wm) throws Exception {
+        URI uri = URI.create("http://localhost:" + wm.getHttpPort());
+
+        try (SdkHttpClient client = AwsCrtHttpClient.builder().maxConcurrency(MAX_CONCURRENCY).build()) {
+            stubSlowServer(2000);
+
+            MetricCollector collector = MetricCollector.create("test");
+            ExecutableHttpRequest req = client.prepareRequest(syncRequest(uri, collector));
+            scheduler.schedule(req::abort, 50, TimeUnit.MILLISECONDS);
+            try {
+                req.call();
+            } catch (Exception e) {
+                // expected — aborted
+            }
+
+            Thread.sleep(200);
+
+            MetricCollection metrics = collector.collect();
+
+            // Recursively search the metric tree for MAX_CONCURRENCY
+            boolean foundConcurrencyMetrics = hasMetricAnywhere(metrics, HttpMetric.MAX_CONCURRENCY);
+
+            assertThat(foundConcurrencyMetrics)
+                .as("Concurrency metrics should be reported even on aborted requests")
+                .isTrue();
+        }
+    }
+
+    private boolean hasMetricAnywhere(MetricCollection collection, software.amazon.awssdk.metrics.SdkMetric<?> metric) {
+        if (!collection.metricValues(metric).isEmpty()) {
+            return true;
+        }
+        for (MetricCollection child : collection.children()) {
+            if (hasMetricAnywhere(child, metric)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private HttpExecuteRequest syncRequest(URI uri, MetricCollector collector) {
+        HttpExecuteRequest.Builder builder = HttpExecuteRequest.builder()
+                                                               .request(createRequest(uri))
+                                                               .contentStreamProvider(() -> new ByteArrayInputStream(new byte[0]));
+        if (collector != null) {
+            builder.metricCollector(collector);
+        }
+        return builder.build();
+    }
+
+    private void stubSlowServer(int delayMs) {
+        mockServer.stubFor(any(urlPathEqualTo("/")).willReturn(
+            aResponse().withFixedDelay(delayMs).withBody("slow")));
+    }
+
+    private void stubFastServer() {
+        mockServer.stubFor(any(urlPathEqualTo("/")).willReturn(
+            aResponse().withStatus(200).withBody("OK")));
+    }
+}


### PR DESCRIPTION
Fix CRT connection pool leak / missing concurrency metrics. 

## Motivation and Context
There is a race condition when methods like cancel/close are called on a CRT stream before activate has been called.  This can result in a connection pool leak and complete exhaustion when api call timeouts are being hit.  Additionally, when this happens, HTTP metrics like concurrency aren't published.

## Modifications
* Call `stream.activate()` in `onAcquireStream()` immediately upon receiving the stream. This ensures the stream is always activated before any cancel() call, guaranteeing the CRT native layer will deliver onResponseComplete and allowing Http1StreamManager to release the connection slot.  `activate()` is idempotent per CRT contract.
* Call `stream.activate()` in `closeConnection()` before cancel() + close() as a defensive measure for the same reason.

## Testing
New and existing tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
