### PR TITLE
Update Netty to 4.1.136

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-1d04142.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-1d04142.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Update Netty to 4.1.136"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <equalsverifier.version>3.15.1</equalsverifier.version>
         <!-- Update netty-open-ssl-version accordingly whenever we update netty version-->
         <!-- https://github.com/netty/netty/blob/4.1/pom.xml search "tcnative.version" -->
-        <netty.version>4.1.135.Final</netty.version>
+        <netty.version>4.1.136.Final</netty.version>
         <unitils.version>3.4.6</unitils.version>
         <xmlunit.version>1.3</xmlunit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Motivation and Context
Netty 4.1.136 fixes 12 CVEs published on 2026-07-14 that affect Netty versions `< 4.1.136.Final`. Of these, 8 target Netty JARs the SDK ships directly (`netty-codec-http`, `netty-codec-http2`, `netty-codec`), and CVE-2026-56819 (HTTP/2 decompression ByteBuf leak, High) is plausibly reachable via the SDK's HTTP/2 client path.

See [Netty security advisories](https://github.com/netty/netty/security/advisories) for the full list.

Fixes #7162

## Modifications
- `netty.version`: 4.1.135.Final → 4.1.136.Final
- `netty-open-ssl-version`: no change (already 2.0.78.Final, which matches Netty 4.1.136's canonical tcnative pin)

## Testing
Relying on PR build for unit tests. No breaking changes identified in the [4.1.135 → 4.1.136 diff](https://github.com/netty/netty/compare/netty-4.1.135.Final...netty-4.1.136.Final).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added a changelog entry.

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
