### PR TITLE
refactor: extract resolveMetricPublishersMethod to ClientClassUtils

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -25,6 +25,7 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.internal.Constant.EVENT_PUBLISHER_PARAM_NAME;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.addS3ArnableFieldCode;
+import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.resolveMetricPublishersMethod;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.transformServiceId;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.updateSdkClientConfigurationMethod;
 import static software.amazon.awssdk.codegen.poet.client.SyncClientClass.addRequestModifierCode;
@@ -41,7 +42,6 @@ import com.squareup.javapoet.WildcardTypeName;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -75,7 +75,6 @@ import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.codegen.poet.model.EventStreamSpecHelper;
 import software.amazon.awssdk.codegen.poet.model.ServiceClientConfigurationUtils;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
-import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.AsyncResponseTransformerUtils;
 import software.amazon.awssdk.core.async.SdkPublisher;
@@ -565,41 +564,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
                                                   .build();
         
         type.addMethod(presignedUrlExtension);
-    }
-
-    private MethodSpec resolveMetricPublishersMethod() {
-        String clientConfigName = "clientConfiguration";
-        String requestOverrideConfigName = "requestOverrideConfiguration";
-
-        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("resolveMetricPublishers")
-                .addModifiers(PRIVATE, STATIC)
-                .returns(ParameterizedTypeName.get(List.class, MetricPublisher.class))
-                .addParameter(SdkClientConfiguration.class, clientConfigName)
-                .addParameter(RequestOverrideConfiguration.class, requestOverrideConfigName);
-
-        String publishersName = "publishers";
-
-        methodBuilder.addStatement("$T $N = null", ParameterizedTypeName.get(List.class, MetricPublisher.class), publishersName);
-
-        methodBuilder.beginControlFlow("if ($N != null)", requestOverrideConfigName)
-                .addStatement("$N = $N.metricPublishers()", publishersName, requestOverrideConfigName)
-                .endControlFlow();
-
-        methodBuilder.beginControlFlow("if ($1N == null || $1N.isEmpty())", publishersName)
-                .addStatement("$N = $N.option($T.$N)",
-                              publishersName,
-                              clientConfigName,
-                              SdkClientOption.class,
-                              "METRIC_PUBLISHERS")
-                .endControlFlow();
-
-        methodBuilder.beginControlFlow("if ($1N == null)", publishersName)
-                .addStatement("$N = $T.emptyList()", publishersName, Collections.class)
-                .endControlFlow();
-
-        methodBuilder.addStatement("return $N", publishersName);
-
-        return methodBuilder.build();
     }
 
     private void addScheduledExecutorIfNeeded(Builder classBuilder) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.codegen.poet.client;
 
 import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.poet.PoetUtils.classNameFromFqcn;
 
 import com.squareup.javapoet.ClassName;
@@ -26,6 +27,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -52,6 +54,7 @@ import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.auth.scheme.AuthSchemeSpecUtils;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.SdkRequest;
@@ -67,6 +70,7 @@ import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -578,6 +582,41 @@ public final class ClientClassUtils {
         b.endControlFlow();
 
         return b.build();
+    }
+
+    static MethodSpec resolveMetricPublishersMethod() {
+        String clientConfigName = "clientConfiguration";
+        String requestOverrideConfigName = "requestOverrideConfiguration";
+
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("resolveMetricPublishers")
+                .addModifiers(PRIVATE, STATIC)
+                .returns(ParameterizedTypeName.get(List.class, MetricPublisher.class))
+                .addParameter(SdkClientConfiguration.class, clientConfigName)
+                .addParameter(RequestOverrideConfiguration.class, requestOverrideConfigName);
+
+        String publishersName = "publishers";
+
+        methodBuilder.addStatement("$T $N = null", ParameterizedTypeName.get(List.class, MetricPublisher.class), publishersName);
+
+        methodBuilder.beginControlFlow("if ($N != null)", requestOverrideConfigName)
+                .addStatement("$N = $N.metricPublishers()", publishersName, requestOverrideConfigName)
+                .endControlFlow();
+
+        methodBuilder.beginControlFlow("if ($1N == null || $1N.isEmpty())", publishersName)
+                .addStatement("$N = $N.option($T.$N)",
+                              publishersName,
+                              clientConfigName,
+                              SdkClientOption.class,
+                              "METRIC_PUBLISHERS")
+                .endControlFlow();
+
+        methodBuilder.beginControlFlow("if ($1N == null)", publishersName)
+                .addStatement("$N = $T.emptyList()", publishersName, Collections.class)
+                .endControlFlow();
+
+        methodBuilder.addStatement("return $N", publishersName);
+
+        return methodBuilder.build();
     }
 
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -22,6 +22,7 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.poet.PoetUtils.classNameFromFqcn;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.addS3ArnableFieldCode;
+import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.resolveMetricPublishersMethod;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.transformServiceId;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.updateSdkClientConfigurationMethod;
 
@@ -34,7 +35,6 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,7 +62,6 @@ import software.amazon.awssdk.codegen.poet.client.specs.QueryProtocolSpec;
 import software.amazon.awssdk.codegen.poet.client.specs.XmlProtocolSpec;
 import software.amazon.awssdk.codegen.poet.model.ServiceClientConfigurationUtils;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
-import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
@@ -410,41 +409,6 @@ public class SyncClientClass extends SyncClientInterface {
             default:
                 throw new RuntimeException("Unknown protocol: " + protocol.name());
         }
-    }
-
-    private MethodSpec resolveMetricPublishersMethod() {
-        String clientConfigName = "clientConfiguration";
-        String requestOverrideConfigName = "requestOverrideConfiguration";
-
-        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("resolveMetricPublishers")
-                .addModifiers(PRIVATE, STATIC)
-                .returns(ParameterizedTypeName.get(List.class, MetricPublisher.class))
-                .addParameter(SdkClientConfiguration.class, clientConfigName)
-                .addParameter(RequestOverrideConfiguration.class, requestOverrideConfigName);
-
-        String publishersName = "publishers";
-
-        methodBuilder.addStatement("$T $N = null", ParameterizedTypeName.get(List.class, MetricPublisher.class), publishersName);
-
-        methodBuilder.beginControlFlow("if ($N != null)", requestOverrideConfigName)
-                .addStatement("$N = $N.metricPublishers()", publishersName, requestOverrideConfigName)
-                .endControlFlow();
-
-        methodBuilder.beginControlFlow("if ($1N == null || $1N.isEmpty())", publishersName)
-                .addStatement("$N = $N.option($T.$N)",
-                              publishersName,
-                              clientConfigName,
-                              SdkClientOption.class,
-                              "METRIC_PUBLISHERS")
-                .endControlFlow();
-
-        methodBuilder.beginControlFlow("if ($1N == null)", publishersName)
-                .addStatement("$N = $T.emptyList()", publishersName, Collections.class)
-                .endControlFlow();
-
-        methodBuilder.addStatement("return $N", publishersName);
-
-        return methodBuilder.build();
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
`resolveMetricPublishersMethod()` was duplicated verbatim in both `AsyncClientClass.java` and `SyncClientClass.java` — identical method body, identical parameters, identical generated output. This duplication makes maintenance error-prone; a fix or change in one copy could easily be missed in the other.

This is a pure internal refactor with no change to generated client code or SDK behavior.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
Extracted the shared `resolveMetricPublishersMethod()` into `ClientClassUtils.java` as a package-private static method (matching existing conventions like `updateSdkClientConfigurationMethod` and `addS3ArnableFieldCode`). Both `AsyncClientClass` and `SyncClientClass` now call it via static import.

Removed now-unused imports (`java.util.Collections`, `RequestOverrideConfiguration`) from both client classes; added the required imports (`Collections`, `RequestOverrideConfiguration`, `MetricPublisher`, `STATIC`) to `ClientClassUtils`.
<!--- Describe your changes in detail -->

## Testing
- `mvn install -pl :codegen -am -DskipTests` passes (compilation verified).
- Ran the codegen test suite locally; failures observed are pre-existing and unrelated to this change (a JDK `URL.getFile()` encoding issue with spaces in Windows paths), with identical failure counts before and after this change.
- Since only the call site of `resolveMetricPublishersMethod()` changed (moved to a shared utility, same method body), generated client output is expected to be unaffected. Have not yet done a full before/after diff of generated sources — will confirm via CI golden-file tests.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

(This is a non-functional refactor; neither box strictly applies, but flagging here for reviewer visibility.)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes (relies on existing codegen golden-file tests, no new tests added)
- [ ] All new and existing tests passed (pre-existing, unrelated Windows test failures — see Testing section)
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license