### PR TITLE
feat(crt): add minTlsVersion option to CRT HTTP clients

### DIFF
--- a/.changes/next-release/feature-AWSCRTHTTPClient-d471f89.json
+++ b/.changes/next-release/feature-AWSCRTHTTPClient-d471f89.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS CRT HTTP Client",
+    "contributor": "",
+    "description": "Add a minTlsVersion(TlsVersion) builder option on AwsCrtHttpClient and AwsCrtAsyncHttpClient that enforces a minimum TLS protocol version for outbound connections. Currently supports TlsVersion.TLS_1_3 and TlsVersion.SYSTEM_DEFAULT (the default). Fixes [#5619](https://github.com/aws/aws-sdk-java-v2/issues/5619)."
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -259,6 +259,28 @@ public final class AwsCrtAsyncHttpClient extends AwsCrtHttpClientBase implements
          * @return The builder of the method chaining.
          */
         AwsCrtAsyncHttpClient.Builder postQuantumTlsEnabled(Boolean postQuantumTlsEnabled);
+
+        /**
+         * Configure the minimum TLS protocol version the client will accept when negotiating
+         * a TLS connection. Handshakes that would negotiate a lower version will fail.
+         *
+         * <p>If not set, the platform + CRT default is used (equivalent to
+         * {@link TlsVersion#SYSTEM_DEFAULT}).
+         *
+         * <p>This option is mutually exclusive with {@link #postQuantumTlsEnabled(Boolean)
+         * postQuantumTlsEnabled(false)}. Attempting to set both will cause client construction
+         * to fail with an {@link IllegalStateException}.
+         *
+         * <p><b>macOS:</b> the default CRT TLS backend on macOS (Apple Secure Transport) does not
+         * support TLS 1.3. To use {@link TlsVersion#TLS_1_3} on macOS you must set the environment
+         * variable {@code AWS_CRT_USE_NON_FIPS_TLS_13} to any non-empty value at process startup so
+         * the CRT selects its s2n-tls backend. See {@link TlsVersion} for details.
+         *
+         * @param minTlsVersion the minimum acceptable TLS version; {@code null} clears
+         *                      the value and reverts to the platform default
+         * @return this builder for method chaining
+         */
+        AwsCrtAsyncHttpClient.Builder minTlsVersion(TlsVersion minTlsVersion);
     }
 
     /**

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
@@ -303,6 +303,28 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
          * @return The builder of the method chaining.
          */
         AwsCrtHttpClient.Builder postQuantumTlsEnabled(Boolean postQuantumTlsEnabled);
+
+        /**
+         * Configure the minimum TLS protocol version the client will accept when negotiating
+         * a TLS connection. Handshakes that would negotiate a lower version will fail.
+         *
+         * <p>If not set, the platform + CRT default is used (equivalent to
+         * {@link TlsVersion#SYSTEM_DEFAULT}).
+         *
+         * <p>This option is mutually exclusive with {@link #postQuantumTlsEnabled(Boolean)
+         * postQuantumTlsEnabled(false)}. Attempting to set both will cause client construction
+         * to fail with an {@link IllegalStateException}.
+         *
+         * <p><b>macOS:</b> the default CRT TLS backend on macOS (Apple Secure Transport) does not
+         * support TLS 1.3. To use {@link TlsVersion#TLS_1_3} on macOS you must set the environment
+         * variable {@code AWS_CRT_USE_NON_FIPS_TLS_13} to any non-empty value at process startup so
+         * the CRT selects its s2n-tls backend. See {@link TlsVersion} for details.
+         *
+         * @param minTlsVersion the minimum acceptable TLS version; {@code null} clears
+         *                      the value and reverts to the platform default
+         * @return this builder for method chaining
+         */
+        AwsCrtHttpClient.Builder minTlsVersion(TlsVersion minTlsVersion);
     }
 
     /**

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
@@ -21,6 +21,7 @@ import static software.amazon.awssdk.http.SdkHttpConfigurationOption.PROTOCOL;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.buildSocketOptions;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.buildTlsConnectionOptions;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.resolveCipherPreference;
+import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.resolveMinTlsVersion;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.net.URI;
@@ -94,6 +95,7 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
         TlsContextOptions clientTlsContextOptions =
             TlsContextOptions.createDefaultClient()
                              .withCipherPreference(resolveCipherPreference(builder.getPostQuantumTlsEnabled()))
+                             .withMinimumTlsVersion(resolveMinTlsVersion(builder.getMinTlsVersion()))
                              .withVerifyPeer(!config.get(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES));
         this.protocol = config.get(PROTOCOL);
         if (protocol == Protocol.HTTP2) {

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/TlsVersion.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/TlsVersion.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * A TLS protocol version that {@link AwsCrtHttpClient} and {@link AwsCrtAsyncHttpClient} uses.
+ *
+ * @see AwsCrtHttpClient.Builder#minTlsVersion(TlsVersion)
+ * @see AwsCrtAsyncHttpClient.Builder#minTlsVersion(TlsVersion)
+ */
+@SdkPublicApi
+public enum TlsVersion {
+
+    /**
+     * TLS 1.3.
+     */
+    TLS_1_3,
+
+    /**
+     * The underlying OS/platform + CRT TLS default.
+     */
+    SYSTEM_DEFAULT
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/TlsVersion.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/TlsVersion.java
@@ -20,6 +20,11 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 /**
  * A TLS protocol version that {@link AwsCrtHttpClient} and {@link AwsCrtAsyncHttpClient} uses.
  *
+ * <p><b>Mac-Only TLS Behavior:</b> the default CRT TLS backend on macOS (Apple Secure Transport) does not
+ * support TLS 1.3. To use {@link TlsVersion#TLS_1_3} on macOS you must set the environment variable
+ * {@code AWS_CRT_USE_NON_FIPS_TLS_13} to any non-empty value at process startup so the CRT selects its s2n-tls backend. See
+ * <a href="https://github.com/awslabs/aws-crt-java/blob/main/README.md">Mac-Only TLS Behavior</a> for more details.
+ *
  * @see AwsCrtHttpClient.Builder#minTlsVersion(TlsVersion)
  * @see AwsCrtAsyncHttpClient.Builder#minTlsVersion(TlsVersion)
  */

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtClientBuilderBase.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtClientBuilderBase.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.crt.ConnectionHealthConfiguration;
 import software.amazon.awssdk.http.crt.ProxyConfiguration;
 import software.amazon.awssdk.http.crt.TcpKeepAliveConfiguration;
+import software.amazon.awssdk.http.crt.TlsVersion;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.Validate;
 
@@ -33,6 +34,7 @@ public class AwsCrtClientBuilderBase<BuilderT> {
     private ConnectionHealthConfiguration connectionHealthConfiguration;
     private TcpKeepAliveConfiguration tcpKeepAliveConfiguration;
     private Boolean postQuantumTlsEnabled;
+    private TlsVersion minTlsVersion;
 
     protected AwsCrtClientBuilderBase() {
     }
@@ -140,6 +142,15 @@ public class AwsCrtClientBuilderBase<BuilderT> {
 
     public Boolean getPostQuantumTlsEnabled() {
         return this.postQuantumTlsEnabled;
+    }
+
+    public BuilderT minTlsVersion(TlsVersion minTlsVersion) {
+        this.minTlsVersion = minTlsVersion;
+        return thisBuilder();
+    }
+
+    public TlsVersion getMinTlsVersion() {
+        return this.minTlsVersion;
     }
 
     public BuilderT proxyConfiguration(Consumer<ProxyConfiguration.Builder> proxyConfigurationBuilderConsumer) {

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
@@ -22,7 +22,9 @@ import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.crt.io.TlsConnectionOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.http.crt.TcpKeepAliveConfiguration;
+import software.amazon.awssdk.http.crt.TlsVersion;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.NumericUtils;
 
@@ -78,6 +80,23 @@ public final class AwsCrtConfigurationUtils {
                            + "Falling back to TLS_CIPHER_SYSTEM_DEFAULT.");
         }
         return TlsCipherPreference.TLS_CIPHER_SYSTEM_DEFAULT;
+    }
+
+    /**
+     * Translate the SDK-owned {@link TlsVersion} into the CRT-native {@link TlsContextOptions.TlsVersions}
+     */
+    public static TlsContextOptions.TlsVersions resolveMinTlsVersion(TlsVersion minTlsVersion) {
+        if (minTlsVersion == null) {
+            return TlsContextOptions.TlsVersions.TLS_VER_SYS_DEFAULTS;
+        }
+        switch (minTlsVersion) {
+            case TLS_1_3:
+                return TlsContextOptions.TlsVersions.TLSv1_3;
+            case SYSTEM_DEFAULT:
+                return TlsContextOptions.TlsVersions.TLS_VER_SYS_DEFAULTS;
+            default:
+                throw new IllegalArgumentException("Unsupported minTlsVersion: " + minTlsVersion);
+        }
     }
 
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientTest.java
@@ -16,15 +16,18 @@
 package software.amazon.awssdk.http.crt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.time.Duration;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -60,10 +63,57 @@ class AwsCrtAsyncHttpClientTest extends AwsCrtHttpClientTestBase {
         }
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("minTlsVersionInputs")
+    void asyncBuilder_minTlsVersion_buildSucceeds(String description, Consumer<AwsCrtAsyncHttpClient.Builder> configure) {
+        assertThatCode(() -> {
+            AwsCrtAsyncHttpClient.Builder builder = AwsCrtAsyncHttpClient.builder();
+            configure.accept(builder);
+            builder.build().close();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void asyncBuilder_postQuantumTrueWithMinTls13_buildSucceeds() {
+        assertThatCode(() -> AwsCrtAsyncHttpClient.builder()
+                                                  .postQuantumTlsEnabled(true)
+                                                  .minTlsVersion(TlsVersion.TLS_1_3)
+                                                  .build()
+                                                  .close())
+            .doesNotThrowAnyException();
+    }
+
+    // CRT enforces mutual exclusivity between a non-default cipher preference and a non-default minimum TLS version
+    // (aws-crt-java TlsContextOptions#getNativeHandle throws IllegalStateException). This surfaces only on platforms
+    // where TLS_CIPHER_NON_PQ_DEFAULT is supported; elsewhere resolveCipherPreference(false) falls back to
+    // TLS_CIPHER_SYSTEM_DEFAULT (see AwsCrtConfigurationUtils) and CRT accepts the combination.
+    @Test
+    void asyncBuilder_postQuantumFalseWithMinTls13_failsWhenCrtEnforcesMutualExclusivity() {
+        assumeTrue(TlsCipherPreference.TLS_CIPHER_NON_PQ_DEFAULT.isSupported());
+        assertThatThrownBy(() -> AwsCrtAsyncHttpClient.builder()
+                                                     .postQuantumTlsEnabled(false)
+                                                     .minTlsVersion(TlsVersion.TLS_1_3)
+                                                     .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    static Stream<Arguments> minTlsVersionInputs() {
+        return Stream.of(
+            Arguments.of("unset -> build succeeds",
+                         (Consumer<AwsCrtAsyncHttpClient.Builder>) b -> { }),
+            Arguments.of("SYSTEM_DEFAULT -> build succeeds",
+                         (Consumer<AwsCrtAsyncHttpClient.Builder>) b -> b.minTlsVersion(TlsVersion.SYSTEM_DEFAULT)),
+            Arguments.of("TLS_1_3 -> build succeeds",
+                         (Consumer<AwsCrtAsyncHttpClient.Builder>) b -> b.minTlsVersion(TlsVersion.TLS_1_3)),
+            Arguments.of("TLS_1_3 then null -> build succeeds",
+                         (Consumer<AwsCrtAsyncHttpClient.Builder>) b ->
+                             b.minTlsVersion(TlsVersion.TLS_1_3).minTlsVersion(null))
+        );
+    }
+
     private static SdkAsyncHttpClient buildAsync(AwsCrtAsyncHttpClient.Builder builder, Duration serviceDefault) {
         return serviceDefault == null
                ? builder.build()
                : builder.buildWithDefaults(serviceDefaultsMap(serviceDefault));
     }
-
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientTest.java
@@ -16,12 +16,18 @@
 package software.amazon.awssdk.http.crt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -67,6 +73,53 @@ public class AwsCrtHttpClientTest extends AwsCrtHttpClientTestBase {
         try (SdkHttpClient client = buildSync(builder, serviceDefault)) {
             assertThat(((AwsCrtHttpClient) client).resolvedTlsNegotiationTimeout()).isEqualTo(expected);
         }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("minTlsVersionInputs")
+    void syncBuilder_minTlsVersion_buildSucceeds(String description, Consumer<AwsCrtHttpClient.Builder> configure) {
+        assertThatCode(() -> {
+            AwsCrtHttpClient.Builder builder = AwsCrtHttpClient.builder();
+            configure.accept(builder);
+            builder.build().close();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void syncBuilder_postQuantumTrueWithMinTls13_buildSucceeds() {
+        assertThatCode(() -> AwsCrtHttpClient.builder()
+                                             .postQuantumTlsEnabled(true)
+                                             .minTlsVersion(TlsVersion.TLS_1_3)
+                                             .build()
+                                             .close())
+            .doesNotThrowAnyException();
+    }
+
+    // CRT enforces mutual exclusivity between a non-default cipher preference and a non-default minimum TLS version
+    // (aws-crt-java TlsContextOptions#getNativeHandle throws IllegalStateException). This surfaces only on platforms
+    // where TLS_CIPHER_NON_PQ_DEFAULT is supported; elsewhere resolveCipherPreference(false) falls back to
+    // TLS_CIPHER_SYSTEM_DEFAULT (see AwsCrtConfigurationUtils) and CRT accepts the combination.
+    @Test
+    void syncBuilder_postQuantumFalseWithMinTls13_failsWhenCrtEnforcesMutualExclusivity() {
+        assumeTrue(TlsCipherPreference.TLS_CIPHER_NON_PQ_DEFAULT.isSupported());
+        assertThatThrownBy(() -> AwsCrtHttpClient.builder()
+                                                 .postQuantumTlsEnabled(false)
+                                                 .minTlsVersion(TlsVersion.TLS_1_3)
+                                                 .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    static Stream<Arguments> minTlsVersionInputs() {
+        return Stream.of(
+            Arguments.of("unset -> build succeeds",
+                         (Consumer<AwsCrtHttpClient.Builder>) b -> { }),
+            Arguments.of("SYSTEM_DEFAULT -> build succeeds",
+                         (Consumer<AwsCrtHttpClient.Builder>) b -> b.minTlsVersion(TlsVersion.SYSTEM_DEFAULT)),
+            Arguments.of("TLS_1_3 -> build succeeds",
+                         (Consumer<AwsCrtHttpClient.Builder>) b -> b.minTlsVersion(TlsVersion.TLS_1_3)),
+            Arguments.of("TLS_1_3 then null -> build succeeds",
+                         (Consumer<AwsCrtHttpClient.Builder>) b -> b.minTlsVersion(TlsVersion.TLS_1_3).minTlsVersion(null))
+        );
     }
 
     private static SdkHttpClient buildSync(AwsCrtHttpClient.Builder builder, Duration serviceDefault) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtilsTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtilsTest.java
@@ -21,14 +21,17 @@ import static software.amazon.awssdk.crt.io.TlsCipherPreference.TLS_CIPHER_SYSTE
 
 import java.time.Duration;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.crt.http.HttpMonitoringOptions;
 import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.crt.TcpKeepAliveConfiguration;
+import software.amazon.awssdk.http.crt.TlsVersion;
 import software.amazon.awssdk.utils.AttributeMap;
 
 class AwsCrtConfigurationUtilsTest {
@@ -98,6 +101,25 @@ class AwsCrtConfigurationUtilsTest {
             )
         );
     }
+
+    @Test
+    void resolveMinTlsVersion_null_returnsSystemDefaults() {
+        assertThat(AwsCrtConfigurationUtils.resolveMinTlsVersion(null))
+            .isEqualTo(TlsContextOptions.TlsVersions.TLS_VER_SYS_DEFAULTS);
+    }
+
+    @Test
+    void resolveMinTlsVersion_systemDefault_returnsSystemDefaults() {
+        assertThat(AwsCrtConfigurationUtils.resolveMinTlsVersion(TlsVersion.SYSTEM_DEFAULT))
+            .isEqualTo(TlsContextOptions.TlsVersions.TLS_VER_SYS_DEFAULTS);
+    }
+
+    @Test
+    void resolveMinTlsVersion_tls13_returnsTLSv1_3() {
+        assertThat(AwsCrtConfigurationUtils.resolveMinTlsVersion(TlsVersion.TLS_1_3))
+            .isEqualTo(TlsContextOptions.TlsVersions.TLSv1_3);
+    }
+
 
     private static Stream<Arguments> defaultConnectionHealthConfigurationCases() {
         return Stream.of(


### PR DESCRIPTION
## Motivation and Context

Fixes #5619.

Customers using the AWS CRT HTTP client have no per-client way to require a minimum TLS protocol version.


## Modifications

Adds a `minTlsVersion(TlsVersion)` builder option on both `AwsCrtHttpClient.Builder` and `AwsCrtAsyncHttpClient.Builder`.

- New `@SdkPublicApi` enum `software.amazon.awssdk.http.crt.TlsVersion` with two values: `TLS_1_3` and `SYSTEM_DEFAULT`.
- New builder methods are additive; no existing public method or type signature changed.
- `postQuantumTlsEnabled(false)` combined with `minTlsVersion(TLS_1_3)` fails at `build()` on platforms where `TLS_CIPHER_NON_PQ_DEFAULT` is supported. The failure surfaces as the CRT-native `IllegalStateException` from `TlsContextOptions#getNativeHandle` ("tlsCipherPreference and minTlsVersion are mutually exclusive"). The SDK does not wrap or replace this exception.
- macOS caveat is documented on both the `TlsVersion` type Javadoc and the two `minTlsVersion(...)` builder-method Javadocs: Apple Secure Transport (the default macOS CRT TLS backend) does not support TLS 1.3. To use `TlsVersion.TLS_1_3` on macOS the customer must set env var `AWS_CRT_USE_NON_FIPS_TLS_13` to a non-empty value at process startup, which switches CRT to its s2n-tls backend (not FIPS-validated, no macOS Keychain integration). The SDK does not read or interpret this env var; the failure otherwise surfaces on the first request as a CRT-side error.

## Testing

Added new tests

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [[LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

Note on the `mvn install` box: only the `http-clients/aws-crt-client` module was built locally (`BUILD SUCCESS`, 247 tests, 0 failures, 2 platform-skipped). A full-repo `mvn install` was not run.

## License

- [x] I confirm that this pull request can be released under the Apache 2 license