### PR TITLE
fix: report correct rb# body metric in AsyncRequestBody wrappers

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-9609e34.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-9609e34.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed several delegating AsyncRequestBody implementations (including those used by S3 Transfer Manager uploads) that reported the request-body type as unknown in the user-agent business metric instead of the actual type (file, bytes, or stream)."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/listener/AsyncRequestBodyListener.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/listener/AsyncRequestBodyListener.java
@@ -68,6 +68,11 @@ public interface AsyncRequestBodyListener extends PublisherListener<ByteBuffer> 
         }
 
         @Override
+        public String body() {
+            return delegate.body();
+        }
+
+        @Override
         public SdkPublisher<AsyncRequestBody> split(AsyncRequestBodySplitConfiguration splitConfiguration) {
             return delegate.split(splitConfiguration);
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ChecksumCalculatingAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ChecksumCalculatingAsyncRequestBody.java
@@ -187,6 +187,11 @@ public class ChecksumCalculatingAsyncRequestBody implements AsyncRequestBody {
     }
 
     @Override
+    public String body() {
+        return wrapped.body();
+    }
+
+    @Override
     public void subscribe(Subscriber<? super ByteBuffer> s) {
         Validate.notNull(s, "Subscription MUST NOT be null.");
         if (sdkChecksum != null) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBody.java
@@ -70,6 +70,11 @@ public class CompressionAsyncRequestBody implements AsyncRequestBody {
         return wrapped.contentType();
     }
 
+    @Override
+    public String body() {
+        return wrapped.body();
+    }
+
     private SdkPublisher<Iterable<ByteBuffer>> split(SdkPublisher<ByteBuffer> source) {
         return subscriber -> source.subscribe(new SplittingSubscriber(subscriber));
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodySplitHelper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodySplitHelper.java
@@ -196,5 +196,10 @@ public final class FileAsyncRequestBodySplitHelper {
         public Optional<Long> contentLength() {
             return fileAsyncRequestBody.contentLength();
         }
+
+        @Override
+        public String body() {
+            return fileAsyncRequestBody.body();
+        }
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/listener/NotifyingAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/listener/NotifyingAsyncRequestBodyTest.java
@@ -15,16 +15,24 @@
 
 package software.amazon.awssdk.core.async.listener;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Consumer;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBody.BodyType;
 import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
 
 public class NotifyingAsyncRequestBodyTest {
@@ -53,6 +61,35 @@ public class NotifyingAsyncRequestBodyTest {
 
         notifying.contentType();
         verify(mockRequestBody).contentType();
+    }
+
+    @Test
+    public void body_delegatesCall() {
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(mockRequestBody, mockListener);
+
+        notifying.body();
+        verify(mockRequestBody).body();
+    }
+
+    @Test
+    public void body_wrappingFileRequestBody_returnsFile() throws IOException {
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        Path path = fs.getPath("./test");
+        Files.write(path, "Hello world".getBytes());
+
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(AsyncRequestBody.fromFile(path), mockListener);
+
+        assertThat(notifying.body()).isEqualTo(BodyType.FILE.getName());
+    }
+
+    @Test
+    public void body_wrappingBytesRequestBody_returnsBytes() {
+        AsyncRequestBodyListener.NotifyingAsyncRequestBody notifying =
+            new AsyncRequestBodyListener.NotifyingAsyncRequestBody(AsyncRequestBody.fromString("Hello world"), mockListener);
+
+        assertThat(notifying.body()).isEqualTo(BodyType.BYTES.getName());
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ChecksumCalculatingAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ChecksumCalculatingAsyncRequestBodyTest.java
@@ -35,12 +35,14 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBody.BodyType;
 import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.http.async.SimpleSubscriber;
 import software.amazon.awssdk.http.auth.spi.signer.PayloadChecksumStore;
@@ -163,6 +165,18 @@ public class ChecksumCalculatingAsyncRequestBodyTest {
 
         assertThat(provider.contentLength()).hasValue((long) tc.expectedBody.length());
         assertThat(sb).hasToString(tc.expectedBody);
+    }
+
+    private static Stream<Arguments> bodyTypeCases() {
+        return Stream.of(
+            Arguments.of("file source -> File", AsyncRequestBody.fromFile(path), BodyType.FILE),
+            Arguments.of("bytes source -> Bytes", AsyncRequestBody.fromString(testString), BodyType.BYTES));
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("bodyTypeCases")
+    public void body_forwardsWrappedBodyType(String description, AsyncRequestBody wrapped, BodyType expected) {
+        assertThat(checksumPublisher(wrapped).body()).isEqualTo(expected.getName());
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/CompressionAsyncRequestBodyTest.java
@@ -17,22 +17,32 @@ package software.amazon.awssdk.core.internal.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import io.reactivex.Flowable;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBody.BodyType;
 import software.amazon.awssdk.core.internal.compression.Compressor;
 import software.amazon.awssdk.core.internal.compression.GzipCompressor;
 import software.amazon.awssdk.core.internal.util.Mimetype;
@@ -124,6 +134,36 @@ public final class CompressionAsyncRequestBodyTest {
         assertThat(byteBuffer.array()).isEmpty();
         assertThat(byteBuffer.array()).isEqualTo(new byte[0]);
         assertThat(requestBody.contentType()).isEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
+    }
+
+    private static Stream<Arguments> bodyTypeCases() {
+        return Stream.of(
+            Arguments.of("file source -> File", AsyncRequestBody.fromFile(fileBody()), BodyType.FILE),
+            Arguments.of("bytes source -> Bytes", AsyncRequestBody.fromString("Hello world"), BodyType.BYTES));
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("bodyTypeCases")
+    public void body_forwardsUnderlyingBodyType(String description, AsyncRequestBody wrapped, BodyType expected) {
+        assertThat(compressionBody(wrapped).body()).isEqualTo(expected.getName());
+    }
+
+    private static CompressionAsyncRequestBody compressionBody(AsyncRequestBody wrapped) {
+        return CompressionAsyncRequestBody.builder()
+                                          .compressor(compressor)
+                                          .asyncRequestBody(wrapped)
+                                          .build();
+    }
+
+    private static Path fileBody() {
+        try {
+            FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+            Path path = fs.getPath("./test");
+            Files.write(path, "Hello world".getBytes());
+            return path;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private static String createCompressibleStringOfGivenSize(int size) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodySplitHelperTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodySplitHelperTest.java
@@ -19,9 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.core.internal.async.SplittingPublisherTestUtils.verifyIndividualAsyncRequestBody;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -29,8 +32,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncRequestBody.BodyType;
 import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
 import software.amazon.awssdk.testutils.RandomTempFile;
 
@@ -83,6 +90,51 @@ public class FileAsyncRequestBodySplitHelperTest {
         scheduledFuture.cancel(true);
         int expectedMaxConcurrency = (int) (bufferSize / chunkSizeInBytes);
         assertThat(maxConcurrency.get()).isLessThanOrEqualTo(expectedMaxConcurrency);
+    }
+
+    @Test
+    public void split_fileRequestBody_partsReportFileBodyType() throws Exception {
+        FileAsyncRequestBody fileAsyncRequestBody = FileAsyncRequestBody.builder()
+                                                                        .path(testFile)
+                                                                        .chunkSizeInBytes(10)
+                                                                        .build();
+        AsyncRequestBodySplitConfiguration config =
+            AsyncRequestBodySplitConfiguration.builder()
+                                              .chunkSizeInBytes((long) CHUNK_SIZE)
+                                              .bufferSizeInBytes(55L)
+                                              .build();
+        FileAsyncRequestBodySplitHelper helper = new FileAsyncRequestBodySplitHelper(fileAsyncRequestBody, config);
+
+        List<String> bodyTypes = new CopyOnWriteArrayList<>();
+        helper.split()
+              .subscribe(requestBody -> {
+                  bodyTypes.add(requestBody.body());
+                  // Draining each part lets the buffer-limited publisher emit the next one.
+                  requestBody.subscribe(new DrainingSubscriber());
+              })
+              .get(5, TimeUnit.SECONDS);
+
+        assertThat(bodyTypes).isNotEmpty();
+        assertThat(bodyTypes).containsOnly(BodyType.FILE.getName());
+    }
+
+    private static final class DrainingSubscriber implements Subscriber<ByteBuffer> {
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
     }
 
     private static Runnable verifyConcurrentRequests(FileAsyncRequestBodySplitHelper helper, AtomicInteger maxConcurrency) {

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerUploadUserAgentBusinessMetricWireMockTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerUploadUserAgentBusinessMetricWireMockTest.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
@@ -62,6 +63,7 @@ public class TransferManagerUploadUserAgentBusinessMetricWireMockTest {
     private static final long PART_SIZE = 100L;
     private static Path smallFile;
     private static Path largeFile;
+    private static ExecutorService streamExecutor;
 
     @BeforeAll
     public static void setup() throws IOException {
@@ -69,6 +71,7 @@ public class TransferManagerUploadUserAgentBusinessMetricWireMockTest {
         writeTestFile(smallFile, PART_SIZE / 2);
         largeFile = Files.createTempFile("multi-part", ".dat");
         writeTestFile(largeFile, PART_SIZE * 2);
+        streamExecutor = Executors.newSingleThreadExecutor();
         wireMock.start();
     }
 
@@ -76,6 +79,7 @@ public class TransferManagerUploadUserAgentBusinessMetricWireMockTest {
     public static void teardown() throws IOException {
         Files.deleteIfExists(smallFile);
         Files.deleteIfExists(largeFile);
+        streamExecutor.shutdownNow();
         wireMock.stop();
     }
 
@@ -256,7 +260,7 @@ public class TransferManagerUploadUserAgentBusinessMetricWireMockTest {
             @Override
             void runUpload(S3TransferManager tm) {
                 upload(tm, AsyncRequestBody.fromInputStream(new ByteArrayInputStream(new byte[16]), 16L,
-                                                            Executors.newSingleThreadExecutor()));
+                                                            streamExecutor));
             }
 
             @Override

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerUploadUserAgentBusinessMetricWireMockTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerUploadUserAgentBusinessMetricWireMockTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.internal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.Executors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.UploadRequest;
+
+/**
+ * Verifies that {@link S3TransferManager} uploads propagate the request-body business metric ({@code md/rb#<code>}) onto the user
+ * agent of the request that carries the body, on the wire, across both TM flavors (Java-based and CRT-based) and the file, bytes,
+ * and stream body types.
+ */
+public class TransferManagerUploadUserAgentBusinessMetricWireMockTest {
+    private static final WireMockServer wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+    private static final long PART_SIZE = 100L;
+    private static Path smallFile;
+    private static Path largeFile;
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        smallFile = Files.createTempFile("single-part", ".dat");
+        writeTestFile(smallFile, PART_SIZE / 2);
+        largeFile = Files.createTempFile("multi-part", ".dat");
+        writeTestFile(largeFile, PART_SIZE * 2);
+        wireMock.start();
+    }
+
+    @AfterAll
+    public static void teardown() throws IOException {
+        Files.deleteIfExists(smallFile);
+        Files.deleteIfExists(largeFile);
+        wireMock.stop();
+    }
+
+    private static Stream<Arguments> uploadMatrix() {
+        return Stream.of(
+            Arguments.of("JAVA / single-part file -> PutObject", TmFlavor.JAVA, Scenario.SINGLE_PART_FILE, "md/rb#f"),
+            Arguments.of("JAVA / single-part bytes -> PutObject", TmFlavor.JAVA, Scenario.SINGLE_PART_BYTES, "md/rb#b"),
+            Arguments.of("JAVA / single-part stream -> PutObject", TmFlavor.JAVA, Scenario.SINGLE_PART_STREAM, "md/rb#s"),
+            Arguments.of("JAVA / multipart file -> UploadPart", TmFlavor.JAVA, Scenario.MULTIPART_FILE, "md/rb#f"),
+            Arguments.of("CRT / single-part file -> PutObject", TmFlavor.CRT, Scenario.SINGLE_PART_FILE, "md/rb#f"),
+            Arguments.of("CRT / single-part bytes -> PutObject", TmFlavor.CRT, Scenario.SINGLE_PART_BYTES, "md/rb#b"),
+            Arguments.of("CRT / single-part stream -> PutObject", TmFlavor.CRT, Scenario.SINGLE_PART_STREAM, "md/rb#s"),
+            Arguments.of("CRT / multipart file -> UploadPart", TmFlavor.CRT, Scenario.MULTIPART_FILE, "md/rb#f"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("uploadMatrix")
+    void upload_userAgentCarriesExpectedBodyMetric(String description, TmFlavor flavor, Scenario scenario,
+                                                   String expectedMetric) {
+        wireMock.resetAll();
+        scenario.stub();
+
+        try (S3TransferManager tm = flavor.create(scenario.multipartEnabled())) {
+            scenario.runUpload(tm);
+        }
+
+        wireMock.verify(scenario.verification().withHeader("User-Agent", containing(expectedMetric)));
+    }
+
+    private static void uploadFile(S3TransferManager tm, Path source) {
+        tm.uploadFile(u -> u.source(source).putObjectRequest(put -> put.bucket("bucket").key("key")))
+          .completionFuture().join();
+    }
+
+    private static void upload(S3TransferManager tm, AsyncRequestBody body) {
+        tm.upload(UploadRequest.builder()
+                               .requestBody(body)
+                               .putObjectRequest(put -> put.bucket("bucket").key("key"))
+                               .build())
+          .completionFuture().join();
+    }
+
+    private static S3AsyncClientBuilder javaClientBuilder() {
+        return S3AsyncClient.builder()
+                            .credentialsProvider(StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create("akid", "skid")))
+                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                            .region(Region.US_EAST_1)
+                            .forcePathStyle(true);
+    }
+
+    private static S3CrtAsyncClientBuilder crtClientBuilder() {
+        return S3AsyncClient.crtBuilder()
+                            .credentialsProvider(StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create("akid", "skid")))
+                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                            .region(Region.US_EAST_1)
+                            .forcePathStyle(true);
+    }
+
+    private static void stubSinglePutSuccess() {
+        wireMock.stubFor(put(anyUrl()).willReturn(aResponse().withStatus(200)));
+    }
+
+    private static void stubSuccessfulMultipartUpload() {
+        String mpuInitBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                             + "<InitiateMultipartUploadResult>\n"
+                             + "   <Bucket>bucket</Bucket>\n"
+                             + "   <Key>key</Key>\n"
+                             + "   <UploadId>uploadId</UploadId>\n"
+                             + "</InitiateMultipartUploadResult>";
+        wireMock.stubFor(post(urlEqualTo("/bucket/key?uploads"))
+                             .willReturn(aResponse().withStatus(200).withBody(mpuInitBody)));
+
+        for (int i = 1; i <= 2; i++) {
+            // The CRT native client reads the part ETag from the response header; the Java client reads it from the body.
+            // Provide both so the one stub serves both flavors.
+            wireMock.stubFor(put(urlEqualTo("/bucket/key?partNumber=" + i + "&uploadId=uploadId"))
+                                 .willReturn(aResponse()
+                                                 .withStatus(200)
+                                                 .withHeader("ETag", "\"etag" + i + "\"")
+                                                 .withBody("<Part><PartNumber>" + i +
+                                                           "</PartNumber><ETag>\"etag" + i + "\"</ETag></Part>")));
+        }
+
+        String mpuCompleteBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                 + "<CompleteMultipartUploadResult>\n"
+                                 + "   <Bucket>bucket</Bucket>\n"
+                                 + "   <Key>key</Key>\n"
+                                 + "   <ETag>etag</ETag>\n"
+                                 + "</CompleteMultipartUploadResult>";
+        wireMock.stubFor(post(urlEqualTo("/bucket/key?uploadId=uploadId"))
+                             .willReturn(aResponse().withStatus(200).withBody(mpuCompleteBody)));
+    }
+
+    private static void writeTestFile(Path file, long size) {
+        try (OutputStream os = Files.newOutputStream(file, StandardOpenOption.CREATE)) {
+            byte[] buff = new byte[4096];
+            long remaining = size;
+            while (remaining != 0) {
+                int writeLen = (int) Math.min(remaining, buff.length);
+                os.write(buff, 0, writeLen);
+                remaining -= writeLen;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    enum TmFlavor {
+        JAVA {
+            @Override
+            S3TransferManager create(boolean multipartEnabled) {
+                S3AsyncClientBuilder builder = javaClientBuilder();
+                if (multipartEnabled) {
+                    builder.multipartEnabled(true)
+                           .multipartConfiguration(c -> c.thresholdInBytes(PART_SIZE)
+                                                         .minimumPartSizeInBytes(PART_SIZE)
+                                                         .apiCallBufferSizeInBytes(PART_SIZE * 4));
+                }
+                return S3TransferManager.builder().s3Client(builder.build()).build();
+            }
+        },
+        CRT {
+            @Override
+            S3TransferManager create(boolean multipartEnabled) {
+                S3CrtAsyncClientBuilder builder = crtClientBuilder();
+                if (multipartEnabled) {
+                    // The CRT client always chunks natively; a small part size forces >1 UploadPart against WireMock.
+                    builder.minimumPartSizeInBytes(PART_SIZE).thresholdInBytes(PART_SIZE);
+                }
+                return S3TransferManager.builder().s3Client(builder.build()).build();
+            }
+        };
+
+        abstract S3TransferManager create(boolean multipartEnabled);
+    }
+
+    enum Scenario {
+        SINGLE_PART_FILE(false) {
+            @Override
+            void stub() {
+                stubSinglePutSuccess();
+            }
+
+            @Override
+            void runUpload(S3TransferManager tm) {
+                uploadFile(tm, smallFile);
+            }
+
+            @Override
+            RequestPatternBuilder verification() {
+                return putRequestedFor(urlPathEqualTo("/bucket/key"));
+            }
+        },
+        SINGLE_PART_BYTES(false) {
+            @Override
+            void stub() {
+                stubSinglePutSuccess();
+            }
+
+            @Override
+            void runUpload(S3TransferManager tm) {
+                upload(tm, AsyncRequestBody.fromString("hello world"));
+            }
+
+            @Override
+            RequestPatternBuilder verification() {
+                return putRequestedFor(urlPathEqualTo("/bucket/key"));
+            }
+        },
+        SINGLE_PART_STREAM(false) {
+            @Override
+            void stub() {
+                stubSinglePutSuccess();
+            }
+
+            @Override
+            void runUpload(S3TransferManager tm) {
+                upload(tm, AsyncRequestBody.fromInputStream(new ByteArrayInputStream(new byte[16]), 16L,
+                                                            Executors.newSingleThreadExecutor()));
+            }
+
+            @Override
+            RequestPatternBuilder verification() {
+                return putRequestedFor(urlPathEqualTo("/bucket/key"));
+            }
+        },
+        MULTIPART_FILE(true) {
+            @Override
+            void stub() {
+                stubSuccessfulMultipartUpload();
+            }
+
+            @Override
+            void runUpload(S3TransferManager tm) {
+                uploadFile(tm, largeFile);
+            }
+
+            @Override
+            RequestPatternBuilder verification() {
+                return putRequestedFor(urlPathEqualTo("/bucket/key")).withQueryParam("partNumber", containing("1"));
+            }
+        };
+
+        private final boolean multipartEnabled;
+
+        Scenario(boolean multipartEnabled) {
+            this.multipartEnabled = multipartEnabled;
+        }
+
+        boolean multipartEnabled() {
+            return multipartEnabled;
+        }
+
+        abstract void stub();
+
+        abstract void runUpload(S3TransferManager tm);
+
+        abstract RequestPatternBuilder verification();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtContentLengthOnlyAsyncFileRequestBody.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtContentLengthOnlyAsyncFileRequestBody.java
@@ -51,4 +51,9 @@ public final class CrtContentLengthOnlyAsyncFileRequestBody implements AsyncRequ
         });
 
     }
+
+    @Override
+    public String body() {
+        return asyncRequestBody.body();
+    }
 }


### PR DESCRIPTION
## Motivation and Context
The SDK records which `AsyncRequestBody` type backs a streaming request via a user-agent business metric (`md/rb#<code>`: `f`=file, `b`=bytes, `s`=stream, `p`=publisher, `u`=unknown). Each `AsyncRequestBody` declares its type through the `String body()` default method, and the metric is captured once at execution-context build time from the exact `AsyncRequestBody` instance handed to the client.

Several **delegating/wrapping** `AsyncRequestBody` implementations forward `contentLength()`, `contentType()`, and `split*()` to the body they wrap, but fail to override `body()`. As a result they fall through to the default `"Unknown"` and emit `md/rb#u` even though the real body type is known. This mislabels traffic on the wire. The most customer-relevant path is the Java-based S3 Transfer Manager: `TransferProgressUpdater.wrapRequestBody(...)` wraps the customer's body in `NotifyingAsyncRequestBody` before it reaches `putObject`, so single-part TM uploads reported `rb#u` even for file/byte bodies; the split wrapper caused the same mislabeling on multipart `uploadPart` requests for a file source.

## Modifications
Override `body()` to forward the wrapped body's type in each affected delegating wrapper:

- `NotifyingAsyncRequestBody` (`core/sdk-core` `AsyncRequestBodyListener`) — primary fix for the reported Transfer Manager single-part `rb#u` symptom.
- `FileAsyncRequestBodyWrapper` (`core/sdk-core` `FileAsyncRequestBodySplitHelper`) — fixes multipart file-upload `uploadPart` mislabeling.
- `ChecksumCalculatingAsyncRequestBody` and `CompressionAsyncRequestBody` (`core/sdk-core`) — consistency/future-proofing forwards; these wrap `context.requestProvider()` after the metric is captured, so they have no functional `rb#` impact today. `CompressionAsyncRequestBody` forwards the original body's type (compression is a transform, not a body source), matching the design decision not to introduce a compression-specific code.

Each change is a single `body()` override following the existing `CrtContentLengthOnlyAsyncFileRequestBody` pattern (that CRT file wrapper's forward is included here as the canonical example). No public API, lifecycle, threading, or error-model changes; `body()` is an existing `default` method on the public `AsyncRequestBody` interface. Fully backward compatible.

## Testing

Unit tests (sdk-core): extended `NotifyingAsyncRequestBodyTest`, `ChecksumCalculatingAsyncRequestBodyTest`, `CompressionAsyncRequestBodyTest`, and `FileAsyncRequestBodySplitHelperTest` to assert each wrapper forwards the correct `body()`/`BodyType` (file/bytes; split parts report file).

End-to-end (s3-transfer-manager): added `TransferManagerUploadUserAgentBusinessMetricWireMockTest`, a WireMock request-journal test that asserts the `md/rb#` token on the actual outbound User-Agent across a matrix of {TM flavor: Java, CRT} x {body/operation: single-part file/bytes/stream, multipart file}. 8 combinations, all asserting the correct metric (`rb#f`/`rb#b`/`rb#s`) on `PutObject` or `UploadPart`.

Build/test scope: `:sdk-core` and `:s3-transfer-manager` module builds pass with all new/existing tests green (sdk-core wrapper tests; s3-transfer-manager matrix 8/8). A full-repo `mvn install` was not run.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] Local run of `mvn install` succeeds  <!-- built only the affected modules (:sdk-core, :s3-transfer-manager), not a full-repo mvn install -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog

## License

- [x] I confirm that this pull request can be released under the Apache 2 license