### PR TITLE
Remove ServiceMetadata dependency while resolving signing region

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -563,6 +563,49 @@ public class BaseClientBuilderClass implements ClassSpec {
                         ClassName.get("software.amazon.awssdk.core", "ClientEndpointProvider"))
                .addCode("});\n");
 
+        builder.addCode("builder.lazyOptionIfAbsent($T.SIGNING_REGION, c -> {\n", AwsClientOption.class)
+               .addCode("  $T region = c.get($T.AWS_REGION);\n",
+                        ClassName.get("software.amazon.awssdk.regions", "Region"),
+                        AwsClientOption.class)
+               .addCode("  try {\n")
+               .addCode("    $T endpointParams = $T.builder()\n",
+                        endpointRulesSpecUtils.parametersClassName(), endpointRulesSpecUtils.parametersClassName())
+               .addCode("      .region(region)\n");
+
+        if (hasBuiltIn(BuiltInParameter.AWS_USE_DUAL_STACK)) {
+            builder.addCode("      .useDualStack(c.get($T.DUALSTACK_ENDPOINT_ENABLED))\n", AwsClientOption.class);
+        }
+        if (hasBuiltIn(BuiltInParameter.AWS_USE_FIPS)) {
+            builder.addCode("      .useFips(c.get($T.FIPS_ENDPOINT_ENABLED))\n", AwsClientOption.class);
+        }
+
+        builder.addCode("      .build();\n")
+               .addCode("    $T endpoint = $T.joinLikeSync(defaultEndpointProvider().resolveEndpoint(endpointParams));\n",
+                        ClassName.get("software.amazon.awssdk.endpoints", "Endpoint"),
+                        ClassName.get("software.amazon.awssdk.utils", "CompletableFutureUtils"))
+               .addCode("    $T<$T> authSchemes = endpoint.attribute($T.AUTH_SCHEMES);\n",
+                        List.class,
+                        ClassName.get("software.amazon.awssdk.awscore.endpoints.authscheme", "EndpointAuthScheme"),
+                        ClassName.get("software.amazon.awssdk.awscore.endpoints", "AwsEndpointAttribute"))
+               .addCode("    if (authSchemes != null && !authSchemes.isEmpty()) {\n")
+               .addCode("      $T firstScheme = authSchemes.get(0);\n",
+                        ClassName.get("software.amazon.awssdk.awscore.endpoints.authscheme", "EndpointAuthScheme"))
+               .addCode("      if (firstScheme instanceof $T) {\n",
+                        ClassName.get("software.amazon.awssdk.awscore.endpoints.authscheme", "SigV4AuthScheme"))
+               .addCode("        String signingRegion = (($T) firstScheme).signingRegion();\n",
+                        ClassName.get("software.amazon.awssdk.awscore.endpoints.authscheme", "SigV4AuthScheme"))
+               .addCode("        if (signingRegion != null) {\n")
+               .addCode("          return $T.of(signingRegion);\n",
+                        ClassName.get("software.amazon.awssdk.regions", "Region"))
+               .addCode("        }\n")
+               .addCode("      }\n")
+               .addCode("    }\n")
+               .addCode("  } catch (Exception e) {\n")
+               .addCode("    // Endpoint resolution failed. Fall back to using the client region as signing region.\n")
+               .addCode("  }\n")
+               .addCode("  return region;\n")
+               .addCode("});\n");
+
         if (model.getMetadata().isJsonProtocol()) {
             builder.addStatement("builder.option($1T.ENABLE_FAST_UNMARSHALLER, true)",
                                  SdkClientJsonProtocolAdvancedOption.class);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -16,6 +16,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -123,6 +126,29 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -18,6 +18,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.codegen.poet.plugins.InternalTestPlugin1;
 import software.amazon.awssdk.codegen.poet.plugins.InternalTestPlugin2;
@@ -195,10 +198,10 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
                 Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
-                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
-                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
-                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                                                                          .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
+                                                                          .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
+                                                                          .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                          .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
                 if (overrideEndpoint.isPresent()) {
                     return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
@@ -219,6 +222,29 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         SdkClientConfiguration clientConfig = config;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-endpoints-auth-params.java
@@ -18,6 +18,9 @@ import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointMode;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointModeResolver;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -114,10 +117,10 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
                 Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
-                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
-                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
-                                                                                                  .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                                                                          .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
+                                                                          .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
+                                                                          .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                          .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
                 if (overrideEndpoint.isPresent()) {
                     return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
@@ -140,6 +143,31 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    QueryEndpointParams endpointParams = QueryEndpointParams.builder().region(region)
+                                                                            .useDualStack(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
+                                                                            .useFips(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         SdkClientConfiguration clientConfig = config;
         builder.lazyOption(SdkClientOption.REQUEST_CHECKSUM_CALCULATION, c -> resolveRequestChecksumCalculation(clientConfig));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -14,6 +14,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -125,6 +128,29 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-composed-sync-default-client-builder.java
@@ -16,6 +16,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -118,10 +121,10 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
                 Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
-                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
-                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
-                                                                                                  .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                                                                          .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_JSON_SERVICE")
+                                                                          .serviceEndpointOverrideSystemProperty("aws.endpointUrlJson").serviceProfileProperty("json_service")
+                                                                          .profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                          .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
                 if (overrideEndpoint.isPresent()) {
                     return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
@@ -142,6 +145,29 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         SdkClientConfiguration clientConfig = config;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-env-bearer-token-client-builder-class.java
@@ -17,6 +17,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -139,6 +142,29 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    JsonEndpointParams endpointParams = JsonEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-service-client-builder-class.java
@@ -14,6 +14,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -120,6 +123,29 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-h2-usePriorKnowledgeForH2-service-client-builder-class.java
@@ -14,6 +14,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -119,6 +122,29 @@ abstract class DefaultH2BaseClientBuilder<B extends H2BaseClientBuilder<B, C>, C
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    H2EndpointParams endpointParams = H2EndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-multi-auth-sigv4a-client-builder-class.java
@@ -14,6 +14,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -119,6 +122,29 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-ops-client-builder-class.java
@@ -16,6 +16,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -129,6 +132,29 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-no-auth-service-client-builder-class.java
@@ -14,6 +14,9 @@ import software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -111,6 +114,29 @@ abstract class DefaultDatabaseBaseClientBuilder<B extends DatabaseBaseClientBuil
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    DatabaseEndpointParams endpointParams = DatabaseEndpointParams.builder().region(region).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         builder.option(SdkClientJsonProtocolAdvancedOption.ENABLE_FAST_UNMARSHALLER, true);
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -18,6 +18,9 @@ import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointMode;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointModeResolver;
+import software.amazon.awssdk.awscore.endpoints.AwsEndpointAttribute;
+import software.amazon.awssdk.awscore.endpoints.authscheme.EndpointAuthScheme;
+import software.amazon.awssdk.awscore.endpoints.authscheme.SigV4AuthScheme;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.SdkPlugin;
@@ -112,10 +115,10 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
             SdkClientOption.CLIENT_ENDPOINT_PROVIDER,
             c -> {
                 Optional<URI> overrideEndpoint = AwsClientEndpointProvider.builder()
-                                                                                                  .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
-                                                                                                  .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
-                                                                                                  .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
-                                                                                                  .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
+                                                                          .serviceEndpointOverrideEnvironmentVariable("AWS_ENDPOINT_URL_QUERY_SERVICE")
+                                                                          .serviceEndpointOverrideSystemProperty("aws.endpointUrlQuery")
+                                                                          .serviceProfileProperty("query_service").profileFile(c.get(SdkClientOption.PROFILE_FILE_SUPPLIER))
+                                                                          .profileName(c.get(SdkClientOption.PROFILE_NAME)).resolveFromOverrides();
                 if (overrideEndpoint.isPresent()) {
                     return ClientEndpointProvider.create(overrideEndpoint.get(), true);
                 }
@@ -138,6 +141,31 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
                                                     + clientEndpointUri + ". This is usually caused by an invalid region configuration.");
                 }
                 return ClientEndpointProvider.create(clientEndpointUri, false);
+            });
+        builder.lazyOptionIfAbsent(
+            AwsClientOption.SIGNING_REGION,
+            c -> {
+                Region region = c.get(AwsClientOption.AWS_REGION);
+                try {
+                    QueryEndpointParams endpointParams = QueryEndpointParams.builder().region(region)
+                                                                            .useDualStack(c.get(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
+                                                                            .useFips(c.get(AwsClientOption.FIPS_ENDPOINT_ENABLED)).build();
+                    Endpoint endpoint = CompletableFutureUtils.joinLikeSync(defaultEndpointProvider().resolveEndpoint(
+                        endpointParams));
+                    List<EndpointAuthScheme> authSchemes = endpoint.attribute(AwsEndpointAttribute.AUTH_SCHEMES);
+                    if (authSchemes != null && !authSchemes.isEmpty()) {
+                        EndpointAuthScheme firstScheme = authSchemes.get(0);
+                        if (firstScheme instanceof SigV4AuthScheme) {
+                            String signingRegion = ((SigV4AuthScheme) firstScheme).signingRegion();
+                            if (signingRegion != null) {
+                                return Region.of(signingRegion);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // Endpoint resolution failed. Fall back to using the client region as signing region.
+                }
+                return region;
             });
         SdkClientConfiguration clientConfig = config;
         builder.lazyOption(SdkClientOption.REQUEST_CHECKSUM_CALCULATION, c -> resolveRequestChecksumCalculation(clientConfig));

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -64,7 +64,6 @@ import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.identity.spi.IdentityProviders;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.regions.ServiceMetadataAdvancedOption;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.retries.api.RetryStrategy;
@@ -192,7 +191,7 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                             // Set ENDPOINT and ENDPOINT_OVERRIDDEN, because older clients may be relying on it
                             .lazyOptionIfAbsent(SdkClientOption.ENDPOINT, this::resolveEndpoint)
                             .lazyOptionIfAbsent(SdkClientOption.ENDPOINT_OVERRIDDEN, this::resolveEndpointOverridden)
-                            .lazyOption(AwsClientOption.SIGNING_REGION, this::resolveSigningRegion)
+                            .lazyOptionIfAbsent(AwsClientOption.SIGNING_REGION, this::resolveSigningRegion)
                             .lazyOption(SdkClientOption.HTTP_CLIENT_CONFIG, this::resolveHttpClientConfig)
                             .applyMutation(this::configureRetryPolicy)
                             .applyMutation(this::configureRetryStrategy)
@@ -313,11 +312,12 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     }
 
     /**
-     * Resolve the signing region from the default-applied configuration.
+     * Fallback signing region resolution. Returns the client region as-is.
+     * Generated service builders resolve the signing region from endpoint rules in finalizeServiceConfiguration,
+     * which takes precedence over this fallback via lazyOptionIfAbsent ordering.
      */
     private Region resolveSigningRegion(LazyValueSource config) {
-        return ServiceMetadata.of(serviceEndpointPrefix())
-                              .signingRegion(config.get(AwsClientOption.AWS_REGION));
+        return config.get(AwsClientOption.AWS_REGION);
     }
 
     /**

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
@@ -162,6 +162,43 @@ public class DefaultAwsClientBuilderTest {
     }
 
     @Test
+    public void resolveSigningRegion_withGlobalRegion_resolvesCorrectlyFromEndpointRules() {
+        ClientOverrideConfiguration overrideConfig =
+            ClientOverrideConfiguration.builder()
+                                       .putAdvancedOption(SIGNER, TEST_SIGNER)
+                                       .putAdvancedOption(ENABLE_DEFAULT_REGION_DETECTION, false)
+                                       .build();
+
+        TestClient client = new TestClientBuilderWithEndpointRulesSigningRegion(Region.US_EAST_1)
+            .credentialsProvider(AnonymousCredentialsProvider.create())
+            .overrideConfiguration(overrideConfig)
+            .region(Region.AWS_GLOBAL)
+            .build();
+
+        // The endpoint-rules-resolved signing region (us-east-1) is used, not the client region (aws-global)
+        assertThat(client.clientConfiguration.option(SIGNING_REGION)).isEqualTo(Region.US_EAST_1);
+    }
+
+    @Test
+    public void signingRegionFromEndpointRules_fallsBackToClientRegionOnFailure() {
+        // Simulates a generated builder where endpoint resolution fails.
+        // Should fall back to client region.
+        ClientOverrideConfiguration overrideConfig =
+            ClientOverrideConfiguration.builder()
+                                       .putAdvancedOption(SIGNER, TEST_SIGNER)
+                                       .putAdvancedOption(ENABLE_DEFAULT_REGION_DETECTION, false)
+                                       .build();
+
+        TestClient client = new TestClientBuilderWithFailingEndpointResolution()
+            .credentialsProvider(AnonymousCredentialsProvider.create())
+            .overrideConfiguration(overrideConfig)
+            .region(Region.US_WEST_2)
+            .build();
+
+        assertThat(client.clientConfiguration.option(SIGNING_REGION)).isEqualTo(Region.US_WEST_2);
+    }
+
+    @Test
     public void noClientProvided_DefaultHttpClientIsManagedBySdk() {
         TestClient client = testClientBuilder().region(Region.US_WEST_2).build();
         assertThat(client.clientConfiguration.option(SdkClientOption.SYNC_HTTP_CLIENT))
@@ -466,5 +503,94 @@ public class DefaultAwsClientBuilderTest {
     }
 
     private static class TestException extends Throwable {
+    }
+
+    /**
+     * Test builder that sets SIGNING_REGION from endpoint rules in finalizeServiceConfiguration.
+     */
+    private class TestClientBuilderWithEndpointRulesSigningRegion
+        extends AwsDefaultClientBuilder<TestClientBuilderWithEndpointRulesSigningRegion, TestClient>
+        implements AwsClientBuilder<TestClientBuilderWithEndpointRulesSigningRegion, TestClient> {
+
+        private final Region resolvedSigningRegion;
+
+        public TestClientBuilderWithEndpointRulesSigningRegion(Region resolvedSigningRegion) {
+            super(defaultHttpClientBuilder, null, autoModeDiscovery);
+            this.resolvedSigningRegion = resolvedSigningRegion;
+        }
+
+        @Override
+        protected TestClient buildClient() {
+            return new TestClient(super.syncClientConfiguration());
+        }
+
+        @Override
+        protected SdkClientConfiguration finalizeServiceConfiguration(SdkClientConfiguration config) {
+            return config.toBuilder()
+                         .lazyOptionIfAbsent(AwsClientOption.SIGNING_REGION, c -> resolvedSigningRegion)
+                         .build();
+        }
+
+        @Override
+        protected String serviceEndpointPrefix() {
+            return ENDPOINT_PREFIX;
+        }
+
+        @Override
+        protected String signingName() {
+            return SIGNING_NAME;
+        }
+
+        @Override
+        protected String serviceName() {
+            return SERVICE_NAME;
+        }
+
+        @Override
+        protected AttributeMap serviceHttpConfig() {
+            return MOCK_DEFAULTS;
+        }
+    }
+
+    /**
+     * Test builder where finalizeServiceConfiguration does not set SIGNING_REGION.
+     */
+    private class TestClientBuilderWithFailingEndpointResolution
+        extends AwsDefaultClientBuilder<TestClientBuilderWithFailingEndpointResolution, TestClient>
+        implements AwsClientBuilder<TestClientBuilderWithFailingEndpointResolution, TestClient> {
+
+        public TestClientBuilderWithFailingEndpointResolution() {
+            super(defaultHttpClientBuilder, null, autoModeDiscovery);
+        }
+
+        @Override
+        protected TestClient buildClient() {
+            return new TestClient(super.syncClientConfiguration());
+        }
+
+        @Override
+        protected SdkClientConfiguration finalizeServiceConfiguration(SdkClientConfiguration config) {
+            return config;
+        }
+
+        @Override
+        protected String serviceEndpointPrefix() {
+            return ENDPOINT_PREFIX;
+        }
+
+        @Override
+        protected String signingName() {
+            return SIGNING_NAME;
+        }
+
+        @Override
+        protected String serviceName() {
+            return SERVICE_NAME;
+        }
+
+        @Override
+        protected AttributeMap serviceHttpConfig() {
+            return MOCK_DEFAULTS;
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`resolveSigningRegion()` in `AwsDefaultClientBuilder` uses `ServiceMetadata.of(serviceEndpointPrefix()).signingRegion(region)` to determine the signing region at client build time. This loads per-service metadata classes generated from endpoints.json, adding unnecessary class loading overhead to client initialization.

This signing region is a build-time that gets overridden at request time by EndpointResolutionStage, which resolves the correct signing region from the service's endpoint rules. The build-time value is still needed for validation (client won't build without it) and as an initial value in execution attributes for customers with custom interceptors or overridden signers that read SIGNING_REGION before pipeline stages run.

## Modifications
- BaseClientBuilderClass (codegen): Added lazyOptionIfAbsent(SIGNING_REGION, ...) in finalizeServiceConfiguration that resolves the endpoint via endpoint rules and extracts the signing region from the SigV4AuthScheme. Falls back to client region if endpoint resolution fails (e.g., services with required params beyond region).
- AwsDefaultClientBuilder: Changed lazyOption to lazyOptionIfAbsent for SIGNING_REGION and simplified resolveSigningRegion() to return the client region directly. This serves as a fallback when the generated builder's endpoint resolution doesn't set it.

## Testing
- Added unit tests in DefaultAwsClientBuilderTest:
- resolveSigningRegion_withGlobalRegion_resolvesCorrectlyFromEndpointRules — verifies endpoint rules correctly resolve AWS_GLOBAL → us-east-1 for global services
- signingRegionFromEndpointRules_fallsBackToClientRegionOnFailure — verifies fallback to client region when endpoint resolution doesn't set signing region

   - Updated codegen golden files to include the new SIGNING_REGION resolution block
   - Existing tests continue to pass (signing region resolves correctly for standard regions)
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
