### PR TITLE
#6949 Fix Netty streaming completion guard

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-6949.json
+++ b/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-6949.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO Async HTTP Client",
+    "contributor": "",
+    "description": "Fix async streaming responses so channel-inactive errors are surfaced until the response has been finalized."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -25,7 +25,6 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_CONTENT_LENGTH;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_DATA_READ;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_STATUS_CODE;
-import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.STREAMING_COMPLETE_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatch;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatchFinally;
 
@@ -462,10 +461,9 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
     private void notifyIfResponseNotCompleted(ChannelHandlerContext handlerCtx) {
         RequestContext requestCtx = handlerCtx.channel().attr(REQUEST_CONTEXT_KEY).get();
         Boolean responseCompleted = handlerCtx.channel().attr(RESPONSE_COMPLETE_KEY).get();
-        Boolean isStreamingComplete = handlerCtx.channel().attr(STREAMING_COMPLETE_KEY).get();
         handlerCtx.channel().attr(KEEP_ALIVE).set(false);
 
-        if (!Boolean.TRUE.equals(responseCompleted) && !Boolean.TRUE.equals(isStreamingComplete)) {
+        if (!Boolean.TRUE.equals(responseCompleted)) {
             IOException err = new IOException(NettyUtils.closedChannelMessage(handlerCtx.channel()));
             runAndLogError(handlerCtx.channel(), () -> "Fail to execute SdkAsyncHttpResponseHandler#onError",
                            () -> requestCtx.handler().onError(err));

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTE_FUTURE_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.PROTOCOL_FUTURE;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.STREAMING_COMPLETE_KEY;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.EmptyByteBuf;
@@ -311,6 +312,20 @@ public class PublisherAdapterTest {
 
         publisherAdapter.subscribe(subscriber);
 
+        verify(ctx).close();
+        verify(channelPool).release(channel);
+    }
+
+    @Test
+    public void channelInactive_streamingCompleteButResponseNotComplete_shouldInvokeResponseHandler() {
+        channel.attr(STREAMING_COMPLETE_KEY).set(true);
+
+        nettyResponseHandler.channelInactive(ctx);
+
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(responseHandler).onError(errorCaptor.capture());
+        assertThat(errorCaptor.getValue()).isInstanceOf(IOException.class);
+        assertThat(executeFuture).isCompletedExceptionally();
         verify(ctx).close();
         verify(channelPool).release(channel);
     }


### PR DESCRIPTION
## Motivation and Context

Fixes https://github.com/aws/aws-sdk-java-v2/issues/6949.

`NettyNioAsyncHttpClient` could suppress a channel-inactive fallback error when `STREAMING_COMPLETE_KEY` was true but `RESPONSE_COMPLETE_KEY` was not yet true. For `AsyncResponseTransformer.toPublisher()`, observing the final HTTP content does not necessarily mean the caller-visible response publisher has received a terminal signal, so this could leave subscribers waiting indefinitely.

## Modifications

Changed `ResponseHandler.notifyIfResponseNotCompleted()` to treat only `RESPONSE_COMPLETE_KEY=true` as sufficient proof that the response has completed.

Added a regression test covering the problematic state where streaming is marked complete, response finalization has not happened, and the channel becomes inactive. The test verifies that an `IOException` is surfaced, the execute future completes exceptionally, and the channel is released.

Added a changelog entry for the Netty NIO Async HTTP Client bug fix.

## Testing

Ran:

```sh
.\mvnw.cmd -pl http-clients\netty-nio-client -Dtest=PublisherAdapterTest test
```

Result: passed, 6 tests.

Also ran:

```sh
.\mvnw.cmd -pl http-clients\netty-nio-client -am test
```

This failed before reaching the Netty module in `core/annotations` during SpotBugs.

Also ran:

```sh
.\mvnw.cmd -pl http-clients\netty-nio-client test
```

This failed due to unrelated local runtime/tooling issues: WireMock certificate generation was unsupported on this runtime, and JaCoCo reported `Unsupported class file major version 70`.

Ran:

```sh
git diff --check
```

Result: passed.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [[LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license