### PR TITLE
Fix rare race condition in multipart upload with low maxInFlightParts

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-8f2c1a4.json
+++ b/.changes/next-release/bugfix-AmazonS3-8f2c1a4.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "contributor": "",
+    "description": "Fix a race condition in multipart upload with low maxInFlightParts where CompleteMultipartUpload could be initiated while the final part was still uploading."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
@@ -207,7 +207,7 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
                                              subscription.request(1);
                                          }
                                      }
-                                     completeMultipartUploadIfFinished(inFlight);
+                                     completeMultipartUploadIfFinished();
                                  }
                              });
     }
@@ -263,12 +263,20 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
         log.debug(() -> "Received onComplete()");
         isDone = true;
         if (!isPaused) {
-            completeMultipartUploadIfFinished(asyncRequestBodyInFlight.get());
+            completeMultipartUploadIfFinished();
         }
     }
 
-    private void completeMultipartUploadIfFinished(int requestsInFlight) {
-        if (isDone && requestsInFlight == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
+    private void completeMultipartUploadIfFinished() {
+        // asyncRequestBodyInFlight MUST be re-read here rather than passed in by the caller. In the upload
+        // completion callback, subscription.request(1) is invoked between decrementAndGet() and this method,
+        // which can synchronously deliver the final AsyncRequestBody (starting a new upload) followed by
+        // onComplete() (setting isDone). A stale snapshot of 0 taken before those deliveries would then
+        // initiate CompleteMultipartUpload while the final part is still in flight, completing the upload
+        // with a missing (null) part. Reading isDone (volatile) before the counter guarantees that, once
+        // isDone is observed as true, all onNext() increments are visible, so a fresh read of 0 means every
+        // upload that was started has finished and its CompletedPart is visible in completedParts.
+        if (isDone && asyncRequestBodyInFlight.get() == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
             CompletedPart[] parts;
 
             if (existingParts.isEmpty()) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriber.java
@@ -268,14 +268,7 @@ public class KnownContentLengthAsyncRequestBodySubscriber implements Subscriber<
     }
 
     private void completeMultipartUploadIfFinished() {
-        // asyncRequestBodyInFlight MUST be re-read here rather than passed in by the caller. In the upload
-        // completion callback, subscription.request(1) is invoked between decrementAndGet() and this method,
-        // which can synchronously deliver the final AsyncRequestBody (starting a new upload) followed by
-        // onComplete() (setting isDone). A stale snapshot of 0 taken before those deliveries would then
-        // initiate CompleteMultipartUpload while the final part is still in flight, completing the upload
-        // with a missing (null) part. Reading isDone (volatile) before the counter guarantees that, once
-        // isDone is observed as true, all onNext() increments are visible, so a fresh read of 0 means every
-        // upload that was started has finished and its CompletedPart is visible in completedParts.
+        // All atomics including asyncRequestBodyInFlight MUST be re-read here rather than passed in by the caller.
         if (isDone && asyncRequestBodyInFlight.get() == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
             CompletedPart[] parts;
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriber.java
@@ -232,7 +232,7 @@ public class UnknownContentLengthAsyncRequestBodySubscriber implements Subscribe
                             subscription.request(1);
                         }
                     }
-                    completeMultipartUploadIfFinish(inFlight);
+                    completeMultipartUploadIfFinish();
                 }
             });
     }
@@ -266,12 +266,20 @@ public class UnknownContentLengthAsyncRequestBodySubscriber implements Subscribe
             multipartUploadHelper.uploadInOneChunk(putObjectRequest, entireRequestBody, returnFuture);
         } else {
             isDone = true;
-            completeMultipartUploadIfFinish(asyncRequestBodyInFlight.get());
+            completeMultipartUploadIfFinish();
         }
     }
 
-    private void completeMultipartUploadIfFinish(int requestsInFlight) {
-        if (isDone && requestsInFlight == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
+    private void completeMultipartUploadIfFinish() {
+        // asyncRequestBodyInFlight MUST be re-read here rather than passed in by the caller. In the upload
+        // completion callback, subscription.request(1) is invoked between decrementAndGet() and this method,
+        // which can synchronously deliver the final AsyncRequestBody (starting a new upload) followed by
+        // onComplete() (setting isDone). A stale snapshot of 0 taken before those deliveries would then
+        // initiate CompleteMultipartUpload while the final part is still in flight, completing the upload
+        // with a missing part. Reading isDone (volatile) before the counter guarantees that, once isDone is
+        // observed as true, all onNext() increments are visible, so a fresh read of 0 means every upload
+        // that was started has finished and its CompletedPart is visible in completedParts.
+        if (isDone && asyncRequestBodyInFlight.get() == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
             CompletedPart[] parts = completedParts.stream()
                                                   .sorted(Comparator.comparingInt(CompletedPart::partNumber))
                                                   .toArray(CompletedPart[]::new);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriber.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriber.java
@@ -271,14 +271,7 @@ public class UnknownContentLengthAsyncRequestBodySubscriber implements Subscribe
     }
 
     private void completeMultipartUploadIfFinish() {
-        // asyncRequestBodyInFlight MUST be re-read here rather than passed in by the caller. In the upload
-        // completion callback, subscription.request(1) is invoked between decrementAndGet() and this method,
-        // which can synchronously deliver the final AsyncRequestBody (starting a new upload) followed by
-        // onComplete() (setting isDone). A stale snapshot of 0 taken before those deliveries would then
-        // initiate CompleteMultipartUpload while the final part is still in flight, completing the upload
-        // with a missing part. Reading isDone (volatile) before the counter guarantees that, once isDone is
-        // observed as true, all onNext() increments are visible, so a fresh read of 0 means every upload
-        // that was started has finished and its CompletedPart is visible in completedParts.
+        // All atomics including asyncRequestBodyInFlight MUST be re-read here rather than passed in by the caller.
         if (isDone && asyncRequestBodyInFlight.get() == 0 && completedMultipartInitiated.compareAndSet(false, true)) {
             CompletedPart[] parts = completedParts.stream()
                                                   .sorted(Comparator.comparingInt(CompletedPart::partNumber))

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
@@ -17,18 +17,24 @@ package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -46,6 +52,7 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.multipart.S3ResumeToken;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.utils.Pair;
@@ -259,6 +266,164 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         // Complete the first part — callback decrements to 1, sees 1 < 2, calls request(1)
         pendingFuture1.complete(CompletedPart.builder().partNumber(1).build());
         verify(mockSubscription, times(1)).request(1);
+    }
+
+    /**
+     * Regression test for early CompleteMultipartUpload with a missing part under low maxInFlightParts.
+     *
+     * <p>In the upload completion callback, {@code subscription.request(1)} is invoked between
+     * {@code asyncRequestBodyInFlight.decrementAndGet()} and {@code completeMultipartUploadIfFinished}.
+     * The upstream SimplePublisher delivers queued signals synchronously on the requesting thread, so
+     * that request can deliver the final AsyncRequestBody (starting a new upload) followed by
+     * onComplete() (setting isDone) before the callback finishes. If completion is then decided using
+     * the stale decrement snapshot of 0, the part-count validation passes (partNumber was already
+     * incremented by the final onNext) and CompleteMultipartUpload is sent with a null entry for the
+     * still-in-flight final part.
+     *
+     * <p>This test scripts that exact delivery order with a Subscription that mimics SimplePublisher's
+     * synchronous, demand-gated delivery.
+     */
+    @Test
+    void lastBodyAndOnCompleteDeliveredInsideCompletionCallback_shouldCompleteWithAllParts() {
+        int maxInFlight = 2;
+        int totalParts = 5;
+        long contentSize = totalParts * PART_SIZE;
+
+        MpuRequestContext context = MpuRequestContext.builder()
+                .request(Pair.of(putObjectRequest, asyncRequestBody))
+                .contentLength(contentSize)
+                .partSize(PART_SIZE)
+                .uploadId(UPLOAD_ID)
+                .numPartsCompleted(0L)
+                .expectedNumParts(totalParts)
+                .build();
+
+        UploadPartRecorder recorder = new UploadPartRecorder();
+        when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
+                .thenAnswer(recorder);
+
+        KnownContentLengthAsyncRequestBodySubscriber sub = createSubscriber(context, maxInFlight);
+        ScriptedSubscription scriptedSubscription = new ScriptedSubscription(sub);
+        sub.onSubscribe(scriptedSubscription);          // requests maxInFlight upfront
+
+        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 1 starts
+        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 2 starts
+        recorder.completePart(1);                                                          // frees a slot
+        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 3 starts
+        recorder.completePart(2);
+        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 4 starts
+
+        // Part 3 completes while the final chunk is not buffered yet: its request(1) delivers nothing.
+        recorder.completePart(3);
+
+        // The producer now queues the final body and the stream-complete signal. They will be delivered
+        // synchronously inside the next request(1), which happens in part 4's completion callback,
+        // between its decrementAndGet() (returning the stale 0) and completeMultipartUploadIfFinished.
+        scriptedSubscription.enqueueBodyQuietly(createMockAsyncRequestBody(PART_SIZE));
+        scriptedSubscription.enqueueStreamCompleteQuietly();
+        recorder.completePart(4);
+
+        // With the stale-snapshot bug, CompleteMultipartUpload was initiated here with parts[4] == null:
+        verify(multipartUploadHelper, never()).completeMultipartUpload(any(), any(), any(), any(), anyLong());
+        verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
+
+        // Part 5's upload finishes; only now should CompleteMultipartUpload be sent, with all 5 parts.
+        recorder.completePart(5);
+
+        ArgumentCaptor<CompletedPart[]> partsCaptor = ArgumentCaptor.forClass(CompletedPart[].class);
+        verify(multipartUploadHelper).completeMultipartUpload(eq(returnFuture), eq(UPLOAD_ID), partsCaptor.capture(),
+                                                              eq(putObjectRequest), eq(contentSize));
+        assertThat(partsCaptor.getValue()).hasSize(totalParts).doesNotContainNull();
+        verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * Records the consumer and pending future of each UploadPart request so the test can complete parts
+     * the same way MultipartUploadHelper does: consumer.accept(completedPart) followed by future completion.
+     */
+    private static final class UploadPartRecorder implements org.mockito.stubbing.Answer<CompletableFuture<CompletedPart>> {
+        private final Map<Integer, Consumer<CompletedPart>> consumers = new HashMap<>();
+        private final Map<Integer, CompletableFuture<CompletedPart>> futures = new HashMap<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public CompletableFuture<CompletedPart> answer(org.mockito.invocation.InvocationOnMock invocation) {
+            Consumer<CompletedPart> consumer = invocation.getArgument(1, Consumer.class);
+            Pair<UploadPartRequest, AsyncRequestBody> pair = invocation.getArgument(3, Pair.class);
+            int partNumber = pair.left().partNumber();
+            CompletableFuture<CompletedPart> future = new CompletableFuture<>();
+            consumers.put(partNumber, consumer);
+            futures.put(partNumber, future);
+            return future;
+        }
+
+        void completePart(int partNumber) {
+            CompletableFuture<CompletedPart> future = futures.get(partNumber);
+            assertThat(future).withFailMessage("UploadPart request for part %d was never sent", partNumber).isNotNull();
+            CompletedPart part = CompletedPart.builder().partNumber(partNumber).eTag("etag-" + partNumber).build();
+            consumers.get(partNumber).accept(part);
+            future.complete(part);
+        }
+    }
+
+    /**
+     * A Subscription that mimics {@link software.amazon.awssdk.utils.async.SimplePublisher}: queued signals
+     * are delivered synchronously on the thread that calls request(), onNext delivery is gated on demand,
+     * and onComplete is delivered once the queue drains, without needing demand.
+     */
+    private static final class ScriptedSubscription implements Subscription {
+        private final KnownContentLengthAsyncRequestBodySubscriber subscriber;
+        private final Deque<CloseableAsyncRequestBody> queuedBodies = new ArrayDeque<>();
+        private long demand;
+        private boolean streamComplete;
+        private boolean onCompleteDelivered;
+        private boolean draining;
+
+        ScriptedSubscription(KnownContentLengthAsyncRequestBodySubscriber subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void request(long n) {
+            demand += n;
+            drain();
+        }
+
+        @Override
+        public void cancel() {
+        }
+
+        void enqueueBodyAndDeliver(CloseableAsyncRequestBody body) {
+            queuedBodies.add(body);
+            drain();
+        }
+
+        void enqueueBodyQuietly(CloseableAsyncRequestBody body) {
+            queuedBodies.add(body);
+        }
+
+        void enqueueStreamCompleteQuietly() {
+            streamComplete = true;
+        }
+
+        private void drain() {
+            if (draining) {
+                return; // mirrors SimplePublisher's processingQueue flag: no re-entrant delivery
+            }
+            draining = true;
+            try {
+                while (demand > 0 && !queuedBodies.isEmpty()) {
+                    demand--;
+                    subscriber.onNext(queuedBodies.poll());
+                }
+                if (streamComplete && queuedBodies.isEmpty() && !onCompleteDelivered) {
+                    onCompleteDelivered = true;
+                    subscriber.onComplete();
+                }
+            } finally {
+                draining = false;
+            }
+        }
     }
 
     private MpuRequestContext createDefaultMpuRequestContext() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/KnownContentLengthAsyncRequestBodySubscriberTest.java
@@ -26,15 +26,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -48,11 +44,12 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.internal.multipart.utils.ControlledSubscription;
+import software.amazon.awssdk.services.s3.internal.multipart.utils.ManagedUploadPart;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
-import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.multipart.S3ResumeToken;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.utils.Pair;
@@ -270,18 +267,6 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
 
     /**
      * Regression test for early CompleteMultipartUpload with a missing part under low maxInFlightParts.
-     *
-     * <p>In the upload completion callback, {@code subscription.request(1)} is invoked between
-     * {@code asyncRequestBodyInFlight.decrementAndGet()} and {@code completeMultipartUploadIfFinished}.
-     * The upstream SimplePublisher delivers queued signals synchronously on the requesting thread, so
-     * that request can deliver the final AsyncRequestBody (starting a new upload) followed by
-     * onComplete() (setting isDone) before the callback finishes. If completion is then decided using
-     * the stale decrement snapshot of 0, the part-count validation passes (partNumber was already
-     * incremented by the final onNext) and CompleteMultipartUpload is sent with a null entry for the
-     * still-in-flight final part.
-     *
-     * <p>This test scripts that exact delivery order with a Subscription that mimics SimplePublisher's
-     * synchronous, demand-gated delivery.
      */
     @Test
     void lastBodyAndOnCompleteDeliveredInsideCompletionCallback_shouldCompleteWithAllParts() {
@@ -298,20 +283,20 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
                 .expectedNumParts(totalParts)
                 .build();
 
-        UploadPartRecorder recorder = new UploadPartRecorder();
+        ManagedUploadPart recorder = new ManagedUploadPart();
         when(multipartUploadHelper.sendIndividualUploadPartRequest(eq(UPLOAD_ID), any(), any(), any(), any()))
                 .thenAnswer(recorder);
 
         KnownContentLengthAsyncRequestBodySubscriber sub = createSubscriber(context, maxInFlight);
-        ScriptedSubscription scriptedSubscription = new ScriptedSubscription(sub);
-        sub.onSubscribe(scriptedSubscription);          // requests maxInFlight upfront
+        ControlledSubscription controlledSubscription = new ControlledSubscription(sub);
+        sub.onSubscribe(controlledSubscription);          // requests maxInFlight upfront
 
-        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 1 starts
-        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 2 starts
+        controlledSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 1 starts
+        controlledSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 2 starts
         recorder.completePart(1);                                                          // frees a slot
-        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 3 starts
+        controlledSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 3 starts
         recorder.completePart(2);
-        scriptedSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 4 starts
+        controlledSubscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 4 starts
 
         // Part 3 completes while the final chunk is not buffered yet: its request(1) delivers nothing.
         recorder.completePart(3);
@@ -319,11 +304,11 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
         // The producer now queues the final body and the stream-complete signal. They will be delivered
         // synchronously inside the next request(1), which happens in part 4's completion callback,
         // between its decrementAndGet() (returning the stale 0) and completeMultipartUploadIfFinished.
-        scriptedSubscription.enqueueBodyQuietly(createMockAsyncRequestBody(PART_SIZE));
-        scriptedSubscription.enqueueStreamCompleteQuietly();
+        controlledSubscription.enqueueBodyQuietly(createMockAsyncRequestBody(PART_SIZE));
+        controlledSubscription.enqueueStreamCompleteQuietly();
         recorder.completePart(4);
 
-        // With the stale-snapshot bug, CompleteMultipartUpload was initiated here with parts[4] == null:
+        // verify we haven't called CompleteMultipartUpload yet.
         verify(multipartUploadHelper, never()).completeMultipartUpload(any(), any(), any(), any(), anyLong());
         verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
 
@@ -335,95 +320,6 @@ public class KnownContentLengthAsyncRequestBodySubscriberTest {
                                                               eq(putObjectRequest), eq(contentSize));
         assertThat(partsCaptor.getValue()).hasSize(totalParts).doesNotContainNull();
         verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
-    }
-
-    /**
-     * Records the consumer and pending future of each UploadPart request so the test can complete parts
-     * the same way MultipartUploadHelper does: consumer.accept(completedPart) followed by future completion.
-     */
-    private static final class UploadPartRecorder implements org.mockito.stubbing.Answer<CompletableFuture<CompletedPart>> {
-        private final Map<Integer, Consumer<CompletedPart>> consumers = new HashMap<>();
-        private final Map<Integer, CompletableFuture<CompletedPart>> futures = new HashMap<>();
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public CompletableFuture<CompletedPart> answer(org.mockito.invocation.InvocationOnMock invocation) {
-            Consumer<CompletedPart> consumer = invocation.getArgument(1, Consumer.class);
-            Pair<UploadPartRequest, AsyncRequestBody> pair = invocation.getArgument(3, Pair.class);
-            int partNumber = pair.left().partNumber();
-            CompletableFuture<CompletedPart> future = new CompletableFuture<>();
-            consumers.put(partNumber, consumer);
-            futures.put(partNumber, future);
-            return future;
-        }
-
-        void completePart(int partNumber) {
-            CompletableFuture<CompletedPart> future = futures.get(partNumber);
-            assertThat(future).withFailMessage("UploadPart request for part %d was never sent", partNumber).isNotNull();
-            CompletedPart part = CompletedPart.builder().partNumber(partNumber).eTag("etag-" + partNumber).build();
-            consumers.get(partNumber).accept(part);
-            future.complete(part);
-        }
-    }
-
-    /**
-     * A Subscription that mimics {@link software.amazon.awssdk.utils.async.SimplePublisher}: queued signals
-     * are delivered synchronously on the thread that calls request(), onNext delivery is gated on demand,
-     * and onComplete is delivered once the queue drains, without needing demand.
-     */
-    private static final class ScriptedSubscription implements Subscription {
-        private final KnownContentLengthAsyncRequestBodySubscriber subscriber;
-        private final Deque<CloseableAsyncRequestBody> queuedBodies = new ArrayDeque<>();
-        private long demand;
-        private boolean streamComplete;
-        private boolean onCompleteDelivered;
-        private boolean draining;
-
-        ScriptedSubscription(KnownContentLengthAsyncRequestBodySubscriber subscriber) {
-            this.subscriber = subscriber;
-        }
-
-        @Override
-        public void request(long n) {
-            demand += n;
-            drain();
-        }
-
-        @Override
-        public void cancel() {
-        }
-
-        void enqueueBodyAndDeliver(CloseableAsyncRequestBody body) {
-            queuedBodies.add(body);
-            drain();
-        }
-
-        void enqueueBodyQuietly(CloseableAsyncRequestBody body) {
-            queuedBodies.add(body);
-        }
-
-        void enqueueStreamCompleteQuietly() {
-            streamComplete = true;
-        }
-
-        private void drain() {
-            if (draining) {
-                return; // mirrors SimplePublisher's processingQueue flag: no re-entrant delivery
-            }
-            draining = true;
-            try {
-                while (demand > 0 && !queuedBodies.isEmpty()) {
-                    demand--;
-                    subscriber.onNext(queuedBodies.poll());
-                }
-                if (streamComplete && queuedBodies.isEmpty() && !onCompleteDelivered) {
-                    onCompleteDelivered = true;
-                    subscriber.onComplete();
-                }
-            } finally {
-                draining = false;
-            }
-        }
     }
 
     private MpuRequestContext createDefaultMpuRequestContext() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriberTest.java
@@ -18,24 +18,34 @@ package software.amazon.awssdk.services.s3.internal.multipart;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.utils.Pair;
 
 public class UnknownContentLengthAsyncRequestBodySubscriberTest {
 
@@ -163,6 +173,158 @@ public class UnknownContentLengthAsyncRequestBodySubscriberTest {
         subscriber.onComplete();
 
         verify(multipartUploadHelper).uploadInOneChunk(eq(putObjectRequest), any(), eq(returnFuture));
+    }
+
+    /**
+     * Regression test for the "Expected: N, Actual: N-1" part-count failure seen with low maxInFlightParts.
+     *
+     * <p>In the upload completion callback, {@code subscription.request(1)} is invoked between
+     * {@code asyncRequestBodyInFlight.decrementAndGet()} and {@code completeMultipartUploadIfFinish}.
+     * The upstream SimplePublisher delivers queued signals synchronously on the requesting thread, so that
+     * request can deliver the final AsyncRequestBody (starting a new upload) followed by onComplete()
+     * (setting isDone) before the callback finishes. If completion is then decided using the stale
+     * decrement snapshot of 0, CompleteMultipartUpload is initiated while the final part is still in
+     * flight, and the upload fails with "The number of UploadParts requests is not equal to the expected
+     * number of parts" (or, without the part-count validation, would complete with a missing part).
+     *
+     * <p>This test scripts that exact delivery order with a Subscription that mimics SimplePublisher's
+     * synchronous, demand-gated delivery.
+     */
+    @Test
+    void lastBodyAndOnCompleteDeliveredInsideCompletionCallback_shouldCompleteWithAllParts() {
+        int maxInFlight = 2;
+        int numParts = 5;
+        UnknownContentLengthAsyncRequestBodySubscriber subscriber = createSubscriber(maxInFlight);
+
+        stubSuccessfulCreateMultipartCall();
+        when(genericMultipartHelper.determinePartCount(anyLong(), anyLong()))
+            .thenAnswer(invocation -> (int) Math.ceil(invocation.getArgument(0, Long.class)
+                                                      / (double) invocation.getArgument(1, Long.class)));
+        UploadPartRecorder recorder = new UploadPartRecorder();
+        when(multipartUploadHelper.sendIndividualUploadPartRequest(any(), any(), any(), any(), any()))
+            .thenAnswer(recorder);
+
+        ScriptedSubscription subscription = new ScriptedSubscription(subscriber);
+        subscriber.onSubscribe(subscription);
+
+        subscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // held as firstRequestBody
+        subscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // triggers MPU; parts 1, 2 start
+        recorder.completePart(1);                                                  // frees a slot
+        subscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 3 starts
+        recorder.completePart(2);
+        subscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // part 4 starts
+
+        // Part 3 completes while the final chunk is not buffered yet: its request(1) delivers nothing.
+        recorder.completePart(3);
+
+        // The producer now queues the final body and the stream-complete signal. They will be delivered
+        // synchronously inside the next request(1), which happens in part 4's completion callback,
+        // between its decrementAndGet() (returning the stale 0) and completeMultipartUploadIfFinish.
+        subscription.enqueueBodyQuietly(createMockAsyncRequestBody(PART_SIZE));
+        subscription.enqueueStreamCompleteQuietly();
+        recorder.completePart(4);
+
+        // With the stale-snapshot bug, completion was initiated here with only 4 parts:
+        verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
+        verify(multipartUploadHelper, never()).completeMultipartUpload(any(), any(), any(), any(), anyLong());
+
+        // Part 5's upload finishes; only now should CompleteMultipartUpload be sent, with all 5 parts.
+        recorder.completePart(5);
+
+        ArgumentCaptor<CompletedPart[]> partsCaptor = ArgumentCaptor.forClass(CompletedPart[].class);
+        verify(multipartUploadHelper).completeMultipartUpload(eq(returnFuture), eq(UPLOAD_ID), partsCaptor.capture(),
+                                                              eq(putObjectRequest), eq(numParts * PART_SIZE));
+        assertThat(partsCaptor.getValue()).hasSize(numParts).doesNotContainNull();
+        verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * Records the consumer and pending future of each UploadPart request so the test can complete parts
+     * the same way MultipartUploadHelper does: consumer.accept(completedPart) followed by future completion.
+     */
+    private static final class UploadPartRecorder implements org.mockito.stubbing.Answer<CompletableFuture<CompletedPart>> {
+        private final Map<Integer, Consumer<CompletedPart>> consumers = new HashMap<>();
+        private final Map<Integer, CompletableFuture<CompletedPart>> futures = new HashMap<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public CompletableFuture<CompletedPart> answer(org.mockito.invocation.InvocationOnMock invocation) {
+            Consumer<CompletedPart> consumer = invocation.getArgument(1, Consumer.class);
+            Pair<UploadPartRequest, AsyncRequestBody> pair = invocation.getArgument(3, Pair.class);
+            int partNumber = pair.left().partNumber();
+            CompletableFuture<CompletedPart> future = new CompletableFuture<>();
+            consumers.put(partNumber, consumer);
+            futures.put(partNumber, future);
+            return future;
+        }
+
+        void completePart(int partNumber) {
+            CompletableFuture<CompletedPart> future = futures.get(partNumber);
+            assertThat(future).withFailMessage("UploadPart request for part %d was never sent", partNumber).isNotNull();
+            CompletedPart part = CompletedPart.builder().partNumber(partNumber).eTag("etag-" + partNumber).build();
+            consumers.get(partNumber).accept(part);
+            future.complete(part);
+        }
+    }
+
+    /**
+     * A Subscription that mimics {@link software.amazon.awssdk.utils.async.SimplePublisher}: queued signals
+     * are delivered synchronously on the thread that calls request(), onNext delivery is gated on demand,
+     * and onComplete is delivered once the queue drains, without needing demand.
+     */
+    private static final class ScriptedSubscription implements Subscription {
+        private final UnknownContentLengthAsyncRequestBodySubscriber subscriber;
+        private final Deque<CloseableAsyncRequestBody> queuedBodies = new ArrayDeque<>();
+        private long demand;
+        private boolean streamComplete;
+        private boolean onCompleteDelivered;
+        private boolean draining;
+
+        ScriptedSubscription(UnknownContentLengthAsyncRequestBodySubscriber subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void request(long n) {
+            demand += n;
+            drain();
+        }
+
+        @Override
+        public void cancel() {
+        }
+
+        void enqueueBodyAndDeliver(CloseableAsyncRequestBody body) {
+            queuedBodies.add(body);
+            drain();
+        }
+
+        void enqueueBodyQuietly(CloseableAsyncRequestBody body) {
+            queuedBodies.add(body);
+        }
+
+        void enqueueStreamCompleteQuietly() {
+            streamComplete = true;
+        }
+
+        private void drain() {
+            if (draining) {
+                return; // mirrors SimplePublisher's processingQueue flag: no re-entrant delivery
+            }
+            draining = true;
+            try {
+                while (demand > 0 && !queuedBodies.isEmpty()) {
+                    demand--;
+                    subscriber.onNext(queuedBodies.poll());
+                }
+                if (streamComplete && queuedBodies.isEmpty() && !onCompleteDelivered) {
+                    onCompleteDelivered = true;
+                    subscriber.onComplete();
+                }
+            } finally {
+                draining = false;
+            }
+        }
     }
 
     private UnknownContentLengthAsyncRequestBodySubscriber createSubscriber(int maxInFlightParts) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriberTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/UnknownContentLengthAsyncRequestBodySubscriberTest.java
@@ -26,26 +26,19 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.reactivestreams.Subscription;
-import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.internal.multipart.utils.ControlledSubscription;
+import software.amazon.awssdk.services.s3.internal.multipart.utils.ManagedUploadPart;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
-import software.amazon.awssdk.services.s3.model.UploadPartRequest;
-import software.amazon.awssdk.utils.Pair;
 
 public class UnknownContentLengthAsyncRequestBodySubscriberTest {
 
@@ -177,18 +170,6 @@ public class UnknownContentLengthAsyncRequestBodySubscriberTest {
 
     /**
      * Regression test for the "Expected: N, Actual: N-1" part-count failure seen with low maxInFlightParts.
-     *
-     * <p>In the upload completion callback, {@code subscription.request(1)} is invoked between
-     * {@code asyncRequestBodyInFlight.decrementAndGet()} and {@code completeMultipartUploadIfFinish}.
-     * The upstream SimplePublisher delivers queued signals synchronously on the requesting thread, so that
-     * request can deliver the final AsyncRequestBody (starting a new upload) followed by onComplete()
-     * (setting isDone) before the callback finishes. If completion is then decided using the stale
-     * decrement snapshot of 0, CompleteMultipartUpload is initiated while the final part is still in
-     * flight, and the upload fails with "The number of UploadParts requests is not equal to the expected
-     * number of parts" (or, without the part-count validation, would complete with a missing part).
-     *
-     * <p>This test scripts that exact delivery order with a Subscription that mimics SimplePublisher's
-     * synchronous, demand-gated delivery.
      */
     @Test
     void lastBodyAndOnCompleteDeliveredInsideCompletionCallback_shouldCompleteWithAllParts() {
@@ -200,11 +181,11 @@ public class UnknownContentLengthAsyncRequestBodySubscriberTest {
         when(genericMultipartHelper.determinePartCount(anyLong(), anyLong()))
             .thenAnswer(invocation -> (int) Math.ceil(invocation.getArgument(0, Long.class)
                                                       / (double) invocation.getArgument(1, Long.class)));
-        UploadPartRecorder recorder = new UploadPartRecorder();
+        ManagedUploadPart recorder = new ManagedUploadPart();
         when(multipartUploadHelper.sendIndividualUploadPartRequest(any(), any(), any(), any(), any()))
             .thenAnswer(recorder);
 
-        ScriptedSubscription subscription = new ScriptedSubscription(subscriber);
+        ControlledSubscription subscription = new ControlledSubscription(subscriber);
         subscriber.onSubscribe(subscription);
 
         subscription.enqueueBodyAndDeliver(createMockAsyncRequestBody(PART_SIZE)); // held as firstRequestBody
@@ -224,7 +205,7 @@ public class UnknownContentLengthAsyncRequestBodySubscriberTest {
         subscription.enqueueStreamCompleteQuietly();
         recorder.completePart(4);
 
-        // With the stale-snapshot bug, completion was initiated here with only 4 parts:
+        // verify we haven't called CompleteMultipartUpload yet.
         verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
         verify(multipartUploadHelper, never()).completeMultipartUpload(any(), any(), any(), any(), anyLong());
 
@@ -236,95 +217,6 @@ public class UnknownContentLengthAsyncRequestBodySubscriberTest {
                                                               eq(putObjectRequest), eq(numParts * PART_SIZE));
         assertThat(partsCaptor.getValue()).hasSize(numParts).doesNotContainNull();
         verify(multipartUploadHelper, never()).failRequestsElegantly(any(), any(), any(), any(), any());
-    }
-
-    /**
-     * Records the consumer and pending future of each UploadPart request so the test can complete parts
-     * the same way MultipartUploadHelper does: consumer.accept(completedPart) followed by future completion.
-     */
-    private static final class UploadPartRecorder implements org.mockito.stubbing.Answer<CompletableFuture<CompletedPart>> {
-        private final Map<Integer, Consumer<CompletedPart>> consumers = new HashMap<>();
-        private final Map<Integer, CompletableFuture<CompletedPart>> futures = new HashMap<>();
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public CompletableFuture<CompletedPart> answer(org.mockito.invocation.InvocationOnMock invocation) {
-            Consumer<CompletedPart> consumer = invocation.getArgument(1, Consumer.class);
-            Pair<UploadPartRequest, AsyncRequestBody> pair = invocation.getArgument(3, Pair.class);
-            int partNumber = pair.left().partNumber();
-            CompletableFuture<CompletedPart> future = new CompletableFuture<>();
-            consumers.put(partNumber, consumer);
-            futures.put(partNumber, future);
-            return future;
-        }
-
-        void completePart(int partNumber) {
-            CompletableFuture<CompletedPart> future = futures.get(partNumber);
-            assertThat(future).withFailMessage("UploadPart request for part %d was never sent", partNumber).isNotNull();
-            CompletedPart part = CompletedPart.builder().partNumber(partNumber).eTag("etag-" + partNumber).build();
-            consumers.get(partNumber).accept(part);
-            future.complete(part);
-        }
-    }
-
-    /**
-     * A Subscription that mimics {@link software.amazon.awssdk.utils.async.SimplePublisher}: queued signals
-     * are delivered synchronously on the thread that calls request(), onNext delivery is gated on demand,
-     * and onComplete is delivered once the queue drains, without needing demand.
-     */
-    private static final class ScriptedSubscription implements Subscription {
-        private final UnknownContentLengthAsyncRequestBodySubscriber subscriber;
-        private final Deque<CloseableAsyncRequestBody> queuedBodies = new ArrayDeque<>();
-        private long demand;
-        private boolean streamComplete;
-        private boolean onCompleteDelivered;
-        private boolean draining;
-
-        ScriptedSubscription(UnknownContentLengthAsyncRequestBodySubscriber subscriber) {
-            this.subscriber = subscriber;
-        }
-
-        @Override
-        public void request(long n) {
-            demand += n;
-            drain();
-        }
-
-        @Override
-        public void cancel() {
-        }
-
-        void enqueueBodyAndDeliver(CloseableAsyncRequestBody body) {
-            queuedBodies.add(body);
-            drain();
-        }
-
-        void enqueueBodyQuietly(CloseableAsyncRequestBody body) {
-            queuedBodies.add(body);
-        }
-
-        void enqueueStreamCompleteQuietly() {
-            streamComplete = true;
-        }
-
-        private void drain() {
-            if (draining) {
-                return; // mirrors SimplePublisher's processingQueue flag: no re-entrant delivery
-            }
-            draining = true;
-            try {
-                while (demand > 0 && !queuedBodies.isEmpty()) {
-                    demand--;
-                    subscriber.onNext(queuedBodies.poll());
-                }
-                if (streamComplete && queuedBodies.isEmpty() && !onCompleteDelivered) {
-                    onCompleteDelivered = true;
-                    subscriber.onComplete();
-                }
-            } finally {
-                draining = false;
-            }
-        }
     }
 
     private UnknownContentLengthAsyncRequestBodySubscriber createSubscriber(int maxInFlightParts) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/utils/ControlledSubscription.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/utils/ControlledSubscription.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.multipart.utils;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
+
+/**
+ * A Subscription that mimics {@link software.amazon.awssdk.utils.async.SimplePublisher}: queued signals
+ * are delivered synchronously on the thread that calls request(), onNext delivery is gated on demand,
+ * and onComplete is delivered once the queue drains, without needing demand.
+ */
+public final class ControlledSubscription implements Subscription {
+    private final Subscriber<? super CloseableAsyncRequestBody> subscriber;
+    private final Deque<CloseableAsyncRequestBody> queuedBodies = new ArrayDeque<>();
+    private long demand;
+    private boolean streamComplete;
+    private boolean onCompleteDelivered;
+    private boolean draining;
+
+    public ControlledSubscription(Subscriber<? super CloseableAsyncRequestBody> subscriber) {
+        this.subscriber = subscriber;
+    }
+
+    @Override
+    public void request(long n) {
+        demand += n;
+        drain();
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    public void enqueueBodyAndDeliver(CloseableAsyncRequestBody body) {
+        queuedBodies.add(body);
+        drain();
+    }
+
+    public void enqueueBodyQuietly(CloseableAsyncRequestBody body) {
+        queuedBodies.add(body);
+    }
+
+    public void enqueueStreamCompleteQuietly() {
+        streamComplete = true;
+    }
+
+    private void drain() {
+        if (draining) {
+            return; // mirrors SimplePublisher's processingQueue flag: no re-entrant delivery
+        }
+        draining = true;
+        try {
+            while (demand > 0 && !queuedBodies.isEmpty()) {
+                demand--;
+                subscriber.onNext(queuedBodies.poll());
+            }
+            if (streamComplete && queuedBodies.isEmpty() && !onCompleteDelivered) {
+                onCompleteDelivered = true;
+                subscriber.onComplete();
+            }
+        } finally {
+            draining = false;
+        }
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/utils/ManagedUploadPart.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/utils/ManagedUploadPart.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.multipart.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.utils.Pair;
+
+/**
+ * Records the consumer and pending future of each UploadPart request so a test can complete parts
+ * the same way MultipartUploadHelper does: consumer.accept(completedPart) followed by future completion.
+ *
+ * <p>Intended to be used as a Mockito {@link Answer} for
+ * {@code MultipartUploadHelper#sendIndividualUploadPartRequest}.
+ */
+public final class ManagedUploadPart implements Answer<CompletableFuture<CompletedPart>> {
+    private final Map<Integer, Consumer<CompletedPart>> consumers = new HashMap<>();
+    private final Map<Integer, CompletableFuture<CompletedPart>> futures = new HashMap<>();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public CompletableFuture<CompletedPart> answer(InvocationOnMock invocation) {
+        Consumer<CompletedPart> consumer = invocation.getArgument(1, Consumer.class);
+        Pair<UploadPartRequest, AsyncRequestBody> pair = invocation.getArgument(3, Pair.class);
+        int partNumber = pair.left().partNumber();
+        CompletableFuture<CompletedPart> future = new CompletableFuture<>();
+        consumers.put(partNumber, consumer);
+        futures.put(partNumber, future);
+        return future;
+    }
+
+    public void completePart(int partNumber) {
+        CompletableFuture<CompletedPart> future = futures.get(partNumber);
+        assertThat(future).withFailMessage("UploadPart request for part %d was never sent", partNumber).isNotNull();
+        CompletedPart part = CompletedPart.builder().partNumber(partNumber).eTag("etag-" + partNumber).build();
+        consumers.get(partNumber).accept(part);
+        future.complete(part);
+    }
+}


### PR DESCRIPTION
Fix rare race condition in multipart upload with low maxInFlightParts

## Motivation and Context
With maxInFlightParts=2 and the unknown-content-length upload path, multipart uploads can very rarely fail with `SdkClientException: The number of UploadParts requests is not equal to the expected number of parts. Expected: N, Actual: N-1.`

The upload completion callback in both MPU subscribers takes a snapshot via asyncRequestBodyInFlight.decrementAndGet(), then calls subscription.request(1), then decides completion using the stale snapshot. SimplePublisher delivers queued signals synchronously on the requesting thread, so that request(1) can deliver the final part body (starting a new upload) followed by onComplete() (setting isDone) inside the window. The callback then sees isDone == true with its stale count of 0 and initiates CompleteMultipartUpload while the final part is still in flight. The known-content-length subscriber has the same window but passes its part-count validation, sending CompleteMultipartUpload with a null part entry. 

## Modifications
re-read InFlight where it is used instead of trusting the caller's snapshot. Since isDone is volatile and written after all serialized onNext increments, observing it true guarantees the increments are visible, so a fresh read of 0 means every started upload has finished.

## Testing
Added new regression tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
