### PR TITLE
Fix S3 multipart copy requiring permissions on versioned buckets

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-94d95b3.json
+++ b/.changes/next-release/bugfix-AmazonS3-94d95b3.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fix regression where the SDK automatically attached the source object's versionId to UploadPartCopy requests during multipart copy, causing S3 to require `s3:GetObjectVersion` permission. Updated to only add versionId when explicitly provided by the caller."
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/multipart/S3ClientMultiPartCopyIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/multipart/S3ClientMultiPartCopyIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import javax.crypto.KeyGenerator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -48,6 +49,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.internal.multipart.MultipartS3AsyncClient;
+import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.EncryptionType;
@@ -58,6 +60,7 @@ import software.amazon.awssdk.utils.Md5Utils;
 @Timeout(value = 3, unit = TimeUnit.MINUTES)
 public class S3ClientMultiPartCopyIntegrationTest extends S3IntegrationTestBase {
     private static final String BUCKET = temporaryBucketName(S3ClientMultiPartCopyIntegrationTest.class);
+    private static final String VERSIONED_BUCKET = temporaryBucketName("mpu-copy-versioned");
     private static final CapturingInterceptor CAPTURING_INTERCEPTOR = new CapturingInterceptor();
     private static final String ORIGINAL_OBJ = "test_file.dat";
     private static final String COPIED_OBJ = "test_file_copy.dat";
@@ -72,6 +75,10 @@ public class S3ClientMultiPartCopyIntegrationTest extends S3IntegrationTestBase 
     public static void setUp() throws Exception {
         S3IntegrationTestBase.setUp();
         createBucket(BUCKET);
+        createBucket(VERSIONED_BUCKET);
+
+        s3.putBucketVersioning(r -> r.bucket(VERSIONED_BUCKET)
+                                     .versioningConfiguration(v -> v.status(BucketVersioningStatus.ENABLED)));
 
         s3.putBucketEncryption(r -> r.bucket(BUCKET)
                                      .serverSideEncryptionConfiguration(c -> c.rules(
@@ -99,6 +106,7 @@ public class S3ClientMultiPartCopyIntegrationTest extends S3IntegrationTestBase 
         s3CrtAsyncClient.close();
         s3MpuClient.close();
         deleteBucketAndAllContents(BUCKET);
+        deleteBucketAndAllContents(VERSIONED_BUCKET);
     }
 
     public static Stream<S3AsyncClient> s3AsyncClient() {
@@ -171,6 +179,28 @@ public class S3ClientMultiPartCopyIntegrationTest extends S3IntegrationTestBase 
         assertThat(copyObjectResponse.responseMetadata().requestId()).isNotNull();
         assertThat(copyObjectResponse.sdkHttpResponse()).isNotNull();
         verifyCopyContainsCrc32Header(s3AsyncClient);
+    }
+
+    @Test
+    void copy_fromVersionedBucket_withoutExplicitVersionId_shouldSucceed() {
+        byte[] originalContent = randomBytes(OBJ_SIZE);
+        String sourceKey = "versioned-source";
+        String destKey = "versioned-dest";
+
+        s3MpuClient.putObject(r -> r.bucket(VERSIONED_BUCKET).key(sourceKey),
+                              AsyncRequestBody.fromBytes(originalContent)).join();
+
+        CopyObjectResponse response = s3MpuClient.copyObject(c -> c
+            .sourceBucket(VERSIONED_BUCKET)
+            .sourceKey(sourceKey)
+            .destinationBucket(VERSIONED_BUCKET)
+            .destinationKey(destKey)).join();
+
+        assertThat(response.responseMetadata().requestId()).isNotNull();
+
+        ResponseBytes<GetObjectResponse> copiedObject = s3.getObject(
+            r -> r.bucket(VERSIONED_BUCKET).key(destKey), ResponseTransformer.toBytes());
+        assertThat(computeCheckSum(copiedObject.asByteBuffer())).isEqualTo(computeCheckSum(ByteBuffer.wrap(originalContent)));
     }
 
     private static byte[] generateSecretKey() {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
@@ -347,8 +347,7 @@ public final class CopyObjectHelper {
         log.debug(() -> String.format("Starting multipart copy with partCount: %s, optimalPartSize: %s",
                                       partCount, optimalPartSize));
 
-        CopyObjectRequest copyRequestWithPinnedSource =
-            pinSourceVersionAndETag(ctx.copyObjectRequest, ctx.sourceVersionId, ctx.sourceETag);
+        CopyObjectRequest copyRequestWithPinnedSource = pinSourceETag(ctx.copyObjectRequest, ctx.sourceETag);
 
         // The list of completed parts must be sorted
         AtomicReferenceArray<CompletedPart> completedParts = new AtomicReferenceArray<>(partCount);
@@ -422,17 +421,13 @@ public final class CopyObjectHelper {
     }
 
     /**
-     * Returns a CopyObjectRequest with sourceVersionId and copySourceIfMatch set to the pinned values
-     * from HeadObject. This ensures all UploadPartCopy requests target the same source version and
-     * detect source mutation via ETag conditional.
+     * Returns a CopyObjectRequest with copySourceIfMatch set to the ETag from HeadObject.
+     * This detects source mutation via ETag conditional without requiring s3:GetObjectVersion.
+     * If the user explicitly provided sourceVersionId on the original request, it is already
+     * present on the builder and will be preserved.
      */
-    private CopyObjectRequest pinSourceVersionAndETag(CopyObjectRequest request,
-                                                      String sourceVersionId,
-                                                      String sourceETag) {
+    private CopyObjectRequest pinSourceETag(CopyObjectRequest request, String sourceETag) {
         CopyObjectRequest.Builder builder = request.toBuilder();
-        if (sourceVersionId != null) {
-            builder.sourceVersionId(sourceVersionId);
-        }
         if (sourceETag != null) {
             builder.copySourceIfMatch(sourceETag);
         }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -469,7 +469,7 @@ class CopyObjectHelperTest {
     }
 
     @Test
-    void multiPartCopy_shouldPinSourceVersionIdAndETag() {
+    void multiPartCopy_shouldPinSourceETagButNotVersionId() {
         String sourceVersionId = "version-abc-123";
         String sourceETag = "\"etag-xyz-456\"";
 
@@ -485,7 +485,7 @@ class CopyObjectHelperTest {
 
         List<UploadPartCopyRequest> partRequests = captor.getAllValues();
         assertThat(partRequests).allSatisfy(r -> {
-            assertThat(r.sourceVersionId()).isEqualTo(sourceVersionId);
+            assertThat(r.sourceVersionId()).isNull();
             assertThat(r.copySourceIfMatch()).isEqualTo(sourceETag);
         });
     }
@@ -1035,10 +1035,10 @@ class CopyObjectHelperTest {
                 public CompletableFuture<UploadPartCopyResponse> answer(InvocationOnMock invocationOnMock) {
                     numberOfCalls++;
                     return CompletableFuture.completedFuture(UploadPartCopyResponse.builder()
-                                                                .copyPartResult(CopyPartResult.builder()
-                                                                                              .checksumCRC32("crc" + numberOfCalls)
-                                                                                              .build())
-                                                                .build());
+                                                                                   .copyPartResult(CopyPartResult.builder()
+                                                                                                                 .checksumCRC32("crc" + numberOfCalls)
+                                                                                                                 .build())
+                                                                                   .build());
                 }
             });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix bug https://github.com/aws/aws-sdk-java-v2/issues/7117

## Modifications
<!--- Describe your changes in detail -->
- Removed automatic pinning of `sourceVersionId` from `HeadObject` response onto `UploadPartCopy` requests in `CopyObjectHelper`
- The ETag conditional (`copySourceIfMatch`) is still pinned to detect source mutation. User-provided `sourceVersionId` is still preserved

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit and integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
