### PR TITLE
Add overloaded menthod for SdkWarmUp.prime overloaded to accept speci…

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
@@ -70,6 +70,9 @@ public final class SdkWarmUp {
      * Discovers every {@link SdkWarmUpProvider} on the classpath and invokes {@link SdkWarmUpProvider#warmUp()}
      * on each, honoring the idempotency, per-provider resilience, and empty-classpath behavior described on
      * this class. Safe to call concurrently.
+     *
+     * <p>This method and {@link #prime(Class[])} track primed state independently: this method warms
+     * every provider and does not skip clients that were warmed by a targeted {@link #prime(Class[])} call.
      */
     public static void prime() {
         if (primed) {
@@ -88,12 +91,14 @@ public final class SdkWarmUp {
 
     /**
      * Primes only the given service clients, warming the sync path for a sync client and the async path for an async
-     * client. Best-effort and safe to call concurrently; a client already primed by a previous call is skipped.
+     * client. A client already primed by this method is skipped; a class matched by no provider, or whose warm-up
+     * fails, is logged at warn and retried on the next call.Best-effort and safe to call concurrently.
      *
-     * <p>A class matched by no provider, or whose warm-up fails, is logged at warn and retried by a later call.
+     * <p>This method and {@link #prime()} track primed state independently: this method does not skip
+     * clients that {@link #prime()} already warmed.
      *
-     * @param clients the service client classes to prime, for example {@code S3Client.class} or
-     *                {@code S3AsyncClient.class}.
+     * @param clients the service client classes to prime, for example {@code ServiceClient.class} or
+     *                {@code ServiceAsyncClient.class}.
      */
     @SafeVarargs
     public static void prime(Class<? extends SdkClient>... clients) {
@@ -115,10 +120,10 @@ public final class SdkWarmUp {
 
         // Racing calls may double-warm the same client; warming is idempotent, so that is harmless.
         TargetedWarmUpResult result = TargetedWarmUpInvoker.create().invoke(toPrime);
-        if (result.matchedTransports().contains(ClientType.SYNC)) {
+        if (result.matchedClientTypes().contains(ClientType.SYNC)) {
             SyncHttpClientWarmer.create().warmAll();
         }
-        if (result.matchedTransports().contains(ClientType.ASYNC)) {
+        if (result.matchedClientTypes().contains(ClientType.ASYNC)) {
             AsyncHttpClientWarmer.create().warmAll();
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
@@ -15,16 +15,15 @@
 
 package software.amazon.awssdk.core.crac;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.ServiceLoader;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.internal.crac.ClasspathWarmUpInvoker;
+import software.amazon.awssdk.core.internal.crac.PrimedClientRegistry;
 import software.amazon.awssdk.core.internal.crac.TargetedWarmUpInvoker;
 import software.amazon.awssdk.core.internal.http.loader.AsyncHttpClientWarmer;
 import software.amazon.awssdk.core.internal.http.loader.ClasspathHttpWarmupInvoker;
@@ -61,10 +60,7 @@ public final class SdkWarmUp {
 
     private static volatile boolean primed = false;
 
-    // Client class names already primed by prime(Class...). Access guarded by TARGETED_LOCK.
-    private static final Set<String> PRIMED_CLIENTS = new HashSet<>();
-
-    private static final Object TARGETED_LOCK = new Object();
+    private static final PrimedClientRegistry PRIMED_CLIENTS = new PrimedClientRegistry();
 
     private SdkWarmUp() {
     }
@@ -104,24 +100,18 @@ public final class SdkWarmUp {
             return;
         }
 
-        Set<String> toPrime = new LinkedHashSet<>();
-        synchronized (TARGETED_LOCK) {
-            for (Class<? extends SdkClient> client : clients) {
-                if (client == null) {
-                    continue;
-                }
-                String name = client.getName();
-                if (!PRIMED_CLIENTS.contains(name)) {
-                    toPrime.add(name);
-                }
+        Set<String> requested = new LinkedHashSet<>();
+        for (Class<? extends SdkClient> client : clients) {
+            if (client != null) {
+                requested.add(client.getName());
             }
         }
+        Set<String> toPrime = PRIMED_CLIENTS.selectUnprimed(requested);
         if (toPrime.isEmpty()) {
             return;
         }
 
-        // Warm outside TARGETED_LOCK so no lock is held across network I/O. Concurrent calls racing on the same
-        // client may warm it twice; warming is idempotent, so that is harmless.
+        // Racing calls may double-warm the same client; warming is idempotent, so that is harmless.
         Set<ClientType> matched = TargetedWarmUpInvoker.create().invoke(toPrime);
         if (matched.contains(ClientType.SYNC)) {
             SyncHttpClientWarmer.create().warmAll();
@@ -131,15 +121,6 @@ public final class SdkWarmUp {
         }
 
         // Record names only after warming completes, so a run that throws is retried by a later call.
-        synchronized (TARGETED_LOCK) {
-            PRIMED_CLIENTS.addAll(toPrime);
-        }
-    }
-
-    @SdkTestInternalApi
-    public static void resetTargetedPrimeStateForTesting() {
-        synchronized (TARGETED_LOCK) {
-            PRIMED_CLIENTS.clear();
-        }
+        PRIMED_CLIENTS.markPrimed(toPrime);
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
@@ -15,11 +15,21 @@
 
 package software.amazon.awssdk.core.crac;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.ServiceLoader;
+import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.internal.crac.ClasspathWarmUpInvoker;
+import software.amazon.awssdk.core.internal.crac.TargetedWarmUpInvoker;
+import software.amazon.awssdk.core.internal.http.loader.AsyncHttpClientWarmer;
 import software.amazon.awssdk.core.internal.http.loader.ClasspathHttpWarmupInvoker;
+import software.amazon.awssdk.core.internal.http.loader.SyncHttpClientWarmer;
+import software.amazon.awssdk.utils.Logger;
 
 /**
  * Entry point for warming up SDK service request paths before a Coordinated Restore at Checkpoint (CRaC)
@@ -45,9 +55,16 @@ import software.amazon.awssdk.core.internal.http.loader.ClasspathHttpWarmupInvok
 @SdkPublicApi
 public final class SdkWarmUp {
 
+    private static final Logger log = Logger.loggerFor(SdkWarmUp.class);
+
     private static final Object PRIME_LOCK = new Object();
 
     private static volatile boolean primed = false;
+
+    // Client class names already primed by prime(Class...). Access guarded by TARGETED_LOCK.
+    private static final Set<String> PRIMED_CLIENTS = new HashSet<>();
+
+    private static final Object TARGETED_LOCK = new Object();
 
     private SdkWarmUp() {
     }
@@ -69,6 +86,60 @@ public final class SdkWarmUp {
             ClasspathWarmUpInvoker.create().invokeAll();
             ClasspathHttpWarmupInvoker.create().invokeAll();
             primed = true;
+        }
+    }
+
+    /**
+     * Primes only the given service clients, warming the sync path for a sync client and the async path for an async
+     * client. A class matched by no provider is logged at warn and skipped. Best-effort and safe to call concurrently;
+     * a client already primed by a previous call is skipped.
+     *
+     * @param clients the service client classes to prime, for example {@code S3Client.class} or
+     *                {@code S3AsyncClient.class}.
+     */
+    @SafeVarargs
+    public static void prime(Class<? extends SdkClient>... clients) {
+        if (clients == null || clients.length == 0) {
+            log.debug(() -> "SdkWarmUp.prime(Class...) called with no clients; nothing to do.");
+            return;
+        }
+
+        Set<String> toPrime = new LinkedHashSet<>();
+        synchronized (TARGETED_LOCK) {
+            for (Class<? extends SdkClient> client : clients) {
+                if (client == null) {
+                    continue;
+                }
+                String name = client.getName();
+                if (!PRIMED_CLIENTS.contains(name)) {
+                    toPrime.add(name);
+                }
+            }
+        }
+        if (toPrime.isEmpty()) {
+            return;
+        }
+
+        // Warm outside TARGETED_LOCK so no lock is held across network I/O. Concurrent calls racing on the same
+        // client may warm it twice; warming is idempotent, so that is harmless.
+        Set<ClientType> matched = TargetedWarmUpInvoker.create().invoke(toPrime);
+        if (matched.contains(ClientType.SYNC)) {
+            SyncHttpClientWarmer.create().warmAll();
+        }
+        if (matched.contains(ClientType.ASYNC)) {
+            AsyncHttpClientWarmer.create().warmAll();
+        }
+
+        // Record names only after warming completes, so a run that throws is retried by a later call.
+        synchronized (TARGETED_LOCK) {
+            PRIMED_CLIENTS.addAll(toPrime);
+        }
+    }
+
+    @SdkTestInternalApi
+    public static void resetTargetedPrimeStateForTesting() {
+        synchronized (TARGETED_LOCK) {
+            PRIMED_CLIENTS.clear();
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/crac/SdkWarmUp.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.internal.crac.ClasspathWarmUpInvoker;
 import software.amazon.awssdk.core.internal.crac.PrimedClientRegistry;
 import software.amazon.awssdk.core.internal.crac.TargetedWarmUpInvoker;
+import software.amazon.awssdk.core.internal.crac.TargetedWarmUpResult;
 import software.amazon.awssdk.core.internal.http.loader.AsyncHttpClientWarmer;
 import software.amazon.awssdk.core.internal.http.loader.ClasspathHttpWarmupInvoker;
 import software.amazon.awssdk.core.internal.http.loader.SyncHttpClientWarmer;
@@ -87,8 +88,9 @@ public final class SdkWarmUp {
 
     /**
      * Primes only the given service clients, warming the sync path for a sync client and the async path for an async
-     * client. A class matched by no provider is logged at warn and skipped. Best-effort and safe to call concurrently;
-     * a client already primed by a previous call is skipped.
+     * client. Best-effort and safe to call concurrently; a client already primed by a previous call is skipped.
+     *
+     * <p>A class matched by no provider, or whose warm-up fails, is logged at warn and retried by a later call.
      *
      * @param clients the service client classes to prime, for example {@code S3Client.class} or
      *                {@code S3AsyncClient.class}.
@@ -112,15 +114,15 @@ public final class SdkWarmUp {
         }
 
         // Racing calls may double-warm the same client; warming is idempotent, so that is harmless.
-        Set<ClientType> matched = TargetedWarmUpInvoker.create().invoke(toPrime);
-        if (matched.contains(ClientType.SYNC)) {
+        TargetedWarmUpResult result = TargetedWarmUpInvoker.create().invoke(toPrime);
+        if (result.matchedTransports().contains(ClientType.SYNC)) {
             SyncHttpClientWarmer.create().warmAll();
         }
-        if (matched.contains(ClientType.ASYNC)) {
+        if (result.matchedTransports().contains(ClientType.ASYNC)) {
             AsyncHttpClientWarmer.create().warmAll();
         }
 
-        // Record names only after warming completes, so a run that throws is retried by a later call.
-        PRIMED_CLIENTS.markPrimed(toPrime);
+        // Only successfully warmed names are recorded; unmatched or failed ones are retried on a later call.
+        PRIMED_CLIENTS.markPrimed(result.warmedClientNames());
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/PrimedClientRegistry.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/PrimedClientRegistry.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.crac;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * Tracks which service clients {@code SdkWarmUp.prime(Class...)} has already warmed, so each is warmed at most once per
+ * JVM. State is per-instance, so it is unit-testable with fresh instances; production uses a single long-lived instance.
+ */
+@ThreadSafe
+@SdkInternalApi
+public final class PrimedClientRegistry {
+
+    private final Set<String> primed = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Returns the not-yet-primed subset of {@code clientClassNames}, in encounter order, ignoring nulls. Warm the
+     * returned names, then pass them to {@link #markPrimed(Collection)}.
+     */
+    public Set<String> selectUnprimed(Collection<String> clientClassNames) {
+        Set<String> unprimed = new LinkedHashSet<>();
+        for (String name : clientClassNames) {
+            if (name != null && !primed.contains(name)) {
+                unprimed.add(name);
+            }
+        }
+        return unprimed;
+    }
+
+    /**
+     * Records the given names as primed. Call only after warming completes, so a failed run is retried by a later call.
+     */
+    public void markPrimed(Collection<String> clientClassNames) {
+        primed.addAll(clientClassNames);
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvoker.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvoker.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.internal.crac;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -51,40 +52,40 @@ public final class TargetedWarmUpInvoker {
      * at warn and skipped, and a provider that fails does not stop the others.
      *
      * @param requestedClassNames the fully qualified sync or async client class names to warm.
-     * @return the transports that were matched, for narrowing the follow-on HTTP-client warm-up.
+     * @return the matched transports and the names that warmed successfully.
      */
-    public Set<ClientType> invoke(Collection<String> requestedClassNames) {
+    public TargetedWarmUpResult invoke(Collection<String> requestedClassNames) {
         Set<ClientType> matchedTransports = EnumSet.noneOf(ClientType.class);
+        Set<String> warmedClientNames = new LinkedHashSet<>();
         if (requestedClassNames.isEmpty()) {
-            return matchedTransports;
+            return new TargetedWarmUpResult(matchedTransports, warmedClientNames);
         }
 
         List<SdkWarmUpProvider> providers = loadProviders();
         for (String requested : requestedClassNames) {
-            Set<ClientType> matched = warmMatching(requested, providers);
+            boolean warmFailed = false;
+            Set<ClientType> matched = EnumSet.noneOf(ClientType.class);
+            for (SdkWarmUpProvider provider : providers) {
+                ClientType transport = transportFor(requested, provider);
+                if (transport == null) {
+                    continue;
+                }
+                matched.add(transport);
+                try {
+                    provider.warmUpClient(transport);
+                } catch (RuntimeException | LinkageError e) {
+                    warmFailed = true;
+                    log.warn(() -> "Warm-up failed for " + provider.getClass().getName() + " and was skipped.", e);
+                }
+            }
             if (matched.isEmpty()) {
                 log.warn(() -> "No warm-up provider matched client class " + requested + "; skipping.");
+            } else if (!warmFailed) {
+                warmedClientNames.add(requested);
             }
             matchedTransports.addAll(matched);
         }
-        return matchedTransports;
-    }
-
-    private Set<ClientType> warmMatching(String requested, List<SdkWarmUpProvider> providers) {
-        Set<ClientType> matched = EnumSet.noneOf(ClientType.class);
-        for (SdkWarmUpProvider provider : providers) {
-            ClientType transport = transportFor(requested, provider);
-            if (transport == null) {
-                continue;
-            }
-            matched.add(transport);
-            try {
-                provider.warmUpClient(transport);
-            } catch (RuntimeException | LinkageError e) {
-                log.warn(() -> "Warm-up failed for " + provider.getClass().getName() + " and was skipped.", e);
-            }
-        }
-        return matched;
+        return new TargetedWarmUpResult(matchedTransports, warmedClientNames);
     }
 
     private ClientType transportFor(String requested, SdkWarmUpProvider provider) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvoker.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvoker.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.crac;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Warms only the service clients named by {@code SdkWarmUp.prime(Class...)}. Matches each requested client class name
+ * against the discovered {@link SdkWarmUpProvider}s' sync and async class names, then warms the matched transport only.
+ */
+@SdkInternalApi
+public final class TargetedWarmUpInvoker {
+
+    private static final Logger log = Logger.loggerFor(TargetedWarmUpInvoker.class);
+
+    private final WarmUpServiceLoader serviceLoader;
+
+    @SdkTestInternalApi
+    TargetedWarmUpInvoker(WarmUpServiceLoader serviceLoader) {
+        this.serviceLoader = serviceLoader;
+    }
+
+    public static TargetedWarmUpInvoker create() {
+        return new TargetedWarmUpInvoker(WarmUpServiceLoader.INSTANCE);
+    }
+
+    /**
+     * Warms the provider transport matching each requested client class name. Best-effort: an unmatched name is logged
+     * at warn and skipped, and a provider that fails does not stop the others.
+     *
+     * @param requestedClassNames the fully qualified sync or async client class names to warm.
+     * @return the transports that were matched, for narrowing the follow-on HTTP-client warm-up.
+     */
+    public Set<ClientType> invoke(Collection<String> requestedClassNames) {
+        Set<ClientType> matchedTransports = EnumSet.noneOf(ClientType.class);
+        if (requestedClassNames.isEmpty()) {
+            return matchedTransports;
+        }
+
+        List<SdkWarmUpProvider> providers = loadProviders();
+        for (String requested : requestedClassNames) {
+            Set<ClientType> matched = warmMatching(requested, providers);
+            if (matched.isEmpty()) {
+                log.warn(() -> "No warm-up provider matched client class " + requested + "; skipping.");
+            }
+            matchedTransports.addAll(matched);
+        }
+        return matchedTransports;
+    }
+
+    private Set<ClientType> warmMatching(String requested, List<SdkWarmUpProvider> providers) {
+        Set<ClientType> matched = EnumSet.noneOf(ClientType.class);
+        for (SdkWarmUpProvider provider : providers) {
+            ClientType transport = transportFor(requested, provider);
+            if (transport == null) {
+                continue;
+            }
+            matched.add(transport);
+            try {
+                provider.warmUpClient(transport);
+            } catch (RuntimeException | LinkageError e) {
+                log.warn(() -> "Warm-up failed for " + provider.getClass().getName() + " and was skipped.", e);
+            }
+        }
+        return matched;
+    }
+
+    private ClientType transportFor(String requested, SdkWarmUpProvider provider) {
+        if (requested.equals(provider.syncClientClassName())) {
+            return ClientType.SYNC;
+        }
+        if (requested.equals(provider.asyncClientClassName())) {
+            return ClientType.ASYNC;
+        }
+        return null;
+    }
+
+    private List<SdkWarmUpProvider> loadProviders() {
+        List<SdkWarmUpProvider> providers = new ArrayList<>();
+        WarmUpDiscovery.forEachDiscovered(serviceLoader.loadProviders(), providers::add);
+        return providers;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvoker.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvoker.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.utils.Logger;
 
 /**
  * Warms only the service clients named by {@code SdkWarmUp.prime(Class...)}. Matches each requested client class name
- * against the discovered {@link SdkWarmUpProvider}s' sync and async class names, then warms the matched transport only.
+ * against the discovered {@link SdkWarmUpProvider}s' sync and async class names, then warms the matched client type only.
  */
 @SdkInternalApi
 public final class TargetedWarmUpInvoker {
@@ -48,17 +48,17 @@ public final class TargetedWarmUpInvoker {
     }
 
     /**
-     * Warms the provider transport matching each requested client class name. Best-effort: an unmatched name is logged
+     * Warms the provider client type matching each requested client class name. An unmatched name is logged
      * at warn and skipped, and a provider that fails does not stop the others.
      *
      * @param requestedClassNames the fully qualified sync or async client class names to warm.
-     * @return the matched transports and the names that warmed successfully.
+     * @return the matched client types and the names that warmed successfully.
      */
     public TargetedWarmUpResult invoke(Collection<String> requestedClassNames) {
-        Set<ClientType> matchedTransports = EnumSet.noneOf(ClientType.class);
+        Set<ClientType> matchedClientTypes = EnumSet.noneOf(ClientType.class);
         Set<String> warmedClientNames = new LinkedHashSet<>();
         if (requestedClassNames.isEmpty()) {
-            return new TargetedWarmUpResult(matchedTransports, warmedClientNames);
+            return new TargetedWarmUpResult(matchedClientTypes, warmedClientNames);
         }
 
         List<SdkWarmUpProvider> providers = loadProviders();
@@ -66,13 +66,13 @@ public final class TargetedWarmUpInvoker {
             boolean warmFailed = false;
             Set<ClientType> matched = EnumSet.noneOf(ClientType.class);
             for (SdkWarmUpProvider provider : providers) {
-                ClientType transport = transportFor(requested, provider);
-                if (transport == null) {
+                ClientType clientType = clientTypeFor(requested, provider);
+                if (clientType == null) {
                     continue;
                 }
-                matched.add(transport);
+                matched.add(clientType);
                 try {
-                    provider.warmUpClient(transport);
+                    provider.warmUpClient(clientType);
                 } catch (RuntimeException | LinkageError e) {
                     warmFailed = true;
                     log.warn(() -> "Warm-up failed for " + provider.getClass().getName() + " and was skipped.", e);
@@ -83,12 +83,12 @@ public final class TargetedWarmUpInvoker {
             } else if (!warmFailed) {
                 warmedClientNames.add(requested);
             }
-            matchedTransports.addAll(matched);
+            matchedClientTypes.addAll(matched);
         }
-        return new TargetedWarmUpResult(matchedTransports, warmedClientNames);
+        return new TargetedWarmUpResult(matchedClientTypes, warmedClientNames);
     }
 
-    private ClientType transportFor(String requested, SdkWarmUpProvider provider) {
+    private ClientType clientTypeFor(String requested, SdkWarmUpProvider provider) {
         if (requested.equals(provider.syncClientClassName())) {
             return ClientType.SYNC;
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpResult.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpResult.java
@@ -19,27 +19,60 @@ import java.util.Collections;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.utils.ToString;
 
 /**
- * Outcome of a {@link TargetedWarmUpInvoker} run: the transports that matched and the client names that warmed
+ * Outcome of a {@link TargetedWarmUpInvoker} run: the client types that matched and the client names that warmed
  * successfully.
  */
 @SdkInternalApi
 public final class TargetedWarmUpResult {
 
-    private final Set<ClientType> matchedTransports;
+    private final Set<ClientType> matchedClientTypes;
     private final Set<String> warmedClientNames;
 
-    TargetedWarmUpResult(Set<ClientType> matchedTransports, Set<String> warmedClientNames) {
-        this.matchedTransports = Collections.unmodifiableSet(matchedTransports);
+    TargetedWarmUpResult(Set<ClientType> matchedClientTypes, Set<String> warmedClientNames) {
+        this.matchedClientTypes = Collections.unmodifiableSet(matchedClientTypes);
         this.warmedClientNames = Collections.unmodifiableSet(warmedClientNames);
     }
 
-    public Set<ClientType> matchedTransports() {
-        return matchedTransports;
+    public Set<ClientType> matchedClientTypes() {
+        return matchedClientTypes;
     }
 
     public Set<String> warmedClientNames() {
         return warmedClientNames;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TargetedWarmUpResult that = (TargetedWarmUpResult) o;
+
+        if (!matchedClientTypes.equals(that.matchedClientTypes)) {
+            return false;
+        }
+        return warmedClientNames.equals(that.warmedClientNames);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = matchedClientTypes.hashCode();
+        result = 31 * result + warmedClientNames.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("TargetedWarmUpResult")
+                       .add("matchedClientTypes", matchedClientTypes)
+                       .add("warmedClientNames", warmedClientNames)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpResult.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.crac;
+
+import java.util.Collections;
+import java.util.Set;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.ClientType;
+
+/**
+ * Outcome of a {@link TargetedWarmUpInvoker} run: the transports that matched and the client names that warmed
+ * successfully.
+ */
+@SdkInternalApi
+public final class TargetedWarmUpResult {
+
+    private final Set<ClientType> matchedTransports;
+    private final Set<String> warmedClientNames;
+
+    TargetedWarmUpResult(Set<ClientType> matchedTransports, Set<String> warmedClientNames) {
+        this.matchedTransports = Collections.unmodifiableSet(matchedTransports);
+        this.warmedClientNames = Collections.unmodifiableSet(warmedClientNames);
+    }
+
+    public Set<ClientType> matchedTransports() {
+        return matchedTransports;
+    }
+
+    public Set<String> warmedClientNames() {
+        return warmedClientNames;
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredAsyncClient.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredAsyncClient.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.crac;
+
+import software.amazon.awssdk.core.SdkClient;
+
+/**
+ * Test-only client whose fully qualified name matches {@link RegisteredWarmUpProvider#asyncClientClassName()}.
+ */
+public interface RegisteredAsyncClient extends SdkClient {
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredSyncClient.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredSyncClient.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.crac;
+
+import software.amazon.awssdk.core.SdkClient;
+
+/**
+ * Test-only client whose fully qualified name matches {@link RegisteredWarmUpProvider#syncClientClassName()}, so
+ * {@code SdkWarmUp.prime(RegisteredSyncClient.class)} matches that provider's sync transport.
+ */
+public interface RegisteredSyncClient extends SdkClient {
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredWarmUpProvider.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredWarmUpProvider.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.core.ClientType;
  * java.util.ServiceLoader} discovers and instantiates it by name. Both static fields are static because the loader
  * builds its own instance. Must be public with a no-arg constructor for ServiceLoader.
  *
- * <p>{@code INVOCATIONS} counts full {@link #warmUp()} calls; {@code WARMED_CLIENTS} records the transports passed to
+ * <p>{@code INVOCATIONS} counts full {@link #warmUp()} calls; {@code WARMED_CLIENTS} records the client types passed to
  * {@link #warmUpClient(ClientType)}, so a test can tell the targeted path from the full one.
  */
 public final class RegisteredWarmUpProvider implements SdkWarmUpProvider {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredWarmUpProvider.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/RegisteredWarmUpProvider.java
@@ -15,17 +15,26 @@
 
 package software.amazon.awssdk.core.crac;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import software.amazon.awssdk.core.ClientType;
 
 /**
  * Test-only {@link SdkWarmUpProvider} registered in test-scoped {@code META-INF/services} so a real {@link
- * java.util.ServiceLoader} discovers and instantiates it by name. {@code INVOCATIONS} is static because the loader
+ * java.util.ServiceLoader} discovers and instantiates it by name. Both static fields are static because the loader
  * builds its own instance. Must be public with a no-arg constructor for ServiceLoader.
+ *
+ * <p>{@code INVOCATIONS} counts full {@link #warmUp()} calls; {@code WARMED_CLIENTS} records the transports passed to
+ * {@link #warmUpClient(ClientType)}, so a test can tell the targeted path from the full one.
  */
 public final class RegisteredWarmUpProvider implements SdkWarmUpProvider {
 
     public static final AtomicInteger INVOCATIONS = new AtomicInteger();
+
+    public static final Set<ClientType> WARMED_CLIENTS =
+        Collections.synchronizedSet(EnumSet.noneOf(ClientType.class));
 
     @Override
     public void warmUp() {
@@ -44,5 +53,6 @@ public final class RegisteredWarmUpProvider implements SdkWarmUpProvider {
 
     @Override
     public void warmUpClient(ClientType clientType) {
+        WARMED_CLIENTS.add(clientType);
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.crac;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,8 @@ import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.SdkClient;
 
 /**
  * Tests the static {@link SdkWarmUp#prime()} entry point end to end through {@link java.util.ServiceLoader},
@@ -38,6 +41,9 @@ class SdkWarmUpTest {
         // Dummy region so prime()'s HTTP warm-up resolves a non-existent STS host and fails DNS immediately, keeping the test offline.
         savedRegionProperty = System.getProperty("aws.region");
         System.setProperty("aws.region", "warmup-unit-test");
+        SdkWarmUp.resetTargetedPrimeStateForTesting();
+        RegisteredWarmUpProvider.INVOCATIONS.set(0);
+        RegisteredWarmUpProvider.WARMED_CLIENTS.clear();
     }
 
     @AfterEach
@@ -51,7 +57,6 @@ class SdkWarmUpTest {
 
     @Test
     void prime_concurrentCalls_invokeRegisteredProviderExactlyOnce() throws InterruptedException {
-        RegisteredWarmUpProvider.INVOCATIONS.set(0);
         int threadCount = 16;
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(threadCount);
@@ -79,5 +84,34 @@ class SdkWarmUpTest {
         }
 
         assertThat(RegisteredWarmUpProvider.INVOCATIONS.get()).isEqualTo(1);
+    }
+
+    @Test
+    void prime_withMatchingSyncClient_warmsSyncTransportThroughWarmUpClient() {
+        SdkWarmUp.prime(RegisteredSyncClient.class);
+
+        assertThat(RegisteredWarmUpProvider.INVOCATIONS.get()).isEqualTo(0);
+        assertThat(RegisteredWarmUpProvider.WARMED_CLIENTS).containsExactly(ClientType.SYNC);
+    }
+
+    @Test
+    void prime_withMatchingAsyncClient_warmsAsyncTransportThroughWarmUpClient() {
+        SdkWarmUp.prime(RegisteredAsyncClient.class);
+
+        assertThat(RegisteredWarmUpProvider.INVOCATIONS.get()).isEqualTo(0);
+        assertThat(RegisteredWarmUpProvider.WARMED_CLIENTS).containsExactly(ClientType.ASYNC);
+    }
+
+    @Test
+    void prime_withUnmatchedClient_doesNotThrow() {
+        assertThatCode(() -> SdkWarmUp.prime(UnmatchedClient.class)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_withEmptyArray_isNoOp() {
+        assertThatCode(() -> SdkWarmUp.prime(new Class[0])).doesNotThrowAnyException();
+    }
+
+    interface UnmatchedClient extends SdkClient {
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
@@ -41,7 +41,6 @@ class SdkWarmUpTest {
         // Dummy region so prime()'s HTTP warm-up resolves a non-existent STS host and fails DNS immediately, keeping the test offline.
         savedRegionProperty = System.getProperty("aws.region");
         System.setProperty("aws.region", "warmup-unit-test");
-        SdkWarmUp.resetTargetedPrimeStateForTesting();
         RegisteredWarmUpProvider.INVOCATIONS.set(0);
         RegisteredWarmUpProvider.WARMED_CLIENTS.clear();
     }
@@ -90,6 +89,7 @@ class SdkWarmUpTest {
     void prime_withMatchingSyncClient_warmsSyncTransportThroughWarmUpClient() {
         SdkWarmUp.prime(RegisteredSyncClient.class);
 
+        // Targeted prime warms via warmUpClient() only; the full warmUp() path (counted by INVOCATIONS) must not run.
         assertThat(RegisteredWarmUpProvider.INVOCATIONS.get()).isEqualTo(0);
         assertThat(RegisteredWarmUpProvider.WARMED_CLIENTS).containsExactly(ClientType.SYNC);
     }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
@@ -88,7 +88,7 @@ class SdkWarmUpTest {
     }
 
     @Test
-    void prime_withMatchingSyncClient_warmsSyncTransportThroughWarmUpClient() {
+    void prime_withMatchingSyncClient_warmsSyncClientTypeThroughWarmUpClient() {
         SdkWarmUp.prime(RegisteredSyncClient.class);
 
         // Targeted prime warms via warmUpClient() only; the full warmUp() path (counted by INVOCATIONS) must not run.
@@ -97,7 +97,7 @@ class SdkWarmUpTest {
     }
 
     @Test
-    void prime_withMatchingAsyncClient_warmsAsyncTransportThroughWarmUpClient() {
+    void prime_withMatchingAsyncClient_warmsAsyncClientTypeThroughWarmUpClient() {
         SdkWarmUp.prime(RegisteredAsyncClient.class);
 
         assertThat(RegisteredWarmUpProvider.INVOCATIONS.get()).isEqualTo(0);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/crac/SdkWarmUpTest.java
@@ -21,11 +21,13 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.testutils.LogCaptor;
 
 /**
  * Tests the static {@link SdkWarmUp#prime()} entry point end to end through {@link java.util.ServiceLoader},
@@ -108,10 +110,29 @@ class SdkWarmUpTest {
     }
 
     @Test
+    void prime_withUnmatchedClient_warnsOnEveryCallAndIsRetried() {
+        // An unmatched client is not recorded as primed, so every call warns and retries.
+        try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
+            SdkWarmUp.prime(RetriedUnmatchedClient.class);
+            SdkWarmUp.prime(RetriedUnmatchedClient.class);
+
+            long unmatchedWarns = logCaptor.loggedEvents().stream()
+                .filter(event -> event.getLevel() == Level.WARN
+                                 && event.getMessage().getFormattedMessage()
+                                         .contains(RetriedUnmatchedClient.class.getName()))
+                .count();
+            assertThat(unmatchedWarns).isEqualTo(2);
+        }
+    }
+
+    @Test
     void prime_withEmptyArray_isNoOp() {
         assertThatCode(() -> SdkWarmUp.prime(new Class[0])).doesNotThrowAnyException();
     }
 
     interface UnmatchedClient extends SdkClient {
+    }
+
+    interface RetriedUnmatchedClient extends SdkClient {
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/PrimedClientRegistryTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/PrimedClientRegistryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.crac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PrimedClientRegistry}. Each test uses a fresh instance, so the dedup state is isolated without
+ * any static reset hook or reflection.
+ */
+class PrimedClientRegistryTest {
+
+    private static final String SERVICE1_SYNC = "software.amazon.awssdk.services.service1.Service1Client";
+    private static final String SERVICE1_ASYNC = "software.amazon.awssdk.services.service1.Service1AsyncClient";
+
+    @Test
+    void selectUnprimed_freshRegistry_returnsAllRequested() {
+        PrimedClientRegistry registry = new PrimedClientRegistry();
+
+        assertThat(registry.selectUnprimed(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC)))
+            .containsExactly(SERVICE1_SYNC, SERVICE1_ASYNC);
+    }
+
+    @Test
+    void selectUnprimed_afterMarkPrimed_skipsAlreadyPrimed() {
+        PrimedClientRegistry registry = new PrimedClientRegistry();
+        registry.markPrimed(Collections.singletonList(SERVICE1_SYNC));
+
+        assertThat(registry.selectUnprimed(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC)))
+            .containsExactly(SERVICE1_ASYNC);
+    }
+
+    @Test
+    void selectUnprimed_allAlreadyPrimed_returnsEmpty() {
+        PrimedClientRegistry registry = new PrimedClientRegistry();
+        registry.markPrimed(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC));
+
+        assertThat(registry.selectUnprimed(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC))).isEmpty();
+    }
+
+    @Test
+    void selectUnprimed_preservesEncounterOrderAndDeduplicates() {
+        PrimedClientRegistry registry = new PrimedClientRegistry();
+
+        assertThat(registry.selectUnprimed(Arrays.asList(SERVICE1_ASYNC, SERVICE1_SYNC, SERVICE1_ASYNC)))
+            .containsExactly(SERVICE1_ASYNC, SERVICE1_SYNC);
+    }
+
+    @Test
+    void selectUnprimed_ignoresNullNames() {
+        PrimedClientRegistry registry = new PrimedClientRegistry();
+
+        assertThat(registry.selectUnprimed(Arrays.asList(SERVICE1_SYNC, null, SERVICE1_ASYNC)))
+            .containsExactly(SERVICE1_SYNC, SERVICE1_ASYNC);
+    }
+
+    @Test
+    void selectUnprimed_emptyInput_returnsEmpty() {
+        PrimedClientRegistry registry = new PrimedClientRegistry();
+
+        assertThat(registry.selectUnprimed(Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    void separateInstances_doNotShareState() {
+        PrimedClientRegistry first = new PrimedClientRegistry();
+        first.markPrimed(Collections.singletonList(SERVICE1_SYNC));
+
+        PrimedClientRegistry second = new PrimedClientRegistry();
+
+        assertThat(second.selectUnprimed(Collections.singletonList(SERVICE1_SYNC)))
+            .containsExactly(SERVICE1_SYNC);
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.crac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.Set;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
+import software.amazon.awssdk.testutils.LogCaptor;
+
+class TargetedWarmUpInvokerTest {
+
+    private static final String S3_SYNC = "software.amazon.awssdk.services.s3.S3Client";
+    private static final String S3_ASYNC = "software.amazon.awssdk.services.s3.S3AsyncClient";
+    private static final String DDB_SYNC = "software.amazon.awssdk.services.dynamodb.DynamoDbClient";
+
+    @Test
+    void invoke_syncClassRequested_warmsSyncTransportOnly() {
+        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+
+        Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList(S3_SYNC));
+
+        assertThat(s3.warmedTypes()).containsExactly(ClientType.SYNC);
+        assertThat(matched).containsExactly(ClientType.SYNC);
+    }
+
+    @Test
+    void invoke_asyncClassRequested_warmsAsyncTransportOnly() {
+        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+
+        Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList(S3_ASYNC));
+
+        assertThat(s3.warmedTypes()).containsExactly(ClientType.ASYNC);
+        assertThat(matched).containsExactly(ClientType.ASYNC);
+    }
+
+    @Test
+    void invoke_bothClassesRequested_warmsBothTransports() {
+        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+
+        Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList(S3_SYNC, S3_ASYNC));
+
+        assertThat(s3.warmedTypes()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
+        assertThat(matched).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
+    }
+
+    @Test
+    void invoke_classAcrossTwoProviders_warmsOnlyTheMatchingProvider() {
+        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+        RecordingProvider ddb = new RecordingProvider(DDB_SYNC, null);
+
+        invokerLoading(s3, ddb).invoke(Arrays.asList(DDB_SYNC));
+
+        assertThat(s3.warmedTypes()).isEmpty();
+        assertThat(ddb.warmedTypes()).containsExactly(ClientType.SYNC);
+    }
+
+    @Test
+    void invoke_unmatchedClass_logsWarnAndDoesNotThrow() {
+        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+
+        try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
+            Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList("com.example.NotAClient"));
+
+            assertThat(matched).isEmpty();
+            assertThat(s3.warmedTypes()).isEmpty();
+            assertThat(logCaptor.loggedEvents())
+                .anyMatch(event -> event.getLevel() == Level.WARN
+                                   && event.getMessage().getFormattedMessage().contains("com.example.NotAClient"));
+        }
+    }
+
+    @Test
+    void invoke_whenProviderWarmUpThrows_stillReturnsMatchedTransport() {
+        SdkWarmUpProvider throwing = new TestProvider(S3_SYNC, S3_ASYNC) {
+            @Override
+            public void warmUpClient(ClientType clientType) {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        // A throwing warmUpClient must not stop the follow-on HTTP warm-up: the matched transport is still returned so
+        // the caller can narrow the HTTP warmers.
+        Set<ClientType> matched = invokerLoading(throwing).invoke(Arrays.asList(S3_SYNC));
+
+        assertThat(matched).containsExactly(ClientType.SYNC);
+    }
+
+    @Test
+    void invoke_emptyRequest_isNoOp() {
+        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+
+        Set<ClientType> matched = invokerLoading(s3).invoke(Collections.emptyList());
+
+        assertThat(matched).isEmpty();
+        assertThat(s3.warmedTypes()).isEmpty();
+    }
+
+    private TargetedWarmUpInvoker invokerLoading(SdkWarmUpProvider... providers) {
+        WarmUpServiceLoader loader = new WarmUpServiceLoader() {
+            @Override
+            Iterator<SdkWarmUpProvider> loadProviders() {
+                return Arrays.asList(providers).iterator();
+            }
+        };
+        return new TargetedWarmUpInvoker(loader);
+    }
+
+    private static class TestProvider implements SdkWarmUpProvider {
+        private final String syncName;
+        private final String asyncName;
+
+        TestProvider(String syncName, String asyncName) {
+            this.syncName = syncName;
+            this.asyncName = asyncName;
+        }
+
+        @Override
+        public String syncClientClassName() {
+            return syncName;
+        }
+
+        @Override
+        public String asyncClientClassName() {
+            return asyncName;
+        }
+
+        @Override
+        public void warmUpClient(ClientType clientType) {
+        }
+    }
+
+    private static final class RecordingProvider extends TestProvider {
+        private final Set<ClientType> warmed = EnumSet.noneOf(ClientType.class);
+
+        RecordingProvider(String syncName, String asyncName) {
+            super(syncName, asyncName);
+        }
+
+        @Override
+        public void warmUpClient(ClientType clientType) {
+            warmed.add(clientType);
+        }
+
+        Set<ClientType> warmedTypes() {
+            return warmed;
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
@@ -35,36 +35,36 @@ class TargetedWarmUpInvokerTest {
     private static final String SERVICE2_SYNC = "software.amazon.awssdk.services.service2.Service2Client";
 
     @Test
-    void invoke_syncClassRequested_warmsSyncTransportOnly() {
+    void invoke_syncClassRequested_warmsSyncClientTypeOnly() {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
         TargetedWarmUpResult result = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC));
 
         assertThat(service1.warmedTypes()).containsExactly(ClientType.SYNC);
-        assertThat(result.matchedTransports()).containsExactly(ClientType.SYNC);
+        assertThat(result.matchedClientTypes()).containsExactly(ClientType.SYNC);
         assertThat(result.warmedClientNames()).containsExactly(SERVICE1_SYNC);
     }
 
     @Test
-    void invoke_asyncClassRequested_warmsAsyncTransportOnly() {
+    void invoke_asyncClassRequested_warmsAsyncClientTypeOnly() {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
         TargetedWarmUpResult result = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_ASYNC));
 
         assertThat(service1.warmedTypes()).containsExactly(ClientType.ASYNC);
-        assertThat(result.matchedTransports()).containsExactly(ClientType.ASYNC);
+        assertThat(result.matchedClientTypes()).containsExactly(ClientType.ASYNC);
         assertThat(result.warmedClientNames()).containsExactly(SERVICE1_ASYNC);
     }
 
     @Test
-    void invoke_bothClassesRequested_warmsBothTransports() {
+    void invoke_bothClassesRequested_warmsBothClientTypes() {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
         TargetedWarmUpResult result =
             invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC));
 
         assertThat(service1.warmedTypes()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
-        assertThat(result.matchedTransports()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
+        assertThat(result.matchedClientTypes()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
         assertThat(result.warmedClientNames()).containsExactly(SERVICE1_SYNC, SERVICE1_ASYNC);
     }
 
@@ -87,7 +87,7 @@ class TargetedWarmUpInvokerTest {
             TargetedWarmUpResult result =
                 invokerLoading(service1).invoke(Arrays.asList("com.example.NotAClient"));
 
-            assertThat(result.matchedTransports()).isEmpty();
+            assertThat(result.matchedClientTypes()).isEmpty();
             assertThat(result.warmedClientNames()).isEmpty();
             assertThat(service1.warmedTypes()).isEmpty();
             assertThat(logCaptor.loggedEvents())
@@ -97,7 +97,7 @@ class TargetedWarmUpInvokerTest {
     }
 
     @Test
-    void invoke_whenProviderWarmUpThrows_stillReturnsMatchedTransport() {
+    void invoke_whenProviderWarmUpThrows_stillReturnsMatchedClientType() {
         SdkWarmUpProvider throwing = new TestProvider(SERVICE1_SYNC, SERVICE1_ASYNC) {
             @Override
             public void warmUpClient(ClientType clientType) {
@@ -105,11 +105,11 @@ class TargetedWarmUpInvokerTest {
             }
         };
 
-        // A throwing warmUpClient must not stop the follow-on HTTP warm-up: the matched transport is still returned so
+        // A throwing warmUpClient must not stop the follow-on HTTP warm-up: the matched client type is still returned so
         // the caller can narrow the HTTP warmers.
         TargetedWarmUpResult result = invokerLoading(throwing).invoke(Arrays.asList(SERVICE1_SYNC));
 
-        assertThat(result.matchedTransports()).containsExactly(ClientType.SYNC);
+        assertThat(result.matchedClientTypes()).containsExactly(ClientType.SYNC);
     }
 
     @Test
@@ -140,7 +140,7 @@ class TargetedWarmUpInvokerTest {
             invokerLoading(healthy, throwing).invoke(Arrays.asList(SERVICE1_SYNC, SERVICE2_SYNC));
 
         assertThat(result.warmedClientNames()).containsExactly(SERVICE1_SYNC);
-        assertThat(result.matchedTransports()).containsExactly(ClientType.SYNC);
+        assertThat(result.matchedClientTypes()).containsExactly(ClientType.SYNC);
     }
 
     @Test
@@ -149,7 +149,7 @@ class TargetedWarmUpInvokerTest {
 
         TargetedWarmUpResult result = invokerLoading(service1).invoke(Collections.emptyList());
 
-        assertThat(result.matchedTransports()).isEmpty();
+        assertThat(result.matchedClientTypes()).isEmpty();
         assertThat(result.warmedClientNames()).isEmpty();
         assertThat(service1.warmedTypes()).isEmpty();
     }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.core.internal.crac;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,60 +30,60 @@ import software.amazon.awssdk.testutils.LogCaptor;
 
 class TargetedWarmUpInvokerTest {
 
-    private static final String S3_SYNC = "software.amazon.awssdk.services.s3.S3Client";
-    private static final String S3_ASYNC = "software.amazon.awssdk.services.s3.S3AsyncClient";
-    private static final String DDB_SYNC = "software.amazon.awssdk.services.dynamodb.DynamoDbClient";
+    private static final String SERVICE1_SYNC = "software.amazon.awssdk.services.service1.Service1Client";
+    private static final String SERVICE1_ASYNC = "software.amazon.awssdk.services.service1.Service1AsyncClient";
+    private static final String SERVICE2_SYNC = "software.amazon.awssdk.services.service2.Service2Client";
 
     @Test
     void invoke_syncClassRequested_warmsSyncTransportOnly() {
-        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+        RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList(S3_SYNC));
+        Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC));
 
-        assertThat(s3.warmedTypes()).containsExactly(ClientType.SYNC);
+        assertThat(service1.warmedTypes()).containsExactly(ClientType.SYNC);
         assertThat(matched).containsExactly(ClientType.SYNC);
     }
 
     @Test
     void invoke_asyncClassRequested_warmsAsyncTransportOnly() {
-        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+        RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList(S3_ASYNC));
+        Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_ASYNC));
 
-        assertThat(s3.warmedTypes()).containsExactly(ClientType.ASYNC);
+        assertThat(service1.warmedTypes()).containsExactly(ClientType.ASYNC);
         assertThat(matched).containsExactly(ClientType.ASYNC);
     }
 
     @Test
     void invoke_bothClassesRequested_warmsBothTransports() {
-        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+        RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList(S3_SYNC, S3_ASYNC));
+        Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC));
 
-        assertThat(s3.warmedTypes()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
+        assertThat(service1.warmedTypes()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
         assertThat(matched).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
     }
 
     @Test
     void invoke_classAcrossTwoProviders_warmsOnlyTheMatchingProvider() {
-        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
-        RecordingProvider ddb = new RecordingProvider(DDB_SYNC, null);
+        RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
+        RecordingProvider service2 = new RecordingProvider(SERVICE2_SYNC, null);
 
-        invokerLoading(s3, ddb).invoke(Arrays.asList(DDB_SYNC));
+        invokerLoading(service1, service2).invoke(Arrays.asList(SERVICE2_SYNC));
 
-        assertThat(s3.warmedTypes()).isEmpty();
-        assertThat(ddb.warmedTypes()).containsExactly(ClientType.SYNC);
+        assertThat(service1.warmedTypes()).isEmpty();
+        assertThat(service2.warmedTypes()).containsExactly(ClientType.SYNC);
     }
 
     @Test
     void invoke_unmatchedClass_logsWarnAndDoesNotThrow() {
-        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+        RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
         try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
-            Set<ClientType> matched = invokerLoading(s3).invoke(Arrays.asList("com.example.NotAClient"));
+            Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList("com.example.NotAClient"));
 
             assertThat(matched).isEmpty();
-            assertThat(s3.warmedTypes()).isEmpty();
+            assertThat(service1.warmedTypes()).isEmpty();
             assertThat(logCaptor.loggedEvents())
                 .anyMatch(event -> event.getLevel() == Level.WARN
                                    && event.getMessage().getFormattedMessage().contains("com.example.NotAClient"));
@@ -93,7 +92,7 @@ class TargetedWarmUpInvokerTest {
 
     @Test
     void invoke_whenProviderWarmUpThrows_stillReturnsMatchedTransport() {
-        SdkWarmUpProvider throwing = new TestProvider(S3_SYNC, S3_ASYNC) {
+        SdkWarmUpProvider throwing = new TestProvider(SERVICE1_SYNC, SERVICE1_ASYNC) {
             @Override
             public void warmUpClient(ClientType clientType) {
                 throw new RuntimeException("boom");
@@ -102,19 +101,19 @@ class TargetedWarmUpInvokerTest {
 
         // A throwing warmUpClient must not stop the follow-on HTTP warm-up: the matched transport is still returned so
         // the caller can narrow the HTTP warmers.
-        Set<ClientType> matched = invokerLoading(throwing).invoke(Arrays.asList(S3_SYNC));
+        Set<ClientType> matched = invokerLoading(throwing).invoke(Arrays.asList(SERVICE1_SYNC));
 
         assertThat(matched).containsExactly(ClientType.SYNC);
     }
 
     @Test
     void invoke_emptyRequest_isNoOp() {
-        RecordingProvider s3 = new RecordingProvider(S3_SYNC, S3_ASYNC);
+        RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(s3).invoke(Collections.emptyList());
+        Set<ClientType> matched = invokerLoading(service1).invoke(Collections.emptyList());
 
         assertThat(matched).isEmpty();
-        assertThat(s3.warmedTypes()).isEmpty();
+        assertThat(service1.warmedTypes()).isEmpty();
     }
 
     private TargetedWarmUpInvoker invokerLoading(SdkWarmUpProvider... providers) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpInvokerTest.java
@@ -38,30 +38,34 @@ class TargetedWarmUpInvokerTest {
     void invoke_syncClassRequested_warmsSyncTransportOnly() {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC));
+        TargetedWarmUpResult result = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC));
 
         assertThat(service1.warmedTypes()).containsExactly(ClientType.SYNC);
-        assertThat(matched).containsExactly(ClientType.SYNC);
+        assertThat(result.matchedTransports()).containsExactly(ClientType.SYNC);
+        assertThat(result.warmedClientNames()).containsExactly(SERVICE1_SYNC);
     }
 
     @Test
     void invoke_asyncClassRequested_warmsAsyncTransportOnly() {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_ASYNC));
+        TargetedWarmUpResult result = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_ASYNC));
 
         assertThat(service1.warmedTypes()).containsExactly(ClientType.ASYNC);
-        assertThat(matched).containsExactly(ClientType.ASYNC);
+        assertThat(result.matchedTransports()).containsExactly(ClientType.ASYNC);
+        assertThat(result.warmedClientNames()).containsExactly(SERVICE1_ASYNC);
     }
 
     @Test
     void invoke_bothClassesRequested_warmsBothTransports() {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC));
+        TargetedWarmUpResult result =
+            invokerLoading(service1).invoke(Arrays.asList(SERVICE1_SYNC, SERVICE1_ASYNC));
 
         assertThat(service1.warmedTypes()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
-        assertThat(matched).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
+        assertThat(result.matchedTransports()).containsExactlyInAnyOrder(ClientType.SYNC, ClientType.ASYNC);
+        assertThat(result.warmedClientNames()).containsExactly(SERVICE1_SYNC, SERVICE1_ASYNC);
     }
 
     @Test
@@ -80,9 +84,11 @@ class TargetedWarmUpInvokerTest {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
         try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
-            Set<ClientType> matched = invokerLoading(service1).invoke(Arrays.asList("com.example.NotAClient"));
+            TargetedWarmUpResult result =
+                invokerLoading(service1).invoke(Arrays.asList("com.example.NotAClient"));
 
-            assertThat(matched).isEmpty();
+            assertThat(result.matchedTransports()).isEmpty();
+            assertThat(result.warmedClientNames()).isEmpty();
             assertThat(service1.warmedTypes()).isEmpty();
             assertThat(logCaptor.loggedEvents())
                 .anyMatch(event -> event.getLevel() == Level.WARN
@@ -101,18 +107,50 @@ class TargetedWarmUpInvokerTest {
 
         // A throwing warmUpClient must not stop the follow-on HTTP warm-up: the matched transport is still returned so
         // the caller can narrow the HTTP warmers.
-        Set<ClientType> matched = invokerLoading(throwing).invoke(Arrays.asList(SERVICE1_SYNC));
+        TargetedWarmUpResult result = invokerLoading(throwing).invoke(Arrays.asList(SERVICE1_SYNC));
 
-        assertThat(matched).containsExactly(ClientType.SYNC);
+        assertThat(result.matchedTransports()).containsExactly(ClientType.SYNC);
+    }
+
+    @Test
+    void invoke_whenProviderWarmUpThrows_doesNotReportClientWarmed() {
+        SdkWarmUpProvider throwing = new TestProvider(SERVICE1_SYNC, SERVICE1_ASYNC) {
+            @Override
+            public void warmUpClient(ClientType clientType) {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        TargetedWarmUpResult result = invokerLoading(throwing).invoke(Arrays.asList(SERVICE1_SYNC));
+
+        assertThat(result.warmedClientNames()).isEmpty();
+    }
+
+    @Test
+    void invoke_mixedSuccessAndFailure_reportsOnlySuccessfulClientWarmed() {
+        RecordingProvider healthy = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
+        SdkWarmUpProvider throwing = new TestProvider(SERVICE2_SYNC, null) {
+            @Override
+            public void warmUpClient(ClientType clientType) {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        TargetedWarmUpResult result =
+            invokerLoading(healthy, throwing).invoke(Arrays.asList(SERVICE1_SYNC, SERVICE2_SYNC));
+
+        assertThat(result.warmedClientNames()).containsExactly(SERVICE1_SYNC);
+        assertThat(result.matchedTransports()).containsExactly(ClientType.SYNC);
     }
 
     @Test
     void invoke_emptyRequest_isNoOp() {
         RecordingProvider service1 = new RecordingProvider(SERVICE1_SYNC, SERVICE1_ASYNC);
 
-        Set<ClientType> matched = invokerLoading(service1).invoke(Collections.emptyList());
+        TargetedWarmUpResult result = invokerLoading(service1).invoke(Collections.emptyList());
 
-        assertThat(matched).isEmpty();
+        assertThat(result.matchedTransports()).isEmpty();
+        assertThat(result.warmedClientNames()).isEmpty();
         assertThat(service1.warmedTypes()).isEmpty();
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpResultTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/crac/TargetedWarmUpResultTest.java
@@ -13,13 +13,17 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.crac;
+package software.amazon.awssdk.core.internal.crac;
 
-import software.amazon.awssdk.core.SdkClient;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
-/**
- * Test-only client whose fully qualified name matches {@link RegisteredWarmUpProvider#syncClientClassName()}, so
- * {@code SdkWarmUp.prime(RegisteredSyncClient.class)} matches that provider's sync client type.
- */
-public interface RegisteredSyncClient extends SdkClient {
+public class TargetedWarmUpResultTest {
+
+    @Test
+    public void equalsHashCode() {
+        EqualsVerifier.forClass(TargetedWarmUpResult.class)
+                      .withNonnullFields("matchedClientTypes", "warmedClientNames")
+                      .verify();
+    }
 }

--- a/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/CodingConventionWithSuppressionTest.java
+++ b/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/CodingConventionWithSuppressionTest.java
@@ -61,7 +61,8 @@ public class CodingConventionWithSuppressionTest {
                       ArchUtils.classNameToPattern(KnownContentLengthAsyncRequestBodySubscriber.class),
                       ArchUtils.classNameToPattern(UnknownContentLengthAsyncRequestBodySubscriber.class),
                       ArchUtils.classNameToPattern(CopyObjectHelper.class),
-                      ArchUtils.classNameToPattern("software.amazon.awssdk.core.internal.crac.WarmUpDiscovery")));
+                      ArchUtils.classNameToPattern("software.amazon.awssdk.core.internal.crac.WarmUpDiscovery"),
+                      ArchUtils.classNameToPattern("software.amazon.awssdk.core.internal.crac.TargetedWarmUpInvoker")));
 
     private static final Set<Pattern> ALLOWED_ERROR_LOG_SUPPRESSION = new HashSet<>(
         Arrays.asList(

--- a/test/warmup-tests/pom.xml
+++ b/test/warmup-tests/pom.xml
@@ -48,7 +48,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
             <version>${awsjavasdk.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -77,6 +76,18 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
             <version>${awsjavasdk.version}</version>
             <scope>test</scope>
         </dependency>

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/IdempotenceSyncClient.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/IdempotenceSyncClient.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import software.amazon.awssdk.core.SdkClient;
+
+/**
+ * Test-only client matching {@link IdempotenceWarmUpProvider#syncClientClassName()}, primed only by
+ * {@link SdkWarmUpPrimeIdempotenceTest}.
+ */
+public interface IdempotenceSyncClient extends SdkClient {
+}

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/IdempotenceWarmUpProvider.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/IdempotenceWarmUpProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
+
+/**
+ * Test-only {@link SdkWarmUpProvider} for {@link SdkWarmUpPrimeIdempotenceTest}. Matches {@link IdempotenceSyncClient}
+ * only and counts sync warms; performs no I/O.
+ */
+public final class IdempotenceWarmUpProvider implements SdkWarmUpProvider {
+
+    private static final AtomicInteger SYNC_WARMS = new AtomicInteger();
+
+    public static int syncWarmCount() {
+        return SYNC_WARMS.get();
+    }
+
+    @Override
+    public void warmUp() {
+    }
+
+    @Override
+    public String syncClientClassName() {
+        return "software.amazon.awssdk.http.warmup.IdempotenceSyncClient";
+    }
+
+    @Override
+    public String asyncClientClassName() {
+        return "software.amazon.awssdk.http.warmup.IdempotenceAsyncClient";
+    }
+
+    @Override
+    public void warmUpClient(ClientType clientType) {
+        if (clientType == ClientType.SYNC) {
+            SYNC_WARMS.incrementAndGet();
+        }
+    }
+}

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/RetrySyncClient.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/RetrySyncClient.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import software.amazon.awssdk.core.SdkClient;
+
+/**
+ * Test-only client matching {@link RetryWarmUpProvider#syncClientClassName()}.
+ */
+public interface RetrySyncClient extends SdkClient {
+}

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/RetryWarmUpProvider.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/RetryWarmUpProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
+
+/**
+ * Test-only provider whose first {@code warmUpClient(SYNC)} call throws; later calls succeed.
+ */
+public final class RetryWarmUpProvider implements SdkWarmUpProvider {
+
+    private static final AtomicInteger SYNC_ATTEMPTS = new AtomicInteger();
+    private static final AtomicInteger SYNC_SUCCESSES = new AtomicInteger();
+
+    public static int syncAttemptCount() {
+        return SYNC_ATTEMPTS.get();
+    }
+
+    public static int syncSuccessCount() {
+        return SYNC_SUCCESSES.get();
+    }
+
+    @Override
+    public void warmUp() {
+    }
+
+    @Override
+    public String syncClientClassName() {
+        return "software.amazon.awssdk.http.warmup.RetrySyncClient";
+    }
+
+    @Override
+    public String asyncClientClassName() {
+        return null;
+    }
+
+    @Override
+    public void warmUpClient(ClientType clientType) {
+        if (clientType != ClientType.SYNC) {
+            return;
+        }
+        if (SYNC_ATTEMPTS.incrementAndGet() == 1) {
+            throw new RuntimeException("Simulated transient warm-up failure (test)");
+        }
+        SYNC_SUCCESSES.incrementAndGet();
+    }
+}

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveAsyncClient.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveAsyncClient.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import software.amazon.awssdk.core.SdkClient;
+
+/**
+ * Test-only client matching {@link SelectiveWarmUpProvider#asyncClientClassName()}, primed only by
+ * {@link SdkWarmUpPrimeSelectiveTest}.
+ */
+public interface SelectiveAsyncClient extends SdkClient {
+}

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveSyncClient.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveSyncClient.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import software.amazon.awssdk.core.SdkClient;
+
+/**
+ * Test-only client matching {@link SelectiveWarmUpProvider#syncClientClassName()}, primed only by
+ * {@link SdkWarmUpPrimeSelectiveTest}.
+ */
+public interface SelectiveSyncClient extends SdkClient {
+}

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveWarmUpProvider.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveWarmUpProvider.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
 
 /**
  * Test-only {@link SdkWarmUpProvider} for {@link SdkWarmUpPrimeSelectiveTest}. Matches {@link SelectiveSyncClient} and
- * {@link SelectiveAsyncClient} and counts warms per transport; performs no I/O.
+ * {@link SelectiveAsyncClient} and counts warms per client type; performs no I/O.
  */
 public final class SelectiveWarmUpProvider implements SdkWarmUpProvider {
 

--- a/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveWarmUpProvider.java
+++ b/test/warmup-tests/src/main/java/software/amazon/awssdk/http/warmup/SelectiveWarmUpProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
+
+/**
+ * Test-only {@link SdkWarmUpProvider} for {@link SdkWarmUpPrimeSelectiveTest}. Matches {@link SelectiveSyncClient} and
+ * {@link SelectiveAsyncClient} and counts warms per transport; performs no I/O.
+ */
+public final class SelectiveWarmUpProvider implements SdkWarmUpProvider {
+
+    private static final AtomicInteger SYNC_WARMS = new AtomicInteger();
+    private static final AtomicInteger ASYNC_WARMS = new AtomicInteger();
+
+    public static int syncWarmCount() {
+        return SYNC_WARMS.get();
+    }
+
+    public static int asyncWarmCount() {
+        return ASYNC_WARMS.get();
+    }
+
+    @Override
+    public void warmUp() {
+    }
+
+    @Override
+    public String syncClientClassName() {
+        return "software.amazon.awssdk.http.warmup.SelectiveSyncClient";
+    }
+
+    @Override
+    public String asyncClientClassName() {
+        return "software.amazon.awssdk.http.warmup.SelectiveAsyncClient";
+    }
+
+    @Override
+    public void warmUpClient(ClientType clientType) {
+        if (clientType == ClientType.SYNC) {
+            SYNC_WARMS.incrementAndGet();
+        } else if (clientType == ClientType.ASYNC) {
+            ASYNC_WARMS.incrementAndGet();
+        }
+    }
+}

--- a/test/warmup-tests/src/main/resources/META-INF/services/software.amazon.awssdk.core.crac.SdkWarmUpProvider
+++ b/test/warmup-tests/src/main/resources/META-INF/services/software.amazon.awssdk.core.crac.SdkWarmUpProvider
@@ -1,0 +1,2 @@
+software.amazon.awssdk.http.warmup.IdempotenceWarmUpProvider
+software.amazon.awssdk.http.warmup.SelectiveWarmUpProvider

--- a/test/warmup-tests/src/main/resources/META-INF/services/software.amazon.awssdk.core.crac.SdkWarmUpProvider
+++ b/test/warmup-tests/src/main/resources/META-INF/services/software.amazon.awssdk.core.crac.SdkWarmUpProvider
@@ -1,2 +1,3 @@
 software.amazon.awssdk.http.warmup.IdempotenceWarmUpProvider
 software.amazon.awssdk.http.warmup.SelectiveWarmUpProvider
+software.amazon.awssdk.http.warmup.RetryWarmUpProvider

--- a/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeIdempotenceTest.java
+++ b/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeIdempotenceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.crac.SdkWarmUp;
+
+/**
+ * Verifies {@link SdkWarmUp#prime(Class...)} warms a client at most once per JVM. Uses a dedicated
+ * {@link IdempotenceSyncClient} that no other test primes, so the "first warms, repeat no-ops" transition is observable
+ * regardless of execution order or JVM sharing.
+ */
+class SdkWarmUpPrimeIdempotenceTest {
+
+    private String savedRegionProperty;
+
+    @BeforeEach
+    void setUp() {
+        savedRegionProperty = System.getProperty("aws.region");
+        System.setProperty("aws.region", "warmup-idempotence-test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedRegionProperty != null) {
+            System.setProperty("aws.region", savedRegionProperty);
+        } else {
+            System.clearProperty("aws.region");
+        }
+    }
+
+    @Test
+    void prime_sameClientTwice_warmsProviderExactlyOnce() {
+        SdkWarmUp.prime(IdempotenceSyncClient.class);
+        assertThat(IdempotenceWarmUpProvider.syncWarmCount())
+            .as("first prime warms the sync transport once")
+            .isEqualTo(1);
+
+        // Second call for the same client must be a no-op: it is already recorded as primed.
+        SdkWarmUp.prime(IdempotenceSyncClient.class);
+        assertThat(IdempotenceWarmUpProvider.syncWarmCount())
+            .as("second prime of the same client does not warm again")
+            .isEqualTo(1);
+    }
+}

--- a/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeIdempotenceTest.java
+++ b/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeIdempotenceTest.java
@@ -50,7 +50,7 @@ class SdkWarmUpPrimeIdempotenceTest {
     void prime_sameClientTwice_warmsProviderExactlyOnce() {
         SdkWarmUp.prime(IdempotenceSyncClient.class);
         assertThat(IdempotenceWarmUpProvider.syncWarmCount())
-            .as("first prime warms the sync transport once")
+            .as("first prime warms the sync client type once")
             .isEqualTo(1);
 
         // Second call for the same client must be a no-op: it is already recorded as primed.

--- a/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeRetryTest.java
+++ b/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeRetryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.crac.SdkWarmUp;
+
+/**
+ * Verifies a failed {@link SdkWarmUp#prime(Class...)} warm-up is retried on the next call.
+ */
+class SdkWarmUpPrimeRetryTest {
+
+    private String savedRegionProperty;
+
+    @BeforeEach
+    void setUp() {
+        savedRegionProperty = System.getProperty("aws.region");
+        System.setProperty("aws.region", "warmup-retry-test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedRegionProperty != null) {
+            System.setProperty("aws.region", savedRegionProperty);
+        } else {
+            System.clearProperty("aws.region");
+        }
+    }
+
+    @Test
+    void prime_afterWarmUpFailure_retriesOnNextCallThenStops() {
+        // First call: the provider throws, so the client is not recorded as primed.
+        assertThatCode(() -> SdkWarmUp.prime(RetrySyncClient.class)).doesNotThrowAnyException();
+        assertThat(RetryWarmUpProvider.syncAttemptCount()).as("first call attempts the warm").isEqualTo(1);
+        assertThat(RetryWarmUpProvider.syncSuccessCount()).as("first call fails").isEqualTo(0);
+
+        // Second call: retried; this time it succeeds.
+        SdkWarmUp.prime(RetrySyncClient.class);
+        assertThat(RetryWarmUpProvider.syncAttemptCount()).as("failure is retried").isEqualTo(2);
+        assertThat(RetryWarmUpProvider.syncSuccessCount()).as("retry succeeds").isEqualTo(1);
+
+        // Third call: already primed, no further attempt.
+        SdkWarmUp.prime(RetrySyncClient.class);
+        assertThat(RetryWarmUpProvider.syncAttemptCount()).as("successful warm is not repeated").isEqualTo(2);
+    }
+}

--- a/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeSelectiveTest.java
+++ b/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeSelectiveTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.crac.SdkWarmUp;
+
+/**
+ * Verifies that when {@link SdkWarmUp#prime(Class...)} is called with a batch mixing an already-primed client and a new
+ * one, only the new client is warmed. Uses dedicated clients that no other test primes.
+ */
+class SdkWarmUpPrimeSelectiveTest {
+
+    private String savedRegionProperty;
+
+    @BeforeEach
+    void setUp() {
+        savedRegionProperty = System.getProperty("aws.region");
+        System.setProperty("aws.region", "warmup-selective-test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedRegionProperty != null) {
+            System.setProperty("aws.region", savedRegionProperty);
+        } else {
+            System.clearProperty("aws.region");
+        }
+    }
+
+    @Test
+    void prime_previouslyPrimedClientInNewBatch_warmsOnlyTheNewClient() {
+        // Prime the sync client first.
+        SdkWarmUp.prime(SelectiveSyncClient.class);
+        assertThat(SelectiveWarmUpProvider.syncWarmCount()).isEqualTo(1);
+        assertThat(SelectiveWarmUpProvider.asyncWarmCount()).isEqualTo(0);
+
+        // Now prime a batch containing the already-primed sync client plus a new async client.
+        SdkWarmUp.prime(SelectiveSyncClient.class, SelectiveAsyncClient.class);
+
+        assertThat(SelectiveWarmUpProvider.syncWarmCount())
+            .as("already-primed sync client is not warmed again")
+            .isEqualTo(1);
+        assertThat(SelectiveWarmUpProvider.asyncWarmCount())
+            .as("the new async client is warmed once")
+            .isEqualTo(1);
+    }
+}

--- a/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeTargetedTest.java
+++ b/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeTargetedTest.java
@@ -19,20 +19,25 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.crac.SdkWarmUp;
 import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
@@ -43,19 +48,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 
 /**
  * End-to-end integration test of {@link SdkWarmUp#prime(Class...)} with real service clients (STS, DynamoDB) whose
- * generated {@link SdkWarmUpProvider} implementations are on the classpath via ServiceLoader. Verifies that:
- * <ul>
- *     <li>Passing a sync client class routes through {@code warmUpClient(SYNC)} and triggers the sync HTTP warmer.</li>
- *     <li>Passing an async client class routes through {@code warmUpClient(ASYNC)} and triggers the async HTTP warmer.</li>
- *     <li>Idempotency: a second call with the same client is a no-op.</li>
- *     <li>Multiple services can be primed in one call.</li>
- *     <li>Concurrent callers do not throw or corrupt state.</li>
- *     <li>An unmatched client is a safe no-op.</li>
- * </ul>
- *
- * <p>The HTTP warmers resolve their endpoint via {@code RegionEndpointResolver}, which reads {@code aws.region}. Tests
- * set a dummy region so DNS fails fast and no real network traffic leaves the host. The generated providers use
- * {@code CannedResponseHttpClient}, so their {@code warmUpClient} does not need the network either.
+ * generated {@link SdkWarmUpProvider} implementations are on the classpath via ServiceLoader.
  */
 class SdkWarmUpPrimeTargetedTest {
 
@@ -70,12 +63,8 @@ class SdkWarmUpPrimeTargetedTest {
             .withStatus(302)
             .withHeader("Location", "https://aws.amazon.com/iam")));
 
-        // Use a non-routable region so the HTTP warmer's STS endpoint fails DNS immediately; the warm-up is best-effort
-        // and swallows the failure, keeping the test offline.
         savedRegionProperty = System.getProperty("aws.region");
         System.setProperty("aws.region", "warmup-integration-test");
-
-        SdkWarmUp.resetTargetedPrimeStateForTesting();
     }
 
     @AfterEach
@@ -101,24 +90,19 @@ class SdkWarmUpPrimeTargetedTest {
         assertThat(count).isGreaterThanOrEqualTo(3);
     }
 
-    @Test
-    void prime_withStsSyncClient_completesWithoutError() {
-        assertThatCode(() -> SdkWarmUp.prime(StsClient.class)).doesNotThrowAnyException();
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("singleClientCases")
+    void prime_withSingleClient_completesWithoutError(String description, Class<? extends SdkClient> client) {
+        assertThatCode(() -> SdkWarmUp.prime(client)).doesNotThrowAnyException();
     }
 
-    @Test
-    void prime_withStsAsyncClient_completesWithoutError() {
-        assertThatCode(() -> SdkWarmUp.prime(StsAsyncClient.class)).doesNotThrowAnyException();
-    }
-
-    @Test
-    void prime_withDynamoDbSyncClient_completesWithoutError() {
-        assertThatCode(() -> SdkWarmUp.prime(DynamoDbClient.class)).doesNotThrowAnyException();
-    }
-
-    @Test
-    void prime_withDynamoDbAsyncClient_completesWithoutError() {
-        assertThatCode(() -> SdkWarmUp.prime(DynamoDbAsyncClient.class)).doesNotThrowAnyException();
+    private static Stream<Arguments> singleClientCases() {
+        return Stream.of(
+            arguments("STS sync", StsClient.class),
+            arguments("STS async", StsAsyncClient.class),
+            arguments("DynamoDB sync", DynamoDbClient.class),
+            arguments("DynamoDB async", DynamoDbAsyncClient.class)
+        );
     }
 
     @Test
@@ -144,11 +128,13 @@ class SdkWarmUpPrimeTargetedTest {
     }
 
     @Test
-    void prime_concurrentCalls_doNotThrow() throws InterruptedException {
+    void prime_concurrentCalls_allCompleteSuccessfully() throws InterruptedException {
         int threadCount = 8;
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(threadCount);
         List<Thread> threads = new ArrayList<>();
+        List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger completed = new AtomicInteger();
 
         Class<?>[] clients = {StsClient.class, StsAsyncClient.class, DynamoDbClient.class, DynamoDbAsyncClient.class};
         for (int i = 0; i < threadCount; i++) {
@@ -158,8 +144,11 @@ class SdkWarmUpPrimeTargetedTest {
                 try {
                     start.await();
                     SdkWarmUp.prime(client);
+                    completed.incrementAndGet();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                } catch (Throwable t) {
+                    failures.add(t);
                 } finally {
                     done.countDown();
                 }
@@ -173,7 +162,9 @@ class SdkWarmUpPrimeTargetedTest {
         for (Thread thread : threads) {
             thread.join();
         }
-        // If we get here without exceptions or hangs, concurrency is safe.
+
+        assertThat(failures).as("no prime(Class...) call threw").isEmpty();
+        assertThat(completed.get()).as("every prime(Class...) call completed").isEqualTo(threadCount);
     }
 
     @Test
@@ -186,16 +177,20 @@ class SdkWarmUpPrimeTargetedTest {
         mockServer.verify(0, anyRequestedFor(anyUrl()));
     }
 
-    @Test
-    void prime_withNullArray_isNoOp() {
-        assertThatCode(() -> SdkWarmUp.prime((Class<? extends SdkClient>[]) null)).doesNotThrowAnyException();
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("noOpInputCases")
+    void prime_withNoOpInput_doesNotThrow(String description, Class<? extends SdkClient>[] clients) {
+        assertThatCode(() -> SdkWarmUp.prime(clients)).doesNotThrowAnyException();
     }
 
-    @Test
-    void prime_withEmptyArray_isNoOp() {
-        assertThatCode(() -> SdkWarmUp.prime(new Class[0])).doesNotThrowAnyException();
+    private static Stream<Arguments> noOpInputCases() {
+        return Stream.of(
+            arguments("null array", (Class<? extends SdkClient>[]) null),
+            arguments("empty array", new Class[0])
+        );
     }
 
     interface UnregisteredClient extends SdkClient {
     }
 }
+

--- a/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeTargetedTest.java
+++ b/test/warmup-tests/src/test/java/software/amazon/awssdk/http/warmup/SdkWarmUpPrimeTargetedTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.warmup;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.core.crac.SdkWarmUp;
+import software.amazon.awssdk.core.crac.SdkWarmUpProvider;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.sts.StsAsyncClient;
+import software.amazon.awssdk.services.sts.StsClient;
+
+/**
+ * End-to-end integration test of {@link SdkWarmUp#prime(Class...)} with real service clients (STS, DynamoDB) whose
+ * generated {@link SdkWarmUpProvider} implementations are on the classpath via ServiceLoader. Verifies that:
+ * <ul>
+ *     <li>Passing a sync client class routes through {@code warmUpClient(SYNC)} and triggers the sync HTTP warmer.</li>
+ *     <li>Passing an async client class routes through {@code warmUpClient(ASYNC)} and triggers the async HTTP warmer.</li>
+ *     <li>Idempotency: a second call with the same client is a no-op.</li>
+ *     <li>Multiple services can be primed in one call.</li>
+ *     <li>Concurrent callers do not throw or corrupt state.</li>
+ *     <li>An unmatched client is a safe no-op.</li>
+ * </ul>
+ *
+ * <p>The HTTP warmers resolve their endpoint via {@code RegionEndpointResolver}, which reads {@code aws.region}. Tests
+ * set a dummy region so DNS fails fast and no real network traffic leaves the host. The generated providers use
+ * {@code CannedResponseHttpClient}, so their {@code warmUpClient} does not need the network either.
+ */
+class SdkWarmUpPrimeTargetedTest {
+
+    private WireMockServer mockServer;
+    private String savedRegionProperty;
+
+    @BeforeEach
+    void setUp() {
+        mockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        mockServer.start();
+        mockServer.stubFor(any(anyUrl()).willReturn(aResponse()
+            .withStatus(302)
+            .withHeader("Location", "https://aws.amazon.com/iam")));
+
+        // Use a non-routable region so the HTTP warmer's STS endpoint fails DNS immediately; the warm-up is best-effort
+        // and swallows the failure, keeping the test offline.
+        savedRegionProperty = System.getProperty("aws.region");
+        System.setProperty("aws.region", "warmup-integration-test");
+
+        SdkWarmUp.resetTargetedPrimeStateForTesting();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop();
+        if (savedRegionProperty != null) {
+            System.setProperty("aws.region", savedRegionProperty);
+        } else {
+            System.clearProperty("aws.region");
+        }
+    }
+
+    /**
+     * Sanity check: ServiceLoader must discover at least the STS and DynamoDB providers we depend on.
+     */
+    @Test
+    void serviceLoader_discoversExpectedProviders() {
+        int count = 0;
+        for (SdkWarmUpProvider ignored : ServiceLoader.load(SdkWarmUpProvider.class)) {
+            count++;
+        }
+        // STS has 1 provider, DynamoDB has 2 (DynamoDb + DynamoDbStreams).
+        assertThat(count).isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void prime_withStsSyncClient_completesWithoutError() {
+        assertThatCode(() -> SdkWarmUp.prime(StsClient.class)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_withStsAsyncClient_completesWithoutError() {
+        assertThatCode(() -> SdkWarmUp.prime(StsAsyncClient.class)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_withDynamoDbSyncClient_completesWithoutError() {
+        assertThatCode(() -> SdkWarmUp.prime(DynamoDbClient.class)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_withDynamoDbAsyncClient_completesWithoutError() {
+        assertThatCode(() -> SdkWarmUp.prime(DynamoDbAsyncClient.class)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_withMultipleServices_completesWithoutError() {
+        assertThatCode(() -> SdkWarmUp.prime(StsClient.class, DynamoDbClient.class, StsAsyncClient.class))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_calledTwiceWithSameClient_isIdempotent() {
+        SdkWarmUp.prime(StsClient.class);
+
+        // Second call should be a no-op (client already recorded as primed).
+        assertThatCode(() -> SdkWarmUp.prime(StsClient.class)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_calledWithNewClientAfterPrevious_primesOnlyNewClient() {
+        SdkWarmUp.prime(StsClient.class);
+
+        // DynamoDB is new; STS should not be re-primed.
+        assertThatCode(() -> SdkWarmUp.prime(DynamoDbClient.class, StsClient.class)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_concurrentCalls_doNotThrow() throws InterruptedException {
+        int threadCount = 8;
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        List<Thread> threads = new ArrayList<>();
+
+        Class<?>[] clients = {StsClient.class, StsAsyncClient.class, DynamoDbClient.class, DynamoDbAsyncClient.class};
+        for (int i = 0; i < threadCount; i++) {
+            @SuppressWarnings("unchecked")
+            Class<? extends SdkClient> client = (Class<? extends SdkClient>) clients[i % clients.length];
+            Thread thread = new Thread(() -> {
+                try {
+                    start.await();
+                    SdkWarmUp.prime(client);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+            threads.add(thread);
+            thread.start();
+        }
+
+        start.countDown();
+        done.await();
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        // If we get here without exceptions or hangs, concurrency is safe.
+    }
+
+    @Test
+    void prime_withUnmatchedClient_isNoOpAndSendsNoRequest() {
+        mockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
+
+        assertThatCode(() -> SdkWarmUp.prime(UnregisteredClient.class)).doesNotThrowAnyException();
+
+        // No provider matches, so no HTTP warmer runs and nothing hits the mock server.
+        mockServer.verify(0, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void prime_withNullArray_isNoOp() {
+        assertThatCode(() -> SdkWarmUp.prime((Class<? extends SdkClient>[]) null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void prime_withEmptyArray_isNoOp() {
+        assertThatCode(() -> SdkWarmUp.prime(new Class[0])).doesNotThrowAnyException();
+    }
+
+    interface UnregisteredClient extends SdkClient {
+    }
+}


### PR DESCRIPTION
## Motivation and Context

`SdkWarmUp.prime()` warms every `SdkWarmUpProvider` on the classpath and the discovered HTTP transports. Applications that use a single client (for example only `S3AsyncClient`) pay the cost of warming clients and transports they never use. This change adds a targeted overload, `SdkWarmUp.prime(Class...)`, that warms only the requested service clients and only the transports they need.

## Modifications

- `SdkWarmUp.prime(Class<? extends SdkClient>...)`: new `@SdkPublicApi` overload. Matches each requested class against the registered providers, warms the matched transport through `SdkWarmUpProvider.warmUpClient(ClientType)`, then runs only the HTTP warmer for the matched transports (sync, async, or both). Unmatched classes are logged at warn and skipped. Clients already primed in this JVM are skipped on later calls.
- `TargetedWarmUpInvoker` (new, internal): stateless matcher that maps requested class names against each provider's `syncClientClassName()`/`asyncClientClassName()` and returns the matched transports so the caller can narrow the HTTP warm-up.
- `PrimedClientRegistry` (new, internal): owns the "which clients are already primed" dedup state, so a client is warmed at most once per JVM. State is per-instance (unit-testable with fresh instances); `SdkWarmUp` holds one long-lived instance.
- Concurrency: `prime(Class...)` is lock-free — dedup uses a thread-safe set, and warm-up (network I/O) runs outside any lock. Concurrent calls may briefly double-warm the same client, which is harmless because warming is idempotent. A run that throws before completing does not record the client as primed, so it is retried on the next call. (The `PRIME_LOCK` mutex is used only by the existing no-arg `prime()`.)

## Testing
- Junits added

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
