### PR TITLE
Remove ServiceMetadata usage from DefaultS3Presigner, S3Utilities,and DefaultPollyPresigner

### DIFF
--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -343,7 +343,6 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     }
 
     private URI resolveEndpoint() {
-        // If user configured an endpoint override or one is set via environment/profile, use it.
         Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                                                   .clientEndpointOverride(endpointOverride)
                                                                   .serviceEndpointOverrideEnvironmentVariable(
@@ -354,9 +353,6 @@ public final class DefaultPollyPresigner implements PollyPresigner {
                                                                   .profileName(profileName)
                                                                   .resolveFromOverrides();
 
-        // Resolve endpoint using the service's Endpoints 2.0 provider. Unlike S3, the Polly presigner
-        // does not have an endpoint resolution interceptor chain — this endpoint becomes the final
-        // presigned URL host, so it must be accurate.
         return overrideEndpoint.orElseGet(() -> CompletableFutureUtils.joinLikeSync(
             PollyEndpointProvider.defaultProvider()
                                  .resolveEndpoint(p -> p.region(region)

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -70,6 +71,7 @@ import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.polly.auth.scheme.PollyAuthSchemeProvider;
+import software.amazon.awssdk.services.polly.endpoints.PollyEndpointProvider;
 import software.amazon.awssdk.services.polly.internal.presigner.model.transform.SynthesizeSpeechRequestMarshaller;
 import software.amazon.awssdk.services.polly.model.PollyRequest;
 import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
@@ -341,20 +343,26 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     }
 
     private URI resolveEndpoint() {
-        return AwsClientEndpointProvider.builder()
-                                        .clientEndpointOverride(endpointOverride)
-                                        .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_POLLY")
-                                        .serviceEndpointOverrideSystemProperty("aws.endpointUrlPolly")
-                                        .serviceProfileProperty("polly")
-                                        .serviceEndpointPrefix(SERVICE_NAME)
-                                        .defaultProtocol("https")
-                                        .region(region)
-                                        .profileFile(profileFile)
-                                        .profileName(profileName)
-                                        .dualstackEnabled(dualstackEnabled)
-                                        .fipsEnabled(fipsEnabled)
-                                        .build()
-                                        .clientEndpoint();
+        // If user configured an endpoint override or one is set via environment/profile, use it.
+        Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
+                                                                  .clientEndpointOverride(endpointOverride)
+                                                                  .serviceEndpointOverrideEnvironmentVariable(
+                                                                      "AWS_ENDPOINT_URL_POLLY")
+                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlPolly")
+                                                                  .serviceProfileProperty("polly")
+                                                                  .profileFile(profileFile)
+                                                                  .profileName(profileName)
+                                                                  .resolveFromOverrides();
+
+        // Resolve endpoint using the service's Endpoints 2.0 provider. Unlike S3, the Polly presigner
+        // does not have an endpoint resolution interceptor chain — this endpoint becomes the final
+        // presigned URL host, so it must be accurate.
+        return overrideEndpoint.orElseGet(() -> CompletableFutureUtils.joinLikeSync(
+            PollyEndpointProvider.defaultProvider()
+                                 .resolveEndpoint(p -> p.region(region)
+                                                        .useDualStack(dualstackEnabled)
+                                                        .useFips(fipsEnabled))
+        ).url());
     }
 
     public static class BuilderImpl implements PollyPresigner.Builder {

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -96,6 +96,7 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     private final URI endpointOverride;
     private final Boolean dualstackEnabled;
     private final Boolean fipsEnabled;
+    private final URI resolvedEndpoint;
 
     private DefaultPollyPresigner(BuilderImpl builder) {
         this.signingClock = builder.signingClock != null ? builder.signingClock
@@ -128,6 +129,7 @@ public final class DefaultPollyPresigner implements PollyPresigner {
                                                                             .build()
                                                                             .isFipsEnabled()
                                                                             .orElse(false);
+        this.resolvedEndpoint = resolveEndpoint();
     }
 
     IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider() {
@@ -336,10 +338,9 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     }
 
     private void applyEndpoint(SdkHttpFullRequest.Builder httpRequestBuilder) {
-        URI uri = resolveEndpoint();
-        httpRequestBuilder.protocol(uri.getScheme())
-                          .host(uri.getHost())
-                          .port(uri.getPort());
+        httpRequestBuilder.protocol(resolvedEndpoint.getScheme())
+                          .host(resolvedEndpoint.getHost())
+                          .port(resolvedEndpoint.getPort());
     }
 
     private URI resolveEndpoint() {

--- a/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerTest.java
+++ b/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerTest.java
@@ -192,6 +192,26 @@ class DefaultPollyPresignerTest {
     }
 
     @Test
+    void presign_noEndpointOverride_usesDefaultEndpoint() {
+        PollyPresigner presigner = DefaultPollyPresigner.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        SynthesizeSpeechPresignRequest presignRequest = SynthesizeSpeechPresignRequest.builder()
+                .synthesizeSpeechRequest(BASIC_SYNTHESIZE_SPEECH_REQUEST)
+                .signatureDuration(Duration.ofHours(3))
+                .build();
+
+        PresignedSynthesizeSpeechRequest presigned = presigner.presignSynthesizeSpeech(presignRequest);
+
+        URL presignedUrl = presigned.url();
+        assertThat(presignedUrl.getProtocol()).isEqualTo("https");
+        assertThat(presignedUrl.getHost()).isEqualTo("polly.us-east-1.amazonaws.com");
+        assertThat(presignedUrl.getPath()).isEqualTo("/v1/speech");
+    }
+
+    @Test
     void presign_endpointOverriden() {
         PollyPresigner presigner = DefaultPollyPresigner.builder()
                 .region(Region.US_EAST_1)

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
@@ -426,21 +426,25 @@ public final class S3Utilities {
 
     /**
      * If endpoint is not present, construct a default endpoint using the region information.
+     * The endpoint resolved here is only used for initial request marshalling — it gets completely replaced
+     * by S3ResolveEndpointInterceptor during the getUrl flow.
      */
     private ClientEndpointProvider clientEndpointProvider(URI overrideEndpoint, Region region) {
-        return AwsClientEndpointProvider.builder()
-                                        .clientEndpointOverride(overrideEndpoint)
-                                        .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_S3")
-                                        .serviceEndpointOverrideSystemProperty("aws.endpointUrlS3")
-                                        .serviceProfileProperty("s3")
-                                        .serviceEndpointPrefix(SERVICE_NAME)
-                                        .defaultProtocol("https")
-                                        .region(region)
-                                        .profileFile(profileFile)
-                                        .profileName(profileName)
-                                        .dualstackEnabled(s3Configuration.dualstackEnabled())
-                                        .fipsEnabled(fipsEnabled)
-                                        .build();
+        // First check if there's an endpoint override from the user or environment.
+        Optional<URI> resolvedOverride = AwsClientEndpointProvider.builder()
+                                             .clientEndpointOverride(overrideEndpoint)
+                                             .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_S3")
+                                             .serviceEndpointOverrideSystemProperty("aws.endpointUrlS3")
+                                             .serviceProfileProperty("s3")
+                                             .profileFile(profileFile)
+                                             .profileName(profileName)
+                                             .resolveFromOverrides();
+
+        // If an override is configured, use it (marked as overridden). Otherwise, use a localhost placeholder
+        // marked as NOT overridden — S3ResolveEndpointInterceptor will replace it with the real endpoint.
+        return resolvedOverride
+            .map(uri -> ClientEndpointProvider.create(uri, true))
+            .orElseGet(() -> ClientEndpointProvider.create(URI.create("https://localhost"), false));
     }
 
     private URI getEndpointOverride(GetUrlRequest request) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
@@ -442,6 +442,7 @@ public final class S3Utilities {
 
         return resolvedOverride
             .map(uri -> ClientEndpointProvider.create(uri, true))
+            // Need an endpoint to marshall but this will be overwritten in modifyHttpRequest
             .orElseGet(() -> ClientEndpointProvider.create(URI.create("https://localhost"), false));
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
@@ -442,7 +442,7 @@ public final class S3Utilities {
 
         return resolvedOverride
             .map(uri -> ClientEndpointProvider.create(uri, true))
-            // Need an endpoint to marshall but this will be overwritten in modifyHttpRequest
+            // Need an endpoint to marshall but this will be overwritten later with Endpoints 2.0 resolution
             .orElseGet(() -> ClientEndpointProvider.create(URI.create("https://localhost"), false));
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
@@ -425,12 +425,12 @@ public final class S3Utilities {
     }
 
     /**
-     * If endpoint is not present, construct a default endpoint using the region information.
-     * The endpoint resolved here is only used for initial request marshalling — it gets completely replaced
-     * by S3ResolveEndpointInterceptor during the getUrl flow.
+     * Resolve the client endpoint provider for request marshalling. Checks client override,
+     * environment variables, system properties, and profile configuration. If no override is found,
+     * a localhost placeholder is used — the actual endpoint is resolved by S3EndpointProvider
+     * during the getUrl flow.
      */
     private ClientEndpointProvider clientEndpointProvider(URI overrideEndpoint, Region region) {
-        // First check if there's an endpoint override from the user or environment.
         Optional<URI> resolvedOverride = AwsClientEndpointProvider.builder()
                                              .clientEndpointOverride(overrideEndpoint)
                                              .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_S3")
@@ -440,8 +440,6 @@ public final class S3Utilities {
                                              .profileName(profileName)
                                              .resolveFromOverrides();
 
-        // If an override is configured, use it (marked as overridden). Otherwise, use a localhost placeholder
-        // marked as NOT overridden — S3ResolveEndpointInterceptor will replace it with the real endpoint.
         return resolvedOverride
             .map(uri -> ClientEndpointProvider.create(uri, true))
             .orElseGet(() -> ClientEndpointProvider.create(URI.create("https://localhost"), false));

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -274,6 +274,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                                                 + testEndpoint + ". This is usually caused by an invalid region "
                                                 + "configuration.");
             }
+            // Need an endpoint to marshall but this will be overwritten in modifyHttpRequest
             endpointProvider = ClientEndpointProvider.create(URI.create("https://localhost"), false);
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -21,6 +21,7 @@ import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttrib
 import static software.amazon.awssdk.utils.CollectionUtils.mergeLists;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
+import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -45,6 +46,7 @@ import software.amazon.awssdk.awscore.internal.AwsExecutionContextBuilder;
 import software.amazon.awssdk.awscore.internal.defaultsmode.DefaultsModeConfiguration;
 import software.amazon.awssdk.awscore.presigner.PresignRequest;
 import software.amazon.awssdk.awscore.presigner.PresignedRequest;
+import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkBytes;
@@ -53,6 +55,7 @@ import software.amazon.awssdk.core.SelectedAuthScheme;
 import software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.ExecutionContext;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -251,28 +254,34 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
      * Copied from {@link AwsDefaultClientBuilder}.
      */
     private SdkClientConfiguration createClientConfiguration() {
-        AwsClientEndpointProvider endpointProvider =
-            AwsClientEndpointProvider.builder()
-                                     .clientEndpointOverride(endpointOverride())
-                                     .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_S3")
-                                     .serviceEndpointOverrideSystemProperty("aws.endpointUrlS3")
-                                     .serviceProfileProperty("s3")
-                                     .serviceEndpointPrefix(SERVICE_NAME)
-                                     .defaultProtocol("https")
-                                     .region(region())
-                                     .profileFile(profileFileSupplier())
-                                     .profileName(profileName())
-                                     .dualstackEnabled(serviceConfiguration.dualstackEnabled())
-                                     .fipsEnabled(fipsEnabled())
-                                     .build();
+        // First check if there's an endpoint override from the user or environment.
+        Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
+                                             .clientEndpointOverride(endpointOverride())
+                                             .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_S3")
+                                             .serviceEndpointOverrideSystemProperty("aws.endpointUrlS3")
+                                             .serviceProfileProperty("s3")
+                                             .profileFile(profileFileSupplier())
+                                             .profileName(profileName())
+                                             .resolveFromOverrides();
 
-        // Make sure the endpoint resolver can actually resolve an endpoint, so that we fail now instead of
-        // when a request is made.
-        endpointProvider.clientEndpoint();
+        // If an override is configured, use it (marked as overridden). Otherwise, use a localhost placeholder
+        // marked as NOT overridden — S3ResolveEndpointInterceptor will replace it with the real endpoint
+        // at presigning time using S3EndpointProvider with the full request context.
+        ClientEndpointProvider endpointProvider;
+        if (overrideEndpoint.isPresent()) {
+            endpointProvider = ClientEndpointProvider.create(overrideEndpoint.get(), true);
+        } else {
+            // Validate region at construction time to fail fast for invalid regions (e.g., US_EAST_1 with underscores).
+            URI testEndpoint = URI.create("https://s3." + region().id() + ".amazonaws.com");
+            if (testEndpoint.getHost() == null) {
+                throw SdkClientException.create("Configured region (" + region() + ") and tags ([]) resulted in an invalid URI: "
+                                                + testEndpoint + ". This is usually caused by an invalid region configuration.");
+            }
+            endpointProvider = ClientEndpointProvider.create(URI.create("https://localhost"), false);
+        }
 
         return SdkClientConfiguration.builder()
-                                     .option(SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
-                                             endpointProvider)
+                                     .option(SdkClientOption.CLIENT_ENDPOINT_PROVIDER, endpointProvider)
                                      .build();
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -274,7 +274,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                                                 + testEndpoint + ". This is usually caused by an invalid region "
                                                 + "configuration.");
             }
-            // Need an endpoint to marshall but this will be overwritten in modifyHttpRequest
+            // Need an endpoint to marshall but this will be overwritten later with Endpoints 2.0 resolution
             endpointProvider = ClientEndpointProvider.create(URI.create("https://localhost"), false);
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -254,7 +254,6 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
      * Copied from {@link AwsDefaultClientBuilder}.
      */
     private SdkClientConfiguration createClientConfiguration() {
-        // First check if there's an endpoint override from the user or environment.
         Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
                                              .clientEndpointOverride(endpointOverride())
                                              .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_S3")
@@ -264,9 +263,6 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                                              .profileName(profileName())
                                              .resolveFromOverrides();
 
-        // If an override is configured, use it (marked as overridden). Otherwise, use a localhost placeholder
-        // marked as NOT overridden — S3ResolveEndpointInterceptor will replace it with the real endpoint
-        // at presigning time using S3EndpointProvider with the full request context.
         ClientEndpointProvider endpointProvider;
         if (overrideEndpoint.isPresent()) {
             endpointProvider = ClientEndpointProvider.create(overrideEndpoint.get(), true);
@@ -274,8 +270,9 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
             // Validate region at construction time to fail fast for invalid regions (e.g., US_EAST_1 with underscores).
             URI testEndpoint = URI.create("https://s3." + region().id() + ".amazonaws.com");
             if (testEndpoint.getHost() == null) {
-                throw SdkClientException.create("Configured region (" + region() + ") and tags ([]) resulted in an invalid URI: "
-                                                + testEndpoint + ". This is usually caused by an invalid region configuration.");
+                throw SdkClientException.create("Configured region (" + region() + ") resulted in an invalid URI: "
+                                                + testEndpoint + ". This is usually caused by an invalid region "
+                                                + "configuration.");
             }
             endpointProvider = ClientEndpointProvider.create(URI.create("https://localhost"), false);
         }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/InvalidRegionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/InvalidRegionTest.java
@@ -32,9 +32,7 @@ public class InvalidRegionTest {
 
         assertThatThrownBy(() -> utilities.getUrl(r -> r.bucket("foo").key("bar")))
             .isInstanceOf(SdkClientException.class)
-            .hasMessageContaining("US_EAST_1")
-            .hasMessageContaining("region")
-            .hasMessageContaining("us-east-1");
+            .hasMessageContaining("Invalid region");
     }
 
     @Test
@@ -43,9 +41,7 @@ public class InvalidRegionTest {
 
         assertThatThrownBy(() -> utilities.getUrl(r -> r.bucket("foo").key("bar").region(Region.of("US_WEST_2"))))
             .isInstanceOf(SdkClientException.class)
-            .hasMessageContaining("US_WEST_2")
-            .hasMessageContaining("region")
-            .hasMessageContaining("us-west-2");
+            .hasMessageContaining("Invalid region");
     }
 
     @Test
@@ -77,7 +73,8 @@ public class InvalidRegionTest {
     public void invalidS3PresignerRegionAtClientGivesHelpfulMessage() {
         assertThatThrownBy(() -> S3Presigner.builder().region(Region.of("US_EAST_1")).build())
             .isInstanceOf(SdkClientException.class)
-            .hasMessageContaining("Configured region (US_EAST_1) and tags ([]) resulted in an invalid URI");
+            .hasMessageContaining("Configured region (US_EAST_1)")
+            .hasMessageContaining("invalid URI");
     }
 
     @Test


### PR DESCRIPTION

## Motivation and Context
Remove ServiceMetadata dependency from DefaultS3Presigner, S3Utilities, and DefaultPollyPresigner. These three classes call AwsClientEndpointProvider with serviceEndpointPrefix/defaultProtocol/region, which triggers the expensive clientEndpointFromServiceMetadata() code path — loading GeneratedServiceMetadataProvider and incurring 350-500ms static initialization overhead. This is part of the ServiceMetadata removal work, feature branch - `feature/master/remove-service-metadata-usage`

## Modifications

 - **DefaultS3Presigner**: Use resolveFromOverrides() to check for endpoint overrides/environment. If none found, use https://localhost placeholder (marked as not overridden) — S3ResolveEndpointInterceptor replaces it with the real endpoint during presigning. Added region validation at build time for fail-fast on invalid regions.
  
  - **S3Utilities**: Same approach — resolveFromOverrides() with localhost fallback. The endpoint is replaced by S3EndpointProvider during the getUrl() flow.
  
- **DefaultPollyPresigner**: Use resolveFromOverrides() to check for overrides/environment. If none found, call PollyEndpointProvider (Endpoints 2.0) directly to get an accurate endpoint. Unlike S3, the Polly presigner has no downstream endpoint resolution — the endpoint becomes the final presigned URL host.

- **InvalidRegionTest**: Updated assertions to match new error messages. S3Utilities errors now come from S3EndpointProvider ("Invalid region: region was not a valid DNS name.") and S3Presigner errors come from build-time validation ("Configured region ..  resulted in an invalid URI"). the exception type is same, but the error message slightly varies( the exception type and fail-fast behavior are preserved).

## Testing

- Existing `S3PresignerTest` and `S3UtilitiesTest` suites validate full endpoint URLs (virtual-hosted, path-style, accelerate, dualstack, overrides) — any localhost leak would immediately fail these tests.
- Updated `InvalidRegionTest` assertions to match new error messages.
- Added `presign_noEndpointOverride_usesDefaultEndpoint` test in `DefaultPollyPresignerTest` to verify that the Endpoints 2.0 fallback produces the correct host (polly.us-east-1.amazonaws.com).

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
