### PR TITLE
#7102 Fix enhanced client list projection placeholders

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-8a26648.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-8a26648.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "description": "Fix projection expression placeholders for list-index attributes in the enhanced DynamoDB client. Resolves [#7102](https://github.com/aws/aws-sdk-java-v2/issues/7102).",
+    "contributor": "Arnab"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/ProjectionExpression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/ProjectionExpression.java
@@ -93,7 +93,8 @@ import software.amazon.awssdk.utils.Pair;
 public class ProjectionExpression {
 
     private static final String AMZN_MAPPED = "#AMZN_MAPPED_";
-    private static final UnaryOperator<String> PROJECTION_EXPRESSION_KEY_MAPPER = k -> AMZN_MAPPED + cleanAttributeName(k);
+    private static final UnaryOperator<String> PROJECTION_EXPRESSION_KEY_MAPPER =
+        k -> AMZN_MAPPED + cleanAttributeName(attributeNameWithoutListDereference(k));
 
     private final Optional<String> projectionExpressionAsString;
     private final Map<String, String> expressionAttributeNames;
@@ -132,6 +133,7 @@ public class ProjectionExpression {
         Map<String, List<String>> placeholderToAttributeNames =
             nestedAttributeNames.stream()
                                 .flatMap(n -> n.elements().stream())
+                                .map(ProjectionExpression::attributeNameWithoutListDereference)
                                 .distinct()
                                 .collect(Collectors.groupingBy(PROJECTION_EXPRESSION_KEY_MAPPER, Collectors.toList()));
 
@@ -180,8 +182,45 @@ public class ProjectionExpression {
                                                   Map<String, String> attributeToSanitizedMap) {
         return nestedAttributeName.elements()
                                   .stream()
-                                  .map(attributeToSanitizedMap::get)
+                                  .map(element -> attributeToSanitizedMap.get(attributeNameWithoutListDereference(element))
+                                                  + listDereferenceSuffix(element))
                                   .collect(Collectors.joining("."));
+    }
+
+    private static String attributeNameWithoutListDereference(String attributeName) {
+        int firstListDereferenceIndex = firstListDereferenceIndex(attributeName);
+        return firstListDereferenceIndex == -1 ? attributeName : attributeName.substring(0, firstListDereferenceIndex);
+    }
+
+    private static String listDereferenceSuffix(String attributeName) {
+        int firstListDereferenceIndex = firstListDereferenceIndex(attributeName);
+        return firstListDereferenceIndex == -1 ? "" : attributeName.substring(firstListDereferenceIndex);
+    }
+
+    private static int firstListDereferenceIndex(String attributeName) {
+        int position = attributeName.length();
+        int firstListDereferenceIndex = position;
+
+        while (position > 0 && attributeName.charAt(position - 1) == ']') {
+            int openBracketIndex = attributeName.lastIndexOf('[', position - 1);
+            if (openBracketIndex == -1 || openBracketIndex == position - 1 ||
+                !containsOnlyDigits(attributeName, openBracketIndex + 1, position - 1)) {
+                return -1;
+            }
+            firstListDereferenceIndex = openBracketIndex;
+            position = openBracketIndex;
+        }
+
+        return firstListDereferenceIndex == attributeName.length() ? -1 : firstListDereferenceIndex;
+    }
+
+    private static boolean containsOnlyDigits(String value, int beginIndex, int endIndex) {
+        for (int i = beginIndex; i < endIndex; i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/ProjectionExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/ProjectionExpressionTest.java
@@ -22,7 +22,7 @@ public class ProjectionExpressionTest {
     static {
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_attribute", "attribute");
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_Attribute", "Attribute");
-        EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_firstiteminlist[0]", "firstiteminlist[0]");
+        EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_firstiteminlist", "firstiteminlist");
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_March_2021", "March-2021");
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_Why_Make_This_An_Attribute_Name", "Why.Make-This*An:Attribute:Name");
     }
@@ -100,6 +100,23 @@ public class ProjectionExpressionTest {
 
         String expectedProjectionExpression = "#AMZN_MAPPED_0_attribute_03.#AMZN_MAPPED_1_attribute_03,"
                                               + "#AMZN_MAPPED_2_attribute_03";
+
+        assertProjectionExpression(attributeNames, expectedAttributeNames, expectedProjectionExpression);
+    }
+
+    @Test
+    public void listDereferenceAttributes_AreMappedToAttributeName() {
+        Map<String, String> expectedAttributeNames = new HashMap<>();
+        expectedAttributeNames.put("#AMZN_MAPPED_tags", "tags");
+        expectedAttributeNames.put("#AMZN_MAPPED_metadata", "metadata");
+        expectedAttributeNames.put("#AMZN_MAPPED_values", "values");
+
+        List<NestedAttributeName> attributeNames = Arrays.asList(
+            NestedAttributeName.create("tags[0]"),
+            NestedAttributeName.create("metadata", "values[1][2]")
+        );
+
+        String expectedProjectionExpression = "#AMZN_MAPPED_tags[0],#AMZN_MAPPED_metadata.#AMZN_MAPPED_values[1][2]";
 
         assertProjectionExpression(attributeNames, expectedAttributeNames, expectedProjectionExpression);
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/ScanOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/ScanOperationTest.java
@@ -230,6 +230,25 @@ public class ScanOperationTest {
     }
 
     @Test
+    public void generateRequest_projectionExpressionWithListDereference() {
+        ScanOperation<FakeItem> operation = ScanOperation.create(
+                ScanEnhancedRequest.builder()
+                        .addAttributeToProject("tags[0]")
+                        .build()
+        );
+        ScanRequest request = operation.generateRequest(FakeItem.getTableSchema(),
+                PRIMARY_CONTEXT,
+                null);
+
+        ScanRequest expectedRequest = ScanRequest.builder()
+                .tableName(TABLE_NAME)
+                .projectionExpression("#AMZN_MAPPED_tags[0]")
+                .expressionAttributeNames(singletonMap("#AMZN_MAPPED_tags", "tags"))
+                .build();
+        assertThat(request, is(expectedRequest));
+    }
+
+    @Test
     public void generateRequest_hashKeyOnly_exclusiveStartKey() {
         FakeItem exclusiveStartKey = createUniqueFakeItem();
         Map<String, AttributeValue> keyMap = FakeItem.getTableSchema().itemToMap(exclusiveStartKey, singletonList("id"));


### PR DESCRIPTION
## Motivation and Context
Fixes https://github.com/aws/aws-sdk-java-v2/issues/7102.

`addAttributeToProject("tags[0]")` in the DynamoDB Enhanced Client generated an invalid `ExpressionAttributeNames` key containing brackets, such as `#AMZN_MAPPED_tags[0]`. DynamoDB rejects that key. The placeholder should map only the attribute name, while the list dereference remains in the projection expression.

## Modifications
- Updated `ProjectionExpression` to strip trailing list dereferences when generating expression attribute name placeholders.
- Preserved list dereference suffixes in the final projection expression, so `tags[0]` now produces:
  - `ExpressionAttributeNames: { "#AMZN_MAPPED_tags": "tags" }`
  - `ProjectionExpression: "#AMZN_MAPPED_tags[0]"`
- Added unit coverage for projection expressions with list dereferences, including nested paths.
- Added scan request generation coverage for `ScanEnhancedRequest.builder().addAttributeToProject("tags[0]")`.
- Added a changelog entry via `scripts/new-change`.

## Testing
- Ran `git diff --check` successfully.
- Attempted targeted Maven test runs, but local verification was blocked by unrelated repository/build state:
  - module-only test run could not resolve local snapshot artifacts: `dynamodb` and `service-test-utils`
  - reactor `-am` run hit unrelated generated-region clobber/stale target output and Apache client target-class issues before reaching the enhanced client tests

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license