### PR TITLE
[EndpointUri PR 1/4] Add EndpointUrl class

### DIFF
--- a/core/endpoints-spi/src/main/java/software/amazon/awssdk/endpoints/Endpoint.java
+++ b/core/endpoints-spi/src/main/java/software/amazon/awssdk/endpoints/Endpoint.java
@@ -28,18 +28,34 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  */
 @SdkPublicApi
 public final class Endpoint {
-    private final URI url;
+    private final EndpointUrl endpointUrl;
     private final Map<String, List<String>> headers;
     private final Map<EndpointAttributeKey<?>, Object> attributes;
 
     private Endpoint(BuilderImpl b) {
-        this.url = b.url;
+        this.endpointUrl = b.endpointUrl;
         this.headers = b.headers;
         this.attributes = b.attributes;
     }
 
+    /**
+     * Returns the URI.
+     * Delegates to {@link EndpointUrl#toUri()} which lazily constructs the URI.
+     *
+     * @deprecated Use {@link #endpointUrl()} instead, which provides direct access to URL components
+     *             without the overhead of constructing a {@link URI}.
+     */
+    @Deprecated
     public URI url() {
-        return url;
+        return endpointUrl.toUri();
+    }
+
+    /**
+     * Returns the {@link EndpointUrl} for efficient access to URL components
+     * without URI construction overhead.
+     */
+    public EndpointUrl endpointUrl() {
+        return endpointUrl;
     }
 
     public Map<String, List<String>> headers() {
@@ -66,7 +82,11 @@ public final class Endpoint {
 
         Endpoint endpoint = (Endpoint) o;
 
-        if (url != null ? !url.equals(endpoint.url) : endpoint.url != null) {
+        // ensures Endpoints built via url(URI) and
+        // endpointUrl(EndpointUrl) are equal when the URLs are equivalent (e.g., IPv6 bracket differences).
+        URI thisUrl = endpointUrl != null ? endpointUrl.toUri() : null;
+        URI thatUrl = endpoint.endpointUrl != null ? endpoint.endpointUrl.toUri() : null;
+        if (thisUrl != null ? !thisUrl.equals(thatUrl) : thatUrl != null) {
             return false;
         }
         if (headers != null ? !headers.equals(endpoint.headers) : endpoint.headers != null) {
@@ -77,7 +97,9 @@ public final class Endpoint {
 
     @Override
     public int hashCode() {
-        int result = url != null ? url.hashCode() : 0;
+        // Use toUri() for consistency with equals()
+        URI uri = endpointUrl != null ? endpointUrl.toUri() : null;
+        int result = uri != null ? uri.hashCode() : 0;
         result = 31 * result + (headers != null ? headers.hashCode() : 0);
         result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
         return result;
@@ -88,7 +110,23 @@ public final class Endpoint {
     }
 
     public interface Builder {
+        /**
+         * Sets the endpoint URL from a {@link URI}.
+         * Internally converts to an {@link EndpointUrl} via {@link EndpointUrl#fromUri(URI)}.
+         *
+         * @deprecated Use {@link #endpointUrl(EndpointUrl)} instead.
+         */
+        @Deprecated
         Builder url(URI url);
+
+        /**
+         * Sets the endpoint URL from an {@link EndpointUrl} directly.
+         * This is the preferred path for code that already has an {@code EndpointUrl}
+         * (e.g., generated endpoint providers).
+         */
+        default Builder endpointUrl(EndpointUrl endpointUrl) {
+            throw new UnsupportedOperationException();
+        }
 
         Builder putHeader(String name, String value);
 
@@ -98,7 +136,7 @@ public final class Endpoint {
     }
 
     private static class BuilderImpl implements Builder {
-        private URI url;
+        private EndpointUrl endpointUrl;
         private final Map<String, List<String>> headers = new HashMap<>();
         private final Map<EndpointAttributeKey<?>, Object> attributes = new HashMap<>();
 
@@ -106,7 +144,7 @@ public final class Endpoint {
         }
 
         private BuilderImpl(Endpoint e) {
-            this.url = e.url;
+            this.endpointUrl = e.endpointUrl;
             if (e.headers != null) {
                 e.headers.forEach((n, v) -> {
                     this.headers.put(n, new ArrayList<>(v));
@@ -115,9 +153,16 @@ public final class Endpoint {
             this.attributes.putAll(e.attributes);
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public Builder url(URI url) {
-            this.url = url;
+            this.endpointUrl = EndpointUrl.fromUri(url);
+            return this;
+        }
+
+        @Override
+        public Builder endpointUrl(EndpointUrl endpointUrl) {
+            this.endpointUrl = endpointUrl;
             return this;
         }
 

--- a/core/endpoints-spi/src/main/java/software/amazon/awssdk/endpoints/EndpointUrl.java
+++ b/core/endpoints-spi/src/main/java/software/amazon/awssdk/endpoints/EndpointUrl.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.endpoints;
+
+import java.net.URI;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * A lightweight, immutable representation of a resolved endpoint URL that stores pre-parsed components
+ * (scheme, host, port, path) as strings, avoiding the cost of {@link URI} construction.
+ *
+ * <p>Three factory methods are provided:
+ * <ul>
+ *   <li>{@link #fromString(String)} — parses a URL string using simple string operations (no URI construction)</li>
+ *   <li>{@link #fromComponents(String, String, int, String)} — creates from individual components (no query/fragment)</li>
+ *   <li>{@link #fromUri(URI)} — creates from an existing URI (pre-populates the cached URI field, preserves
+ *       query and fragment)</li>
+ * </ul>
+ */
+@SdkPublicApi
+public final class EndpointUrl {
+
+    private final String scheme;
+    private final String host;
+    private final int port;
+    private final String encodedPath;
+    private final String queryAndFragment;
+    private final String rawUrl;
+
+    // Inline lazy URI — avoids dependency on utils module's Lazy<T>.
+    // Uses double-checked locking.
+    private volatile URI uri;
+
+    private EndpointUrl(String scheme, String host, int port, String encodedPath,
+                        String queryAndFragment, String rawUrl, URI uri) {
+        this.scheme = scheme;
+        this.host = host;
+        this.port = port;
+        this.encodedPath = encodedPath;
+        this.queryAndFragment = queryAndFragment;
+        this.rawUrl = rawUrl;
+        this.uri = uri;
+    }
+
+    /**
+     * Parse a URL string into its components without constructing a {@link URI}.
+     *
+     * <p>Performs minimal string splitting only — no validation beyond checking for the {@code ://} separator.
+     * The original URL string is retained for faithful URI reconstruction via {@link #toUri()}. Path, query and fragment
+     * components (if present) MUST already be url encoded.
+     *
+     * <p>Expected format: {@code scheme://host[:port][/encodedPath][?query][#fragment]}
+     *
+     * @param url the URL string to parse
+     * @return a new {@code EndpointUrl} with pre-parsed components
+     * @throws IllegalArgumentException if the URL does not contain {@code ://}
+     */
+    public static EndpointUrl fromString(String url) {
+        int schemeEnd = url.indexOf("://");
+        if (schemeEnd < 0) {
+            throw new IllegalArgumentException("Invalid URL: missing '://' separator: " + url);
+        }
+
+        String scheme = url.substring(0, schemeEnd);
+        int authorityStart = schemeEnd + 3;
+
+        // Find where authority ends: first '/', '?', or '#' after authority start, or end of string.
+        // RFC 3986: authority is terminated by '/', '?', '#', or end of URI.
+        int pathStart = -1;
+        int len = url.length();
+        for (int i = authorityStart; i < len; i++) {
+            char c = url.charAt(i);
+            if (c == '/' || c == '?' || c == '#') {
+                pathStart = i;
+                break;
+            }
+        }
+
+        String authority;
+        String pathAndRest;
+        if (pathStart < 0) {
+            authority = url.substring(authorityStart);
+            pathAndRest = "";
+        } else {
+            authority = url.substring(authorityStart, pathStart);
+            pathAndRest = url.substring(pathStart);
+        }
+
+        // Separate path from query/fragment
+        String encodedPath;
+        String queryAndFragment;
+        int queryStart = pathAndRest.indexOf('?');
+        int fragmentStart = pathAndRest.indexOf('#');
+        int separatorPos = -1;
+        if (queryStart >= 0 && fragmentStart >= 0) {
+            separatorPos = Math.min(queryStart, fragmentStart);
+        } else if (queryStart >= 0) {
+            separatorPos = queryStart;
+        } else if (fragmentStart >= 0) {
+            separatorPos = fragmentStart;
+        }
+
+        if (separatorPos >= 0) {
+            encodedPath = pathAndRest.substring(0, separatorPos);
+            queryAndFragment = pathAndRest.substring(separatorPos);
+        } else {
+            encodedPath = pathAndRest;
+            queryAndFragment = "";
+        }
+
+        // Split authority into host and optional port, handling IPv6 addresses
+        String host;
+        int port;
+        if (!authority.isEmpty() && authority.charAt(0) == '[') {
+            // IPv6: [::1]:8080
+            int bracketEnd = authority.indexOf(']');
+            host = authority.substring(0, bracketEnd + 1);
+            if (bracketEnd + 1 < authority.length() && authority.charAt(bracketEnd + 1) == ':') {
+                port = Integer.parseInt(authority.substring(bracketEnd + 2));
+            } else {
+                port = -1;
+            }
+        } else {
+            int colonPos = authority.lastIndexOf(':');
+            if (colonPos < 0) {
+                host = authority;
+                port = -1;
+            } else {
+                host = authority.substring(0, colonPos);
+                port = Integer.parseInt(authority.substring(colonPos + 1));
+            }
+        }
+
+        return new EndpointUrl(scheme, host, port, encodedPath, queryAndFragment, url, null);
+    }
+
+    /**
+     * Create an {@code EndpointUrl} from individual components.
+     *
+     * <p>Used internally (e.g., by {@code addHostPrefix} and codegen) to avoid re-parsing.
+     * The {@code rawUrl} field is {@code null} in this case, so {@link #toUri()} reconstructs
+     * the URI from components. No query or fragment is included.
+     *
+     * @param scheme      the URL scheme (e.g., "https")
+     * @param host        the hostname (e.g., "s3.us-east-1.amazonaws.com")
+     * @param port        the port number, or -1 if not specified
+     * @param encodedPath the encoded path (e.g., "/bucket/key"), or empty string if no path
+     * @return a new {@code EndpointUrl}
+     */
+    public static EndpointUrl fromComponents(String scheme, String host, int port, String encodedPath) {
+        return new EndpointUrl(scheme, host, port, encodedPath, "", null, null);
+    }
+
+    /**
+     * Create an {@code EndpointUrl} from individual components, including query and fragment.
+     *
+     * <p>This overload is used when reconstructing an EndpointUrl with modifications (e.g., host prefix)
+     * while preserving the original query and fragment components.
+     *
+     * @param scheme            the URL scheme (e.g., "https")
+     * @param host              the hostname (e.g., "s3.us-east-1.amazonaws.com")
+     * @param port              the port number, or -1 if not specified
+     * @param encodedPath       the encoded path (e.g., "/bucket/key"), or empty string if no path
+     * @param queryAndFragment  the query and fragment string (e.g., "?key=value#section"), or empty string if none
+     * @return a new {@code EndpointUrl}
+     */
+    public static EndpointUrl fromComponents(String scheme, String host, int port, String encodedPath,
+                                             String queryAndFragment) {
+        return new EndpointUrl(scheme, host, port, encodedPath, queryAndFragment, null, null);
+    }
+
+    /**
+     * Create an {@code EndpointUrl} from an existing {@link URI}.
+     *
+     * <p>The URI field is pre-populated, so {@link #toUri()}
+     * returns the original URI instance without any additional construction.
+     *
+     * @param uri the URI to create from
+     * @return a new {@code EndpointUrl} with components extracted from the URI
+     */
+    public static EndpointUrl fromUri(URI uri) {
+        String rawPath = uri.getRawPath();
+        String queryAndFragment = buildQueryAndFragment(uri);
+        return new EndpointUrl(
+            uri.getScheme(),
+            uri.getHost(),
+            uri.getPort(),
+            rawPath != null ? rawPath : "",
+            queryAndFragment,
+            null,
+            uri
+        );
+    }
+
+    /**
+     * Returns the URL scheme (e.g., "https").
+     */
+    public String scheme() {
+        return scheme;
+    }
+
+    /**
+     * Returns the hostname (e.g., "s3.us-east-1.amazonaws.com").
+     */
+    public String host() {
+        return host;
+    }
+
+    /**
+     * Returns the port number, or -1 if not explicitly specified.
+     */
+    public int port() {
+        return port;
+    }
+
+    /**
+     * Returns the encoded path (e.g., "/bucket/key"), or an empty string if no path is present.
+     */
+    public String encodedPath() {
+        return encodedPath;
+    }
+
+    /**
+     * Returns the query and fragment portion of the URL (e.g., {@code "?key=value#section"}),
+     * or an empty string if neither is present.
+     */
+    public String queryAndFragment() {
+        return queryAndFragment;
+    }
+
+    /**
+     * Returns the {@link URI} representation. Lazily constructed on first call using double-checked locking.
+     *
+     * <p>When created via {@link #fromString(String)}, uses the original URL string for faithful reconstruction.
+     * When created via {@link #fromComponents(String, String, int, String)}  reconstructs from components (no query/fragment).
+     * When created via {@link #fromUri(URI)}, returns the original URI instance.
+     *
+     * @return the URI representation of this endpoint URL
+     */
+    public URI toUri() {
+        URI result = uri;
+        if (result == null) {
+            synchronized (this) {
+                result = uri;
+                if (result == null) {
+                    if (rawUrl != null) {
+                        result = URI.create(rawUrl);
+                    } else {
+                        StringBuilder sb = new StringBuilder();
+                        sb.append(scheme).append("://").append(host);
+                        if (port >= 0) {
+                            sb.append(':').append(port);
+                        }
+                        sb.append(encodedPath);
+                        sb.append(queryAndFragment);
+                        result = URI.create(sb.toString());
+                    }
+                    uri = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EndpointUrl that = (EndpointUrl) o;
+
+        if (port != that.port) {
+            return false;
+        }
+        if (scheme != null ? !scheme.equals(that.scheme) : that.scheme != null) {
+            return false;
+        }
+        if (host != null ? !host.equals(that.host) : that.host != null) {
+            return false;
+        }
+        if (encodedPath != null ? !encodedPath.equals(that.encodedPath) : that.encodedPath != null) {
+            return false;
+        }
+        return queryAndFragment.equals(that.queryAndFragment);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = scheme != null ? scheme.hashCode() : 0;
+        result = 31 * result + (host != null ? host.hashCode() : 0);
+        result = 31 * result + port;
+        result = 31 * result + (encodedPath != null ? encodedPath.hashCode() : 0);
+        result = 31 * result + queryAndFragment.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "EndpointUrl("
+               + "scheme=" + scheme
+               + ", host=" + host
+               + ", port=" + port
+               + ", encodedPath=" + encodedPath
+               + ", queryAndFragment=" + queryAndFragment
+               + ")";
+    }
+
+    /**
+     * Build the query and fragment string from a URI, or return empty string if neither is present.
+     */
+    private static String buildQueryAndFragment(URI uri) {
+        String rawQuery = uri.getRawQuery();
+        String rawFragment = uri.getRawFragment();
+        if (rawQuery == null && rawFragment == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        if (rawQuery != null) {
+            sb.append('?').append(rawQuery);
+        }
+        if (rawFragment != null) {
+            sb.append('#').append(rawFragment);
+        }
+        return sb.toString();
+    }
+}

--- a/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointTest.java
+++ b/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointTest.java
@@ -88,4 +88,53 @@ public class EndpointTest {
 
         assertThat(original.attribute(TEST_STRING_ATTR)).isEqualTo("foo");
     }
+
+    // -----------------------------------------------------------------------
+    // Equality tests across construction paths (url(URI) vs endpointUrl(EndpointUrl))
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void equality_acrossConstructionPaths() {
+        URI uri = URI.create("https://[::1]:8080/path?key=value#frag");
+
+        Endpoint viaUri = Endpoint.builder().url(uri).build();
+        Endpoint viaFromString = Endpoint.builder()
+                                         .endpointUrl(EndpointUrl.fromString("https://[::1]:8080/path?key=value#frag"))
+                                         .build();
+        Endpoint viaFromComponents = Endpoint.builder()
+                                             .endpointUrl(EndpointUrl.fromComponents("https", "[::1]", 8080, "/path",
+                                                                                     "?key=value#frag"))
+                                             .build();
+
+        assertThat(viaUri).isEqualTo(viaFromString);
+        assertThat(viaUri).isEqualTo(viaFromComponents);
+        assertThat(viaUri.hashCode()).isEqualTo(viaFromString.hashCode());
+        assertThat(viaUri.hashCode()).isEqualTo(viaFromComponents.hashCode());
+    }
+
+    @Test
+    public void inequality_differentUrlComponents() {
+        Endpoint endpoint1 = Endpoint.builder()
+                                     .endpointUrl(EndpointUrl.fromString("https://example.com/path?key=value"))
+                                     .build();
+        Endpoint endpoint2 = Endpoint.builder()
+                                     .endpointUrl(EndpointUrl.fromString("https://example.com/path"))
+                                     .build();
+
+        assertThat(endpoint1).isNotEqualTo(endpoint2);
+    }
+
+    @Test
+    public void endpointUrlAccessor_returnsCorrectComponents() {
+        Endpoint endpoint = Endpoint.builder()
+                                    .url(URI.create("https://s3.us-east-1.amazonaws.com:443/bucket"))
+                                    .build();
+
+        EndpointUrl endpointUrl = endpoint.endpointUrl();
+        assertThat(endpointUrl.scheme()).isEqualTo("https");
+        assertThat(endpointUrl.host()).isEqualTo("s3.us-east-1.amazonaws.com");
+        assertThat(endpointUrl.port()).isEqualTo(443);
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/bucket");
+        assertThat(endpointUrl.queryAndFragment()).isEmpty();
+    }
 }

--- a/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointTest.java
+++ b/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointTest.java
@@ -89,10 +89,6 @@ public class EndpointTest {
         assertThat(original.attribute(TEST_STRING_ATTR)).isEqualTo("foo");
     }
 
-    // -----------------------------------------------------------------------
-    // Equality tests across construction paths (url(URI) vs endpointUrl(EndpointUrl))
-    // -----------------------------------------------------------------------
-
     @Test
     public void equality_acrossConstructionPaths() {
         URI uri = URI.create("https://[::1]:8080/path?key=value#frag");

--- a/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointUrlTest.java
+++ b/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointUrlTest.java
@@ -97,13 +97,13 @@ public class EndpointUrlTest {
 
     @ParameterizedTest
     @MethodSource("urls")
-    void parseToUriRoundTrip(String url) {
+    void fromStringToUriRoundTrip(String url) {
         assertThat(EndpointUrl.fromString(url).toUri()).isEqualTo(URI.create(url));
     }
 
     @ParameterizedTest
     @MethodSource("urls")
-    void toUriCaching_parse(String url) {
+    void toUriCaching_fromString(String url) {
         EndpointUrl endpointUrl = EndpointUrl.fromString(url);
         URI first = endpointUrl.toUri();
         URI second = endpointUrl.toUri();
@@ -111,7 +111,7 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void toUriCaching_of() {
+    void toUriCaching_fromComponents() {
         EndpointUrl endpointUrl = EndpointUrl.fromComponents("https", "s3.us-east-1.amazonaws.com", -1, "");
         URI first = endpointUrl.toUri();
         URI second = endpointUrl.toUri();
@@ -153,19 +153,19 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_noPath_encodedPathIsEmpty() {
+    void fromString_noPath_encodedPathIsEmpty() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://dynamodb.us-west-2.amazonaws.com");
         assertThat(endpointUrl.encodedPath()).isEmpty();
     }
 
     @Test
-    void parse_trailingSlash_encodedPathIsSlash() {
+    void fromString_trailingSlash_encodedPathIsSlash() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://s3.amazonaws.com/");
         assertThat(endpointUrl.encodedPath()).isEqualTo("/");
     }
 
     @Test
-    void parse_ipv6WithPort() {
+    void fromString_ipv6WithPort() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://[::1]:8080/path");
         assertThat(endpointUrl.host()).isEqualTo("[::1]");
         assertThat(endpointUrl.port()).isEqualTo(8080);
@@ -173,7 +173,7 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_ipv6WithoutPort() {
+    void fromString_ipv6WithoutPort() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://[::1]/path");
         assertThat(endpointUrl.host()).isEqualTo("[::1]");
         assertThat(endpointUrl.port()).isEqualTo(-1);
@@ -181,7 +181,7 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_explicitPort() {
+    void fromString_explicitPort() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://localhost:8080/path");
         assertThat(endpointUrl.scheme()).isEqualTo("https");
         assertThat(endpointUrl.host()).isEqualTo("localhost");
@@ -190,7 +190,7 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_noPort() {
+    void fromString_noPort() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://s3.us-east-1.amazonaws.com");
         assertThat(endpointUrl.port()).isEqualTo(-1);
     }
@@ -246,7 +246,7 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_withQueryOnly() {
+    void fromString_withQueryOnly() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path?key=value&foo=bar");
         assertThat(endpointUrl.scheme()).isEqualTo("https");
         assertThat(endpointUrl.host()).isEqualTo("example.com");
@@ -256,7 +256,7 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_withFragmentOnly() {
+    void fromString_withFragmentOnly() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path#section");
         assertThat(endpointUrl.scheme()).isEqualTo("https");
         assertThat(endpointUrl.host()).isEqualTo("example.com");
@@ -265,20 +265,20 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_withQueryAndFragment() {
+    void fromString_withQueryAndFragment() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path?key=value#section");
         assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
         assertThat(endpointUrl.queryAndFragment()).isEqualTo("?key=value#section");
     }
 
     @Test
-    void parse_noQueryOrFragment() {
+    void fromString_noQueryOrFragment() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path");
         assertThat(endpointUrl.queryAndFragment()).isEmpty();
     }
 
     @Test
-    void parse_queryWithNoPath() {
+    void fromString_queryWithNoPath() {
         EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com?key=value");
         assertThat(endpointUrl.host()).isEqualTo("example.com");
         assertThat(endpointUrl.encodedPath()).isEmpty();
@@ -286,7 +286,7 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void parse_withQueryAndFragment_toUriRoundTrip() {
+    void fromString_withQueryAndFragment_toUriRoundTrip() {
         String url = "https://example.com/path?key=value#section";
         EndpointUrl endpointUrl = EndpointUrl.fromString(url);
         assertThat(endpointUrl.toUri()).isEqualTo(URI.create(url));
@@ -311,20 +311,20 @@ public class EndpointUrlTest {
     }
 
     @Test
-    void of_withQueryAndFragment_toUriIncludesThem() {
+    void fromComponents_withQueryAndFragment_toUriIncludesThem() {
         EndpointUrl endpointUrl = EndpointUrl.fromComponents("https", "example.com", -1, "/path", "?key=value#section");
         assertThat(endpointUrl.toUri()).isEqualTo(URI.create("https://example.com/path?key=value#section"));
     }
 
     @Test
-    void of_withQueryAndFragment_preservedInEquality() {
+    void fromComponents_withQueryAndFragment_preservedInEquality() {
         EndpointUrl with = EndpointUrl.fromComponents("https", "example.com", -1, "/path", "?key=value");
         EndpointUrl without = EndpointUrl.fromComponents("https", "example.com", -1, "/path");
         assertThat(with).isNotEqualTo(without);
     }
 
     @Test
-    void of_withEmptyQueryAndFragment_equalsOfWithoutIt() {
+    void fromComponents_withEmptyQueryAndFragment_equalsOfWithoutIt() {
         EndpointUrl withEmpty = EndpointUrl.fromComponents("https", "example.com", -1, "/path", "");
         EndpointUrl without = EndpointUrl.fromComponents("https", "example.com", -1, "/path");
         assertThat(withEmpty).isEqualTo(without);

--- a/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointUrlTest.java
+++ b/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointUrlTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.endpoints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link EndpointUrl}.
+ */
+public class EndpointUrlTest {
+
+    /**
+     * Representative AWS URLs used across parameterized tests.
+     */
+    static List<String> urls() {
+        return Arrays.asList(
+            "https://s3.us-east-1.amazonaws.com",
+            "https://s3.us-east-1.amazonaws.com/bucket/key",
+            "https://localhost:8080/path",
+            "https://s3.amazonaws.com/",
+            "https://[::1]:8080/path",
+            "https://dynamodb.us-west-2.amazonaws.com"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("urls")
+    void componentFidelity_scheme(String url) {
+        EndpointUrl endpointUrl = EndpointUrl.fromString(url);
+        URI uri = URI.create(url);
+        assertThat(endpointUrl.scheme()).isEqualTo(uri.getScheme());
+    }
+
+    /**
+     * Non-IPv6 URLs for host fidelity comparison against {@code URI.getHost()}.
+     *
+     * <p>IPv6 is excluded because {@code EndpointUrl.fromString()} always stores the host WITH brackets
+     * (e.g., "[::1]"), while {@code URI.getHost()} behavior for IPv6 varies across JDK versions
+     * (Java 8 strips brackets, Java 17+ keeps them). IPv6 host parsing is verified directly
+     * in the dedicated edge-case tests below.</p>
+     */
+    static List<String> nonIpv6Urls() {
+        return Arrays.asList(
+            "https://s3.us-east-1.amazonaws.com",
+            "https://s3.us-east-1.amazonaws.com/bucket/key",
+            "https://localhost:8080/path",
+            "https://s3.amazonaws.com/",
+            "https://dynamodb.us-west-2.amazonaws.com"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonIpv6Urls")
+    void componentFidelity_host(String url) {
+        EndpointUrl endpointUrl = EndpointUrl.fromString(url);
+        URI uri = URI.create(url);
+        assertThat(endpointUrl.host()).isEqualTo(uri.getHost());
+    }
+
+    @ParameterizedTest
+    @MethodSource("urls")
+    void componentFidelity_port(String url) {
+        EndpointUrl endpointUrl = EndpointUrl.fromString(url);
+        URI uri = URI.create(url);
+        assertThat(endpointUrl.port()).isEqualTo(uri.getPort());
+    }
+
+    @ParameterizedTest
+    @MethodSource("urls")
+    void componentFidelity_encodedPath(String url) {
+        EndpointUrl endpointUrl = EndpointUrl.fromString(url);
+        URI uri = URI.create(url);
+        String expectedPath = uri.getRawPath() != null ? uri.getRawPath() : "";
+        assertThat(endpointUrl.encodedPath()).isEqualTo(expectedPath);
+    }
+
+    @ParameterizedTest
+    @MethodSource("urls")
+    void parseToUriRoundTrip(String url) {
+        assertThat(EndpointUrl.fromString(url).toUri()).isEqualTo(URI.create(url));
+    }
+
+    @ParameterizedTest
+    @MethodSource("urls")
+    void toUriCaching_parse(String url) {
+        EndpointUrl endpointUrl = EndpointUrl.fromString(url);
+        URI first = endpointUrl.toUri();
+        URI second = endpointUrl.toUri();
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    void toUriCaching_of() {
+        EndpointUrl endpointUrl = EndpointUrl.fromComponents("https", "s3.us-east-1.amazonaws.com", -1, "");
+        URI first = endpointUrl.toUri();
+        URI second = endpointUrl.toUri();
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    void toUriCaching_fromUri() {
+        URI original = URI.create("https://s3.us-east-1.amazonaws.com");
+        EndpointUrl endpointUrl = EndpointUrl.fromUri(original);
+        URI first = endpointUrl.toUri();
+        URI second = endpointUrl.toUri();
+        assertThat(first).isSameAs(second);
+    }
+
+    @ParameterizedTest
+    @MethodSource("urls")
+    void fromUriRoundTripIdentity(String url) {
+        URI original = URI.create(url);
+        assertThat(EndpointUrl.fromUri(original).toUri()).isSameAs(original);
+    }
+
+    @Test
+    void malformedUrl_noSchemeSeparator() {
+        assertThatThrownBy(() -> EndpointUrl.fromString("not-a-url"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void malformedUrl_emptyString() {
+        assertThatThrownBy(() -> EndpointUrl.fromString(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void malformedUrl_singleColon() {
+        assertThatThrownBy(() -> EndpointUrl.fromString("https:host"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void parse_noPath_encodedPathIsEmpty() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://dynamodb.us-west-2.amazonaws.com");
+        assertThat(endpointUrl.encodedPath()).isEmpty();
+    }
+
+    @Test
+    void parse_trailingSlash_encodedPathIsSlash() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://s3.amazonaws.com/");
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/");
+    }
+
+    @Test
+    void parse_ipv6WithPort() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://[::1]:8080/path");
+        assertThat(endpointUrl.host()).isEqualTo("[::1]");
+        assertThat(endpointUrl.port()).isEqualTo(8080);
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
+    }
+
+    @Test
+    void parse_ipv6WithoutPort() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://[::1]/path");
+        assertThat(endpointUrl.host()).isEqualTo("[::1]");
+        assertThat(endpointUrl.port()).isEqualTo(-1);
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
+    }
+
+    @Test
+    void parse_explicitPort() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://localhost:8080/path");
+        assertThat(endpointUrl.scheme()).isEqualTo("https");
+        assertThat(endpointUrl.host()).isEqualTo("localhost");
+        assertThat(endpointUrl.port()).isEqualTo(8080);
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
+    }
+
+    @Test
+    void parse_noPort() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://s3.us-east-1.amazonaws.com");
+        assertThat(endpointUrl.port()).isEqualTo(-1);
+    }
+
+    static List<String> preParsedEquivalenceUrls() {
+        return Arrays.asList(
+            // Simple URL (no port, no path)
+            "https://s3.us-east-1.amazonaws.com",
+            // URL with port only
+            "https://runtime.sagemaker.us-east-1.amazonaws.com:8443",
+            // URL with path only
+            "https://places.geo.us-east-1.amazonaws.com/v2",
+            // URL with both port and path
+            "https://localhost:8443/v2/api",
+            // URL with trailing slash
+            "https://s3.amazonaws.com/",
+            // HTTP scheme with port and path
+            "http://localhost:8080/path",
+            // URL with deeper path
+            "https://s3.us-west-2.amazonaws.com/prefix/key"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("preParsedEquivalenceUrls")
+    void preParsedEquivalence_components(String url) {
+        EndpointUrl parsed = EndpointUrl.fromString(url);
+        EndpointUrl constructed = EndpointUrl.fromComponents(parsed.scheme(), parsed.host(), parsed.port(), parsed.encodedPath());
+
+        assertThat(constructed.scheme()).isEqualTo(parsed.scheme());
+        assertThat(constructed.host()).isEqualTo(parsed.host());
+        assertThat(constructed.port()).isEqualTo(parsed.port());
+        assertThat(constructed.encodedPath()).isEqualTo(parsed.encodedPath());
+    }
+
+    @ParameterizedTest
+    @MethodSource("preParsedEquivalenceUrls")
+    void preParsedEquivalence_toUri(String url) {
+        EndpointUrl parsed = EndpointUrl.fromString(url);
+        EndpointUrl constructed = EndpointUrl.fromComponents(parsed.scheme(), parsed.host(), parsed.port(), parsed.encodedPath());
+
+        assertThat(constructed.toUri()).isEqualTo(parsed.toUri());
+    }
+
+    @ParameterizedTest
+    @MethodSource("preParsedEquivalenceUrls")
+    void preParsedEquivalence_objectEquality(String url) {
+        EndpointUrl parsed = EndpointUrl.fromString(url);
+        EndpointUrl constructed = EndpointUrl.fromComponents(parsed.scheme(), parsed.host(), parsed.port(), parsed.encodedPath());
+
+        assertThat(constructed).isEqualTo(parsed);
+        assertThat(constructed.hashCode()).isEqualTo(parsed.hashCode());
+    }
+
+    @Test
+    void parse_withQueryOnly() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path?key=value&foo=bar");
+        assertThat(endpointUrl.scheme()).isEqualTo("https");
+        assertThat(endpointUrl.host()).isEqualTo("example.com");
+        assertThat(endpointUrl.port()).isEqualTo(-1);
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
+        assertThat(endpointUrl.queryAndFragment()).isEqualTo("?key=value&foo=bar");
+    }
+
+    @Test
+    void parse_withFragmentOnly() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path#section");
+        assertThat(endpointUrl.scheme()).isEqualTo("https");
+        assertThat(endpointUrl.host()).isEqualTo("example.com");
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
+        assertThat(endpointUrl.queryAndFragment()).isEqualTo("#section");
+    }
+
+    @Test
+    void parse_withQueryAndFragment() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path?key=value#section");
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
+        assertThat(endpointUrl.queryAndFragment()).isEqualTo("?key=value#section");
+    }
+
+    @Test
+    void parse_noQueryOrFragment() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com/path");
+        assertThat(endpointUrl.queryAndFragment()).isEmpty();
+    }
+
+    @Test
+    void parse_queryWithNoPath() {
+        EndpointUrl endpointUrl = EndpointUrl.fromString("https://example.com?key=value");
+        assertThat(endpointUrl.host()).isEqualTo("example.com");
+        assertThat(endpointUrl.encodedPath()).isEmpty();
+        assertThat(endpointUrl.queryAndFragment()).isEqualTo("?key=value");
+    }
+
+    @Test
+    void parse_withQueryAndFragment_toUriRoundTrip() {
+        String url = "https://example.com/path?key=value#section";
+        EndpointUrl endpointUrl = EndpointUrl.fromString(url);
+        assertThat(endpointUrl.toUri()).isEqualTo(URI.create(url));
+    }
+
+    @Test
+    void fromUri_withQueryAndFragment_preservesComponents() {
+        URI uri = URI.create("https://example.com/path?key=value#section");
+        EndpointUrl endpointUrl = EndpointUrl.fromUri(uri);
+        assertThat(endpointUrl.scheme()).isEqualTo("https");
+        assertThat(endpointUrl.host()).isEqualTo("example.com");
+        assertThat(endpointUrl.encodedPath()).isEqualTo("/path");
+        assertThat(endpointUrl.queryAndFragment()).isEqualTo("?key=value#section");
+        assertThat(endpointUrl.toUri()).isSameAs(uri);
+    }
+
+    @Test
+    void fromUri_noQueryOrFragment() {
+        URI uri = URI.create("https://example.com/path");
+        EndpointUrl endpointUrl = EndpointUrl.fromUri(uri);
+        assertThat(endpointUrl.queryAndFragment()).isEmpty();
+    }
+
+    @Test
+    void of_withQueryAndFragment_toUriIncludesThem() {
+        EndpointUrl endpointUrl = EndpointUrl.fromComponents("https", "example.com", -1, "/path", "?key=value#section");
+        assertThat(endpointUrl.toUri()).isEqualTo(URI.create("https://example.com/path?key=value#section"));
+    }
+
+    @Test
+    void of_withQueryAndFragment_preservedInEquality() {
+        EndpointUrl with = EndpointUrl.fromComponents("https", "example.com", -1, "/path", "?key=value");
+        EndpointUrl without = EndpointUrl.fromComponents("https", "example.com", -1, "/path");
+        assertThat(with).isNotEqualTo(without);
+    }
+
+    @Test
+    void of_withEmptyQueryAndFragment_equalsOfWithoutIt() {
+        EndpointUrl withEmpty = EndpointUrl.fromComponents("https", "example.com", -1, "/path", "");
+        EndpointUrl without = EndpointUrl.fromComponents("https", "example.com", -1, "/path");
+        assertThat(withEmpty).isEqualTo(without);
+    }
+}


### PR DESCRIPTION
This is PR 1/4 for replacing URI.create with the lightweight EndpointUrl class.

**Note: This PR merges to feature/master/endpoint-remove-uri and NOT to master**


## Modifications
Introduce EndpointUrl, a lightweight immutable URL representation that stores pre-parsed components (scheme, host, port, path) as strings, avoiding the cost of URI.create() on the endpoint resolution hot path. Modify Endpoint to store EndpointUrl internally instead of URI. The public API is fully preserved: url() still returns URI via lazy construction, and the builder still accepts URI via fromUri(). A new endpointUrl() accessor and Builder.endpointUrl() method are added for internal consumers that can work directly with the components.

## Testing
New and existing unit tests.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
