### PR TITLE
Allow PR workflow to run for doc only updates

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -2,10 +2,6 @@ name: Build SDK
 on:
   merge_group:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '.all-contributorsrc'
-      - 'docs/**'
 
 concurrency:
   group: start-pull-request-build-${{ github.ref }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Doc only PRs are currently blocked, this allows the required CI to run and PR to be merged