### PR TITLE
[EndpointUri PR 2/4] Switch runtime consumers to EndpointUrl

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoints/AwsEndpointProviderUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoints/AwsEndpointProviderUtils.java
@@ -128,7 +128,11 @@ public final class AwsEndpointProviderUtils {
      * However, we also pass the endpoint to provider as a parameter, and the resolver returns
      * {@code https://example.com/a/b}. This method takes care of combining the paths correctly so that the resulting
      * path is {@code https://example.com/a/b/c}.
+     *
+     * @deprecated Use {@link #setUri(SdkHttpRequest, URI, EndpointUrl)} instead for better performance by avoiding
+     *             intermediate URI construction.
      */
+    @Deprecated
     public static SdkHttpRequest setUri(SdkHttpRequest request, URI clientEndpoint, URI resolvedUri) {
         String clientEndpointPath = clientEndpoint.getRawPath();
         String requestPath = request.encodedPath();
@@ -140,6 +144,33 @@ public final class AwsEndpointProviderUtils {
         }
 
         return request.toBuilder().protocol(resolvedUri.getScheme()).host(resolvedUri.getHost()).port(resolvedUri.getPort())
+                .encodedPath(finalPath).build();
+    }
+
+    /**
+     * Sets the request URI to the resolved endpoint URL returned by the endpoint provider, reading URL components
+     * directly from the {@link EndpointUrl} without constructing an intermediate {@link URI}.
+     * <p>
+     * This overload has the same behavior as {@link #setUri(SdkHttpRequest, URI, URI)} but avoids the cost of
+     * {@link URI} construction, making it suitable for presigners and other code paths that resolve endpoints outside
+     * the main pipeline.
+     *
+     * @param request        the current HTTP request
+     * @param clientEndpoint the endpoint configured on the client (may include a path prefix from endpoint override)
+     * @param resolvedUrl    the resolved endpoint URL from the rules engine
+     * @return a new {@link SdkHttpRequest} with scheme, host, port, and path applied from the resolved URL
+     */
+    public static SdkHttpRequest setUri(SdkHttpRequest request, URI clientEndpoint, EndpointUrl resolvedUrl) {
+        String clientEndpointPath = clientEndpoint.getRawPath();
+        String requestPath = request.encodedPath();
+        String resolvedUrlPath = resolvedUrl.encodedPath();
+
+        String finalPath = requestPath;
+        if (!resolvedUrlPath.equals(clientEndpointPath)) {
+            finalPath = combinePath(clientEndpointPath, requestPath, resolvedUrlPath);
+        }
+
+        return request.toBuilder().protocol(resolvedUrl.scheme()).host(resolvedUrl.host()).port(resolvedUrl.port())
                 .encodedPath(finalPath).build();
     }
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoints/AwsEndpointProviderUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoints/AwsEndpointProviderUtils.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.HostnameValidator;
@@ -101,11 +102,12 @@ public final class AwsEndpointProviderUtils {
             return endpoint;
         }
         validatePrefixIsHostNameCompliant(prefix);
-        URI originalUrl = endpoint.url();
-        String newHost = prefix + endpoint.url().getHost();
-        URI newUrl = invokeSafely(() -> new URI(originalUrl.getScheme(), null, newHost, originalUrl.getPort(),
-                originalUrl.getPath(), originalUrl.getQuery(), originalUrl.getFragment()));
-        return endpoint.toBuilder().url(newUrl).build();
+
+        EndpointUrl originalUrl = endpoint.endpointUrl();
+        String newHost = prefix + originalUrl.host();
+        EndpointUrl newUrl = EndpointUrl.fromComponents(originalUrl.scheme(), newHost, originalUrl.port(),
+                                                        originalUrl.encodedPath(), originalUrl.queryAndFragment());
+        return endpoint.toBuilder().endpointUrl(newUrl).build();
     }
 
     /**

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/endpoints/AwsEndpointProviderUtilsTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/endpoints/AwsEndpointProviderUtilsTest.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.useragent.BusinessMetricCollection;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.regions.Region;
@@ -215,6 +216,91 @@ class AwsEndpointProviderUtilsTest {
         SdkHttpRequest result = AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUri);
         assertThat(result.host()).isEqualTo("resolved.example.com");
         assertThat(result.encodedPath()).isEqualTo("/operation");
+    }
+
+    @Test
+    void setUri_endpointUrl_combinesPathsCorrectly() {
+        URI clientEndpoint = URI.create("https://override.example.com/a");
+        EndpointUrl resolvedUrl = EndpointUrl.fromString("https://override.example.com/a/b");
+        SdkHttpRequest request = SdkHttpRequest.builder()
+                                               .uri(URI.create("https://override.example.com/a/c"))
+                                               .method(SdkHttpMethod.GET)
+                                               .build();
+
+        assertThat(AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUrl).getUri().toString())
+            .isEqualTo("https://override.example.com/a/b/c");
+    }
+
+    @Test
+    void setUri_endpointUrl_doubleSlash_combinesPathsCorrectly() {
+        URI clientEndpoint = URI.create("https://override.example.com/a");
+        EndpointUrl resolvedUrl = EndpointUrl.fromString("https://override.example.com/a/b");
+        SdkHttpRequest request = SdkHttpRequest.builder()
+                                               .uri(URI.create("https://override.example.com/a//c"))
+                                               .method(SdkHttpMethod.GET)
+                                               .build();
+
+        assertThat(AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUrl).getUri().toString())
+            .isEqualTo("https://override.example.com/a/b//c");
+    }
+
+    @Test
+    void setUri_endpointUrl_withTrailingSlashNoPath_combinesPathsCorrectly() {
+        URI clientEndpoint = URI.create("https://override.example.com/");
+        EndpointUrl resolvedUrl = EndpointUrl.fromString("https://override.example.com/");
+        SdkHttpRequest request = SdkHttpRequest.builder()
+                                               .uri(URI.create("https://override.example.com//a"))
+                                               .method(SdkHttpMethod.GET)
+                                               .build();
+
+        assertThat(AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUrl).getUri().toString())
+            .isEqualTo("https://override.example.com//a");
+    }
+
+    @Test
+    void setUri_endpointUrl_noPathDifference_keepsRequestPath() {
+        URI clientEndpoint = URI.create("https://example.com");
+        EndpointUrl resolvedUrl = EndpointUrl.fromString("https://resolved.example.com");
+        SdkHttpRequest request = SdkHttpRequest.builder()
+                                               .uri(URI.create("https://example.com/operation"))
+                                               .method(SdkHttpMethod.GET)
+                                               .build();
+
+        SdkHttpRequest result = AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUrl);
+        assertThat(result.host()).isEqualTo("resolved.example.com");
+        assertThat(result.encodedPath()).isEqualTo("/operation");
+    }
+
+    @Test
+    void setUri_endpointUrl_withPort_setsPortCorrectly() {
+        URI clientEndpoint = URI.create("https://example.com:8080");
+        EndpointUrl resolvedUrl = EndpointUrl.fromString("https://resolved.example.com:9090/path");
+        SdkHttpRequest request = SdkHttpRequest.builder()
+                                               .uri(URI.create("https://example.com:8080/operation"))
+                                               .method(SdkHttpMethod.GET)
+                                               .build();
+
+        SdkHttpRequest result = AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUrl);
+        assertThat(result.host()).isEqualTo("resolved.example.com");
+        assertThat(result.port()).isEqualTo(9090);
+        assertThat(result.protocol()).isEqualTo("https");
+        assertThat(result.encodedPath()).isEqualTo("/path/operation");
+    }
+
+    @Test
+    void setUri_endpointUrl_producesIdenticalResultToUriOverload() {
+        URI clientEndpoint = URI.create("https://override.example.com/a");
+        URI resolvedUri = URI.create("https://override.example.com/a/b");
+        EndpointUrl resolvedUrl = EndpointUrl.fromUri(resolvedUri);
+        SdkHttpRequest request = SdkHttpRequest.builder()
+                                               .uri(URI.create("https://override.example.com/a/c"))
+                                               .method(SdkHttpMethod.GET)
+                                               .build();
+
+        SdkHttpRequest uriResult = AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUri);
+        SdkHttpRequest endpointUrlResult = AwsEndpointProviderUtils.setUri(request, clientEndpoint, resolvedUrl);
+
+        assertThat(endpointUrlResult.getUri()).isEqualTo(uriResult.getUri());
     }
 
     private static ClientEndpointProvider endpointProvider(boolean isEndpointOverridden) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.MutableRequestToRequestPipeline;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.utils.StringUtils;
@@ -98,10 +99,10 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
         ClientEndpointProvider clientEndpointProvider =
             attrs.getAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER);
         if (interceptorModifiedEndpoint(request, attrs)) {
-            applyResolvedPath(request, clientEndpointProvider.clientEndpoint(), endpoint.url());
+            applyResolvedPath(request, clientEndpointProvider.clientEndpoint(), endpoint.endpointUrl());
             return request;
         }
-        return setUri(request, clientEndpointProvider.clientEndpoint(), endpoint.url());
+        return setUri(request, clientEndpointProvider.clientEndpoint(), endpoint.endpointUrl());
     }
 
     /**
@@ -127,19 +128,19 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
      */
     private static SdkHttpFullRequest.Builder setUri(SdkHttpFullRequest.Builder request,
                                                       URI clientEndpoint,
-                                                      URI resolvedUri) {
-        applyResolvedPath(request, clientEndpoint, resolvedUri);
-        return request.protocol(resolvedUri.getScheme())
-                      .host(resolvedUri.getHost())
-                      .port(resolvedUri.getPort());
+                                                      EndpointUrl resolvedUrl) {
+        applyResolvedPath(request, clientEndpoint, resolvedUrl);
+        return request.protocol(resolvedUrl.scheme())
+                      .host(resolvedUrl.host())
+                      .port(resolvedUrl.port());
     }
 
     private static void applyResolvedPath(SdkHttpFullRequest.Builder request,
                                            URI clientEndpoint,
-                                           URI resolvedUri) {
+                                           EndpointUrl resolvedUrl) {
         String clientEndpointPath = clientEndpoint.getRawPath();
         String requestPath = request.encodedPath();
-        String resolvedUriPath = resolvedUri.getRawPath();
+        String resolvedUriPath = resolvedUrl.encodedPath();
 
         if (!resolvedUriPath.equals(clientEndpointPath)) {
             request.encodedPath(combinePath(clientEndpointPath, requestPath, resolvedUriPath));

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
@@ -273,4 +273,45 @@ class EndpointResolutionStageTest {
         assertThat(result).isSameAs(request);
         assertThat(executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT)).isSameAs(preResolved);
     }
+
+    @Test
+    void execute_resolvedEndpointWithPort_appliesPort() throws Exception {
+        Endpoint endpoint = Endpoint.builder().url(URI.create("https://resolved.amazonaws.com:8443/v2")).build();
+        SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
+                                                                .method(SdkHttpMethod.GET)
+                                                                .protocol("https")
+                                                                .host("myservice.amazonaws.com")
+                                                                .encodedPath("/operation");
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
+                                         ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
+        RequestExecutionContext context = createContext();
+
+        SdkHttpFullRequest.Builder result = stage.execute(request, context);
+
+        assertThat(result.host()).isEqualTo("resolved.amazonaws.com");
+        assertThat(result.port()).isEqualTo(8443);
+        assertThat(result.protocol()).isEqualTo("https");
+    }
+
+    @Test
+    void execute_resolvedPathWithEncodedCharacters_preservesEncoding() throws Exception {
+        URI clientEndpoint = URI.create("https://s3.amazonaws.com");
+        Endpoint endpoint = Endpoint.builder()
+                                    .url(URI.create("https://s3.amazonaws.com/bucket%20name"))
+                                    .build();
+        SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
+                                                                .method(SdkHttpMethod.GET)
+                                                                .protocol("https")
+                                                                .host("s3.amazonaws.com")
+                                                                .encodedPath("/key%2Fwith%2Fslashes");
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
+                                         ClientEndpointProvider.forEndpointOverride(clientEndpoint));
+        RequestExecutionContext context = createContext();
+
+        SdkHttpFullRequest.Builder result = stage.execute(request, context);
+
+        assertThat(result.encodedPath()).isEqualTo("/bucket%20name/key%2Fwith%2Fslashes");
+    }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
@@ -518,7 +518,7 @@ public final class S3Utilities {
         ClientEndpointProvider clientEndpointProvider =
             executionAttributes.getAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER);
         SdkHttpRequest result = AwsEndpointProviderUtils.setUri(httpRequest,
-                                                                clientEndpointProvider.clientEndpoint(), endpoint.url());
+                                                                clientEndpointProvider.clientEndpoint(), endpoint.endpointUrl());
 
         if (!endpoint.headers().isEmpty()) {
             SdkHttpRequest.Builder builder = result.toBuilder();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -677,7 +677,7 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
         ClientEndpointProvider clientEndpointProvider =
             executionAttributes.getAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER);
         SdkHttpRequest updatedRequest = AwsEndpointProviderUtils.setUri(httpRequest,
-            clientEndpointProvider.clientEndpoint(), endpoint.url());
+            clientEndpointProvider.clientEndpoint(), endpoint.endpointUrl());
 
         if (!endpoint.headers().isEmpty()) {
             SdkHttpRequest.Builder requestBuilder = updatedRequest.toBuilder();


### PR DESCRIPTION
This is PR 2/4 for replacing Uri.create in endpoint resoultion with the light weight EndpointUrl.

**Note: This PR merges to feature/master/endpoint-remove-uri and NOT to master**

Previous PRs:
* #7155 

## Modifications
Switch runtime consumers to use EndpointUrl:
* Update addHostPrefix to work with EndpointUrl components, preserving query and fragment 
* Switch EndpointResolutionStage to call endpoint.endpointUrl() instead of endpoint.url(), eliminating URI construction from the request pipeline when the resolved endpoint is consumed.

## Testing
New and existing tests.

## Screenshots (if appropriate)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
