### PR TITLE
Handle race condition in CRT tx pause

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-29053ac.json
+++ b/.changes/next-release/bugfix-S3TransferManager-29053ac.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Fix race condition when invoking pausing upload that can cause a `NullPointerException`."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3MetaRequestPauseObservable.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3MetaRequestPauseObservable.java
@@ -43,7 +43,11 @@ public class S3MetaRequestPauseObservable {
      * Pause the request
      */
     public ResumeToken pause() {
-        return pause.apply(request);
+        S3MetaRequestWrapper r = this.request;
+        if (r != null) {
+            return pause.apply(r);
+        }
+        return null;
     }
 }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3MetaRequestPauseObservable.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3MetaRequestPauseObservable.java
@@ -43,9 +43,8 @@ public class S3MetaRequestPauseObservable {
      * Pause the request
      */
     public ResumeToken pause() {
-        S3MetaRequestWrapper r = this.request;
-        if (r != null) {
-            return pause.apply(r);
+        if (this.request != null) {
+            return pause.apply(this.request);
         }
         return null;
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3MetaRequestPauseObservableTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3MetaRequestPauseObservableTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class S3MetaRequestPauseObservableTest {
+    @Test
+    void pause_notYetSubscribed_returnsNull() {
+        S3MetaRequestPauseObservable observable = new S3MetaRequestPauseObservable();
+        assertThat(observable.pause()).isNull();
+    }
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
If S3MetaRequestPauseObservable#pause is invoked before S3MetaRequestPauseObservable#subscribe is executed, an NPE can occur. This can happen if the transfer hasn't actually begin before the pause() was invoked.

Fix this by returning `null` in this case, which `CrtFileUpload` treats as transfer not yet started.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
