### PR TITLE
Remove ServiceMetadata dependency from HelpfulUnknownHostExceptionInterceptor

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptor.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptor.java
@@ -16,20 +16,11 @@
 package software.amazon.awssdk.awscore.interceptor;
 
 import java.net.UnknownHostException;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
-import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.regions.PartitionMetadata;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.RegionMetadata;
-import software.amazon.awssdk.regions.ServiceMetadata;
-import software.amazon.awssdk.regions.ServicePartitionMetadata;
 
 /**
  * This interceptor will monitor for {@link UnknownHostException}s and provide the customer with additional information they can
@@ -47,80 +38,10 @@ public final class HelpfulUnknownHostExceptionInterceptor implements ExecutionIn
         error.append("Received an UnknownHostException when attempting to interact with a service. See cause for the "
                      + "exact endpoint that is failing to resolve. ");
 
-        Optional<String> globalRegionErrorDetails = getGlobalRegionErrorDetails(executionAttributes);
-
-        if (globalRegionErrorDetails.isPresent()) {
-            error.append(globalRegionErrorDetails.get());
-        } else {
-            error.append("If this is happening on an endpoint that previously worked, there may be a network connectivity "
-                         + "issue or your DNS cache could be storing endpoints for too long.");
-        }
+        error.append("If this is happening on an endpoint that previously worked, there may be a network connectivity "
+                     + "issue or your DNS cache could be storing endpoints for too long.");
 
         return SdkClientException.builder().message(error.toString()).cause(context.exception()).build();
-    }
-
-    /**
-     * If the customer is interacting with a global service (one with a single endpoint/region for an entire partition), this
-     * will return error details that can instruct the customer on how to configure their client for success.
-     */
-    private Optional<String> getGlobalRegionErrorDetails(ExecutionAttributes executionAttributes) {
-        Region clientRegion = clientRegion(executionAttributes);
-        if (clientRegion.isGlobalRegion()) {
-            return Optional.empty();
-        }
-
-        List<ServicePartitionMetadata> globalPartitionsForService = globalPartitionsForService(executionAttributes);
-        if (globalPartitionsForService.isEmpty()) {
-            return Optional.empty();
-        }
-
-        String clientPartition = Optional.ofNullable(clientRegion.metadata())
-                                         .map(RegionMetadata::partition)
-                                         .map(PartitionMetadata::id)
-                                         .orElse(null);
-
-        Optional<Region> globalRegionForClientRegion =
-            globalPartitionsForService.stream()
-                                      .filter(p -> p.partition().id().equals(clientPartition))
-                                      .findAny()
-                                      .flatMap(ServicePartitionMetadata::globalRegion);
-
-        if (!globalRegionForClientRegion.isPresent()) {
-            String globalRegionsForThisService = globalPartitionsForService.stream()
-                                                                           .map(ServicePartitionMetadata::globalRegion)
-                                                                           .filter(Optional::isPresent)
-                                                                           .map(Optional::get)
-                                                                           .filter(Region::isGlobalRegion)
-                                                                           .map(Region::id)
-                                                                           .collect(Collectors.joining("/"));
-
-            return Optional.of("This specific service may be a global service, in which case you should configure a global "
-                               + "region like " + globalRegionsForThisService + " on the client.");
-        }
-
-        Region globalRegion = globalRegionForClientRegion.get();
-
-        return Optional.of("This specific service is global in the same partition as the region configured on this client ("
-                           + clientRegion + "). If this is the first time you're trying to talk to this service in this region, "
-                           + "you should try configuring the global region on your client, instead: " + globalRegion);
-    }
-
-    /**
-     * Retrieve the region configured on the client.
-     */
-    private Region clientRegion(ExecutionAttributes executionAttributes) {
-        return executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
-    }
-
-    /**
-     * Retrieve all global partitions for the AWS service that we're interacting with.
-     */
-    private List<ServicePartitionMetadata> globalPartitionsForService(ExecutionAttributes executionAttributes) {
-        return ServiceMetadata.of(executionAttributes.getAttribute(AwsExecutionAttribute.ENDPOINT_PREFIX))
-                              .servicePartitions()
-                              .stream()
-                              .filter(sp -> sp.globalRegion().isPresent())
-                              .collect(Collectors.toList());
     }
 
     private boolean hasCause(Throwable thrown, Class<? extends Throwable> cause) {

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptor.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptor.java
@@ -28,20 +28,20 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
  */
 @SdkProtectedApi
 public final class HelpfulUnknownHostExceptionInterceptor implements ExecutionInterceptor {
+    private static final String ERROR_MESSAGE =
+        "Received an UnknownHostException when attempting to interact with a service. "
+        + "See cause for the exact endpoint that is failing to resolve. "
+        + "If this is happening on an endpoint that previously worked, "
+        + "there may be a network connectivity issue or your DNS cache "
+        + "could be storing endpoints for too long.";
+
     @Override
     public Throwable modifyException(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
         if (!hasCause(context.exception(), UnknownHostException.class)) {
             return context.exception();
         }
 
-        StringBuilder error = new StringBuilder();
-        error.append("Received an UnknownHostException when attempting to interact with a service. See cause for the "
-                     + "exact endpoint that is failing to resolve. ");
-
-        error.append("If this is happening on an endpoint that previously worked, there may be a network connectivity "
-                     + "issue or your DNS cache could be storing endpoints for too long.");
-
-        return SdkClientException.builder().message(error.toString()).cause(context.exception()).build();
+        return SdkClientException.builder().message(ERROR_MESSAGE).cause(context.exception()).build();
     }
 
     private boolean hasCause(Throwable thrown, Class<? extends Throwable> cause) {

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptorTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptorTest.java
@@ -6,14 +6,12 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
 import software.amazon.awssdk.core.internal.interceptor.DefaultFailedExecutionContext;
-import software.amazon.awssdk.regions.Region;
 
 public class HelpfulUnknownHostExceptionInterceptorTest {
     private static final ExecutionInterceptor INTERCEPTOR = new HelpfulUnknownHostExceptionInterceptor();
@@ -31,29 +29,13 @@ public class HelpfulUnknownHostExceptionInterceptorTest {
         exception = new IllegalArgumentException(exception);
         exception = new UnsupportedOperationException(exception);
 
-        assertThat(modifyException(exception, Region.AWS_GLOBAL)).isInstanceOf(SdkClientException.class);
+        assertThat(modifyException(exception)).isInstanceOf(SdkClientException.class);
     }
 
     @Test
-    public void modifyException_returnsNetworkHelp_forGlobalRegions() {
+    public void modifyException_returnsNetworkHelp_forUnknownHostException() {
         UnknownHostException exception = new UnknownHostException();
-        assertThat(modifyException(exception, Region.AWS_GLOBAL))
-            .isInstanceOf(SdkClientException.class)
-            .hasMessageContaining("network");
-    }
-
-    @Test
-    public void modifyException_returnsNetworkHelp_forUnknownServices() {
-        UnknownHostException exception = new UnknownHostException();
-        assertThat(modifyException(exception, Region.US_EAST_1, "millems-hotdog-stand"))
-            .isInstanceOf(SdkClientException.class)
-            .hasMessageContaining("network");
-    }
-
-    @Test
-    public void modifyException_returnsNetworkHelp_forGlobalServices() {
-        UnknownHostException exception = new UnknownHostException();
-        assertThat(modifyException(exception, Region.US_EAST_1, "iam"))
+        assertThat(modifyException(exception))
             .isInstanceOf(SdkClientException.class)
             .hasMessageContaining("network");
     }
@@ -61,20 +43,12 @@ public class HelpfulUnknownHostExceptionInterceptorTest {
     @Test
     public void modifyException_preservesOriginalExceptionAsCause() {
         UnknownHostException exception = new UnknownHostException("iam.us-east-1.amazonaws.com");
-        Throwable result = modifyException(exception, Region.US_EAST_1, "iam");
+        Throwable result = modifyException(exception);
         assertThat(result).isInstanceOf(SdkClientException.class);
         assertThat(result.getCause()).isSameAs(exception);
     }
 
     private Throwable modifyException(Throwable throwable) {
-        return modifyException(throwable, null);
-    }
-
-    private Throwable modifyException(Throwable throwable, Region clientRegion) {
-        return modifyException(throwable, clientRegion, null);
-    }
-
-    private Throwable modifyException(Throwable throwable, Region clientRegion, String serviceEndpointPrefix) {
         SdkRequest sdkRequest = Mockito.mock(SdkRequest.class);
 
         DefaultFailedExecutionContext context =
@@ -83,10 +57,6 @@ public class HelpfulUnknownHostExceptionInterceptorTest {
                                          .exception(throwable)
                                          .build();
 
-        ExecutionAttributes executionAttributes =
-            new ExecutionAttributes().putAttribute(AwsExecutionAttribute.AWS_REGION, clientRegion)
-                                     .putAttribute(AwsExecutionAttribute.ENDPOINT_PREFIX, serviceEndpointPrefix);
-
-        return INTERCEPTOR.modifyException(context, executionAttributes);
+        return INTERCEPTOR.modifyException(context, new ExecutionAttributes());
     }
 }

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptorTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/interceptor/HelpfulUnknownHostExceptionInterceptorTest.java
@@ -35,7 +35,7 @@ public class HelpfulUnknownHostExceptionInterceptorTest {
     }
 
     @Test
-    public void modifyException_returnsGenericHelp_forGlobalRegions() {
+    public void modifyException_returnsNetworkHelp_forGlobalRegions() {
         UnknownHostException exception = new UnknownHostException();
         assertThat(modifyException(exception, Region.AWS_GLOBAL))
             .isInstanceOf(SdkClientException.class)
@@ -43,53 +43,27 @@ public class HelpfulUnknownHostExceptionInterceptorTest {
     }
 
     @Test
-    public void modifyException_returnsGenericHelp_forUnknownServices() {
+    public void modifyException_returnsNetworkHelp_forUnknownServices() {
         UnknownHostException exception = new UnknownHostException();
         assertThat(modifyException(exception, Region.US_EAST_1, "millems-hotdog-stand"))
             .isInstanceOf(SdkClientException.class)
-            .satisfies(t -> doesNotHaveMessageContaining(t, "global"))
             .hasMessageContaining("network");
     }
 
     @Test
-    public void modifyException_returnsGenericHelp_forUnknownServicesInUnknownRegions() {
+    public void modifyException_returnsNetworkHelp_forGlobalServices() {
         UnknownHostException exception = new UnknownHostException();
-        assertThat(modifyException(exception, Region.of("cn-north-99"), "millems-hotdog-stand"))
+        assertThat(modifyException(exception, Region.US_EAST_1, "iam"))
             .isInstanceOf(SdkClientException.class)
-            .satisfies(t -> doesNotHaveMessageContaining(t, "global"))
             .hasMessageContaining("network");
     }
 
     @Test
-    public void modifyException_returnsGenericHelp_forServicesRegionalizedInAllPartitions() {
-        UnknownHostException exception = new UnknownHostException();
-        assertThat(modifyException(exception, Region.US_EAST_1, "dynamodb"))
-            .isInstanceOf(SdkClientException.class)
-            .satisfies(t -> doesNotHaveMessageContaining(t, "global"))
-            .hasMessageContaining("network");
-    }
-
-    @Test
-    public void modifyException_returnsGenericGlobalRegionHelp_forServicesGlobalInSomePartitionOtherThanTheClientPartition() {
-        UnknownHostException exception = new UnknownHostException();
-        assertThat(modifyException(exception, Region.of("cn-north-99"), "iam"))
-            .isInstanceOf(SdkClientException.class)
-            .satisfies(t -> doesNotHaveMessageContaining(t, "network"))
-            .hasMessageContaining("aws-global")
-            .hasMessageContaining("aws-cn-global");
-    }
-
-    @Test
-    public void modifyException_returnsSpecificGlobalRegionHelp_forServicesGlobalInTheClientRegionPartition() {
-        UnknownHostException exception = new UnknownHostException();
-        assertThat(modifyException(exception, Region.of("cn-north-1"), "iam"))
-            .isInstanceOf(SdkClientException.class)
-            .satisfies(t -> doesNotHaveMessageContaining(t, "aws-global"))
-            .hasMessageContaining("aws-cn-global");
-    }
-
-    private void doesNotHaveMessageContaining(Throwable throwable, String value) {
-        assertThat(throwable.getMessage()).doesNotContain(value);
+    public void modifyException_preservesOriginalExceptionAsCause() {
+        UnknownHostException exception = new UnknownHostException("iam.us-east-1.amazonaws.com");
+        Throwable result = modifyException(exception, Region.US_EAST_1, "iam");
+        assertThat(result).isInstanceOf(SdkClientException.class);
+        assertThat(result.getCause()).isSameAs(exception);
     }
 
     private Throwable modifyException(Throwable throwable) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The HelpfulUnknownHostExceptionInterceptor uses ServiceMetadata to detect global services and suggest global region configuration when DNS resolution fails. With Endpoints 2.0, global services are automatically routed to the correct endpoint regardless of region configuration, making this suggestion outdated. When DNS fails, it's a network issue, not a wrong-region issue.

## Modifications
- Removed getGlobalRegionErrorDetails(), globalPartitionsForService(), and clientRegion() methods
- Simplified to always return the generic network troubleshooting message

## Testing
- Updated existing tests to verify network message is returned for all scenarios (global regions, unknown services, global services)
- Added test verifying original exception is preserved as cause
- Removed tests that asserted global region hints in error messages

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
