### PR TITLE
[EndpointUri PR 3/4] Update codegen to use the EndpointUrl

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderSpec.java
@@ -25,7 +25,6 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +41,7 @@ import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -127,7 +127,7 @@ public class EndpointProviderSpec implements ClassSpec {
                      .addStatement("$T endpoint = $N.expectEndpoint()",
                                    endpointRulesSpecUtils.rulesRuntimeClassName("Value.Endpoint"), valueParamName)
                      .addStatement("$T builder = Endpoint.builder()", Endpoint.Builder.class)
-                     .addStatement("builder.url($T.create(endpoint.getUrl()))", URI.class)
+                     .addStatement("builder.endpointUrl($T.fromString(endpoint.getUrl()))", EndpointUrl.class)
                      .addStatement("$T headers = endpoint.getHeaders()",
                                    ParameterizedTypeName.get(ClassName.get(Map.class),
                                                              TypeName.get(String.class),

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/CodeGeneratorVisitor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/CodeGeneratorVisitor.java
@@ -38,20 +38,17 @@ public class CodeGeneratorVisitor extends WalkRuleExpressionVisitor {
     private final SymbolTable symbolTable;
     private final Map<String, KeyTypePair> knownEndpointAttributes;
     private final Map<String, ComputeScopeTree.Scope> ruleIdToScope;
-    private final boolean endpointCaching;
 
     public CodeGeneratorVisitor(RuleRuntimeTypeMirror typeMirror,
                                 SymbolTable symbolTable,
                                 Map<String, KeyTypePair> knownEndpointAttributes,
                                 Map<String, ComputeScopeTree.Scope> ruleIdToScope,
-                                boolean endpointCaching,
                                 CodeBlock.Builder builder) {
         this.builder = builder;
         this.symbolTable = symbolTable;
         this.knownEndpointAttributes = knownEndpointAttributes;
         this.ruleIdToScope = ruleIdToScope;
         this.typeMirror = typeMirror;
-        this.endpointCaching = endpointCaching;
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/CodeGeneratorVisitor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/CodeGeneratorVisitor.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.codegen.poet.rules2;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +28,7 @@ import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.codegen.model.config.customization.KeyTypePair;
 import software.amazon.awssdk.endpoints.Endpoint;
-import software.amazon.awssdk.utils.uri.SdkUri;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 
 public class CodeGeneratorVisitor extends WalkRuleExpressionVisitor {
     private static final Logger log = LoggerFactory.getLogger(CodeGeneratorVisitor.class);
@@ -333,11 +332,7 @@ public class CodeGeneratorVisitor extends WalkRuleExpressionVisitor {
     @Override
     public Void visitEndpointExpression(EndpointExpression e) {
         builder.add("return $T.endpoint(", typeMirror.rulesResult().type());
-        if (endpointCaching) {
-            builder.add("$T.builder().url($T.getInstance().create(", Endpoint.class, SdkUri.class);
-        } else {
-            builder.add("$T.builder().url($T.create(", Endpoint.class, URI.class);
-        }
+        builder.add("$T.builder().endpointUrl($T.fromString(", Endpoint.class, EndpointUrl.class);
         e.url().accept(this);
         builder.add("))");
         e.headers().accept(this);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/EndpointProviderSpec2.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/EndpointProviderSpec2.java
@@ -229,12 +229,10 @@ public class EndpointProviderSpec2 implements ClassSpec {
     }
 
     private void codegenExpr(RuleSetExpression expr, CodeBlock.Builder builder) {
-        boolean useEndpointCaching = intermediateModel.getCustomizationConfig().getEnableEndpointProviderUriCaching();
         CodeGeneratorVisitor visitor = new CodeGeneratorVisitor(typeMirror,
                                                                 utils.symbolTable(),
                                                                 knownEndpointAttributes,
                                                                 utils.scopesByName(),
-                                                                useEndpointCaching,
                                                                 builder);
         visitor.visitRuleSetExpression(expr);
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.query.endpoints.internal;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -12,6 +11,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
@@ -63,11 +63,11 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         }
         if (params.listOfStrings() != null) {
             paramsMap.put(Identifier.of("listOfStrings"),
-                          Value.fromArray(params.listOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
+                    Value.fromArray(params.listOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.defaultListOfStrings() != null) {
             paramsMap.put(Identifier.of("defaultListOfStrings"),
-                          Value.fromArray(params.defaultListOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
+                    Value.fromArray(params.defaultListOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
@@ -92,11 +92,11 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         }
         if (params.customEndpointArray() != null) {
             paramsMap.put(Identifier.of("CustomEndpointArray"),
-                          Value.fromArray(params.customEndpointArray().stream().map(Value::fromStr).collect(Collectors.toList())));
+                    Value.fromArray(params.customEndpointArray().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.arnList() != null) {
             paramsMap.put(Identifier.of("ArnList"),
-                          Value.fromArray(params.arnList().stream().map(Value::fromStr).collect(Collectors.toList())));
+                    Value.fromArray(params.arnList().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         return paramsMap;
     }
@@ -105,7 +105,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         if (value instanceof Value.Endpoint) {
             Value.Endpoint endpoint = value.expectEndpoint();
             Endpoint.Builder builder = Endpoint.builder();
-            builder.url(URI.create(endpoint.getUrl()));
+            builder.endpointUrl(EndpointUrl.fromString(endpoint.getUrl()));
             Map<String, List<String>> headers = endpoint.getHeaders();
             if (headers != null) {
                 headers.forEach((name, values) -> values.forEach(v -> builder.putHeader(name, v)));
@@ -120,214 +120,214 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             throw SdkClientException.create(errorMsg);
         } else {
             throw SdkClientException.create("Rule engine return neither an endpoint result or error value. Returned value was: "
-                                            + value);
+                    + value);
         }
     }
 
     private static Rule endpointRule_2() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
-                              .validate()).build()).error("FIPS endpoints not supported with multi-region endpoints");
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
+                                        .validate()).build()).error("FIPS endpoints not supported with multi-region endpoints");
     }
 
     private static Rule endpointRule_3() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_4() {
         return Rule.builder()
-                   .endpoint(
-                       EndpointResult
-                           .builder()
-                           .url(Expr.of("https://{endpointId}.query.{partitionResult#dnsSuffix}"))
-                           .addProperty(
-                               Identifier.of("authSchemes"),
-                               Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                              Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                              Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                              Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_1() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("endpointId"))))
-                              .build().validate()).build())
-            .treeRule(Arrays.asList(endpointRule_2(), endpointRule_3(), endpointRule_4()));
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("endpointId"))))
+                                        .build().validate()).build())
+                .treeRule(Arrays.asList(endpointRule_2(), endpointRule_3(), endpointRule_4()));
     }
 
     private static Rule endpointRule_6() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
-                              .validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://query-fips.{region}.{partitionResult#dnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
+                                        .validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://query-fips.{region}.{partitionResult#dnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_7() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://query.{region}.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*"))))), Literal
-                                                            .fromRecord(MapUtils.of(Identifier.of("name"), Literal.fromStr("sigv4"),
-                                                                                    Identifier.of("signingName"), Literal.fromStr("query"),
-                                                                                    Identifier.of("signingRegion"), Literal.fromStr("{region}")))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://query.{region}.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*"))))), Literal
+                                                .fromRecord(MapUtils.of(Identifier.of("name"), Literal.fromStr("sigv4"),
+                                                        Identifier.of("signingName"), Literal.fromStr("query"),
+                                                        Identifier.of("signingRegion"), Literal.fromStr("{region}")))))).build());
     }
 
     private static Rule endpointRule_8() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
-                              .validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://query-fips.{region}.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
+                                        .validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://query-fips.{region}.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_9() {
         return Rule.builder().endpoint(
-            EndpointResult.builder().url(Expr.of("https://query.{region}.{partitionResult#dnsSuffix}")).build());
+                EndpointResult.builder().url(Expr.of("https://query.{region}.{partitionResult#dnsSuffix}")).build());
     }
 
     private static Rule endpointRule_5() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isValidHostLabel")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("region")), Expr.of(false))).build()
-                              .validate()).build())
-            .treeRule(Arrays.asList(endpointRule_6(), endpointRule_7(), endpointRule_8(), endpointRule_9()));
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isValidHostLabel")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("region")), Expr.of(false))).build()
+                                        .validate()).build())
+                .treeRule(Arrays.asList(endpointRule_6(), endpointRule_7(), endpointRule_8(), endpointRule_9()));
     }
 
     private static Rule endpointRule_10() {
@@ -336,133 +336,133 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
 
     private static Rule endpointRule_11() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")))).build()
-                              .validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("getAttr")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")), Expr.of("[0]"))).build()
-                              .validate()).result("FirstArn").build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("aws.parseArn").argv(Arrays.asList(Expr.ref(Identifier.of("FirstArn"))))
-                              .build().validate()).result("ParsedArn").build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")))).build()
+                                        .validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("getAttr")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")), Expr.of("[0]"))).build()
+                                        .validate()).result("FirstArn").build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("aws.parseArn").argv(Arrays.asList(Expr.ref(Identifier.of("FirstArn"))))
+                                        .build().validate()).result("ParsedArn").build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_0() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("aws.partition").argv(Arrays.asList(Expr.ref(Identifier.of("region"))))
-                              .build().validate()).result("partitionResult").build())
-            .treeRule(Arrays.asList(endpointRule_1(), endpointRule_5(), endpointRule_10(), endpointRule_11()));
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("aws.partition").argv(Arrays.asList(Expr.ref(Identifier.of("region"))))
+                                        .build().validate()).result("partitionResult").build())
+                .treeRule(Arrays.asList(endpointRule_1(), endpointRule_5(), endpointRule_10(), endpointRule_11()));
     }
 
     private static EndpointRuleset ruleSet() {
         return EndpointRuleset
-            .builder()
-            .version("1.2")
-            .serviceId("query")
-            .parameters(
-                Parameters
-                    .builder()
-                    .addParameter(
-                        Parameter.builder().name("region").type(ParameterType.fromValue("string")).required(true)
-                                 .builtIn("AWS::Region").documentation("The region to send requests to").build())
-                    .addParameter(
-                        Parameter.builder().name("useDualStackEndpoint").type(ParameterType.fromValue("boolean"))
-                                 .required(false).builtIn("AWS::UseDualStack").build())
-                    .addParameter(
-                        Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
-                                 .required(false).builtIn("AWS::UseFIPS").build())
-                    .addParameter(
-                        Parameter.builder().name("AccountId").type(ParameterType.fromValue("String"))
-                                 .required(false).builtIn("AWS::Auth::AccountId").build())
-                    .addParameter(
-                        Parameter.builder().name("AccountIdEndpointMode").type(ParameterType.fromValue("String"))
-                                 .required(false).builtIn("AWS::Auth::AccountIdEndpointMode").build())
-                    .addParameter(
-                        Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter
-                            .builder()
-                            .name("defaultListOfStrings")
-                            .type(ParameterType.fromValue("stringarray"))
-                            .required(false)
-                            .defaultValue(
-                                Value.fromArray(Arrays.asList("item1", "item2", "item3").stream()
-                                                      .map(Value::fromStr).collect(Collectors.toList()))).build())
-                    .addParameter(
-                        Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("defaultTrueParam").type(ParameterType.fromValue("boolean"))
-                                 .required(false).documentation("A param that defauls to true")
-                                 .defaultValue(Value.fromBool(true)).build())
-                    .addParameter(
-                        Parameter.builder().name("defaultStringParam").type(ParameterType.fromValue("string"))
-                                 .required(false).defaultValue(Value.fromStr("hello endpoints")).build())
-                    .addParameter(
-                        Parameter.builder().name("deprecatedParam").type(ParameterType.fromValue("string"))
-                                 .required(false).deprecated(new Parameter.Deprecated("Don't use!", "2021-01-01"))
-                                 .build())
-                    .addParameter(
-                        Parameter.builder().name("booleanContextParam").type(ParameterType.fromValue("boolean"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("stringContextParam").type(ParameterType.fromValue("string"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("operationContextParam").type(ParameterType.fromValue("string"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("CustomEndpointArray")
-                                 .type(ParameterType.fromValue("StringArray")).required(false)
-                                 .documentation("Parameter from the customization config").build())
-                    .addParameter(
-                        Parameter.builder().name("ArnList").type(ParameterType.fromValue("StringArray"))
-                                 .required(false).documentation("Parameter from the customization config").build())
-                    .build()).addRule(endpointRule_0()).build();
+                .builder()
+                .version("1.2")
+                .serviceId("query")
+                .parameters(
+                        Parameters
+                                .builder()
+                                .addParameter(
+                                        Parameter.builder().name("region").type(ParameterType.fromValue("string")).required(true)
+                                                .builtIn("AWS::Region").documentation("The region to send requests to").build())
+                                .addParameter(
+                                        Parameter.builder().name("useDualStackEndpoint").type(ParameterType.fromValue("boolean"))
+                                                .required(false).builtIn("AWS::UseDualStack").build())
+                                .addParameter(
+                                        Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
+                                                .required(false).builtIn("AWS::UseFIPS").build())
+                                .addParameter(
+                                        Parameter.builder().name("AccountId").type(ParameterType.fromValue("String"))
+                                                .required(false).builtIn("AWS::Auth::AccountId").build())
+                                .addParameter(
+                                        Parameter.builder().name("AccountIdEndpointMode").type(ParameterType.fromValue("String"))
+                                                .required(false).builtIn("AWS::Auth::AccountIdEndpointMode").build())
+                                .addParameter(
+                                        Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter
+                                                .builder()
+                                                .name("defaultListOfStrings")
+                                                .type(ParameterType.fromValue("stringarray"))
+                                                .required(false)
+                                                .defaultValue(
+                                                        Value.fromArray(Arrays.asList("item1", "item2", "item3").stream()
+                                                                .map(Value::fromStr).collect(Collectors.toList()))).build())
+                                .addParameter(
+                                        Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("defaultTrueParam").type(ParameterType.fromValue("boolean"))
+                                                .required(false).documentation("A param that defauls to true")
+                                                .defaultValue(Value.fromBool(true)).build())
+                                .addParameter(
+                                        Parameter.builder().name("defaultStringParam").type(ParameterType.fromValue("string"))
+                                                .required(false).defaultValue(Value.fromStr("hello endpoints")).build())
+                                .addParameter(
+                                        Parameter.builder().name("deprecatedParam").type(ParameterType.fromValue("string"))
+                                                .required(false).deprecated(new Parameter.Deprecated("Don't use!", "2021-01-01"))
+                                                .build())
+                                .addParameter(
+                                        Parameter.builder().name("booleanContextParam").type(ParameterType.fromValue("boolean"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("stringContextParam").type(ParameterType.fromValue("string"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("operationContextParam").type(ParameterType.fromValue("string"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("CustomEndpointArray")
+                                                .type(ParameterType.fromValue("StringArray")).required(false)
+                                                .documentation("Parameter from the customization config").build())
+                                .addParameter(
+                                        Parameter.builder().name("ArnList").type(ParameterType.fromValue("StringArray"))
+                                                .required(false).documentation("Parameter from the customization config").build())
+                                .build()).addRule(endpointRule_0()).build();
     }
 
     @Override
@@ -478,12 +478,12 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
     private void addKnownProperties(Endpoint.Builder builder, Map<String, Value> properties) {
         properties.forEach((n, v) -> {
             switch (n) {
-                case "authSchemes":
-                    builder.putAttribute(AwsEndpointAttribute.AUTH_SCHEMES, endpointAuthSchemeStrategy.createAuthSchemes(v));
-                    break;
-                default:
-                    LOG.debug(() -> "Ignoring unknown endpoint property: " + n);
-                    break;
+            case "authSchemes":
+                builder.putAttribute(AwsEndpointAttribute.AUTH_SCHEMES, endpointAuthSchemeStrategy.createAuthSchemes(v));
+                break;
+            default:
+                LOG.debug(() -> "Ignoring unknown endpoint property: " + n);
+                break;
             }
         });
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.query.endpoints.internal;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -11,6 +10,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
@@ -62,11 +62,11 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         }
         if (params.listOfStrings() != null) {
             paramsMap.put(Identifier.of("listOfStrings"),
-                          Value.fromArray(params.listOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
+                    Value.fromArray(params.listOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.defaultListOfStrings() != null) {
             paramsMap.put(Identifier.of("defaultListOfStrings"),
-                          Value.fromArray(params.defaultListOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
+                    Value.fromArray(params.defaultListOfStrings().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         if (params.endpointId() != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(params.endpointId()));
@@ -91,7 +91,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         }
         if (params.arnList() != null) {
             paramsMap.put(Identifier.of("ArnList"),
-                          Value.fromArray(params.arnList().stream().map(Value::fromStr).collect(Collectors.toList())));
+                    Value.fromArray(params.arnList().stream().map(Value::fromStr).collect(Collectors.toList())));
         }
         return paramsMap;
     }
@@ -100,7 +100,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         if (value instanceof Value.Endpoint) {
             Value.Endpoint endpoint = value.expectEndpoint();
             Endpoint.Builder builder = Endpoint.builder();
-            builder.url(URI.create(endpoint.getUrl()));
+            builder.endpointUrl(EndpointUrl.fromString(endpoint.getUrl()));
             Map<String, List<String>> headers = endpoint.getHeaders();
             if (headers != null) {
                 headers.forEach((name, values) -> values.forEach(v -> builder.putHeader(name, v)));
@@ -115,214 +115,214 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             throw SdkClientException.create(errorMsg);
         } else {
             throw SdkClientException.create("Rule engine return neither an endpoint result or error value. Returned value was: "
-                                            + value);
+                    + value);
         }
     }
 
     private static Rule endpointRule_2() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
-                              .validate()).build()).error("FIPS endpoints not supported with multi-region endpoints");
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
+                                        .validate()).build()).error("FIPS endpoints not supported with multi-region endpoints");
     }
 
     private static Rule endpointRule_3() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_4() {
         return Rule.builder()
-                   .endpoint(
-                       EndpointResult
-                           .builder()
-                           .url(Expr.of("https://{endpointId}.query.{partitionResult#dnsSuffix}"))
-                           .addProperty(
-                               Identifier.of("authSchemes"),
-                               Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                              Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                              Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                              Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_1() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("endpointId"))))
-                              .build().validate()).build())
-            .treeRule(Arrays.asList(endpointRule_2(), endpointRule_3(), endpointRule_4()));
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("endpointId"))))
+                                        .build().validate()).build())
+                .treeRule(Arrays.asList(endpointRule_2(), endpointRule_3(), endpointRule_4()));
     }
 
     private static Rule endpointRule_6() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
-                              .validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://query-fips.{region}.{partitionResult#dnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
+                                        .validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://query-fips.{region}.{partitionResult#dnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_7() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://query.{region}.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*"))))), Literal
-                                                            .fromRecord(MapUtils.of(Identifier.of("name"), Literal.fromStr("sigv4"),
-                                                                                    Identifier.of("signingName"), Literal.fromStr("query"),
-                                                                                    Identifier.of("signingRegion"), Literal.fromStr("{region}")))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://query.{region}.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*"))))), Literal
+                                                .fromRecord(MapUtils.of(Identifier.of("name"), Literal.fromStr("sigv4"),
+                                                        Identifier.of("signingName"), Literal.fromStr("query"),
+                                                        Identifier.of("signingRegion"), Literal.fromStr("{region}")))))).build());
     }
 
     private static Rule endpointRule_8() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
-                              .validate()).build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://query-fips.{region}.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint"))))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")), Expr.of(true))).build()
+                                        .validate()).build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://query-fips.{region}.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_9() {
         return Rule.builder().endpoint(
-            EndpointResult.builder().url(Expr.of("https://query.{region}.{partitionResult#dnsSuffix}")).build());
+                EndpointResult.builder().url(Expr.of("https://query.{region}.{partitionResult#dnsSuffix}")).build());
     }
 
     private static Rule endpointRule_5() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isValidHostLabel")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("region")), Expr.of(false))).build()
-                              .validate()).build())
-            .treeRule(Arrays.asList(endpointRule_6(), endpointRule_7(), endpointRule_8(), endpointRule_9()));
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isValidHostLabel")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("region")), Expr.of(false))).build()
+                                        .validate()).build())
+                .treeRule(Arrays.asList(endpointRule_6(), endpointRule_7(), endpointRule_8(), endpointRule_9()));
     }
 
     private static Rule endpointRule_10() {
@@ -331,129 +331,129 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
 
     private static Rule endpointRule_11() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode
-                            .builder()
-                            .fn("not")
-                            .argv(Arrays.asList(FnNode.builder().fn("isSet")
-                                                      .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
-                                                      .validate())).build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
-                    .build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("booleanEquals")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
-                              .build().validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")))).build()
-                              .validate()).build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("getAttr")
-                              .argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")), Expr.of("[0]"))).build()
-                              .validate()).result("FirstArn").build())
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("aws.parseArn").argv(Arrays.asList(Expr.ref(Identifier.of("FirstArn"))))
-                              .build().validate()).result("ParsedArn").build())
-            .endpoint(
-                EndpointResult
-                    .builder()
-                    .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
-                    .addProperty(
-                        Identifier.of("authSchemes"),
-                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
-                                                                                       Literal.fromStr("sigv4a"), Identifier.of("signingName"),
-                                                                                       Literal.fromStr("query"), Identifier.of("signingRegionSet"),
-                                                                                       Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode
+                                        .builder()
+                                        .fn("not")
+                                        .argv(Arrays.asList(FnNode.builder().fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier.of("useFIPSEndpoint")))).build()
+                                                .validate())).build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")))).build().validate())
+                                .build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("booleanEquals")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("useDualStackEndpoint")), Expr.of(true)))
+                                        .build().validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("isSet").argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")))).build()
+                                        .validate()).build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("getAttr")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("ArnList")), Expr.of("[0]"))).build()
+                                        .validate()).result("FirstArn").build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("aws.parseArn").argv(Arrays.asList(Expr.ref(Identifier.of("FirstArn"))))
+                                        .build().validate()).result("ParsedArn").build())
+                .endpoint(
+                        EndpointResult
+                                .builder()
+                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
+                                .addProperty(
+                                        Identifier.of("authSchemes"),
+                                        Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),
+                                                Literal.fromStr("sigv4a"), Identifier.of("signingName"),
+                                                Literal.fromStr("query"), Identifier.of("signingRegionSet"),
+                                                Literal.fromTuple(Arrays.asList(Literal.fromStr("*")))))))).build());
     }
 
     private static Rule endpointRule_0() {
         return Rule
-            .builder()
-            .addCondition(
-                Condition
-                    .builder()
-                    .fn(FnNode.builder().fn("aws.partition").argv(Arrays.asList(Expr.ref(Identifier.of("region"))))
-                              .build().validate()).result("partitionResult").build())
-            .treeRule(Arrays.asList(endpointRule_1(), endpointRule_5(), endpointRule_10(), endpointRule_11()));
+                .builder()
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("aws.partition").argv(Arrays.asList(Expr.ref(Identifier.of("region"))))
+                                        .build().validate()).result("partitionResult").build())
+                .treeRule(Arrays.asList(endpointRule_1(), endpointRule_5(), endpointRule_10(), endpointRule_11()));
     }
 
     private static EndpointRuleset ruleSet() {
         return EndpointRuleset
-            .builder()
-            .version("1.2")
-            .serviceId("query")
-            .parameters(
-                Parameters
-                    .builder()
-                    .addParameter(
-                        Parameter.builder().name("region").type(ParameterType.fromValue("string")).required(true)
-                                 .builtIn("AWS::Region").documentation("The region to send requests to").build())
-                    .addParameter(
-                        Parameter.builder().name("useDualStackEndpoint").type(ParameterType.fromValue("boolean"))
-                                 .required(false).builtIn("AWS::UseDualStack").build())
-                    .addParameter(
-                        Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
-                                 .required(false).builtIn("AWS::UseFIPS").build())
-                    .addParameter(
-                        Parameter.builder().name("AccountId").type(ParameterType.fromValue("String"))
-                                 .required(false).builtIn("AWS::Auth::AccountId").build())
-                    .addParameter(
-                        Parameter.builder().name("AccountIdEndpointMode").type(ParameterType.fromValue("String"))
-                                 .required(false).builtIn("AWS::Auth::AccountIdEndpointMode").build())
-                    .addParameter(
-                        Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter
-                            .builder()
-                            .name("defaultListOfStrings")
-                            .type(ParameterType.fromValue("stringarray"))
-                            .required(false)
-                            .defaultValue(
-                                Value.fromArray(Arrays.asList("item1", "item2", "item3").stream()
-                                                      .map(Value::fromStr).collect(Collectors.toList()))).build())
-                    .addParameter(
-                        Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("defaultTrueParam").type(ParameterType.fromValue("boolean"))
-                                 .required(false).documentation("A param that defauls to true")
-                                 .defaultValue(Value.fromBool(true)).build())
-                    .addParameter(
-                        Parameter.builder().name("defaultStringParam").type(ParameterType.fromValue("string"))
-                                 .required(false).defaultValue(Value.fromStr("hello endpoints")).build())
-                    .addParameter(
-                        Parameter.builder().name("deprecatedParam").type(ParameterType.fromValue("string"))
-                                 .required(false).deprecated(new Parameter.Deprecated("Don't use!", "2021-01-01"))
-                                 .build())
-                    .addParameter(
-                        Parameter.builder().name("booleanContextParam").type(ParameterType.fromValue("boolean"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("stringContextParam").type(ParameterType.fromValue("string"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("operationContextParam").type(ParameterType.fromValue("string"))
-                                 .required(false).build())
-                    .addParameter(
-                        Parameter.builder().name("ArnList").type(ParameterType.fromValue("StringArray"))
-                                 .required(false).documentation("Parameter from the customization config").build())
-                    .build()).addRule(endpointRule_0()).build();
+                .builder()
+                .version("1.2")
+                .serviceId("query")
+                .parameters(
+                        Parameters
+                                .builder()
+                                .addParameter(
+                                        Parameter.builder().name("region").type(ParameterType.fromValue("string")).required(true)
+                                                .builtIn("AWS::Region").documentation("The region to send requests to").build())
+                                .addParameter(
+                                        Parameter.builder().name("useDualStackEndpoint").type(ParameterType.fromValue("boolean"))
+                                                .required(false).builtIn("AWS::UseDualStack").build())
+                                .addParameter(
+                                        Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
+                                                .required(false).builtIn("AWS::UseFIPS").build())
+                                .addParameter(
+                                        Parameter.builder().name("AccountId").type(ParameterType.fromValue("String"))
+                                                .required(false).builtIn("AWS::Auth::AccountId").build())
+                                .addParameter(
+                                        Parameter.builder().name("AccountIdEndpointMode").type(ParameterType.fromValue("String"))
+                                                .required(false).builtIn("AWS::Auth::AccountIdEndpointMode").build())
+                                .addParameter(
+                                        Parameter.builder().name("listOfStrings").type(ParameterType.fromValue("StringArray"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter
+                                                .builder()
+                                                .name("defaultListOfStrings")
+                                                .type(ParameterType.fromValue("stringarray"))
+                                                .required(false)
+                                                .defaultValue(
+                                                        Value.fromArray(Arrays.asList("item1", "item2", "item3").stream()
+                                                                .map(Value::fromStr).collect(Collectors.toList()))).build())
+                                .addParameter(
+                                        Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("defaultTrueParam").type(ParameterType.fromValue("boolean"))
+                                                .required(false).documentation("A param that defauls to true")
+                                                .defaultValue(Value.fromBool(true)).build())
+                                .addParameter(
+                                        Parameter.builder().name("defaultStringParam").type(ParameterType.fromValue("string"))
+                                                .required(false).defaultValue(Value.fromStr("hello endpoints")).build())
+                                .addParameter(
+                                        Parameter.builder().name("deprecatedParam").type(ParameterType.fromValue("string"))
+                                                .required(false).deprecated(new Parameter.Deprecated("Don't use!", "2021-01-01"))
+                                                .build())
+                                .addParameter(
+                                        Parameter.builder().name("booleanContextParam").type(ParameterType.fromValue("boolean"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("stringContextParam").type(ParameterType.fromValue("string"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("operationContextParam").type(ParameterType.fromValue("string"))
+                                                .required(false).build())
+                                .addParameter(
+                                        Parameter.builder().name("ArnList").type(ParameterType.fromValue("StringArray"))
+                                                .required(false).documentation("Parameter from the customization config").build())
+                                .build()).addRule(endpointRule_0()).build();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-class.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.query.endpoints.internal;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.Generated;
@@ -10,6 +9,7 @@ import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
@@ -66,7 +66,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                     if (parsedArn != null) {
                         return RuleResult.endpoint(Endpoint
                                 .builder()
-                                .url(URI.create("https://" + params.endpointId() + ".query."
+                                .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query."
                                         + partitionResult.dualStackDnsSuffix()))
                                 .putAttribute(
                                         AwsEndpointAttribute.AUTH_SCHEMES,
@@ -87,7 +87,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() == null && params.useDualStackEndpoint() != null && params.useDualStackEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -95,7 +95,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             }
             return RuleResult.endpoint(Endpoint
                     .builder()
-                    .url(URI.create("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
+                    .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
                     .putAttribute(
                             AwsEndpointAttribute.AUTH_SCHEMES,
                             Arrays.asList(SigV4aAuthScheme.builder().signingName("query").signingRegionSet(Arrays.asList("*"))
@@ -109,7 +109,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() != null && params.useFipsEndpoint() && params.useDualStackEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -118,7 +118,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useDualStackEndpoint() != null && params.useDualStackEndpoint() && params.useFipsEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -129,14 +129,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                     && params.useFipsEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
                                         .signingRegionSet(Arrays.asList("*")).build())).build());
             }
             return RuleResult.endpoint(Endpoint.builder()
-                    .url(URI.create("https://query." + region + "." + partitionResult.dnsSuffix())).build());
+                    .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dnsSuffix())).build());
         }
         return RuleResult.carryOn();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-know-prop-override-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-know-prop-override-class.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.query.endpoints.internal;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.Generated;
@@ -10,6 +9,7 @@ import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
@@ -66,7 +66,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                     if (parsedArn != null) {
                         return RuleResult.endpoint(Endpoint
                                 .builder()
-                                .url(URI.create("https://" + params.endpointId() + ".query."
+                                .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query."
                                         + partitionResult.dualStackDnsSuffix()))
                                 .putAttribute(
                                         AwsEndpointAttribute.AUTH_SCHEMES,
@@ -87,7 +87,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() == null && params.useDualStackEndpoint() != null && params.useDualStackEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -95,7 +95,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             }
             return RuleResult.endpoint(Endpoint
                     .builder()
-                    .url(URI.create("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
+                    .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
                     .putAttribute(
                             AwsEndpointAttribute.AUTH_SCHEMES,
                             Arrays.asList(SigV4aAuthScheme.builder().signingName("query").signingRegionSet(Arrays.asList("*"))
@@ -109,7 +109,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() != null && params.useFipsEndpoint() && params.useDualStackEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -118,7 +118,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useDualStackEndpoint() != null && params.useDualStackEndpoint() && params.useFipsEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -129,14 +129,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                     && params.useFipsEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(URI.create("https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
                                         .signingRegionSet(Arrays.asList("*")).build())).build());
             }
             return RuleResult.endpoint(Endpoint.builder()
-                    .url(URI.create("https://query." + region + "." + partitionResult.dnsSuffix())).build());
+                    .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dnsSuffix())).build());
         }
         return RuleResult.carryOn();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-metric-values-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-metric-values-class.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.query.endpoints.internal;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.Generated;
@@ -10,6 +9,7 @@ import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
@@ -70,7 +70,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() == null && params.useDualStackEndpoint() != null && params.useDualStackEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                                                .builder()
-                                               .url(URI.create("https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
+                                               .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
                                                .putAttribute(
                                                    AwsEndpointAttribute.AUTH_SCHEMES,
                                                    Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -78,7 +78,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             }
             return RuleResult.endpoint(Endpoint
                                            .builder()
-                                           .url(URI.create("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
+                                           .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
                                            .putAttribute(
                                                AwsEndpointAttribute.AUTH_SCHEMES,
                                                Arrays.asList(SigV4aAuthScheme.builder().signingName("query").signingRegionSet(Arrays.asList("*"))
@@ -92,7 +92,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() != null && params.useFipsEndpoint() && params.useDualStackEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                                                .builder()
-                                               .url(URI.create("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
+                                               .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
                                                .putAttribute(
                                                    AwsEndpointAttribute.AUTH_SCHEMES,
                                                    Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -101,7 +101,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useDualStackEndpoint() != null && params.useDualStackEndpoint() && params.useFipsEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                                                .builder()
-                                               .url(URI.create("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
+                                               .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
                                                .putAttribute(
                                                    AwsEndpointAttribute.AUTH_SCHEMES,
                                                    Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -112,14 +112,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                 && params.useFipsEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                                                .builder()
-                                               .url(URI.create("https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
+                                               .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
                                                .putAttribute(
                                                    AwsEndpointAttribute.AUTH_SCHEMES,
                                                    Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
                                                                                  .signingRegionSet(Arrays.asList("*")).build())).build());
             }
             return RuleResult.endpoint(Endpoint.builder()
-                                               .url(URI.create("https://query." + region + "." + partitionResult.dnsSuffix())).build());
+                                               .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dnsSuffix())).build());
         }
         return RuleResult.carryOn();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-unknown-property-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-unknown-property-class.java
@@ -1,11 +1,11 @@
 package software.amazon.awssdk.services.query.endpoints.internal;
 
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
@@ -43,7 +43,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
 
     private static RuleResult endpointRule1(QueryEndpointParams params) {
         if (params.endpoint() != null) {
-            return RuleResult.endpoint(Endpoint.builder().url(URI.create(params.endpoint())).build());
+            return RuleResult.endpoint(Endpoint.builder().endpointUrl(EndpointUrl.fromString(params.endpoint())).build());
         }
         return RuleResult.carryOn();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-uri-cache-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-uri-cache-class.java
@@ -9,12 +9,12 @@ import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4aAuthScheme;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Validate;
-import software.amazon.awssdk.utils.uri.SdkUri;
 
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
@@ -66,8 +66,8 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                     if (parsedArn != null) {
                         return RuleResult.endpoint(Endpoint
                                 .builder()
-                                .url(SdkUri.getInstance().create(
-                                        "https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
+                                .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query."
+                                        + partitionResult.dualStackDnsSuffix()))
                                 .putAttribute(
                                         AwsEndpointAttribute.AUTH_SCHEMES,
                                         Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -87,8 +87,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() == null && params.useDualStackEndpoint() != null && params.useDualStackEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(SdkUri.getInstance().create(
-                                "https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -96,7 +95,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             }
             return RuleResult.endpoint(Endpoint
                     .builder()
-                    .url(SdkUri.getInstance().create("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
+                    .endpointUrl(EndpointUrl.fromString("https://" + params.endpointId() + ".query." + partitionResult.dnsSuffix()))
                     .putAttribute(
                             AwsEndpointAttribute.AUTH_SCHEMES,
                             Arrays.asList(SigV4aAuthScheme.builder().signingName("query").signingRegionSet(Arrays.asList("*"))
@@ -110,7 +109,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useFipsEndpoint() != null && params.useFipsEndpoint() && params.useDualStackEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(SdkUri.getInstance().create("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -119,7 +118,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
             if (params.useDualStackEndpoint() != null && params.useDualStackEndpoint() && params.useFipsEndpoint() == null) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(SdkUri.getInstance().create("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
@@ -130,15 +129,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                     && params.useFipsEndpoint()) {
                 return RuleResult.endpoint(Endpoint
                         .builder()
-                        .url(SdkUri.getInstance().create(
-                                "https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
+                        .endpointUrl(EndpointUrl.fromString("https://query-fips." + region + "." + partitionResult.dualStackDnsSuffix()))
                         .putAttribute(
                                 AwsEndpointAttribute.AUTH_SCHEMES,
                                 Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
                                         .signingRegionSet(Arrays.asList("*")).build())).build());
             }
             return RuleResult.endpoint(Endpoint.builder()
-                    .url(SdkUri.getInstance().create("https://query." + region + "." + partitionResult.dnsSuffix())).build());
+                    .endpointUrl(EndpointUrl.fromString("https://query." + region + "." + partitionResult.dnsSuffix())).build());
         }
         return RuleResult.carryOn();
     }


### PR DESCRIPTION
This is PR 3/4 for replacing Uri.create in endpoint resolution with the light weight EndpointUrl.

**Note: This PR merges to feature/master/endpoint-remove-uri and NOT to master**

Previous PRs:
* #7155 
* #7158 


## Modifications
Update both rules1 (EndpointProviderSpec) and rules2 (CodeGeneratorVisitor) codegen to emit EndpointUrl.fromString() instead of URI.create() or SdkUri.getInstance().create() when building Endpoint objects in generated code. This is a uniform change: all URL expressions now go through EndpointUrl.fromString(urlString), which performs lightweight string splitting instead of full URI parsing. 

The endpointCaching/SdkUri path is no longer needed since EndpointUrl.fromString() is already cheaper than both URI.create() and SdkUri.

## Testing
Updated codegen generation files - all existing tests pass (including endpoint resolution) - no new surface area to cover with these changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
