### PR TITLE
docs: fix SsoOidcTokenProvider.Builder Javadoc defaults and typos

### DIFF
--- a/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/SsoOidcTokenProvider.java
+++ b/services/ssooidc/src/main/java/software/amazon/awssdk/services/ssooidc/SsoOidcTokenProvider.java
@@ -116,29 +116,29 @@ public final class SsoOidcTokenProvider implements SdkTokenProvider, SdkAutoClos
         Builder sessionName(String sessionName);
 
         /**
-         *
          * Client to fetch token from SSO OIDC service.
          */
         Builder ssoOidcClient(SsoOidcClient ssoOidcClient);
 
         /**
-         * Configure the amount of time, relative to Sso-Oidc token , that the cached tokens in refresher are considered
+         * Configure the amount of time, relative to SSO OIDC token expiration, that the cached tokens in refresher are considered
          * stale and should no longer be used.
          *
-         * <p>By default, this is 5 minute.</p>
+         * <p>By default, this is 1 minute.</p>
          */
         Builder staleTime(Duration onDiskStaleDuration);
 
         /**
+         * Configure the amount of time, relative to SSO OIDC token expiration, that the cached tokens in refresher are considered
+         * close to stale and should be prefetched from the service.
          *
-         * Configure the amount of time, relative to Sso-Oidc token , that the cached tokens in refresher are considered
-         * prefetched from service..
+         * <p>By default, this is 5 minutes.</p>
          */
         Builder prefetchTime(Duration prefetchTime);
 
         /**
          * Configure whether the provider should fetch tokens asynchronously in the background. If this is true,
-         * threads are less likely to block when token are loaded, but additional resources are used to maintain
+         * threads are less likely to block when tokens are loaded, but additional resources are used to maintain
          * the provider.
          *
          * <p>By default, this is disabled.</p>


### PR DESCRIPTION
## Motivation and Context

The Javadoc for `SsoOidcTokenProvider.Builder` contained errors that could mislead callers, most notably:

1. The `staleTime` setter claimed `"By default, this is 5 minute."` — actual default is **1 minute** (`DEFAULT_STALE_DURATION = Duration.ofMinutes(1)`).
2. The `prefetchTime` setter's Javadoc was missing the default-value statement entirely (actual: 5 minutes).

## Modifications

Doc-only edits to `SsoOidcTokenProvider.java`:

- `staleTime`: fix wrong default (`5 minute` → `1 minute`), add `expiration`, fix capitalization/spacing
- `prefetchTime`: add missing default (`5 minutes`), rewrite for clarity, add `expiration`, fix capitalization/spacing/punctuation
- `ssoOidcClient`: remove stray blank first `*` line
- `asyncTokenUpdateEnabled`: fix `token are loaded` → `tokens are loaded` typo

## Testing

- Javadoc generates without errors (verified locally)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
