### PR TITLE
Compliance with Reactive Streams specs

### DIFF
--- a/core/http-auth-aws/pom.xml
+++ b/core/http-auth-aws/pom.xml
@@ -155,6 +155,33 @@
 
     <build>
         <plugins>
+            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>junit</name>
+                            <value>false</value>
+                        </property>
+                    </properties>
+                    <threadCount>1</threadCount>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/core/http-auth-aws/pom.xml
+++ b/core/http-auth-aws/pom.xml
@@ -127,11 +127,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>test-utils</artifactId>
             <scope>test</scope>
@@ -155,33 +150,6 @@
 
     <build>
         <plugins>
-            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <configuration>
-                    <properties>
-                        <property>
-                            <name>junit</name>
-                            <value>false</value>
-                        </property>
-                    </properties>
-                    <threadCount>1</threadCount>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit-platform</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisherTckTest.java
+++ b/core/http-auth-aws/src/test/java/software/amazon/awssdk/http/auth/aws/internal/signer/chunkedencoding/ChunkedEncodedPublisherTckTest.java
@@ -61,9 +61,14 @@ public class ChunkedEncodedPublisherTckTest extends PublisherVerification<ByteBu
 
         Publisher<ByteBuffer> inputPublisher = Flowable.fromIterable(elements);
 
+        // Required by the builder; must match the data the input publisher produces. Production sets this from the
+        // x-amz-decoded-content-length header (see AwsChunkedV4PayloadSigner).
+        long contentLength = (long) totalElements * INPUT_STREAM_ELEMENT_SIZE;
+
         return ChunkedEncodedPublisher.builder()
                                       .chunkSize(CHUNK_SIZE)
                                       .publisher(inputPublisher)
+                                      .contentLength(contentLength)
                                       .addEmptyTrailingChunk(false)
                                       .build();
     }

--- a/core/sdk-core/pom.xml
+++ b/core/sdk-core/pom.xml
@@ -194,11 +194,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
             <scope>test</scope>
@@ -232,33 +227,6 @@
     </dependencies>
     <build>
         <plugins>
-            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <configuration>
-                    <properties>
-                        <property>
-                            <name>junit</name>
-                            <value>false</value>
-                        </property>
-                    </properties>
-                    <threadCount>1</threadCount>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit-platform</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/http-client-spi/pom.xml
+++ b/http-client-spi/pom.xml
@@ -76,11 +76,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <scope>test</scope>

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -113,11 +113,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <scope>test</scope>

--- a/http-clients/netty-nio-client/pom.xml
+++ b/http-clients/netty-nio-client/pom.xml
@@ -148,11 +148,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <scope>test</scope>
@@ -254,33 +249,6 @@
 
     <build>
         <plugins>
-            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <configuration>
-                    <properties>
-                        <property>
-                            <name>junit</name>
-                            <value>false</value>
-                        </property>
-                    </properties>
-                    <threadCount>1</threadCount>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit-platform</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,15 @@
 
     <dependencies>
         <!-- Internal dependencies are managed in the bom-internal module. -->
+
+        <!-- reactive-streams-tck brings TestNG, which is needed globally so the surefire-testng provider
+             can discover TCK tests in any module without per-module surefire configuration. -->
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>${reactive-streams.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -302,12 +311,24 @@
                             <include>**/*TestCase.java</include>
                         </includes>
                         <skipTests>${skip.unit.tests}</skipTests>
+                        <!-- Prevent TestNG from re-running JUnit tests -->
+                        <properties>
+                            <property>
+                                <name>junit</name>
+                                <value>false</value>
+                            </property>
+                        </properties>
                     </configuration>
                     <!-- Have to explicitly set surefire provider because reactivestreamsTCK is using TestNG-->
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.surefire</groupId>
                             <artifactId>surefire-junit-platform</artifactId>
+                            <version>${maven.surefire.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-testng</artifactId>
                             <version>${maven.surefire.version}</version>
                         </dependency>
                     </dependencies>

--- a/services-custom/s3-transfer-manager/pom.xml
+++ b/services-custom/s3-transfer-manager/pom.xml
@@ -225,6 +225,33 @@
 
     <build>
         <plugins>
+            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>junit</name>
+                            <value>false</value>
+                        </property>
+                    </properties>
+                    <threadCount>1</threadCount>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/services-custom/s3-transfer-manager/pom.xml
+++ b/services-custom/s3-transfer-manager/pom.xml
@@ -186,11 +186,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
             <scope>test</scope>
@@ -225,33 +220,6 @@
 
     <build>
         <plugins>
-            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <configuration>
-                    <properties>
-                        <property>
-                            <name>junit</name>
-                            <value>false</value>
-                        </property>
-                    </properties>
-                    <threadCount>1</threadCount>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit-platform</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
@@ -40,6 +40,7 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
     private final int maxConcurrentExecutions;
     private final AtomicInteger numRequestsInFlight;
     private volatile boolean upstreamDone;
+    private volatile boolean onErrorInvoked;
     private volatile Subscription subscription;
 
     private final Set<CompletableFuture<?>> requestsInFlight;
@@ -56,9 +57,14 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
         returnFuture.whenComplete((r, t) -> {
             if (t != null) {
                 requestsInFlight.forEach(f -> f.cancel(true));
-                synchronized (this) {
-                    if (subscription != null) {
-                        subscription.cancel();
+                // Skip cancelling when the failure came from onError: upstream has already terminated, and cancelling here
+                // would call Subscription::cancel from within onError (Reactive Streams rule 2.3). Still cancel on an
+                // external abort.
+                if (!onErrorInvoked) {
+                    synchronized (this) {
+                        if (subscription != null) {
+                            subscription.cancel();
+                        }
                     }
                 }
             }
@@ -79,6 +85,8 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
 
     @Override
     public void onNext(T item) {
+        // Reactive Streams rule 2.13: onNext must throw NullPointerException on a null element.
+        Validate.paramNotNull(item, "item");
         numRequestsInFlight.incrementAndGet();
         CompletableFuture<?> currentRequest;
 
@@ -111,6 +119,9 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
 
     @Override
     public void onError(Throwable t) {
+        // Set before completing the future: completeExceptionally may run the whenComplete handler synchronously, and it
+        // must see this flag to avoid cancelling the subscription from within onError (see constructor).
+        onErrorInvoked = true;
         // Need to complete future exceptionally first to prevent
         // accidental successful completion by a concurrent checkForCompletion.
         returnFuture.completeExceptionally(t);

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriberTest.java
@@ -128,12 +128,9 @@ class AsyncBufferingSubscriberTest {
         subscriber.onSubscribe(mockSubscription);
         subscriber.onNext("item");
 
-        /*
-        subscription.cancel() now exists in two codepaths:
-        - in onNext() catch block.
-        - in future.whenComplete()
-         */
-        verify(mockSubscription, times(2)).cancel();
+        // Cancelled once, from the onNext() catch block. The whenComplete() handler does not cancel again, which would
+        // violate Reactive Streams rule 2.3 (cancel from within onError).
+        verify(mockSubscription, times(1)).cancel();
         assertThatThrownBy(future::join).hasCause(exception);
     }
 

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -31,6 +31,33 @@
     <url>https://aws.amazon.com/sdkforjava</url>
     <build>
         <plugins>
+            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>junit</name>
+                            <value>false</value>
+                        </property>
+                    </properties>
+                    <threadCount>1</threadCount>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -31,33 +31,6 @@
     <url>https://aws.amazon.com/sdkforjava</url>
     <build>
         <plugins>
-            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <configuration>
-                    <properties>
-                        <property>
-                            <name>junit</name>
-                            <value>false</value>
-                        </property>
-                    </properties>
-                    <threadCount>1</threadCount>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit-platform</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -205,11 +178,6 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -139,6 +139,33 @@
 
     <build>
         <plugins>
+            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>junit</name>
+                            <value>false</value>
+                        </property>
+                    </properties>
+                    <threadCount>1</threadCount>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -95,11 +95,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <scope>test</scope>
@@ -139,33 +134,6 @@
 
     <build>
         <plugins>
-            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <configuration>
-                    <properties>
-                        <property>
-                            <name>junit</name>
-                            <value>false</value>
-                        </property>
-                    </properties>
-                    <threadCount>1</threadCount>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit-platform</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven.surefire.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
@@ -96,7 +96,16 @@ public final class SimplePublisher<T> implements Publisher<T> {
     private final FailureMessage failureMessage = new FailureMessage();
 
     /**
+     * Whether {@link #subscribe(Subscriber)} has already been called, used to reject a second subscription. Tracked
+     * separately from {@link #subscriber} because that field is cleared on termination and must not re-open subscription.
+     */
+    private final AtomicBoolean subscribed = new AtomicBoolean(false);
+
+    /**
      * The subscriber provided via {@link #subscribe(Subscriber)}. This publisher only supports a single subscriber.
+     *
+     * <p>Cleared when the stream terminates (complete, error, or cancel) so the publisher does not retain the subscriber
+     * reference, per Reactive Streams rule 3.13.
      */
     private Subscriber<? super T> subscriber;
 
@@ -196,7 +205,7 @@ public final class SimplePublisher<T> implements Publisher<T> {
      */
     @Override
     public void subscribe(Subscriber<? super T> s) {
-        if (subscriber != null) {
+        if (!subscribed.compareAndSet(false, true)) {
             s.onSubscribe(new NoOpSubscription());
             s.onError(new IllegalStateException("Only one subscription may be active at a time."));
             return;
@@ -275,6 +284,7 @@ public final class SimplePublisher<T> implements Publisher<T> {
 
                         log.trace(() -> "Calling onComplete()");
                         subscriber.onComplete();
+                        subscriber = null;
                         break;
                     case ON_ERROR:
 
@@ -283,9 +293,11 @@ public final class SimplePublisher<T> implements Publisher<T> {
                                                                               onErrorEntry.failure));
                         log.trace(() -> "Calling onError() with " + onErrorEntry.failure, onErrorEntry.failure);
                         subscriber.onError(onErrorEntry.failure);
+                        subscriber = null;
                         break;
                     case CANCEL:
                         failureMessage.trySet(() -> new CancellationException("subscription has been cancelled."));
+                        subscriber = null;
                         break;
                     default:
                         // Should never happen. Famous last words?
@@ -338,7 +350,10 @@ public final class SimplePublisher<T> implements Publisher<T> {
             // Create exception here instead of in supplier to preserve a more-useful stack trace.
             RuntimeException failure = new IllegalStateException("Encountered fatal error in publisher", cause);
             failureMessage.trySet(() -> failure);
-            subscriber.onError(cause instanceof Error ? cause : failure);
+            if (subscriber != null) {
+                subscriber.onError(cause instanceof Error ? cause : failure);
+                subscriber = null;
+            }
 
             while (true) {
                 QueueEntry<T> entry = standardPriorityQueue.poll();

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
@@ -102,6 +102,12 @@ public final class SimplePublisher<T> implements Publisher<T> {
     private final AtomicBoolean subscribed = new AtomicBoolean(false);
 
     /**
+     * True while the subscriber's {@code onSubscribe} is executing. Used to prevent {@link #processEventQueue()} from
+     * delivering {@code onNext} signals before {@code onSubscribe} has returned, as required by Reactive Streams rule 1.03.
+     */
+    private volatile boolean onSubscribeInProgress = false;
+
+    /**
      * The subscriber provided via {@link #subscribe(Subscriber)}. This publisher only supports a single subscriber.
      *
      * <p>Cleared when the stream terminates (complete, error, or cancel) so the publisher does not retain the subscriber
@@ -212,7 +218,12 @@ public final class SimplePublisher<T> implements Publisher<T> {
         }
 
         this.subscriber = s;
-        s.onSubscribe(new SubscriptionImpl());
+        onSubscribeInProgress = true;
+        try {
+            s.onSubscribe(new SubscriptionImpl());
+        } finally {
+            onSubscribeInProgress = false;
+        }
         processEventQueue();
     }
 
@@ -326,6 +337,11 @@ public final class SimplePublisher<T> implements Publisher<T> {
 
         if (subscriber == null) {
             // We don't have a subscriber yet.
+            return false;
+        }
+
+        if (onSubscribeInProgress) {
+            // Do not deliver signals until onSubscribe has returned (Reactive Streams rule 1.03).
             return false;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Reactive Streams TCK tests are TestNG-based, so Surefire only runs them when the `surefire-testng` provider is configured. Only `core/sdk-core` and `http-clients/netty-nio-client` had it. As a result, ~20 TCK tests across four other modules were **silently skipped** — they compiled and looked like they ran, but Surefire never executed them (no report, no "Tests run" line).

## Modifications

<!--- Describe your changes in detail -->

**1. Moved TCK/TestNG surefire configuration to the parent `pom.xml`**

Previously, each module with TCK tests needed to independently declare:

- `reactive-streams-tck` as a test dependency
- `surefire-testng` as a surefire provider dependency

This was error-prone — four modules had the TCK dependency but not the provider, silently skipping their tests.

Now the parent POM declares `reactive-streams-tck` as a global test dependency (which brings TestNG transitively) and configures both `surefire-junit-platform` and `surefire-testng` providers. Any module with a `*TckTest.java` file will have it automatically discovered and executed. The `junit=false` TestNG property prevents double-execution of JUnit tests.

Removed the per-module `reactive-streams-tck` dependency and surefire plugin overrides from: `utils`, `core/sdk-core`, `core/http-auth-aws`, `http-clients/netty-nio-client`, `services/s3`, `services-custom/s3-transfer-manager`. Also removed the unused `reactive-streams-tck` dependency from `http-client-spi` and `http-clients/aws-crt-client` (these had the dependency declared but no actual TCK tests or surefire-testng provider).

**2. `utils` — `SimplePublisher` (Reactive Streams rules 3.13 and 1.03)**

*Rule 3.13:* `SimplePublisher` never released its reference to the subscriber after a terminal event, so the TCK's `required_spec313` (publisher must drop subscriber references after cancellation) failed. Now the `subscriber` field is set to `null` after `onComplete`, `onError`, and `cancel`. A separate `subscribed` `AtomicBoolean` was introduced to keep enforcing the single-subscription guard (previously done by null-checking `subscriber`), and `panicAndDie` guards against the now-nullable field.

This one fix resolved **4** TCK failures, because `OutputStreamPublisher` and `InputStreamConsumingPublisher` (utils) and `SigV4DataFramePublisher` (http-auth-aws) all delegate to `SimplePublisher`.

*Rule 1.03:* When `request(n)` was called from within the subscriber's `onSubscribe`, `processEventQueue()` would immediately deliver `onNext` before `onSubscribe` returned — violating the rule that signals must not be invoked concurrently. Added a `volatile boolean onSubscribeInProgress` flag that suppresses signal delivery until `onSubscribe` completes. The `processEventQueue()` call after the flag is cleared picks up any pending work.

**3. `core/http-auth-aws` — `ChunkedEncodedPublisherTckTest`**

26 failures were a **test defect**, not a production bug: the test never called `.contentLength(...)`, which the builder requires. Production always sets it via the `x-amz-decoded-content-length` header (`AwsChunkedV4PayloadSigner` / `AwsChunkedV4aPayloadSigner`), so the `Validate.notNull` guard is correct. Fixed the test to pass a `contentLength` matching the data it produces.

**4. `services-custom/s3-transfer-manager` — `AsyncBufferingSubscriber`**

Two TCK Subscriber-rule violations:

- **Rule 2.13** (`spec213`): `onNext(null)` must throw `NullPointerException`. Added a null check on the incoming element.
- **Rule 2.3** (`spec203`): a Subscriber must not call `Subscription.cancel()` from within `onError`. The `returnFuture.whenComplete` handler cancelled the subscription whenever the future failed — including when `onError` itself failed it (synchronously, from within `onError`). Added an `onErrorInvoked` flag so the handler skips the subscription cancel when the failure originated from `onError` (upstream has already terminated, so the cancel was redundant anyway). External-abort cancellation is unchanged.

The existing unit test `consumerFunctionThrows_shouldCancelSubscriptionAndCompleteFutureExceptionally` asserted `cancel()` was called **twice** — the second call being the rule-2.3 violation. Updated it to expect a single cancel (from the `onNext` catch block); the subscription is still cancelled and the future still completes exceptionally.

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Newly-enabled TCK tests pass across all affected modules.