### PR TITLE
Updating Lake Formation Access Grants Plugin version to 1.4.3

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-d5c970f.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-d5c970f.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "rajasbh-aws",
+    "description": "Updating Lake Formation Access Grants Plugin version to 1.4.3"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <!-- S3 Access Grants plugin version -->
         <s3accessgrants.version>2.4.1</s3accessgrants.version>
 
-        <lakeformations3accessgrants.version>1.4.2</lakeformations3accessgrants.version>
+        <lakeformations3accessgrants.version>1.4.3</lakeformations3accessgrants.version>
 
         <skip.unit.tests>${skipTests}</skip.unit.tests>
         <v2.migration.tests.skip>true</v2.migration.tests.skip>


### PR DESCRIPTION
# SDK v2 bundle bump PR — Lake Formation plugin 1.4.2 -> 1.4.3
# Repo: aws/aws-sdk-java-v2 | Branch: bump-lakeformation-plugin-1.4.3 (fork rajasbh-aws) | Base: master
# Title: Updating Lake Formation Access Grants Plugin version to 1.4.3

## Description

Bump the bundled Lake Formation Access Grants Plugin from `1.4.2` to `1.4.3` to pick up the
negative-caching change published to Maven Central (plugin PR #41).

This is a patch bump — the change is a backward-compatible behavior fix (fewer redundant
Lake Formation calls on non-retryable failures).

## Changes

- `pom.xml`: `lakeformations3accessgrants.version` `1.4.2` → `1.4.3`
- Added a `.changes/next-release` changelog entry

## Testing

- N/A — dependency version bump. Bundled plugin's own suite is green (80 tests); `1.4.3`
  verified live on Maven Central.

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
