### PR TITLE
Upgrade httpcomponents.client5 to 5.6.2

### DIFF
--- a/.changes/next-release/feature-ApacheHTTPClient5-9937320.json
+++ b/.changes/next-release/feature-ApacheHTTPClient5-9937320.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Apache HTTP Client 5",
+    "contributor": "",
+    "description": "Upgrade httpcomponents.client5 to 5.6.2 to address CVE-2026-54428"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <jre.version>1.8</jre.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
-        <httpcomponents.client5.version>5.6.1</httpcomponents.client5.version>
+        <httpcomponents.client5.version>5.6.2</httpcomponents.client5.version>
         <httpcomponents.core5.version>5.4.3</httpcomponents.core5.version>
         <!-- Reactive Streams version -->
         <reactive-streams.version>1.0.4</reactive-streams.version>


### PR DESCRIPTION
## Motivation and Context

   Upgrade `httpclient5` from `5.6.1` to `5.6.2` to resolve [CVE-2026-54428](https://nvd.nist.gov/vuln/detail/CVE-2026-54428) - a HIGH severity vulnerability (CVSS 7.5) in the transitive dependency `httpcore5-h2`.

   `httpclient5@5.6.2` pulls in `httpcore5-h2@5.4.3` which contains the [fix](https://github.com/apache/httpcomponents-core/commit/cc30ee058a7b10cbf4ad3dd6270ab6d1f6a74c49).

   Fixes #7123

   ## Modifications

Bump `httpcomponents.client5.version` from `5.6.1` to `5.6.2`

   ## No breaking changes

   [httpclient5 5.6.2 release notes](https://downloads.apache.org/httpcomponents/httpclient/RELEASE_NOTES-5.6.x.txt) - shows below changes:
   1. Upgraded HttpCore to 5.4.3
   2. HTTPCLIENT-2422: Restore lazy content decompression

[httpcore5 5.4.3 release notes](https://downloads.apache.org/httpcomponents/httpcore/RELEASE_NOTES-5.4.x.txt) include the fix:
   > Enforce configured HPACK header list size limit upon initialization of HTTP/2 connections.

   All other transitive dependency versions are identical between `5.6.1` and `5.6.2`.

   ## License

   - [x] I confirm that this pull request can be released under the Apache 2 license
